### PR TITLE
feat: allow doi urls with http or no protocol (#112)

### DIFF
--- a/app/utils/doi.ts
+++ b/app/utils/doi.ts
@@ -8,8 +8,12 @@ export function isDoi(value: string): boolean {
 }
 
 export function normalizeDoi(doi: string): string {
-  if (/^https:\/\/doi\.org\//i.test(doi)) {
-    doi = decodeURIComponent(new URL(doi).pathname.replace(/^\//, ""));
+  const urlMatch = /^(?:https?:\/\/)?(doi\.org\/.*$)/i.exec(doi);
+  if (urlMatch) {
+    const [, nonProtocolPart] = urlMatch;
+    doi = decodeURIComponent(
+      new URL("https://" + nonProtocolPart).pathname.replace(/^\//, "")
+    );
   }
   return doi.toLowerCase();
 }


### PR DESCRIPTION
In addition to allowing HTTP URLs as specified in the ticket, this allows URLs with the protocol omitted