### PR TITLE
test: use separate database for tests (#45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,10 @@ To build the development or production app instead, replace `local` with `dev` o
 - Install Postgres using Homebrew: `brew install postgresql`
 - Start the Postgres server: `brew services run postgresql`, or `brew services start postgresql` to have it restart on reboot
 - Create a database: `createdb atlas-tracker`
+- In the app directory, run `npm run migrate` to migrate up
 
 #### Running queries in the terminal
 
 - Run `psql atlas-tracker`
 - Enter a query, e.g. `SELECT * FROM hat.users;`
 - Enter `\q` to exit
-
-#### Using with the app
-
-- To provide the information necessary to connect to the database, run `export DATABASE_URL=postgres://localhost/atlas-tracker`
-- To migrate up, run `npm run migrate up`
-- To migrate down, run `npm run migrate down`

--- a/README.md
+++ b/README.md
@@ -42,3 +42,12 @@ To build the development or production app instead, replace `local` with `dev` o
 - Run `psql atlas-tracker`
 - Enter a query, e.g. `SELECT * FROM hat.users;`
 - Enter `\q` to exit
+
+### Running tests
+
+In order to run tests, a test database must be created:
+
+- `createdb atlas-tracker-test`
+- `npm run migrate-test`
+
+Once this has been done, tests may be run with `npm run test`.

--- a/__tests__/api-atlases.test.ts
+++ b/__tests__/api-atlases.test.ts
@@ -9,6 +9,8 @@ import {
 import { endPgPool } from "../app/utils/api-handler";
 import atlasesHandler from "../pages/api/atlases";
 
+jest.mock("../app/utils/pg-connect-config");
+
 type Atlases = Record<number, HCAAtlasTrackerAtlas>;
 
 afterAll(() => {

--- a/__tests__/api-users-create.test.ts
+++ b/__tests__/api-users-create.test.ts
@@ -10,6 +10,8 @@ import {
 } from "../testing/constants";
 import { TestUser } from "../testing/entities";
 
+jest.mock("../app/utils/pg-connect-config");
+
 const NEW_USER_DATA = {
   disabled: false,
   email: USER_NEW.email,

--- a/__tests__/api-users-id-disable.test.ts
+++ b/__tests__/api-users-id-disable.test.ts
@@ -5,6 +5,8 @@ import disableHandler from "../pages/api/users/[id]/disable";
 import { USER_CONTENT_ADMIN, USER_NORMAL } from "../testing/constants";
 import { TestUser } from "../testing/entities";
 
+jest.mock("../app/utils/pg-connect-config");
+
 let userNormalId: string;
 let nonexistentId: string;
 

--- a/__tests__/api-users-id-enable.test.ts
+++ b/__tests__/api-users-id-enable.test.ts
@@ -9,6 +9,8 @@ import {
 } from "../testing/constants";
 import { TestUser } from "../testing/entities";
 
+jest.mock("../app/utils/pg-connect-config");
+
 let userDisabledId: string;
 let nonexistentId: string;
 

--- a/__tests__/api-users.test.ts
+++ b/__tests__/api-users.test.ts
@@ -9,6 +9,8 @@ import {
 } from "../testing/constants";
 import { TestUser } from "../testing/entities";
 
+jest.mock("../app/utils/pg-connect-config");
+
 afterAll(() => {
   endPgPool();
 });

--- a/app/utils/__mocks__/pg-connect-config.ts
+++ b/app/utils/__mocks__/pg-connect-config.ts
@@ -1,0 +1,12 @@
+import pg from "pg";
+
+/**
+ * Substitute connection information with information for the test database.
+ */
+
+export function getPoolConfig(): pg.PoolConfig {
+  return {
+    database: "atlas-tracker-test",
+    host: "localhost",
+  };
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "prepare": "husky install .husky",
     "test": "jest --runInBand",
     "build-catalog": "esrun ./files/build-catalog.ts",
-    "migrate": "ts-node -O '{\"module\": \"commonjs\"}' ./scripts/migration-runner.ts -j ts"
+    "migrate": "ts-node -O '{\"module\": \"commonjs\"}' ./scripts/migration-runner.ts -j ts",
+    "migrate-test": "ts-node -O '{\"module\": \"commonjs\"}' ./scripts/test-db-migration-runner.ts -j ts"
   },
   "dependencies": {
     "@clevercanary/data-explorer-ui": "69.0.0",

--- a/scripts/migration-runner.ts
+++ b/scripts/migration-runner.ts
@@ -25,7 +25,8 @@ const runMigrations = async (): Promise<void> => {
     migrationsTable: "pgmigrations", // Default migrations table
   });
 
-  await client.release(); // Release the client back to the pool
+  client.release(); // Release the client back to the pool
+  pool.end(); // End the pool
 };
 
 runMigrations().catch((error) => {

--- a/scripts/test-db-migration-runner.ts
+++ b/scripts/test-db-migration-runner.ts
@@ -1,0 +1,28 @@
+import migrate from "node-pg-migrate";
+import pg from "pg";
+import { getPoolConfig } from "../app/utils/__mocks__/pg-connect-config";
+
+const { Pool } = pg;
+
+const runMigrations = async (): Promise<void> => {
+  const poolConfig = getPoolConfig();
+
+  const pool = new Pool(poolConfig);
+  const client = await pool.connect();
+
+  await migrate({
+    count: Infinity,
+    dbClient: client,
+    dir: "migrations",
+    direction: "up",
+    migrationsTable: "pgmigrations",
+  });
+
+  client.release();
+  pool.end();
+};
+
+runMigrations().catch((error) => {
+  console.error("Migration failed:", error);
+  process.exit(1);
+});

--- a/testing/global-setup.ts
+++ b/testing/global-setup.ts
@@ -1,11 +1,16 @@
-import { query } from "../app/utils/api-handler";
+import pg from "pg";
+import { getPoolConfig } from "../app/utils/__mocks__/pg-connect-config";
 import { INITIAL_TEST_USERS } from "./constants";
 
+const { Pool } = pg;
+
 export default async function setup(): Promise<void> {
+  const pool = new Pool(getPoolConfig());
   for (const user of INITIAL_TEST_USERS) {
-    await query(
+    await pool.query(
       "INSERT INTO hat.users (disabled, email, full_name, role) VALUES ($1, $2, $3, $4)",
       [user.disabled.toString(), user.email, user.name, user.role]
     );
   }
+  pool.end();
 }

--- a/testing/global-teardown.ts
+++ b/testing/global-teardown.ts
@@ -1,9 +1,13 @@
-import { endPgPool, query } from "../app/utils/api-handler";
+import pg from "pg";
+import { getPoolConfig } from "../app/utils/__mocks__/pg-connect-config";
 import { INITIAL_TEST_USERS } from "./constants";
 
+const { Pool } = pg;
+
 export default async function teardown(): Promise<void> {
+  const pool = new Pool(getPoolConfig());
   for (const user of INITIAL_TEST_USERS) {
-    await query("DELETE FROM hat.users WHERE email=$1", [user.email]);
+    await pool.query("DELETE FROM hat.users WHERE email=$1", [user.email]);
   }
-  endPgPool();
+  pool.end();
 }


### PR DESCRIPTION
- Slight change to existing migration runner (ending the pool explicitly to avoid a delay in the script completing)
- Separate test DB migration runner
- Mock for pg-connect-config so that tests will use the test database