### PR TITLE
feat: change wave to be a string and be initially unspecified on form (#62)

### DIFF
--- a/__tests__/api-atlases-create.test.ts
+++ b/__tests__/api-atlases-create.test.ts
@@ -12,7 +12,7 @@ const NEW_ATLAS_DATA: NewAtlasData = {
   network: "eye",
   shortName: "test",
   version: "1.0",
-  wave: 1,
+  wave: "1",
 };
 
 let newAtlasId: string;
@@ -46,7 +46,7 @@ describe("/api/atlases/create", () => {
       (
         await doCreateTest(USER_CONTENT_ADMIN, {
           ...NEW_ATLAS_DATA,
-          network: "notanetwork",
+          network: "notanetwork" as NewAtlasData["network"],
         })
       )._getStatusCode()
     ).toEqual(400);
@@ -63,34 +63,12 @@ describe("/api/atlases/create", () => {
     ).toEqual(400);
   });
 
-  it("returns error 400 when wave is not an integer", async () => {
+  it("returns error 400 when wave is is not a valid wave value", async () => {
     expect(
       (
         await doCreateTest(USER_CONTENT_ADMIN, {
           ...NEW_ATLAS_DATA,
-          wave: 1.2,
-        })
-      )._getStatusCode()
-    ).toEqual(400);
-  });
-
-  it("returns error 400 when wave is less than 1", async () => {
-    expect(
-      (
-        await doCreateTest(USER_CONTENT_ADMIN, {
-          ...NEW_ATLAS_DATA,
-          wave: 0,
-        })
-      )._getStatusCode()
-    ).toEqual(400);
-  });
-
-  it("returns error 400 when wave is greater than 3", async () => {
-    expect(
-      (
-        await doCreateTest(USER_CONTENT_ADMIN, {
-          ...NEW_ATLAS_DATA,
-          wave: 4,
+          wave: "0" as NewAtlasData["wave"],
         })
       )._getStatusCode()
     ).toEqual(400);

--- a/__tests__/api-atlases-id.test.ts
+++ b/__tests__/api-atlases-id.test.ts
@@ -20,7 +20,7 @@ const ATLAS_PUBLIC_EDIT: AtlasEditData = {
   network: ATLAS_PUBLIC.network,
   shortName: "test-public-edited",
   version: "2.0",
-  wave: 2,
+  wave: "2",
 };
 
 afterAll(async () => {
@@ -104,7 +104,7 @@ describe("/api/atlases/[id]", () => {
       (
         await doAtlasRequest(ATLAS_PUBLIC.id, USER_CONTENT_ADMIN, METHOD.PUT, {
           ...ATLAS_PUBLIC_EDIT,
-          network: "notanetwork",
+          network: "notanetwork" as AtlasEditData["network"],
         })
       )._getStatusCode()
     ).toEqual(400);
@@ -121,34 +121,12 @@ describe("/api/atlases/[id]", () => {
     ).toEqual(400);
   });
 
-  it("PUT returns error 400 when wave is not an integer", async () => {
+  it("PUT returns error 400 when wave is not a valid wave value", async () => {
     expect(
       (
         await doAtlasRequest(ATLAS_PUBLIC.id, USER_CONTENT_ADMIN, METHOD.PUT, {
           ...ATLAS_PUBLIC_EDIT,
-          wave: 1.2,
-        })
-      )._getStatusCode()
-    ).toEqual(400);
-  });
-
-  it("PUT returns error 400 when wave is less than 1", async () => {
-    expect(
-      (
-        await doAtlasRequest(ATLAS_PUBLIC.id, USER_CONTENT_ADMIN, METHOD.PUT, {
-          ...ATLAS_PUBLIC_EDIT,
-          wave: 0,
-        })
-      )._getStatusCode()
-    ).toEqual(400);
-  });
-
-  it("PUT returns error 400 when wave is greater than 3", async () => {
-    expect(
-      (
-        await doAtlasRequest(ATLAS_PUBLIC.id, USER_CONTENT_ADMIN, METHOD.PUT, {
-          ...ATLAS_PUBLIC_EDIT,
-          wave: 4,
+          wave: "0" as AtlasEditData["wave"],
         })
       )._getStatusCode()
     ).toEqual(400);

--- a/app/apis/catalog/hca-atlas-tracker/common/constants.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/constants.ts
@@ -1,7 +1,6 @@
 import { Network, NetworkKey } from "./entities";
 
-export const MIN_WAVE = 1;
-export const MAX_WAVE = 3;
+export const WAVES = ["1", "2", "3"] as const;
 
 export const NETWORK_KEYS = [
   "adipose",

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -1,4 +1,4 @@
-import { NETWORK_KEYS } from "./constants";
+import { NETWORK_KEYS, WAVES } from "./constants";
 
 export interface HCAAtlasTrackerListAtlas {
   bioNetwork: NetworkKey;
@@ -12,7 +12,7 @@ export interface HCAAtlasTrackerListAtlas {
   status: ATLAS_STATUS;
   title: string;
   version: string;
-  wave: number;
+  wave: Wave;
 }
 
 export interface HCAAtlasTrackerAtlas {
@@ -31,7 +31,7 @@ export interface HCAAtlasTrackerAtlas {
   status: ATLAS_STATUS;
   title: string;
   version: string;
-  wave: number;
+  wave: Wave;
 }
 
 export interface HCAAtlasTrackerComponentAtlas {
@@ -78,7 +78,7 @@ export interface HCAAtlasTrackerDBAtlasOverview {
   network: NetworkKey;
   shortName: string;
   version: string;
-  wave: number;
+  wave: Wave;
 }
 
 export interface HCAAtlasTrackerDBSourceDataset {
@@ -113,6 +113,8 @@ export interface Network {
 }
 
 export type NetworkKey = (typeof NETWORK_KEYS)[number];
+
+export type Wave = (typeof WAVES)[number];
 
 export interface PublicationInfo {
   authors: Author[];

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -1,10 +1,5 @@
-import { escapeRegExp } from "@clevercanary/data-explorer-ui/lib/common/utils";
-import { boolean, InferType, number, object, string } from "yup";
-import { MAX_WAVE, MIN_WAVE, NETWORK_KEYS } from "./constants";
-
-const NETWORK_REGEXP = new RegExp(
-  `^(?:${NETWORK_KEYS.map(escapeRegExp).join("|")})$`
-);
+import { boolean, InferType, object, string } from "yup";
+import { NETWORK_KEYS, WAVES } from "./constants";
 
 /**
  * Schema for data used to create a new atlas.
@@ -13,18 +8,13 @@ export const newAtlasSchema = object({
   network: string()
     .default("")
     .required("Network is required")
-    .matches(
-      NETWORK_REGEXP,
-      `Network must be one of: ${NETWORK_KEYS.join(", ")}`
-    ),
+    .oneOf(NETWORK_KEYS, `Network must be one of: ${NETWORK_KEYS.join(", ")}`),
   shortName: string().default("").required("Short name is required"),
   version: string().default("").required("Version is required"),
-  wave: number()
-    .default(1)
+  wave: string()
+    .default("")
     .required("Wave is required")
-    .integer("Wave must be an integer")
-    .min(MIN_WAVE, `Wave must be greater than or equal to ${MIN_WAVE}`)
-    .max(MAX_WAVE, `Wave must be less than or equal to ${MAX_WAVE}`),
+    .oneOf(WAVES, `Wave must be one of: ${WAVES.join(", ")}`),
 }).strict(true);
 
 export type NewAtlasData = InferType<typeof newAtlasSchema>;

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -8,12 +8,14 @@ export const newAtlasSchema = object({
   network: string()
     .default("")
     .required("Network is required")
+    .notOneOf([""], "Network is required")
     .oneOf(NETWORK_KEYS, `Network must be one of: ${NETWORK_KEYS.join(", ")}`),
   shortName: string().default("").required("Short name is required"),
   version: string().default("").required("Version is required"),
   wave: string()
     .default("")
     .required("Wave is required")
+    .notOneOf([""], "Wave is required")
     .oneOf(WAVES, `Wave must be one of: ${WAVES.join(", ")}`),
 }).strict(true);
 

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -1,4 +1,4 @@
-import { NETWORK_KEYS } from "./constants";
+import { NETWORK_KEYS, WAVES } from "./constants";
 import {
   HCAAtlasTrackerAtlas,
   HCAAtlasTrackerDBAtlas,
@@ -6,6 +6,7 @@ import {
   HCAAtlasTrackerListAtlas,
   HCAAtlasTrackerSourceDataset,
   NetworkKey,
+  Wave,
 } from "./entities";
 
 export function getAtlasId(atlas: HCAAtlasTrackerListAtlas): string {
@@ -86,5 +87,16 @@ export function getAtlasName(atlas: HCAAtlasTrackerAtlas): string {
 export function isNetworkKey(key: unknown): key is NetworkKey {
   return (
     typeof key === "string" && (NETWORK_KEYS as readonly string[]).includes(key)
+  );
+}
+
+/**
+ * Returns true if the given value is a valid wave.
+ * @param value - Value.
+ * @returns true if the value is a valid wave.
+ */
+export function isWaveValue(value: unknown): value is Wave {
+  return (
+    typeof value === "string" && (WAVES as readonly string[]).includes(value)
   );
 }

--- a/app/components/Detail/components/TrackerForm/components/Section/components/Atlas/components/GeneralInfo/generalInfo.tsx
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/Atlas/components/GeneralInfo/generalInfo.tsx
@@ -6,7 +6,10 @@ import {
   WAVES,
 } from "../../../../../../../../../../apis/catalog/hca-atlas-tracker/common/constants";
 import { NewAtlasData } from "../../../../../../../../../../apis/catalog/hca-atlas-tracker/common/schema";
-import { isNetworkKey } from "../../../../../../../../../../apis/catalog/hca-atlas-tracker/common/utils";
+import {
+  isNetworkKey,
+  isWaveValue,
+} from "../../../../../../../../../../apis/catalog/hca-atlas-tracker/common/utils";
 import { FormMethod } from "../../../../../../../../../../hooks/useForm/common/entities";
 import { getBioNetworkByKey } from "../../../../../../../../../../viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders";
 import { Input } from "../../../../../../../../../common/Form/components/Input/input";
@@ -103,11 +106,13 @@ export const GeneralInfo = ({
             return (
               <Select
                 {...field}
+                displayEmpty
                 error={Boolean(errors[FIELD_NAME_WAVE])}
                 helperText={errors[FIELD_NAME_WAVE]?.message as string}
                 isDirty={Boolean(formState.dirtyFields.wave)}
                 label="Select wave"
                 readOnly={false}
+                renderValue={renderWaveSelectValue}
               >
                 {WAVES.map((wave) => {
                   return (
@@ -139,6 +144,18 @@ function renderNetworkSelectValue(value: unknown): ReactNode {
         networkName={networkName ?? value}
       />
     );
+  }
+  return "Choose...";
+}
+
+/**
+ * Renders wave select value.
+ * @param value - Select value.
+ * @returns select value.
+ */
+function renderWaveSelectValue(value: unknown): ReactNode {
+  if (isWaveValue(value)) {
+    return value;
   }
   return "Choose...";
 }

--- a/app/components/Detail/components/TrackerForm/components/Section/components/Atlas/components/GeneralInfo/generalInfo.tsx
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/Atlas/components/GeneralInfo/generalInfo.tsx
@@ -2,9 +2,8 @@ import { MenuItem as MMenuItem } from "@mui/material";
 import { ReactNode } from "react";
 import { Controller } from "react-hook-form";
 import {
-  MAX_WAVE,
-  MIN_WAVE,
   NETWORKS,
+  WAVES,
 } from "../../../../../../../../../../apis/catalog/hca-atlas-tracker/common/constants";
 import { NewAtlasData } from "../../../../../../../../../../apis/catalog/hca-atlas-tracker/common/schema";
 import { isNetworkKey } from "../../../../../../../../../../apis/catalog/hca-atlas-tracker/common/utils";
@@ -110,8 +109,7 @@ export const GeneralInfo = ({
                 label="Select wave"
                 readOnly={false}
               >
-                {Array.from({ length: MAX_WAVE - MIN_WAVE + 1 }, (v, i) => {
-                  const wave = MIN_WAVE + i;
+                {WAVES.map((wave) => {
                   return (
                     <MMenuItem key={wave} value={wave}>
                       {wave}

--- a/app/views/EditAtlasView/hooks/useEditAtlasForm.tsx
+++ b/app/views/EditAtlasView/hooks/useEditAtlasForm.tsx
@@ -30,13 +30,17 @@ export const useEditAtlasForm = (
  * @param atlas - Atlas.
  * @returns schema default values.
  */
-function mapSchemaValues(atlas?: HCAAtlasTrackerAtlas): AtlasEditData {
-  return {
-    [FIELD_NAME_ATLAS_NAME]: atlas?.shortName || "",
-    [FIELD_NAME_BIO_NETWORK]: atlas?.bioNetwork || "",
-    [FIELD_NAME_VERSION]: atlas?.version || "",
-    [FIELD_NAME_WAVE]: atlas?.wave || 1,
-  };
+function mapSchemaValues(
+  atlas?: HCAAtlasTrackerAtlas
+): AtlasEditData | undefined {
+  return (
+    atlas && {
+      [FIELD_NAME_ATLAS_NAME]: atlas.shortName,
+      [FIELD_NAME_BIO_NETWORK]: atlas.bioNetwork,
+      [FIELD_NAME_VERSION]: atlas.version,
+      [FIELD_NAME_WAVE]: atlas.wave,
+    }
+  );
 }
 
 /**

--- a/pages/api/atlases/[atlasId].ts
+++ b/pages/api/atlases/[atlasId].ts
@@ -9,7 +9,6 @@ import {
   ATLAS_STATUS,
   HCAAtlasTrackerDBAtlas,
   HCAAtlasTrackerDBAtlasOverview,
-  NetworkKey,
 } from "../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD } from "../../../app/common/entities";
 import {
@@ -61,7 +60,7 @@ const putHandler = handler(role("CONTENT_ADMIN"), async (req, res) => {
     }
   }
   const newOverviewValues: HCAAtlasTrackerDBAtlasOverview = {
-    network: newInfo.network as NetworkKey,
+    network: newInfo.network,
     shortName: newInfo.shortName,
     version: newInfo.version,
     wave: newInfo.wave,

--- a/pages/api/atlases/create.ts
+++ b/pages/api/atlases/create.ts
@@ -2,7 +2,6 @@ import { ValidationError } from "yup";
 import {
   ATLAS_STATUS,
   HCAAtlasTrackerDBAtlasOverview,
-  NetworkKey,
 } from "../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import {
   NewAtlasData,
@@ -30,7 +29,7 @@ export default handler(
       }
     }
     const newOverview: HCAAtlasTrackerDBAtlasOverview = {
-      network: newInfo.network as NetworkKey,
+      network: newInfo.network,
       shortName: newInfo.shortName,
       version: newInfo.version,
       wave: newInfo.wave,

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -73,7 +73,7 @@ export const ATLAS_DRAFT: TestAtlas = {
   ],
   status: ATLAS_STATUS.DRAFT,
   version: "1.2",
-  wave: 1,
+  wave: "1",
 };
 
 export const ATLAS_PUBLIC: TestAtlas = {
@@ -83,7 +83,7 @@ export const ATLAS_PUBLIC: TestAtlas = {
   sourceDatasets: [SOURCE_DATASET_PUBLIC_NO_CROSSREF.id],
   status: ATLAS_STATUS.PUBLIC,
   version: "2.3",
-  wave: 1,
+  wave: "1",
 };
 
 export const ATLAS_NONEXISTENT = {

--- a/testing/entities.ts
+++ b/testing/entities.ts
@@ -3,6 +3,7 @@ import {
   NetworkKey,
   PublicationInfo,
   PUBLICATION_STATUS,
+  Wave,
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 
 export interface TestUser {
@@ -21,7 +22,7 @@ export interface TestAtlas {
   sourceDatasets: string[];
   status: ATLAS_STATUS;
   version: string;
-  wave: number;
+  wave: Wave;
 }
 
 export interface TestSourceDataset {


### PR DESCRIPTION
Also changes the schema to use `oneOf` for network and and wave, meaning the schema is typed more accurately, hence the changes involving type assertions