### PR TITLE
feat: add wave field (#62)

### DIFF
--- a/__tests__/api-atlases-create.test.ts
+++ b/__tests__/api-atlases-create.test.ts
@@ -12,6 +12,7 @@ const NEW_ATLAS_DATA: NewAtlasData = {
   network: "eye",
   shortName: "test",
   version: "1.0",
+  wave: 1,
 };
 
 let newAtlasId: string;

--- a/__tests__/api-atlases-create.test.ts
+++ b/__tests__/api-atlases-create.test.ts
@@ -63,6 +63,39 @@ describe("/api/atlases/create", () => {
     ).toEqual(400);
   });
 
+  it("returns error 400 when wave is not an integer", async () => {
+    expect(
+      (
+        await doCreateTest(USER_CONTENT_ADMIN, {
+          ...NEW_ATLAS_DATA,
+          wave: 1.2,
+        })
+      )._getStatusCode()
+    ).toEqual(400);
+  });
+
+  it("returns error 400 when wave is less than 1", async () => {
+    expect(
+      (
+        await doCreateTest(USER_CONTENT_ADMIN, {
+          ...NEW_ATLAS_DATA,
+          wave: 0,
+        })
+      )._getStatusCode()
+    ).toEqual(400);
+  });
+
+  it("returns error 400 when wave is greater than 3", async () => {
+    expect(
+      (
+        await doCreateTest(USER_CONTENT_ADMIN, {
+          ...NEW_ATLAS_DATA,
+          wave: 4,
+        })
+      )._getStatusCode()
+    ).toEqual(400);
+  });
+
   it("creates and returns atlas entry", async () => {
     const newAtlas = (
       await doCreateTest(USER_CONTENT_ADMIN, NEW_ATLAS_DATA)

--- a/__tests__/api-atlases-id.test.ts
+++ b/__tests__/api-atlases-id.test.ts
@@ -121,6 +121,39 @@ describe("/api/atlases/[id]", () => {
     ).toEqual(400);
   });
 
+  it("PUT returns error 400 when wave is not an integer", async () => {
+    expect(
+      (
+        await doAtlasRequest(ATLAS_PUBLIC.id, USER_CONTENT_ADMIN, METHOD.PUT, {
+          ...ATLAS_PUBLIC_EDIT,
+          wave: 1.2,
+        })
+      )._getStatusCode()
+    ).toEqual(400);
+  });
+
+  it("PUT returns error 400 when wave is less than 1", async () => {
+    expect(
+      (
+        await doAtlasRequest(ATLAS_PUBLIC.id, USER_CONTENT_ADMIN, METHOD.PUT, {
+          ...ATLAS_PUBLIC_EDIT,
+          wave: 0,
+        })
+      )._getStatusCode()
+    ).toEqual(400);
+  });
+
+  it("PUT returns error 400 when wave is greater than 3", async () => {
+    expect(
+      (
+        await doAtlasRequest(ATLAS_PUBLIC.id, USER_CONTENT_ADMIN, METHOD.PUT, {
+          ...ATLAS_PUBLIC_EDIT,
+          wave: 4,
+        })
+      )._getStatusCode()
+    ).toEqual(400);
+  });
+
   it("PUT updates and returns atlas entry", async () => {
     const updatedAtlas = (
       await doAtlasRequest(

--- a/__tests__/api-atlases-id.test.ts
+++ b/__tests__/api-atlases-id.test.ts
@@ -20,6 +20,7 @@ const ATLAS_PUBLIC_EDIT: AtlasEditData = {
   network: ATLAS_PUBLIC.network,
   shortName: "test-public-edited",
   version: "2.0",
+  wave: 2,
 };
 
 afterAll(async () => {

--- a/app/apis/catalog/hca-atlas-tracker/common/constants.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/constants.ts
@@ -1,5 +1,8 @@
 import { Network, NetworkKey } from "./entities";
 
+export const MIN_WAVE = 1;
+export const MAX_WAVE = 3;
+
 export const NETWORK_KEYS = [
   "adipose",
   "breast",

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -12,6 +12,7 @@ export interface HCAAtlasTrackerListAtlas {
   status: ATLAS_STATUS;
   title: string;
   version: string;
+  wave: number;
 }
 
 export interface HCAAtlasTrackerAtlas {
@@ -30,6 +31,7 @@ export interface HCAAtlasTrackerAtlas {
   status: ATLAS_STATUS;
   title: string;
   version: string;
+  wave: number;
 }
 
 export interface HCAAtlasTrackerComponentAtlas {
@@ -76,6 +78,7 @@ export interface HCAAtlasTrackerDBAtlasOverview {
   network: NetworkKey;
   shortName: string;
   version: string;
+  wave: number;
 }
 
 export interface HCAAtlasTrackerDBSourceDataset {

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -1,6 +1,6 @@
 import { escapeRegExp } from "@clevercanary/data-explorer-ui/lib/common/utils";
-import { boolean, InferType, object, string } from "yup";
-import { NETWORK_KEYS } from "./constants";
+import { boolean, InferType, number, object, string } from "yup";
+import { MAX_WAVE, MIN_WAVE, NETWORK_KEYS } from "./constants";
 
 const NETWORK_REGEXP = new RegExp(
   `^(?:${NETWORK_KEYS.map(escapeRegExp).join("|")})$`
@@ -19,6 +19,12 @@ export const newAtlasSchema = object({
     ),
   shortName: string().default("").required("Short name is required"),
   version: string().default("").required("Version is required"),
+  wave: number()
+    .default(1)
+    .required("Wave is required")
+    .integer("Wave must be an integer")
+    .min(MIN_WAVE, `Wave must be greater than or equal to ${MIN_WAVE}`)
+    .max(MAX_WAVE, `Wave must be less than or equal to ${MAX_WAVE}`),
 }).strict(true);
 
 export type NewAtlasData = InferType<typeof newAtlasSchema>;

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -27,6 +27,7 @@ export function atlasInputMapper(
     status: apiAtlas.status,
     title: apiAtlas.title,
     version: apiAtlas.version,
+    wave: apiAtlas.wave,
   };
 }
 
@@ -49,6 +50,7 @@ export function dbAtlasToApiAtlas(
     status: dbAtlas.status,
     title: "",
     version: dbAtlas.overview.version,
+    wave: dbAtlas.overview.wave,
   };
 }
 

--- a/app/components/Detail/components/TrackerForm/components/Section/components/Atlas/components/GeneralInfo/generalInfo.tsx
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/Atlas/components/GeneralInfo/generalInfo.tsx
@@ -1,7 +1,11 @@
 import { MenuItem as MMenuItem } from "@mui/material";
 import { ReactNode } from "react";
 import { Controller } from "react-hook-form";
-import { NETWORKS } from "../../../../../../../../../../apis/catalog/hca-atlas-tracker/common/constants";
+import {
+  MAX_WAVE,
+  MIN_WAVE,
+  NETWORKS,
+} from "../../../../../../../../../../apis/catalog/hca-atlas-tracker/common/constants";
 import { NewAtlasData } from "../../../../../../../../../../apis/catalog/hca-atlas-tracker/common/schema";
 import { isNetworkKey } from "../../../../../../../../../../apis/catalog/hca-atlas-tracker/common/utils";
 import { FormMethod } from "../../../../../../../../../../hooks/useForm/common/entities";
@@ -19,6 +23,7 @@ import {
 export const FIELD_NAME_ATLAS_NAME = "shortName";
 export const FIELD_NAME_BIO_NETWORK = "network";
 export const FIELD_NAME_VERSION = "version";
+export const FIELD_NAME_WAVE = "wave";
 
 export interface GeneralInfoProps {
   control: FormMethod<NewAtlasData>["control"];
@@ -45,7 +50,7 @@ export const GeneralInfo = ({
                 {...field}
                 error={Boolean(errors[FIELD_NAME_ATLAS_NAME])}
                 helperText={errors[FIELD_NAME_ATLAS_NAME]?.message as string}
-                isDirty={Boolean(field.value)}
+                isDirty={Boolean(formState.dirtyFields.shortName)}
                 label="Short name"
                 placeholder="e.g. Cortex"
                 readOnly={false}
@@ -61,7 +66,7 @@ export const GeneralInfo = ({
               {...field}
               error={Boolean(errors[FIELD_NAME_VERSION])}
               helperText={errors[FIELD_NAME_VERSION]?.message as string}
-              isDirty={Boolean(field.value)}
+              isDirty={Boolean(formState.dirtyFields.version)}
               label="Version"
               placeholder="e.g. 1.0"
               readOnly={false}
@@ -78,10 +83,10 @@ export const GeneralInfo = ({
                 displayEmpty
                 error={Boolean(errors[FIELD_NAME_BIO_NETWORK])}
                 helperText={errors[FIELD_NAME_BIO_NETWORK]?.message as string}
-                isDirty={Boolean(field.value)}
+                isDirty={Boolean(formState.dirtyFields.network)}
                 label="Select network"
                 readOnly={false}
-                renderValue={renderSelectValue}
+                renderValue={renderNetworkSelectValue}
               >
                 {NETWORKS.map(({ key, name }) => (
                   <MMenuItem key={key} value={key}>
@@ -92,17 +97,42 @@ export const GeneralInfo = ({
             );
           }}
         />
+        <Controller
+          control={control}
+          name={FIELD_NAME_WAVE}
+          render={({ field }): JSX.Element => {
+            return (
+              <Select
+                {...field}
+                error={Boolean(errors[FIELD_NAME_WAVE])}
+                helperText={errors[FIELD_NAME_WAVE]?.message as string}
+                isDirty={Boolean(formState.dirtyFields.wave)}
+                label="Select wave"
+                readOnly={false}
+              >
+                {Array.from({ length: MAX_WAVE - MIN_WAVE + 1 }, (v, i) => {
+                  const wave = MIN_WAVE + i;
+                  return (
+                    <MMenuItem key={wave} value={wave}>
+                      {wave}
+                    </MMenuItem>
+                  );
+                })}
+              </Select>
+            );
+          }}
+        />
       </SectionCard>
     </Section>
   );
 };
 
 /**
- * Renders select value.
+ * Renders network select value.
  * @param value - Select value.
  * @returns select value.
  */
-function renderSelectValue(value: unknown): ReactNode {
+function renderNetworkSelectValue(value: unknown): ReactNode {
   if (isNetworkKey(value)) {
     const networkName = getBioNetworkByKey(value)?.name;
     return (

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -189,6 +189,19 @@ export const buildVersion = (
 };
 
 /**
+ * Build props for the wave cell component.
+ * @param atlas - Atlas entity.
+ * @returns Props to be used for the cell.
+ */
+export const buildWave = (
+  atlas: HCAAtlasTrackerListAtlas
+): React.ComponentProps<typeof C.Cell> => {
+  return {
+    value: atlas.wave,
+  };
+};
+
+/**
  * Returns the table column definition model for the atlas (edit mode) source datasets table.
  * @returns Table column definition.
  */

--- a/app/views/EditAtlasView/hooks/useEditAtlasForm.tsx
+++ b/app/views/EditAtlasView/hooks/useEditAtlasForm.tsx
@@ -10,6 +10,7 @@ import {
   FIELD_NAME_ATLAS_NAME,
   FIELD_NAME_BIO_NETWORK,
   FIELD_NAME_VERSION,
+  FIELD_NAME_WAVE,
 } from "../../../components/Detail/components/TrackerForm/components/Section/components/Atlas/components/GeneralInfo/generalInfo";
 import { FormMethod } from "../../../hooks/useForm/common/entities";
 import { useForm } from "../../../hooks/useForm/useForm";
@@ -34,6 +35,7 @@ function mapSchemaValues(atlas?: HCAAtlasTrackerAtlas): AtlasEditData {
     [FIELD_NAME_ATLAS_NAME]: atlas?.shortName || "",
     [FIELD_NAME_BIO_NETWORK]: atlas?.bioNetwork || "",
     [FIELD_NAME_VERSION]: atlas?.version || "",
+    [FIELD_NAME_WAVE]: atlas?.wave || 1,
   };
 }
 

--- a/pages/api/atlases/[atlasId].ts
+++ b/pages/api/atlases/[atlasId].ts
@@ -64,6 +64,7 @@ const putHandler = handler(role("CONTENT_ADMIN"), async (req, res) => {
     network: newInfo.network as NetworkKey,
     shortName: newInfo.shortName,
     version: newInfo.version,
+    wave: newInfo.wave,
   };
   const queryResult = await query(
     "UPDATE hat.atlases SET overview=overview||$1 WHERE id=$2 RETURNING *",

--- a/pages/api/atlases/create.ts
+++ b/pages/api/atlases/create.ts
@@ -33,6 +33,7 @@ export default handler(
       network: newInfo.network as NetworkKey,
       shortName: newInfo.shortName,
       version: newInfo.version,
+      wave: newInfo.wave,
     };
     const queryResult = await query(
       "INSERT INTO hat.atlases (overview, source_datasets, status) VALUES ($1, $2, $3) RETURNING *",

--- a/site-config/hca-atlas-tracker/category.ts
+++ b/site-config/hca-atlas-tracker/category.ts
@@ -16,6 +16,7 @@ export const HCA_ATLAS_TRACKER_CATEGORY_KEY = {
   TISSUE: "tissue",
   TITLE: "title",
   VERSION: "version",
+  WAVE: "wave",
 };
 
 export const HCA_ATLAS_TRACKER_CATEGORY_LABEL = {
@@ -36,4 +37,5 @@ export const HCA_ATLAS_TRACKER_CATEGORY_LABEL = {
   TISSUE: "Tissue",
   TITLE: "Atlas",
   VERSION: "Atlas Version",
+  WAVE: "Wave",
 };

--- a/site-config/hca-atlas-tracker/local/config.ts
+++ b/site-config/hca-atlas-tracker/local/config.ts
@@ -40,6 +40,10 @@ export function makeConfig(browserUrl: string, portalUrl: string): SiteConfig {
             label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.BIONETWORK,
           },
           {
+            key: HCA_ATLAS_TRACKER_CATEGORY_KEY.WAVE,
+            label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.WAVE,
+          },
+          {
             key: HCA_ATLAS_TRACKER_CATEGORY_KEY.TITLE,
             label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.TITLE,
           },

--- a/site-config/hca-atlas-tracker/local/index/atlasEntityConfig.ts
+++ b/site-config/hca-atlas-tracker/local/index/atlasEntityConfig.ts
@@ -65,6 +65,15 @@ export const atlasEntityConfig: EntityConfig = {
       {
         componentConfig: {
           component: C.Cell,
+          viewBuilder: V.buildWave,
+        } as ComponentConfig<typeof C.Cell, HCAAtlasTrackerListAtlas>,
+        header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.WAVE,
+        id: HCA_ATLAS_TRACKER_CATEGORY_KEY.WAVE,
+        width: { max: "0.5fr", min: "68px" },
+      },
+      {
+        componentConfig: {
+          component: C.Cell,
           viewBuilder: V.buildVersion,
         } as ComponentConfig<typeof C.Cell, HCAAtlasTrackerListAtlas>,
         header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.VERSION,

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -73,6 +73,7 @@ export const ATLAS_DRAFT: TestAtlas = {
   ],
   status: ATLAS_STATUS.DRAFT,
   version: "1.2",
+  wave: 1,
 };
 
 export const ATLAS_PUBLIC: TestAtlas = {
@@ -82,6 +83,7 @@ export const ATLAS_PUBLIC: TestAtlas = {
   sourceDatasets: [SOURCE_DATASET_PUBLIC_NO_CROSSREF.id],
   status: ATLAS_STATUS.PUBLIC,
   version: "2.3",
+  wave: 1,
 };
 
 export const ATLAS_NONEXISTENT = {

--- a/testing/entities.ts
+++ b/testing/entities.ts
@@ -21,6 +21,7 @@ export interface TestAtlas {
   sourceDatasets: string[];
   status: ATLAS_STATUS;
   version: string;
+  wave: number;
 }
 
 export interface TestSourceDataset {

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -23,5 +23,6 @@ export function makeTestAtlasOverview(
     network: atlas.network,
     shortName: atlas.shortName,
     version: atlas.version,
+    wave: atlas.wave,
   };
 }


### PR DESCRIPTION
Note: This PR also updates the atlas `GeneralInfo` to pass `isDirty` props based on `formState`, which means that the edit form will now display input values in gray if they haven't been changed