### PR TITLE
feat: add backend support for unpublished source datasets (#131)

### DIFF
--- a/__tests__/api-atlases-create.test.ts
+++ b/__tests__/api-atlases-create.test.ts
@@ -6,7 +6,7 @@ import {
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { NewAtlasData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
 import { dbAtlasToApiAtlas } from "../app/apis/catalog/hca-atlas-tracker/common/utils";
-import { endPgPool, query } from "../app/utils/api-handler";
+import { endPgPool, query } from "../app/services/database";
 import createHandler from "../pages/api/atlases/create";
 import { USER_CONTENT_ADMIN, USER_NORMAL } from "../testing/constants";
 import { TestUser } from "../testing/entities";

--- a/__tests__/api-atlases-id-source-datasets-create.test.ts
+++ b/__tests__/api-atlases-id-source-datasets-create.test.ts
@@ -37,7 +37,7 @@ jest.mock("../app/utils/crossref/crossref-api");
 jest.mock("../app/services/hca-projects");
 jest.mock("../app/services/cellxgene");
 
-const NEW_DATASET_DATA: NewSourceDatasetData = {
+const NEW_DATASET_DATA = {
   doi: DOI_NORMAL,
 };
 
@@ -195,7 +195,7 @@ describe("/api/atlases/[atlasId]/source-datasets/create", () => {
 
 async function testSuccessfulCreate(
   atlas: TestAtlas,
-  newData: NewSourceDatasetData,
+  newData: Record<string, unknown>,
   expectedPublication: PublicationInfo,
   expectedHcaId: string | null,
   expectedCellxGeneId: string | null
@@ -222,7 +222,7 @@ async function testSuccessfulCreate(
 async function doCreateTest(
   user: TestUser | undefined,
   atlas: Pick<TestAtlas, "id">,
-  newData: NewSourceDatasetData,
+  newData: Record<string, unknown>,
   method: "GET" | "POST" = "POST"
 ): Promise<httpMocks.MockResponse<NextApiResponse>> {
   const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>({

--- a/__tests__/api-atlases-id-source-datasets-create.test.ts
+++ b/__tests__/api-atlases-id-source-datasets-create.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { NewSourceDatasetData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
 import { dbSourceDatasetToApiSourceDataset } from "../app/apis/catalog/hca-atlas-tracker/common/utils";
-import { endPgPool, query } from "../app/utils/api-handler";
+import { endPgPool, query } from "../app/services/database";
 import createHandler from "../pages/api/atlases/[atlasId]/source-datasets/create";
 import {
   ATLAS_DRAFT,

--- a/__tests__/api-atlases-id-source-datasets-create.test.ts
+++ b/__tests__/api-atlases-id-source-datasets-create.test.ts
@@ -140,7 +140,7 @@ describe("/api/atlases/[atlasId]/source-datasets/create", () => {
     ).toEqual(400);
   });
 
-  it("returns error 500 for crossref work with unsupported type", async () => {
+  it("returns error 400 for crossref work with unsupported type", async () => {
     expect(
       (
         await doCreateTest(
@@ -149,7 +149,7 @@ describe("/api/atlases/[atlasId]/source-datasets/create", () => {
           NEW_DATASET_UNSUPPORTED_TYPE_DATA
         )
       )._getStatusCode()
-    ).toEqual(500);
+    ).toEqual(400);
   });
 
   it("creates and returns source dataset entry for journal publication", async () => {

--- a/__tests__/api-atlases-id-source-datasets-id.test.ts
+++ b/__tests__/api-atlases-id-source-datasets-id.test.ts
@@ -1,0 +1,270 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
+import {
+  HCAAtlasTrackerDBSourceDataset,
+  HCAAtlasTrackerSourceDataset,
+} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { dbSourceDatasetToApiSourceDataset } from "../app/apis/catalog/hca-atlas-tracker/common/utils";
+import { METHOD } from "../app/common/entities";
+import { endPgPool, query } from "../app/services/database";
+import datasetHandler from "../pages/api/atlases/[atlasId]/source-datasets/[sdId]";
+import {
+  ATLAS_DRAFT,
+  ATLAS_PUBLIC,
+  DOI_PREPRINT_NO_JOURNAL,
+  PUBLICATION_PREPRINT_NO_JOURNAL,
+  SOURCE_DATASET_DRAFT_OK,
+  SOURCE_DATASET_PUBLIC_NO_CROSSREF,
+  USER_CONTENT_ADMIN,
+  USER_NORMAL,
+} from "../testing/constants";
+import { TestSourceDataset, TestUser } from "../testing/entities";
+import { makeTestSourceDatasetOverview } from "../testing/utils";
+
+jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("../app/utils/crossref/crossref-api");
+jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/cellxgene");
+
+const SOURCE_DATASET_PUBLIC_NO_CROSSREF_EDIT = {
+  doi: DOI_PREPRINT_NO_JOURNAL,
+};
+
+const SOURCE_DATASET_DRAFT_OK_EDIT = {
+  contactEmail: "bar@example.com",
+  referenceAuthor: "Bar",
+  title: "Baz",
+};
+
+afterAll(async () => {
+  await query("UPDATE hat.source_datasets SET doi=$1, sd_info=$2 WHERE id=$3", [
+    SOURCE_DATASET_PUBLIC_NO_CROSSREF.doi,
+    JSON.stringify(
+      makeTestSourceDatasetOverview(SOURCE_DATASET_PUBLIC_NO_CROSSREF)
+    ),
+    SOURCE_DATASET_PUBLIC_NO_CROSSREF.id,
+  ]);
+  await query("UPDATE hat.source_datasets SET doi=$1, sd_info=$2 WHERE id=$3", [
+    SOURCE_DATASET_DRAFT_OK.doi,
+    JSON.stringify(makeTestSourceDatasetOverview(SOURCE_DATASET_DRAFT_OK)),
+    SOURCE_DATASET_DRAFT_OK.id,
+  ]);
+  endPgPool();
+});
+
+describe("/api/atlases/[id]", () => {
+  it("returns error 405 for non-GET, non-PUT request", async () => {
+    expect(
+      (
+        await doDatasetRequest(
+          ATLAS_PUBLIC.id,
+          SOURCE_DATASET_PUBLIC_NO_CROSSREF.id,
+          undefined,
+          METHOD.POST
+        )
+      )._getStatusCode()
+    ).toEqual(405);
+  });
+
+  it("returns dataset from public atlas when GET requested by logged out user", async () => {
+    const res = await doDatasetRequest(
+      ATLAS_PUBLIC.id,
+      SOURCE_DATASET_PUBLIC_NO_CROSSREF.id
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const dataset = res._getJSONData() as HCAAtlasTrackerSourceDataset;
+    expect(dataset.doi).toEqual(SOURCE_DATASET_PUBLIC_NO_CROSSREF.doi);
+  });
+
+  it("returns dataset from public atlas when GET requested by logged in user without CONTENT_ADMIN role", async () => {
+    const res = await doDatasetRequest(
+      ATLAS_PUBLIC.id,
+      SOURCE_DATASET_PUBLIC_NO_CROSSREF.id,
+      USER_NORMAL
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const dataset = res._getJSONData() as HCAAtlasTrackerSourceDataset;
+    expect(dataset.doi).toEqual(SOURCE_DATASET_PUBLIC_NO_CROSSREF.doi);
+  });
+
+  it("returns error 404 when dataset is GET requested by user without CONTENT_ADMIN role via public atlas it doesn't exist on", async () => {
+    expect(
+      (
+        await doDatasetRequest(
+          ATLAS_PUBLIC.id,
+          SOURCE_DATASET_DRAFT_OK.id,
+          USER_NORMAL
+        )
+      )._getStatusCode()
+    ).toEqual(404);
+  });
+
+  it("returns error 401 when dataset is GET requested from draft atlas by logged out user", async () => {
+    expect(
+      (
+        await doDatasetRequest(ATLAS_DRAFT.id, SOURCE_DATASET_DRAFT_OK.id)
+      )._getStatusCode()
+    ).toEqual(401);
+  });
+
+  it("returns error 403 when dataset is GET requested from draft atlas by logged in user without CONTENT_ADMIN role", async () => {
+    expect(
+      (
+        await doDatasetRequest(
+          ATLAS_DRAFT.id,
+          SOURCE_DATASET_DRAFT_OK.id,
+          USER_NORMAL
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 404 when dataset is GET requested by user with CONTENT_ADMIN role via atlas it doesn't exist on", async () => {
+    expect(
+      (
+        await doDatasetRequest(
+          ATLAS_DRAFT.id,
+          SOURCE_DATASET_PUBLIC_NO_CROSSREF.id,
+          USER_CONTENT_ADMIN
+        )
+      )._getStatusCode()
+    ).toEqual(404);
+  });
+
+  it("returns dataset from draft atlas when GET requested by logged in user with CONTENT_ADMIN role", async () => {
+    const res = await doDatasetRequest(
+      ATLAS_DRAFT.id,
+      SOURCE_DATASET_DRAFT_OK.id,
+      USER_CONTENT_ADMIN
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const dataset = res._getJSONData() as HCAAtlasTrackerSourceDataset;
+    expect(dataset.doi).toEqual(SOURCE_DATASET_DRAFT_OK.doi);
+  });
+
+  it("returns error 401 when dataset is PUT requested from public atlas by logged out user", async () => {
+    expect(
+      (
+        await doDatasetRequest(
+          ATLAS_PUBLIC.id,
+          SOURCE_DATASET_PUBLIC_NO_CROSSREF.id,
+          undefined,
+          METHOD.PUT,
+          SOURCE_DATASET_PUBLIC_NO_CROSSREF_EDIT
+        )
+      )._getStatusCode()
+    ).toEqual(401);
+    expectDatasetToBeUnchanged(SOURCE_DATASET_PUBLIC_NO_CROSSREF);
+  });
+
+  it("returns error 403 when dataset is PUT requested from public atlas by logged in user without CONTENT_ADMIN role", async () => {
+    expect(
+      (
+        await doDatasetRequest(
+          ATLAS_PUBLIC.id,
+          SOURCE_DATASET_PUBLIC_NO_CROSSREF.id,
+          USER_NORMAL,
+          METHOD.PUT,
+          SOURCE_DATASET_PUBLIC_NO_CROSSREF_EDIT
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    expectDatasetToBeUnchanged(SOURCE_DATASET_PUBLIC_NO_CROSSREF);
+  });
+
+  it("returns error 404 when dataset is PUT requested from atlas it doesn't exist on", async () => {
+    expect(
+      (
+        await doDatasetRequest(
+          ATLAS_DRAFT.id,
+          SOURCE_DATASET_PUBLIC_NO_CROSSREF.id,
+          USER_CONTENT_ADMIN,
+          METHOD.PUT,
+          SOURCE_DATASET_PUBLIC_NO_CROSSREF_EDIT
+        )
+      )._getStatusCode()
+    ).toEqual(404);
+    expectDatasetToBeUnchanged(SOURCE_DATASET_PUBLIC_NO_CROSSREF);
+  });
+
+  it("updates and returns dataset with published data when PUT requested", async () => {
+    const res = await doDatasetRequest(
+      ATLAS_PUBLIC.id,
+      SOURCE_DATASET_PUBLIC_NO_CROSSREF.id,
+      USER_CONTENT_ADMIN,
+      METHOD.PUT,
+      SOURCE_DATASET_PUBLIC_NO_CROSSREF_EDIT
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const updatedDataset = res._getJSONData();
+    const datasetFromDb = await getDatasetFromDatabase(updatedDataset.id);
+    expect(datasetFromDb).toBeDefined();
+    if (!datasetFromDb) return;
+    expect(datasetFromDb.sd_info.publication).toEqual(
+      PUBLICATION_PREPRINT_NO_JOURNAL
+    );
+    expect(datasetFromDb.sd_info.hcaProjectId).toEqual(null);
+    expect(datasetFromDb.sd_info.cellxgeneCollectionId).toEqual(null);
+    expect(dbSourceDatasetToApiSourceDataset(datasetFromDb)).toEqual(
+      updatedDataset
+    );
+  });
+
+  it("updates and returns dataset with published data when PUT requested", async () => {
+    const res = await doDatasetRequest(
+      ATLAS_DRAFT.id,
+      SOURCE_DATASET_DRAFT_OK.id,
+      USER_CONTENT_ADMIN,
+      METHOD.PUT,
+      SOURCE_DATASET_DRAFT_OK_EDIT
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const updatedDataset = res._getJSONData();
+    const datasetFromDb = await getDatasetFromDatabase(updatedDataset.id);
+    expect(datasetFromDb).toBeDefined();
+    if (!datasetFromDb) return;
+    expect(datasetFromDb.doi).toEqual(null);
+    expect(datasetFromDb.sd_info.unpublishedInfo).toEqual(
+      SOURCE_DATASET_DRAFT_OK_EDIT
+    );
+  });
+});
+
+async function doDatasetRequest(
+  atlasId: string,
+  sdId: string,
+  user?: TestUser,
+  method = METHOD.GET,
+  updatedData?: Record<string, unknown>
+): Promise<httpMocks.MockResponse<NextApiResponse>> {
+  const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>({
+    body: updatedData,
+    headers: { authorization: user?.authorization },
+    method,
+    query: { atlasId, sdId },
+  });
+  await datasetHandler(req, res);
+  return res;
+}
+
+async function expectDatasetToBeUnchanged(
+  dataset: TestSourceDataset
+): Promise<void> {
+  const datasetFromDb = await getDatasetFromDatabase(dataset.id);
+  expect(datasetFromDb).toBeDefined();
+  if (!datasetFromDb) return;
+  expect(datasetFromDb.doi).toEqual(dataset.doi);
+  expect(datasetFromDb.sd_info.doiStatus).toEqual(dataset.doiStatus);
+  expect(datasetFromDb.sd_info.publication).toEqual(dataset.publication);
+}
+
+async function getDatasetFromDatabase(
+  id: string
+): Promise<HCAAtlasTrackerDBSourceDataset | undefined> {
+  return (
+    await query<HCAAtlasTrackerDBSourceDataset>(
+      "SELECT * FROM hat.source_datasets WHERE id=$1",
+      [id]
+    )
+  ).rows[0];
+}

--- a/__tests__/api-atlases-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-source-datasets.test.ts
@@ -98,7 +98,7 @@ function expectDatasetPropertiesToMatch(
   expect(apiDataset).toBeDefined();
   expect(apiDataset.id).toEqual(testDataset.id);
   expect(apiDataset.doi).toEqual(testDataset.doi);
-  expect(apiDataset.publicationStatus).toEqual(testDataset.publicationStatus);
+  expect(apiDataset.doiStatus).toEqual(testDataset.doiStatus);
   if (testDataset.publication) {
     expect(apiDataset.title).toEqual(testDataset.publication.title);
     expect(apiDataset.journal).toEqual(testDataset.publication.journal);

--- a/__tests__/api-atlases-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-source-datasets.test.ts
@@ -69,9 +69,12 @@ describe("/api/atlases/[id]", () => {
     expect(res._getStatusCode()).toEqual(200);
     const datasets = res._getJSONData() as HCAAtlasTrackerSourceDataset[];
     expect(datasets).toHaveLength(2);
-    expectDatasetPropertiesToMatch(datasets[0], SOURCE_DATASET_DRAFT_OK);
     expectDatasetPropertiesToMatch(
-      datasets[1],
+      datasets.find((d) => d.id === SOURCE_DATASET_DRAFT_OK.id),
+      SOURCE_DATASET_DRAFT_OK
+    );
+    expectDatasetPropertiesToMatch(
+      datasets.find((d) => d.id === SOURCE_DATASET_DRAFT_NO_CROSSREF.id),
       SOURCE_DATASET_DRAFT_NO_CROSSREF
     );
   });
@@ -92,10 +95,11 @@ async function doDatasetsRequest(
 }
 
 function expectDatasetPropertiesToMatch(
-  apiDataset: HCAAtlasTrackerSourceDataset,
+  apiDataset: HCAAtlasTrackerSourceDataset | undefined,
   testDataset: TestSourceDataset
 ): void {
   expect(apiDataset).toBeDefined();
+  if (!apiDataset) return;
   expect(apiDataset.id).toEqual(testDataset.id);
   expect(apiDataset.doi).toEqual(testDataset.doi);
   expect(apiDataset.doiStatus).toEqual(testDataset.doiStatus);

--- a/__tests__/api-atlases-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-source-datasets.test.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
 import { HCAAtlasTrackerSourceDataset } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/utils/api-handler";
+import { endPgPool } from "../app/services/database";
 import datasetsHandler from "../pages/api/atlases/[atlasId]/source-datasets";
 import {
   ATLAS_DRAFT,

--- a/__tests__/api-atlases-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-source-datasets.test.ts
@@ -105,13 +105,13 @@ function expectDatasetPropertiesToMatch(
     expect(apiDataset.publicationDate).toEqual(
       testDataset.publication.publicationDate
     );
-    expect(apiDataset.firstAuthorPrimaryName).toEqual(
+    expect(apiDataset.referenceAuthor).toEqual(
       testDataset.publication.authors[0]?.name
     );
   } else {
     expect(apiDataset.title).toBeNull();
     expect(apiDataset.journal).toBeNull();
     expect(apiDataset.publicationDate).toBeNull();
-    expect(apiDataset.firstAuthorPrimaryName).toBeNull();
+    expect(apiDataset.referenceAuthor).toBeNull();
   }
 }

--- a/__tests__/api-atlases-id.test.ts
+++ b/__tests__/api-atlases-id.test.ts
@@ -7,7 +7,7 @@ import {
 import { AtlasEditData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
 import { dbAtlasToApiAtlas } from "../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../app/common/entities";
-import { endPgPool, query } from "../app/utils/api-handler";
+import { endPgPool, query } from "../app/services/database";
 import atlasHandler from "../pages/api/atlases/[atlasId]";
 import {
   ATLAS_DRAFT,

--- a/__tests__/api-atlases.test.ts
+++ b/__tests__/api-atlases.test.ts
@@ -6,7 +6,7 @@ import {
   ATLAS_STATUS,
   HCAAtlasTrackerAtlas,
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { endPgPool } from "../app/utils/api-handler";
+import { endPgPool } from "../app/services/database";
 import atlasesHandler from "../pages/api/atlases";
 
 jest.mock("../app/utils/pg-app-connect-config");

--- a/__tests__/api-users-create.test.ts
+++ b/__tests__/api-users-create.test.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
 import { NewUserData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { endPgPool, query } from "../app/utils/api-handler";
+import { endPgPool, query } from "../app/services/database";
 import createHandler from "../pages/api/users/create";
 import {
   USER_CONTENT_ADMIN,

--- a/__tests__/api-users-id-disable.test.ts
+++ b/__tests__/api-users-id-disable.test.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
-import { endPgPool, query } from "../app/utils/api-handler";
+import { endPgPool, query } from "../app/services/database";
 import disableHandler from "../pages/api/users/[id]/disable";
 import { USER_CONTENT_ADMIN, USER_NORMAL } from "../testing/constants";
 import { TestUser } from "../testing/entities";

--- a/__tests__/api-users-id-enable.test.ts
+++ b/__tests__/api-users-id-enable.test.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
-import { endPgPool, query } from "../app/utils/api-handler";
+import { endPgPool, query } from "../app/services/database";
 import enableHandler from "../pages/api/users/[id]/enable";
 import {
   USER_CONTENT_ADMIN,

--- a/__tests__/api-users.test.ts
+++ b/__tests__/api-users.test.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
-import { endPgPool } from "../app/utils/api-handler";
+import { endPgPool } from "../app/services/database";
 import usersHandler from "../pages/api/users";
 import {
   USER_CONTENT_ADMIN,

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -98,11 +98,7 @@ export interface HCAAtlasTrackerDBAtlasOverview {
   wave: Wave;
 }
 
-export type HCAAtlasTrackerDBSourceDataset = {
-  created_at: Date;
-  id: string;
-  updated_at: Date;
-} & (
+export type HCAAtlasTrackerDBSourceDatasetMinimumColumns =
   | {
       doi: string;
       sd_info: HCAAtlasTrackerDBPublishedSourceDatasetInfo;
@@ -110,8 +106,14 @@ export type HCAAtlasTrackerDBSourceDataset = {
   | {
       doi: null;
       sd_info: HCAAtlasTrackerDBUnpublishedSourceDatasetInfo;
-    }
-);
+    };
+
+export type HCAAtlasTrackerDBSourceDataset =
+  HCAAtlasTrackerDBSourceDatasetMinimumColumns & {
+    created_at: Date;
+    id: string;
+    updated_at: Date;
+  };
 
 export interface HCAAtlasTrackerDBPublishedSourceDatasetInfo {
   cellxgeneCollectionId: string | null;

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -129,8 +129,8 @@ export interface HCAAtlasTrackerDBUnpublishedSourceDatasetInfo {
   hcaProjectId: string | null;
   publication: null;
   unpublishedInfo: {
-    author: string;
     contactEmail: string;
+    referenceAuthor: string;
     title: string;
   };
 }

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -98,6 +98,7 @@ export type AtlasId = HCAAtlasTrackerAtlas["id"];
 
 export enum DOI_STATUS {
   DOI_NOT_ON_CROSSREF = "DOI_NOT_ON_CROSSREF",
+  NA = "NA",
   OK = "OK",
 }
 

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -53,12 +53,12 @@ export interface HCAAtlasTrackerSourceDataset {
   capId: string | null;
   cellxgeneCollectionId: string | null;
   doi: string | null;
+  doiStatus: DOI_STATUS;
   firstAuthorPrimaryName: string | null;
   hcaProjectId: string | null;
   id: string;
   journal: string | null;
   publicationDate: string | null;
-  publicationStatus: PUBLICATION_STATUS;
   title: string | null;
 }
 
@@ -89,14 +89,14 @@ export interface HCAAtlasTrackerDBSourceDataset {
 
 export interface HCAAtlasTrackerDBSourceDatasetInfo {
   cellxgeneCollectionId: string | null;
+  doiStatus: DOI_STATUS;
   hcaProjectId: string | null;
   publication: PublicationInfo | null;
-  publicationStatus: PUBLICATION_STATUS;
 }
 
 export type AtlasId = HCAAtlasTrackerAtlas["id"];
 
-export enum PUBLICATION_STATUS {
+export enum DOI_STATUS {
   DOI_NOT_ON_CROSSREF = "DOI_NOT_ON_CROSSREF",
   OK = "OK",
 }

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -53,7 +53,7 @@ export type HCAAtlasTrackerSourceDataset =
   | HCAAtlasTrackerPublishedSourceDataset
   | HCAAtlasTrackerUnpublishedSourceDataset;
 
-interface HCAAtlasTrackerSourceDatasetShared {
+interface HCAAtlasTrackerSourceDatasetCommon {
   capId: string | null;
   cellxgeneCollectionId: string | null;
   doiStatus: DOI_STATUS;
@@ -62,7 +62,7 @@ interface HCAAtlasTrackerSourceDatasetShared {
 }
 
 export interface HCAAtlasTrackerPublishedSourceDataset
-  extends HCAAtlasTrackerSourceDatasetShared {
+  extends HCAAtlasTrackerSourceDatasetCommon {
   contactEmail: null;
   doi: string;
   journal: string | null;
@@ -72,7 +72,7 @@ export interface HCAAtlasTrackerPublishedSourceDataset
 }
 
 export interface HCAAtlasTrackerUnpublishedSourceDataset
-  extends HCAAtlasTrackerSourceDatasetShared {
+  extends HCAAtlasTrackerSourceDatasetCommon {
   contactEmail: string;
   doi: null;
   journal: null;

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -98,20 +98,35 @@ export interface HCAAtlasTrackerDBAtlasOverview {
   wave: Wave;
 }
 
-export interface HCAAtlasTrackerDBSourceDataset {
+export type HCAAtlasTrackerDBSourceDataset = {
   created_at: Date;
-  doi: string | null;
   id: string;
-  sd_info: HCAAtlasTrackerDBSourceDatasetInfo;
   updated_at: Date;
-}
+} & (
+  | {
+      doi: string;
+      sd_info: HCAAtlasTrackerDBPublishedSourceDatasetInfo;
+    }
+  | {
+      doi: null;
+      sd_info: HCAAtlasTrackerDBUnpublishedSourceDatasetInfo;
+    }
+);
 
-export interface HCAAtlasTrackerDBSourceDatasetInfo {
+export interface HCAAtlasTrackerDBPublishedSourceDatasetInfo {
   cellxgeneCollectionId: string | null;
   doiStatus: DOI_STATUS;
   hcaProjectId: string | null;
   publication: PublicationInfo | null;
-  unpublishedInfo: null | {
+  unpublishedInfo: null;
+}
+
+export interface HCAAtlasTrackerDBUnpublishedSourceDatasetInfo {
+  cellxgeneCollectionId: string | null;
+  doiStatus: DOI_STATUS;
+  hcaProjectId: string | null;
+  publication: null;
+  unpublishedInfo: {
     author: string;
     contactEmail: string;
     title: string;

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -54,11 +54,11 @@ export interface HCAAtlasTrackerSourceDataset {
   cellxgeneCollectionId: string | null;
   doi: string | null;
   doiStatus: DOI_STATUS;
-  firstAuthorPrimaryName: string | null;
   hcaProjectId: string | null;
   id: string;
   journal: string | null;
   publicationDate: string | null;
+  referenceAuthor: string | null;
   title: string | null;
 }
 

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -49,17 +49,36 @@ export interface HCAAtlasTrackerNetworkCoordinator {
   email: string;
 }
 
-export interface HCAAtlasTrackerSourceDataset {
+export type HCAAtlasTrackerSourceDataset =
+  | HCAAtlasTrackerPublishedSourceDataset
+  | HCAAtlasTrackerUnpublishedSourceDataset;
+
+interface HCAAtlasTrackerSourceDatasetShared {
   capId: string | null;
   cellxgeneCollectionId: string | null;
-  doi: string | null;
   doiStatus: DOI_STATUS;
   hcaProjectId: string | null;
   id: string;
+}
+
+export interface HCAAtlasTrackerPublishedSourceDataset
+  extends HCAAtlasTrackerSourceDatasetShared {
+  contactEmail: null;
+  doi: string;
   journal: string | null;
   publicationDate: string | null;
   referenceAuthor: string | null;
   title: string | null;
+}
+
+export interface HCAAtlasTrackerUnpublishedSourceDataset
+  extends HCAAtlasTrackerSourceDatasetShared {
+  contactEmail: string;
+  doi: null;
+  journal: null;
+  publicationDate: null;
+  referenceAuthor: string;
+  title: string;
 }
 
 export interface HCAAtlasTrackerDBAtlas {
@@ -92,6 +111,11 @@ export interface HCAAtlasTrackerDBSourceDatasetInfo {
   doiStatus: DOI_STATUS;
   hcaProjectId: string | null;
   publication: PublicationInfo | null;
+  unpublishedInfo: null | {
+    author: string;
+    contactEmail: string;
+    title: string;
+  };
 }
 
 export type AtlasId = HCAAtlasTrackerAtlas["id"];

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -85,13 +85,7 @@ export type NewSourceDatasetData = InferType<typeof newSourceDatasetSchema>;
 /**
  * Schema for data used to apply edits to a source dataset.
  */
-export const sourceDatasetEditSchema = newSourceDatasetSchema.concat(
-  object({
-    cellxgeneCollectionId: string().default("").notRequired(),
-    hcaProjectId: string().default("").notRequired(),
-    title: string().default("").required("Title is required"),
-  })
-);
+export const sourceDatasetEditSchema = newSourceDatasetSchema;
 
 export type SourceDatasetEditData = InferType<typeof sourceDatasetEditSchema>;
 

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -1,4 +1,4 @@
-import { boolean, InferType, object, string } from "yup";
+import { boolean, InferType, mixed, object, string } from "yup";
 import { isDoi } from "../../../../utils/doi";
 import { NETWORK_KEYS, WAVES } from "./constants";
 
@@ -42,12 +42,42 @@ export type AtlasEditData = NewAtlasData;
  * Schema for data used to create a new source dataset.
  */
 export const newSourceDatasetSchema = object({
+  author: string()
+    .default("")
+    .when("doi", {
+      is: undefined,
+      otherwise: () =>
+        mixed().oneOf(
+          [undefined],
+          "Author must be omitted when DOI is present"
+        ),
+      then: (schema) =>
+        schema.required("Author is required when DOI is absent"),
+    }),
+  contactEmail: string()
+    .email()
+    .default("")
+    .when("doi", {
+      is: undefined,
+      otherwise: () =>
+        mixed().oneOf([undefined], "Email must be omitted when DOI is present"),
+      then: (schema) => schema.required("Email is required when DOI is absent"),
+    }),
   doi: string()
     .default("")
-    .required("DOI is required")
-    .test("is-doi", "DOI must be a syntactically-valid DOI", (value) =>
-      isDoi(value)
+    .test(
+      "is-doi",
+      "DOI must be a syntactically-valid DOI",
+      (value) => typeof value !== "string" || isDoi(value)
     ),
+  title: string()
+    .default("")
+    .when("doi", {
+      is: undefined,
+      otherwise: () =>
+        mixed().oneOf([undefined], "Title must be omitted when DOI is present"),
+      then: (schema) => schema.required("Title is required when DOI is absent"),
+    }),
 }).strict(true);
 
 export type NewSourceDatasetData = InferType<typeof newSourceDatasetSchema>;

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -42,18 +42,6 @@ export type AtlasEditData = NewAtlasData;
  * Schema for data used to create a new source dataset.
  */
 export const newSourceDatasetSchema = object({
-  author: string()
-    .default("")
-    .when("doi", {
-      is: undefined,
-      otherwise: () =>
-        mixed().oneOf(
-          [undefined],
-          "Author must be omitted when DOI is present"
-        ),
-      then: (schema) =>
-        schema.required("Author is required when DOI is absent"),
-    }),
   contactEmail: string()
     .email()
     .default("")
@@ -70,6 +58,18 @@ export const newSourceDatasetSchema = object({
       "DOI must be a syntactically-valid DOI",
       (value) => typeof value !== "string" || isDoi(value)
     ),
+  referenceAuthor: string()
+    .default("")
+    .when("doi", {
+      is: undefined,
+      otherwise: () =>
+        mixed().oneOf(
+          [undefined],
+          "Author must be omitted when DOI is present"
+        ),
+      then: (schema) =>
+        schema.required("Author is required when DOI is absent"),
+    }),
   title: string()
     .default("")
     .when("doi", {

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -63,11 +63,11 @@ export function dbSourceDatasetToApiSourceDataset(
     cellxgeneCollectionId,
     doi: dbSourceDataset.doi,
     doiStatus: dbSourceDataset.sd_info.doiStatus,
-    firstAuthorPrimaryName: publication?.authors[0]?.name ?? null,
     hcaProjectId,
     id: dbSourceDataset.id,
     journal: publication?.journal ?? null,
     publicationDate: publication?.publicationDate ?? null,
+    referenceAuthor: publication?.authors[0]?.name ?? null,
     title: publication?.title ?? null,
   };
 }

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -56,20 +56,42 @@ export function dbSourceDatasetToApiSourceDataset(
   dbSourceDataset: HCAAtlasTrackerDBSourceDataset
 ): HCAAtlasTrackerSourceDataset {
   const {
-    sd_info: { cellxgeneCollectionId, hcaProjectId, publication },
+    sd_info: {
+      cellxgeneCollectionId,
+      hcaProjectId,
+      publication,
+      unpublishedInfo,
+    },
   } = dbSourceDataset;
-  return {
-    capId: null,
-    cellxgeneCollectionId,
-    doi: dbSourceDataset.doi,
-    doiStatus: dbSourceDataset.sd_info.doiStatus,
-    hcaProjectId,
-    id: dbSourceDataset.id,
-    journal: publication?.journal ?? null,
-    publicationDate: publication?.publicationDate ?? null,
-    referenceAuthor: publication?.authors[0]?.name ?? null,
-    title: publication?.title ?? null,
-  };
+  if (dbSourceDataset.doi === null) {
+    return {
+      capId: null,
+      cellxgeneCollectionId,
+      contactEmail: unpublishedInfo?.contactEmail ?? "",
+      doi: null,
+      doiStatus: dbSourceDataset.sd_info.doiStatus,
+      hcaProjectId,
+      id: dbSourceDataset.id,
+      journal: null,
+      publicationDate: null,
+      referenceAuthor: unpublishedInfo?.author ?? "",
+      title: unpublishedInfo?.title ?? "",
+    };
+  } else {
+    return {
+      capId: null,
+      cellxgeneCollectionId,
+      contactEmail: null,
+      doi: dbSourceDataset.doi,
+      doiStatus: dbSourceDataset.sd_info.doiStatus,
+      hcaProjectId,
+      id: dbSourceDataset.id,
+      journal: publication?.journal ?? null,
+      publicationDate: publication?.publicationDate ?? null,
+      referenceAuthor: publication?.authors[0]?.name ?? null,
+      title: publication?.title ?? null,
+    };
+  }
 }
 
 export function getAtlasName(atlas: HCAAtlasTrackerAtlas): string {

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -74,7 +74,7 @@ export function dbSourceDatasetToApiSourceDataset(
       id: dbSourceDataset.id,
       journal: null,
       publicationDate: null,
-      referenceAuthor: unpublishedInfo?.author ?? "",
+      referenceAuthor: unpublishedInfo?.referenceAuthor ?? "",
       title: unpublishedInfo?.title ?? "",
     };
   } else {

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -62,12 +62,12 @@ export function dbSourceDatasetToApiSourceDataset(
     capId: null,
     cellxgeneCollectionId,
     doi: dbSourceDataset.doi,
+    doiStatus: dbSourceDataset.sd_info.doiStatus,
     firstAuthorPrimaryName: publication?.authors[0]?.name ?? null,
     hcaProjectId,
     id: dbSourceDataset.id,
     journal: publication?.journal ?? null,
     publicationDate: publication?.publicationDate ?? null,
-    publicationStatus: dbSourceDataset.sd_info.publicationStatus,
     title: publication?.title ?? null,
   };
 }

--- a/app/components/Detail/components/AddSourceDataset/addSourceDataset.tsx
+++ b/app/components/Detail/components/AddSourceDataset/addSourceDataset.tsx
@@ -4,11 +4,11 @@ import { useAuthentication } from "@databiosphere/findable-ui/lib/hooks/useAuthe
 import { useCallback } from "react";
 import { API } from "../../../../apis/catalog/hca-atlas-tracker/common/api";
 import { AtlasId } from "../../../../apis/catalog/hca-atlas-tracker/common/entities";
-import { NewSourceDatasetData } from "../../../../apis/catalog/hca-atlas-tracker/common/schema";
 import { METHOD } from "../../../../common/entities";
 import { getRequestURL, getRouteURL } from "../../../../common/utils";
 import { FormMethod } from "../../../../hooks/useForm/common/entities";
 import { ROUTE } from "../../../../routes/constants";
+import { NewSourceDatasetData } from "../../../../views/AddNewSourceDatasetView/common/entities";
 import { onSuccess } from "../../../../views/AddNewSourceDatasetView/hooks/useAddSourceDatasetForm";
 import {
   ButtonLink,

--- a/app/components/Detail/components/EditSourceDataset/editSourceDataset.tsx
+++ b/app/components/Detail/components/EditSourceDataset/editSourceDataset.tsx
@@ -6,10 +6,10 @@ import {
   AtlasId,
   HCAAtlasTrackerSourceDataset,
 } from "../../../../apis/catalog/hca-atlas-tracker/common/entities";
-import { SourceDatasetEditData } from "../../../../apis/catalog/hca-atlas-tracker/common/schema";
 import { getRouteURL } from "../../../../common/utils";
 import { FormMethod } from "../../../../hooks/useForm/common/entities";
 import { ROUTE } from "../../../../routes/constants";
+import { SourceDatasetEditData } from "../../../../views/EditSourceDatasetView/common/entities";
 import {
   getFormDiscardProps,
   getFormSaveProps,

--- a/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/common/constants.ts
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/common/constants.ts
@@ -22,7 +22,7 @@ export const DEFAULT_INPUT_PROPS = {
   },
 };
 export const FIELD_NAME = {
-  AUTHOR: "author",
+  AUTHOR: "referenceAuthor",
   CELLXGENE_COLLECTION_ID: "cellxgeneCollectionId",
   CONTACT_EMAIL: "contactEmail",
   DOI: "doi",

--- a/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/common/constants.ts
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/common/constants.ts
@@ -22,7 +22,9 @@ export const DEFAULT_INPUT_PROPS = {
   },
 };
 export const FIELD_NAME = {
+  AUTHOR: "author",
   CELLXGENE_COLLECTION_ID: "cellxgeneCollectionId",
+  CONTACT_EMAIL: "contactEmail",
   DOI: "doi",
   HCA_PROJECT_ID: "hcaProjectId",
   TITLE: "title",

--- a/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Add/components/GeneralInfo/generalInfo.tsx
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Add/components/GeneralInfo/generalInfo.tsx
@@ -1,6 +1,6 @@
 import { Controller } from "react-hook-form";
-import { NewSourceDatasetData } from "../../../../../../../../../../../../apis/catalog/hca-atlas-tracker/common/schema";
 import { FormMethod } from "../../../../../../../../../../../../hooks/useForm/common/entities";
+import { NewSourceDatasetData } from "../../../../../../../../../../../../views/AddNewSourceDatasetView/common/entities";
 import { Input } from "../../../../../../../../../../../common/Form/components/Input/input";
 import {
   Section,

--- a/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Edit/components/GeneralInfo/generalInfo.tsx
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Edit/components/GeneralInfo/generalInfo.tsx
@@ -2,8 +2,8 @@ import { ErrorIcon } from "@databiosphere/findable-ui/lib/components/common/Cust
 import { SuccessIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/SuccessIcon/successIcon";
 import { Controller } from "react-hook-form";
 import {
+  DOI_STATUS,
   HCAAtlasTrackerSourceDataset,
-  PUBLICATION_STATUS,
 } from "../../../../../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { SourceDatasetEditData } from "../../../../../../../../../../../../apis/catalog/hca-atlas-tracker/common/schema";
 import { FormMethod } from "../../../../../../../../../../../../hooks/useForm/common/entities";
@@ -77,7 +77,7 @@ export const GeneralInfo = ({ formMethod }: GeneralInfoProps): JSX.Element => {
 function renderDoiEndAdornment(
   sourceDataset: HCAAtlasTrackerSourceDataset | undefined
 ): JSX.Element {
-  if (sourceDataset?.publicationStatus === PUBLICATION_STATUS.OK) {
+  if (sourceDataset?.doiStatus === DOI_STATUS.OK) {
     return <SuccessIcon color="success" fontSize="small" />;
   }
   return <ErrorIcon color="error" fontSize="small" />;

--- a/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Edit/components/GeneralInfo/generalInfo.tsx
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Edit/components/GeneralInfo/generalInfo.tsx
@@ -5,9 +5,9 @@ import {
   DOI_STATUS,
   HCAAtlasTrackerSourceDataset,
 } from "../../../../../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
-import { SourceDatasetEditData } from "../../../../../../../../../../../../apis/catalog/hca-atlas-tracker/common/schema";
 import { FormMethod } from "../../../../../../../../../../../../hooks/useForm/common/entities";
 import { getSourceDatasetCitation } from "../../../../../../../../../../../../viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders";
+import { SourceDatasetEditData } from "../../../../../../../../../../../../views/EditSourceDatasetView/common/entities";
 import { Input } from "../../../../../../../../../../../common/Form/components/Input/input";
 import {
   Section,

--- a/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Edit/components/Identifiers/identifiers.tsx
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Edit/components/Identifiers/identifiers.tsx
@@ -1,7 +1,7 @@
 import { Controller } from "react-hook-form";
 import { HCAAtlasTrackerSourceDataset } from "../../../../../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
-import { SourceDatasetEditData } from "../../../../../../../../../../../../apis/catalog/hca-atlas-tracker/common/schema";
 import { FormMethod } from "../../../../../../../../../../../../hooks/useForm/common/entities";
+import { SourceDatasetEditData } from "../../../../../../../../../../../../views/EditSourceDatasetView/common/entities";
 import { Input } from "../../../../../../../../../../../common/Form/components/Input/input";
 import {
   Section,

--- a/app/services/database.ts
+++ b/app/services/database.ts
@@ -1,0 +1,21 @@
+import pg from "pg";
+import { getPoolConfig } from "../utils/pg-app-connect-config";
+
+const { Pool } = pg;
+
+const pool = new Pool(getPoolConfig());
+
+export function query<T extends pg.QueryResultRow>(
+  queryTextOrConfig: string | pg.QueryConfig<unknown[]>,
+  values?: unknown[] | undefined
+): Promise<pg.QueryResult<T>> {
+  return pool.query<T>(queryTextOrConfig, values);
+}
+
+export function getPoolClient(): Promise<pg.PoolClient> {
+  return pool.connect();
+}
+
+export function endPgPool(): void {
+  pool.end();
+}

--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -1,0 +1,145 @@
+import { ValidationError } from "yup";
+import {
+  DOI_STATUS,
+  HCAAtlasTrackerDBSourceDataset,
+  HCAAtlasTrackerDBSourceDatasetMinimumColumns,
+} from "../apis/catalog/hca-atlas-tracker/common/entities";
+import {
+  NewSourceDatasetData,
+  SourceDatasetEditData,
+} from "../apis/catalog/hca-atlas-tracker/common/schema";
+import { NotFoundError } from "../utils/api-handler";
+import { getCrossrefPublicationInfo } from "../utils/crossref/crossref";
+import { normalizeDoi } from "../utils/doi";
+import { getCellxGeneIdByDoi } from "./cellxgene";
+import { getPoolClient, query } from "./database";
+import { getProjectIdByDoi } from "./hca-projects";
+
+/**
+ * Create a new published or unpublished source dataset.
+ * @param atlasId - Atlas to add new source dataset to.
+ * @param inputData - Values for new source dataset.
+ * @returns database model of new source dataset.
+ */
+export async function createSourceDataset(
+  atlasId: string,
+  inputData: NewSourceDatasetData
+): Promise<HCAAtlasTrackerDBSourceDataset> {
+  const atlasExists = (
+    await query("SELECT EXISTS(SELECT 1 FROM hat.atlases WHERE id=$1)", [
+      atlasId,
+    ])
+  ).rows[0].exists;
+  if (!atlasExists) {
+    throw new NotFoundError(`Atlas with ID ${atlasId} doesn't exist`);
+  }
+
+  const newInfo = await sourceDatasetInputDataToDbData(inputData);
+
+  const client = await getPoolClient();
+  try {
+    await client.query("BEGIN");
+    // Add the new source dataset
+    const newDataset = (
+      await client.query<HCAAtlasTrackerDBSourceDataset>(
+        "INSERT INTO hat.source_datasets (doi, sd_info) VALUES ($1, $2) RETURNING *",
+        [newInfo.doi, JSON.stringify(newInfo.sd_info)]
+      )
+    ).rows[0];
+    // Update the atlas's list of source datasets
+    await client.query(
+      "UPDATE hat.atlases SET source_datasets=source_datasets||$1 WHERE id=$2",
+      [JSON.stringify([newDataset.id]), atlasId]
+    );
+    await client.query("COMMIT");
+    return newDataset;
+  } catch (e) {
+    await client.query("ROLLBACK");
+    throw e;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Derive source dataset information from input values.
+ * @param inputData - Values to derive source dataset from.
+ * @returns database model of values needed to define a source dataset.
+ */
+async function sourceDatasetInputDataToDbData(
+  inputData: NewSourceDatasetData | SourceDatasetEditData
+): Promise<HCAAtlasTrackerDBSourceDatasetMinimumColumns> {
+  return inputData.doi
+    ? await makePublishedSourceDatasetDbData(inputData)
+    : makeUnpublishedSourceDatasetDbData(inputData);
+}
+
+/**
+ * Derive published source dataset information from input values.
+ * @param inputData - Values to derive source dataset from.
+ * @returns database model of values needed to define a source dataset.
+ */
+async function makePublishedSourceDatasetDbData(
+  inputData: NewSourceDatasetData | SourceDatasetEditData
+): Promise<HCAAtlasTrackerDBSourceDatasetMinimumColumns> {
+  const doi = normalizeDoi(inputData.doi);
+
+  let publication;
+  try {
+    publication = await getCrossrefPublicationInfo(doi);
+  } catch (e) {
+    if (e instanceof ValidationError) {
+      throw new ValidationError(
+        `Crossref data doesn't fit: ${e.message}`,
+        undefined,
+        "doi"
+      );
+    }
+    throw e;
+  }
+
+  const dois = [
+    ...(publication?.preprintOfDoi ? [publication.preprintOfDoi] : []),
+    doi,
+    ...(publication?.hasPreprintDoi ? [publication.hasPreprintDoi] : []),
+  ];
+
+  const hcaProjectId = getProjectIdByDoi(dois);
+
+  const cellxgeneCollectionId = getCellxGeneIdByDoi(dois);
+
+  return {
+    doi,
+    sd_info: {
+      cellxgeneCollectionId,
+      doiStatus: publication ? DOI_STATUS.OK : DOI_STATUS.DOI_NOT_ON_CROSSREF,
+      hcaProjectId,
+      publication,
+      unpublishedInfo: null,
+    },
+  };
+}
+
+/**
+ * Derive unpublished source dataset information from input values.
+ * @param inputData - Values to derive source dataset from.
+ * @returns database model of values needed to define a source dataset.
+ */
+function makeUnpublishedSourceDatasetDbData(
+  inputData: NewSourceDatasetData | SourceDatasetEditData
+): HCAAtlasTrackerDBSourceDatasetMinimumColumns {
+  return {
+    doi: null,
+    sd_info: {
+      cellxgeneCollectionId: null,
+      doiStatus: DOI_STATUS.NA,
+      hcaProjectId: null,
+      publication: null,
+      unpublishedInfo: {
+        contactEmail: inputData.contactEmail,
+        referenceAuthor: inputData.referenceAuthor,
+        title: inputData.title,
+      },
+    },
+  };
+}

--- a/app/utils/api-handler.ts
+++ b/app/utils/api-handler.ts
@@ -14,6 +14,10 @@ export type MiddlewareFunction = (
 
 type Handler = (req: NextApiRequest, res: NextApiResponse) => Promise<void>;
 
+export class AccessError extends Error {
+  name = "AccessError";
+}
+
 export class NotFoundError extends Error {
   name = "NotFoundError";
 }

--- a/app/utils/api-handler.ts
+++ b/app/utils/api-handler.ts
@@ -1,6 +1,6 @@
 import { OAuth2Client, TokenInfo } from "google-auth-library";
 import { NextApiRequest, NextApiResponse } from "next";
-import { InferType, Schema, ValidationError } from "yup";
+import { ValidationError } from "yup";
 import { METHOD } from "../common/entities";
 import { FormResponseErrors } from "../hooks/useForm/common/entities";
 import { RefreshDataNotReadyError } from "../services/common/refresh-service";
@@ -14,6 +14,10 @@ export type MiddlewareFunction = (
 
 type Handler = (req: NextApiRequest, res: NextApiResponse) => Promise<void>;
 
+export class NotFoundError extends Error {
+  name = "NotFoundError";
+}
+
 const authClient = new OAuth2Client();
 const accessTokensInfo = new Map<string, TokenInfo>();
 
@@ -24,10 +28,14 @@ const accessTokensInfo = new Map<string, TokenInfo>();
  */
 export function handler(...funcs: MiddlewareFunction[]): Handler {
   return async (req, res) => {
-    for (const f of funcs) {
-      let done = true;
-      await f(req, res, () => (done = false));
-      if (done) return;
+    try {
+      for (const f of funcs) {
+        let done = true;
+        await f(req, res, () => (done = false));
+        if (done) return;
+      }
+    } catch (e) {
+      respondError(res, e);
     }
   };
 }
@@ -42,12 +50,16 @@ export function handleByMethod(
 ): Handler {
   const allowHeaderText = Object.keys(handlers).join(", ");
   return async (req, res) => {
-    const method = req.method;
-    const handler = hasHandlerForMethod(method) && handlers[method];
-    if (handler) {
-      return await handler(req, res);
-    } else {
-      res.status(405).setHeader("Allow", allowHeaderText).end();
+    try {
+      const method = req.method;
+      const handler = hasHandlerForMethod(method) && handlers[method];
+      if (handler) {
+        return await handler(req, res);
+      } else {
+        res.status(405).setHeader("Allow", allowHeaderText).end();
+      }
+    } catch (e) {
+      respondError(res, e);
     }
   };
 
@@ -145,51 +157,20 @@ async function getAccessTokenInfo(
 }
 
 /**
- * Get data validated with a Yup schema, and send an error response if validation fails.
+ * Send an error response, setting status and message based on error type.
  * @param res - Next API response.
- * @param schema - Yup schema.
- * @param data - Data to validate.
- * @returns array of data and boolean; if an error response was sent, data is null and boolean is true.
+ * @param error - Error or other thrown value.
  */
-export async function handleValidation<T extends Schema>(
-  res: NextApiResponse,
-  schema: T,
-  data: unknown
-): Promise<[InferType<T>, false] | [null, true]> {
-  try {
-    return [await schema.validate(data), false];
-  } catch (e) {
-    if (e instanceof ValidationError) {
-      respondValidationError(res, e);
-      return [null, true];
-    } else {
-      throw e;
-    }
-  }
-}
-
-/**
- * Get value from data subject to refreshing, and send an error response if the data is not initialized yet.
- * @param res - Next API response.
- * @param getValue - Function to get the value.
- * @returns array of value and boolean; if an error response was sent, value is null and boolean is true.
- */
-export function handleGetRefreshValue<T>(
-  res: NextApiResponse,
-  getValue: () => T
-): [T, false] | [null, true] {
-  try {
-    return [getValue(), false];
-  } catch (e) {
-    if (e instanceof RefreshDataNotReadyError) {
-      res
-        .status(503)
-        .appendHeader("Retry-After", "20")
-        .json({ message: e.message });
-      return [null, true];
-    }
-    throw e;
-  }
+function respondError(res: NextApiResponse, error: unknown): void {
+  if (error instanceof NotFoundError)
+    res.status(404).json({ message: error.message });
+  else if (error instanceof ValidationError) respondValidationError(res, error);
+  else if (error instanceof RefreshDataNotReadyError)
+    res
+      .status(503)
+      .appendHeader("Retry-After", "30")
+      .json({ message: error.message });
+  else res.status(500).json({ message: String(error) });
 }
 
 /**

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -117,15 +117,9 @@ export const buildPublication = (
 export const buildSourceDatasetPublication = (
   sourceDataset: HCAAtlasTrackerSourceDataset
 ): React.ComponentProps<typeof C.Link> => {
-  const { doi, doiStatus, firstAuthorPrimaryName, journal, publicationDate } =
-    sourceDataset;
+  const { doi } = sourceDataset;
   return {
-    label: getCitation(
-      doiStatus,
-      firstAuthorPrimaryName,
-      publicationDate,
-      journal
-    ),
+    label: getSourceDatasetCitation(sourceDataset),
     url: getDOILink(doi),
   };
 };
@@ -261,14 +255,9 @@ export function getSourceDatasetCitation(
   sourceDataset?: HCAAtlasTrackerSourceDataset
 ): string {
   if (!sourceDataset) return "";
-  const { doiStatus, firstAuthorPrimaryName, journal, publicationDate } =
+  const { doiStatus, journal, publicationDate, referenceAuthor } =
     sourceDataset;
-  return getCitation(
-    doiStatus,
-    firstAuthorPrimaryName,
-    publicationDate,
-    journal
-  );
+  return getCitation(doiStatus, referenceAuthor, publicationDate, journal);
 }
 
 /**

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -215,7 +215,7 @@ export function getBioNetworkName(name: string): string {
   return name.replace(/(\sNetwork.*)/gi, "");
 }
 
-function getCitation(
+function getPublishedCitation(
   doiStatus: DOI_STATUS,
   author: string | null,
   date: string | null,
@@ -234,6 +234,10 @@ function getCitation(
     citation.push(journal);
   }
   return citation.join(" ");
+}
+
+function getUnpublishedCitation(author: string, email: string): string {
+  return `${author}, ${email} - Unpublished`;
 }
 
 /**
@@ -255,9 +259,19 @@ export function getSourceDatasetCitation(
   sourceDataset?: HCAAtlasTrackerSourceDataset
 ): string {
   if (!sourceDataset) return "";
-  const { doiStatus, journal, publicationDate, referenceAuthor } =
-    sourceDataset;
-  return getCitation(doiStatus, referenceAuthor, publicationDate, journal);
+  if (sourceDataset.doi === null) {
+    const { contactEmail, referenceAuthor } = sourceDataset;
+    return getUnpublishedCitation(referenceAuthor, contactEmail);
+  } else {
+    const { doiStatus, journal, publicationDate, referenceAuthor } =
+      sourceDataset;
+    return getPublishedCitation(
+      doiStatus,
+      referenceAuthor,
+      publicationDate,
+      journal
+    );
+  }
 }
 
 /**

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -5,12 +5,12 @@ import { HCA_ATLAS_TRACKER_CATEGORY_LABEL } from "../../../../../site-config/hca
 import {
   AtlasId,
   ATLAS_STATUS,
+  DOI_STATUS,
   HCAAtlasTrackerComponentAtlas,
   HCAAtlasTrackerListAtlas,
   HCAAtlasTrackerSourceDataset,
   Network,
   NetworkKey,
-  PUBLICATION_STATUS,
 } from "../../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { getRouteURL } from "../../../../common/utils";
 import * as C from "../../../../components";
@@ -117,16 +117,11 @@ export const buildPublication = (
 export const buildSourceDatasetPublication = (
   sourceDataset: HCAAtlasTrackerSourceDataset
 ): React.ComponentProps<typeof C.Link> => {
-  const {
-    doi,
-    firstAuthorPrimaryName,
-    journal,
-    publicationDate,
-    publicationStatus,
-  } = sourceDataset;
+  const { doi, doiStatus, firstAuthorPrimaryName, journal, publicationDate } =
+    sourceDataset;
   return {
     label: getCitation(
-      publicationStatus,
+      doiStatus,
       firstAuthorPrimaryName,
       publicationDate,
       journal
@@ -227,13 +222,12 @@ export function getBioNetworkName(name: string): string {
 }
 
 function getCitation(
-  publicationStatus: PUBLICATION_STATUS,
+  doiStatus: DOI_STATUS,
   author: string | null,
   date: string | null,
   journal: string | null
 ): string {
-  if (publicationStatus === PUBLICATION_STATUS.DOI_NOT_ON_CROSSREF)
-    return "Unpublished";
+  if (doiStatus === DOI_STATUS.DOI_NOT_ON_CROSSREF) return "Unpublished";
   const citation = [];
   if (author) {
     citation.push(author);
@@ -267,14 +261,10 @@ export function getSourceDatasetCitation(
   sourceDataset?: HCAAtlasTrackerSourceDataset
 ): string {
   if (!sourceDataset) return "";
-  const {
-    firstAuthorPrimaryName,
-    journal,
-    publicationDate,
-    publicationStatus,
-  } = sourceDataset;
+  const { doiStatus, firstAuthorPrimaryName, journal, publicationDate } =
+    sourceDataset;
   return getCitation(
-    publicationStatus,
+    doiStatus,
     firstAuthorPrimaryName,
     publicationDate,
     journal

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -227,7 +227,7 @@ function getCitation(
   date: string | null,
   journal: string | null
 ): string {
-  if (doiStatus === DOI_STATUS.DOI_NOT_ON_CROSSREF) return "Unpublished";
+  if (doiStatus !== DOI_STATUS.OK) return "Unpublished";
   const citation = [];
   if (author) {
     citation.push(author);

--- a/app/views/AddNewSourceDatasetView/common/entities.ts
+++ b/app/views/AddNewSourceDatasetView/common/entities.ts
@@ -1,0 +1,4 @@
+import { InferType } from "yup";
+import { newSourceDatasetSchema } from "./schema";
+
+export type NewSourceDatasetData = InferType<typeof newSourceDatasetSchema>;

--- a/app/views/AddNewSourceDatasetView/common/schema.ts
+++ b/app/views/AddNewSourceDatasetView/common/schema.ts
@@ -1,0 +1,11 @@
+import { object, string } from "yup";
+import { isDoi } from "../../../utils/doi";
+
+export const newSourceDatasetSchema = object({
+  doi: string()
+    .default("")
+    .required("DOI is required")
+    .test("is-doi", "DOI must be a syntactically-valid DOI", (value) =>
+      isDoi(value)
+    ),
+}).strict(true);

--- a/app/views/AddNewSourceDatasetView/hooks/useAddSourceDatasetForm.tsx
+++ b/app/views/AddNewSourceDatasetView/hooks/useAddSourceDatasetForm.tsx
@@ -1,12 +1,10 @@
 import Router from "next/router";
-import {
-  NewSourceDatasetData,
-  newSourceDatasetSchema,
-} from "../../../apis/catalog/hca-atlas-tracker/common/schema";
 import { getRouteURL } from "../../../common/utils";
 import { FormMethod } from "../../../hooks/useForm/common/entities";
 import { useForm } from "../../../hooks/useForm/useForm";
 import { ROUTE } from "../../../routes/constants";
+import { NewSourceDatasetData } from "../common/entities";
+import { newSourceDatasetSchema } from "../common/schema";
 
 const SCHEMA = newSourceDatasetSchema;
 

--- a/app/views/EditSourceDatasetView/common/entities.ts
+++ b/app/views/EditSourceDatasetView/common/entities.ts
@@ -1,0 +1,4 @@
+import { InferType } from "yup";
+import { sourceDatasetEditSchema } from "./schema";
+
+export type SourceDatasetEditData = InferType<typeof sourceDatasetEditSchema>;

--- a/app/views/EditSourceDatasetView/common/schema.ts
+++ b/app/views/EditSourceDatasetView/common/schema.ts
@@ -1,5 +1,5 @@
 import { object, string } from "yup";
-import { newSourceDatasetSchema } from "../../../apis/catalog/hca-atlas-tracker/common/schema";
+import { newSourceDatasetSchema } from "../../AddNewSourceDatasetView/common/schema";
 
 export const sourceDatasetEditSchema = newSourceDatasetSchema.concat(
   object({

--- a/app/views/EditSourceDatasetView/common/schema.ts
+++ b/app/views/EditSourceDatasetView/common/schema.ts
@@ -1,0 +1,10 @@
+import { object, string } from "yup";
+import { newSourceDatasetSchema } from "../../../apis/catalog/hca-atlas-tracker/common/schema";
+
+export const sourceDatasetEditSchema = newSourceDatasetSchema.concat(
+  object({
+    cellxgeneCollectionId: string().default("").notRequired(),
+    hcaProjectId: string().default("").notRequired(),
+    title: string().default("").required("Title is required"),
+  })
+);

--- a/app/views/EditSourceDatasetView/hooks/useEditSourceDatasetForm.tsx
+++ b/app/views/EditSourceDatasetView/hooks/useEditSourceDatasetForm.tsx
@@ -60,11 +60,9 @@ function mapSchemaValues(
 ): SourceDatasetEditData | undefined {
   if (!sourceDataset) return;
   return {
-    [FIELD_NAME.AUTHOR]: sourceDataset.referenceAuthor ?? "",
     [FIELD_NAME.CELLXGENE_COLLECTION_ID]: mapCELLxGENECollectionId(
       sourceDataset.cellxgeneCollectionId
     ),
-    [FIELD_NAME.CONTACT_EMAIL]: sourceDataset.contactEmail ?? "",
     [FIELD_NAME.DOI]: sourceDataset.doi ?? "",
     [FIELD_NAME.HCA_PROJECT_ID]: mapHCAProjectId(sourceDataset.hcaProjectId),
     [FIELD_NAME.TITLE]: sourceDataset.title ?? "",

--- a/app/views/EditSourceDatasetView/hooks/useEditSourceDatasetForm.tsx
+++ b/app/views/EditSourceDatasetView/hooks/useEditSourceDatasetForm.tsx
@@ -7,14 +7,12 @@ import {
   HCAAtlasTrackerSourceDataset,
   SourceDatasetId,
 } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
-import {
-  SourceDatasetEditData,
-  sourceDatasetEditSchema,
-} from "../../../apis/catalog/hca-atlas-tracker/common/schema";
 import { FIELD_NAME } from "../../../components/Detail/components/TrackerForm/components/Section/components/SourceDataset/common/constants";
 import { useFetchSourceDataset } from "../../../hooks/useFetchSourceDataset";
 import { FormMethod } from "../../../hooks/useForm/common/entities";
 import { useForm } from "../../../hooks/useForm/useForm";
+import { SourceDatasetEditData } from "../common/entities";
+import { sourceDatasetEditSchema } from "../common/schema";
 
 const SCHEMA = sourceDatasetEditSchema;
 

--- a/app/views/EditSourceDatasetView/hooks/useEditSourceDatasetForm.tsx
+++ b/app/views/EditSourceDatasetView/hooks/useEditSourceDatasetForm.tsx
@@ -62,9 +62,11 @@ function mapSchemaValues(
 ): SourceDatasetEditData | undefined {
   if (!sourceDataset) return;
   return {
+    [FIELD_NAME.AUTHOR]: sourceDataset.referenceAuthor ?? "",
     [FIELD_NAME.CELLXGENE_COLLECTION_ID]: mapCELLxGENECollectionId(
       sourceDataset.cellxgeneCollectionId
     ),
+    [FIELD_NAME.CONTACT_EMAIL]: sourceDataset.contactEmail ?? "",
     [FIELD_NAME.DOI]: sourceDataset.doi ?? "",
     [FIELD_NAME.HCA_PROJECT_ID]: mapHCAProjectId(sourceDataset.hcaProjectId),
     [FIELD_NAME.TITLE]: sourceDataset.title ?? "",

--- a/pages/api/atlases.ts
+++ b/pages/api/atlases.ts
@@ -4,11 +4,11 @@ import {
 } from "../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { dbAtlasToApiAtlas } from "../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../app/common/entities";
+import { query } from "../../app/services/database";
 import {
   getUserRoleFromAuthorization,
   handler,
   method,
-  query,
 } from "../../app/utils/api-handler";
 
 /**

--- a/pages/api/atlases/[atlasId].ts
+++ b/pages/api/atlases/[atlasId].ts
@@ -11,11 +11,11 @@ import {
   HCAAtlasTrackerDBAtlasOverview,
 } from "../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD } from "../../../app/common/entities";
+import { query } from "../../../app/services/database";
 import {
   getUserRoleFromAuthorization,
   handleByMethod,
   handler,
-  query,
   respondValidationError,
   role,
 } from "../../../app/utils/api-handler";

--- a/pages/api/atlases/[atlasId]/source-datasets.ts
+++ b/pages/api/atlases/[atlasId]/source-datasets.ts
@@ -5,11 +5,11 @@ import {
 } from "../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { dbSourceDatasetToApiSourceDataset } from "../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../../app/common/entities";
+import { query } from "../../../../app/services/database";
 import {
   getUserRoleFromAuthorization,
   handler,
   method,
-  query,
 } from "../../../../app/utils/api-handler";
 
 export default handler(method(METHOD.GET), async (req, res) => {

--- a/pages/api/atlases/[atlasId]/source-datasets/[sdId].ts
+++ b/pages/api/atlases/[atlasId]/source-datasets/[sdId].ts
@@ -1,0 +1,74 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import {
+  ATLAS_STATUS,
+  HCAAtlasTrackerDBSourceDataset,
+} from "../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { sourceDatasetEditSchema } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/schema";
+import { dbSourceDatasetToApiSourceDataset } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
+import { METHOD } from "../../../../../app/common/entities";
+import { query } from "../../../../../app/services/database";
+import {
+  confirmSourceDatasetExistsOnAtlas,
+  updateSourceDataset,
+} from "../../../../../app/services/source-datasets";
+import {
+  AccessError,
+  getUserRoleFromAuthorization,
+  handleByMethod,
+  handler,
+  NotFoundError,
+  role,
+} from "../../../../../app/utils/api-handler";
+
+async function getHandler(
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<void> {
+  const atlasId = req.query.atlasId as string;
+  const sdId = req.query.sdId as string;
+
+  const role = await getUserRoleFromAuthorization(req.headers.authorization);
+
+  try {
+    await confirmSourceDatasetExistsOnAtlas(
+      sdId,
+      atlasId,
+      role === "CONTENT_ADMIN" ? undefined : [ATLAS_STATUS.PUBLIC]
+    );
+  } catch (e) {
+    if (e instanceof AccessError) {
+      res.status(role ? 403 : 401).json({ message: e.message });
+      return;
+    }
+    throw e;
+  }
+
+  const queryResult = await query<HCAAtlasTrackerDBSourceDataset>(
+    "SELECT * FROM hat.source_datasets WHERE id=$1",
+    [sdId]
+  );
+
+  if (queryResult.rows.length === 0)
+    throw new NotFoundError(`Source dataset with ID ${sdId} doesn't exist`);
+
+  res.json(dbSourceDatasetToApiSourceDataset(queryResult.rows[0]));
+}
+
+const putHandler = handler(
+  role("CONTENT_ADMIN"), // Since the route is restricted to content admins, there are no additional permissions checks
+  async (req, res) => {
+    const atlasId = req.query.atlasId as string;
+    const sdId = req.query.sdId as string;
+    const newDataset = await updateSourceDataset(
+      atlasId,
+      sdId,
+      await sourceDatasetEditSchema.validate(req.body)
+    );
+    res.json(dbSourceDatasetToApiSourceDataset(newDataset));
+  }
+);
+
+export default handleByMethod({
+  [METHOD.GET]: getHandler,
+  [METHOD.PUT]: putHandler,
+});

--- a/pages/api/atlases/[atlasId]/source-datasets/[sdId].ts
+++ b/pages/api/atlases/[atlasId]/source-datasets/[sdId].ts
@@ -37,7 +37,7 @@ async function getHandler(
     );
   } catch (e) {
     if (e instanceof AccessError) {
-      res.status(role ? 403 : 401).json({ message: e.message });
+      res.status(role === null ? 401 : 403).json({ message: e.message });
       return;
     }
     throw e;

--- a/pages/api/atlases/[atlasId]/source-datasets/create.ts
+++ b/pages/api/atlases/[atlasId]/source-datasets/create.ts
@@ -1,33 +1,8 @@
-import { getCellxGeneIdByDoi } from "app/services/cellxgene";
-import { NextApiResponse } from "next";
-import { ValidationError } from "yup";
-import {
-  DOI_STATUS,
-  HCAAtlasTrackerDBSourceDataset,
-  HCAAtlasTrackerDBSourceDatasetMinimumColumns,
-} from "../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
-import {
-  NewSourceDatasetData,
-  newSourceDatasetSchema,
-} from "../../../../../app/apis/catalog/hca-atlas-tracker/common/schema";
+import { createSourceDataset } from "app/services/source-datasets";
+import { newSourceDatasetSchema } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/schema";
 import { dbSourceDatasetToApiSourceDataset } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../../../app/common/entities";
-import { FormResponseErrors } from "../../../../../app/hooks/useForm/common/entities";
-import { getPoolClient, query } from "../../../../../app/services/database";
-import { getProjectIdByDoi } from "../../../../../app/services/hca-projects";
-import {
-  handleGetRefreshValue,
-  handler,
-  handleValidation,
-  method,
-  role,
-} from "../../../../../app/utils/api-handler";
-import { getCrossrefPublicationInfo } from "../../../../../app/utils/crossref/crossref";
-import { normalizeDoi } from "../../../../../app/utils/doi";
-
-type HandledSourceDatasetInfo =
-  | [HCAAtlasTrackerDBSourceDatasetMinimumColumns, false]
-  | [null, true];
+import { handler, method, role } from "../../../../../app/utils/api-handler";
 
 /**
  * API route for creating a source dataset. Source dataset information is provided as a JSON body.
@@ -37,128 +12,10 @@ export default handler(
   role("CONTENT_ADMIN"), // Since the route is restricted to content admins, there are no additional permissions checks
   async (req, res) => {
     const atlasId = req.query.atlasId as string;
-
-    const atlasExists = (
-      await query("SELECT EXISTS(SELECT 1 FROM hat.atlases WHERE id=$1)", [
-        atlasId,
-      ])
-    ).rows[0].exists;
-    if (!atlasExists) {
-      res.status(404).end();
-      return;
-    }
-
-    const [newData, newDataFailed] = await handleValidation(
-      res,
-      newSourceDatasetSchema,
-      req.body
+    const newDataset = await createSourceDataset(
+      atlasId,
+      await newSourceDatasetSchema.validate(req.body)
     );
-    if (newDataFailed) return;
-
-    const [newInfo, newInfoFailed] = newData.doi
-      ? await handleGetPublishedInfo(res, newData)
-      : await handleGetUnpublishedInfo(res, newData);
-    if (newInfoFailed) return;
-
-    const client = await getPoolClient();
-    try {
-      await client.query("BEGIN");
-      // Add the new source dataset
-      const newDataset = (
-        await client.query<HCAAtlasTrackerDBSourceDataset>(
-          "INSERT INTO hat.source_datasets (doi, sd_info) VALUES ($1, $2) RETURNING *",
-          [newInfo.doi, JSON.stringify(newInfo.sd_info)]
-        )
-      ).rows[0];
-      // Update the atlas's list of source datasets
-      await client.query(
-        "UPDATE hat.atlases SET source_datasets=source_datasets||$1 WHERE id=$2",
-        [JSON.stringify([newDataset.id]), atlasId]
-      );
-      await client.query("COMMIT");
-      res.status(201).json(dbSourceDatasetToApiSourceDataset(newDataset));
-    } catch (e) {
-      await client.query("ROLLBACK");
-      throw e;
-    } finally {
-      client.release();
-    }
+    res.status(201).json(dbSourceDatasetToApiSourceDataset(newDataset));
   }
 );
-
-async function handleGetPublishedInfo(
-  res: NextApiResponse,
-  data: NewSourceDatasetData
-): Promise<HandledSourceDatasetInfo> {
-  const doi = normalizeDoi(data.doi);
-
-  let publication;
-  try {
-    publication = await getCrossrefPublicationInfo(doi);
-  } catch (e) {
-    if (e instanceof ValidationError) {
-      const errors: FormResponseErrors = {
-        errors: {
-          doi: [`Crossref data doesn't fit: ${e.message}`],
-        },
-      };
-      res.status(500).json(errors);
-      return [null, true];
-    }
-    throw e;
-  }
-
-  const dois = [
-    ...(publication?.preprintOfDoi ? [publication.preprintOfDoi] : []),
-    doi,
-    ...(publication?.hasPreprintDoi ? [publication.hasPreprintDoi] : []),
-  ];
-
-  const [hcaProjectId, hcaProjectIdFailed] = handleGetRefreshValue(res, () =>
-    getProjectIdByDoi(dois)
-  );
-  if (hcaProjectIdFailed) return [null, true];
-
-  const [cellxgeneCollectionId, cellxgeneIdFailed] = handleGetRefreshValue(
-    res,
-    () => getCellxGeneIdByDoi(dois)
-  );
-  if (cellxgeneIdFailed) return [null, true];
-
-  return [
-    {
-      doi,
-      sd_info: {
-        cellxgeneCollectionId,
-        doiStatus: publication ? DOI_STATUS.OK : DOI_STATUS.DOI_NOT_ON_CROSSREF,
-        hcaProjectId,
-        publication,
-        unpublishedInfo: null,
-      },
-    },
-    false,
-  ];
-}
-
-async function handleGetUnpublishedInfo(
-  res: NextApiResponse,
-  data: NewSourceDatasetData
-): Promise<HandledSourceDatasetInfo> {
-  return [
-    {
-      doi: null,
-      sd_info: {
-        cellxgeneCollectionId: null,
-        doiStatus: DOI_STATUS.NA,
-        hcaProjectId: null,
-        publication: null,
-        unpublishedInfo: {
-          contactEmail: data.contactEmail,
-          referenceAuthor: data.referenceAuthor,
-          title: data.title,
-        },
-      },
-    },
-    false,
-  ];
-}

--- a/pages/api/atlases/[atlasId]/source-datasets/create.ts
+++ b/pages/api/atlases/[atlasId]/source-datasets/create.ts
@@ -13,14 +13,13 @@ import {
 import { dbSourceDatasetToApiSourceDataset } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../../../app/common/entities";
 import { FormResponseErrors } from "../../../../../app/hooks/useForm/common/entities";
+import { getPoolClient, query } from "../../../../../app/services/database";
 import { getProjectIdByDoi } from "../../../../../app/services/hca-projects";
 import {
-  getPoolClient,
   handleGetRefreshValue,
   handler,
   handleValidation,
   method,
-  query,
   role,
 } from "../../../../../app/utils/api-handler";
 import { getCrossrefPublicationInfo } from "../../../../../app/utils/crossref/crossref";

--- a/pages/api/atlases/[atlasId]/source-datasets/create.ts
+++ b/pages/api/atlases/[atlasId]/source-datasets/create.ts
@@ -154,8 +154,8 @@ async function handleGetUnpublishedInfo(
         hcaProjectId: null,
         publication: null,
         unpublishedInfo: {
-          author: data.author,
           contactEmail: data.contactEmail,
+          referenceAuthor: data.referenceAuthor,
           title: data.title,
         },
       },

--- a/pages/api/atlases/[atlasId]/source-datasets/create.ts
+++ b/pages/api/atlases/[atlasId]/source-datasets/create.ts
@@ -2,8 +2,8 @@ import { getCellxGeneIdByDoi } from "app/services/cellxgene";
 import { ValidationError } from "yup";
 import {
   DOI_STATUS,
+  HCAAtlasTrackerDBPublishedSourceDatasetInfo,
   HCAAtlasTrackerDBSourceDataset,
-  HCAAtlasTrackerDBSourceDatasetInfo,
 } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { newSourceDatasetSchema } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/schema";
 import { dbSourceDatasetToApiSourceDataset } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
@@ -87,7 +87,7 @@ export default handler(
 
     // Create new source dataset
 
-    const newInfo: HCAAtlasTrackerDBSourceDatasetInfo = {
+    const newInfo: HCAAtlasTrackerDBPublishedSourceDatasetInfo = {
       cellxgeneCollectionId,
       doiStatus: publication ? DOI_STATUS.OK : DOI_STATUS.DOI_NOT_ON_CROSSREF,
       hcaProjectId,

--- a/pages/api/atlases/[atlasId]/source-datasets/create.ts
+++ b/pages/api/atlases/[atlasId]/source-datasets/create.ts
@@ -92,6 +92,7 @@ export default handler(
       doiStatus: publication ? DOI_STATUS.OK : DOI_STATUS.DOI_NOT_ON_CROSSREF,
       hcaProjectId,
       publication,
+      unpublishedInfo: null,
     };
 
     const client = await getPoolClient();

--- a/pages/api/atlases/[atlasId]/source-datasets/create.ts
+++ b/pages/api/atlases/[atlasId]/source-datasets/create.ts
@@ -1,9 +1,9 @@
 import { getCellxGeneIdByDoi } from "app/services/cellxgene";
 import { ValidationError } from "yup";
 import {
+  DOI_STATUS,
   HCAAtlasTrackerDBSourceDataset,
   HCAAtlasTrackerDBSourceDatasetInfo,
-  PUBLICATION_STATUS,
 } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { newSourceDatasetSchema } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/schema";
 import { dbSourceDatasetToApiSourceDataset } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
@@ -89,11 +89,9 @@ export default handler(
 
     const newInfo: HCAAtlasTrackerDBSourceDatasetInfo = {
       cellxgeneCollectionId,
+      doiStatus: publication ? DOI_STATUS.OK : DOI_STATUS.DOI_NOT_ON_CROSSREF,
       hcaProjectId,
       publication,
-      publicationStatus: publication
-        ? PUBLICATION_STATUS.OK
-        : PUBLICATION_STATUS.DOI_NOT_ON_CROSSREF,
     };
 
     const client = await getPoolClient();

--- a/pages/api/atlases/create.ts
+++ b/pages/api/atlases/create.ts
@@ -10,10 +10,10 @@ import {
 } from "../../../app/apis/catalog/hca-atlas-tracker/common/schema";
 import { dbAtlasToApiAtlas } from "../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../app/common/entities";
+import { query } from "../../../app/services/database";
 import {
   handler,
   method,
-  query,
   respondValidationError,
   role,
 } from "../../../app/utils/api-handler";

--- a/pages/api/users.ts
+++ b/pages/api/users.ts
@@ -1,5 +1,6 @@
 import { METHOD } from "../../app/common/entities";
-import { handler, method, query, role } from "../../app/utils/api-handler";
+import { query } from "../../app/services/database";
+import { handler, method, role } from "../../app/utils/api-handler";
 
 /**
  * API route for list of users. Optional `email` query paramter filters by email.

--- a/pages/api/users/[id]/disable.ts
+++ b/pages/api/users/[id]/disable.ts
@@ -1,9 +1,9 @@
 import { METHOD } from "../../../../app/common/entities";
+import { query } from "../../../../app/services/database";
 import {
   handler,
   handleRequiredParam,
   method,
-  query,
   role,
 } from "../../../../app/utils/api-handler";
 

--- a/pages/api/users/[id]/enable.ts
+++ b/pages/api/users/[id]/enable.ts
@@ -1,9 +1,9 @@
 import { METHOD } from "../../../../app/common/entities";
+import { query } from "../../../../app/services/database";
 import {
   handler,
   handleRequiredParam,
   method,
-  query,
   role,
 } from "../../../../app/utils/api-handler";
 

--- a/pages/api/users/create.ts
+++ b/pages/api/users/create.ts
@@ -4,7 +4,8 @@ import {
   newUserSchema,
 } from "../../../app/apis/catalog/hca-atlas-tracker/common/schema";
 import { METHOD } from "../../../app/common/entities";
-import { handler, method, query, role } from "../../../app/utils/api-handler";
+import { query } from "../../../app/services/database";
+import { handler, method, role } from "../../../app/utils/api-handler";
 
 /**
  * API route for creating a user. New user information is provided as a JSON body.

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -1,8 +1,8 @@
 import { ProjectsResponse } from "app/apis/azul/hca-dcp/common/responses";
 import {
   ATLAS_STATUS,
+  DOI_STATUS,
   PublicationInfo,
-  PUBLICATION_STATUS,
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { CellxGeneCollection } from "../app/utils/cellxgene-api";
 import { CrossrefWork } from "../app/utils/crossref/crossref";
@@ -34,6 +34,7 @@ export const TEST_USERS = [...INITIAL_TEST_USERS, USER_NONEXISTENT, USER_NEW];
 
 export const SOURCE_DATASET_DRAFT_OK: TestSourceDataset = {
   doi: "10.123/sd-draft-ok",
+  doiStatus: DOI_STATUS.OK,
   id: "d2932506-0af5-4030-920c-07f6beeb817a",
   publication: {
     authors: [
@@ -48,21 +49,20 @@ export const SOURCE_DATASET_DRAFT_OK: TestSourceDataset = {
     publicationDate: "2024-04-09",
     title: "draft-ok-title",
   },
-  publicationStatus: PUBLICATION_STATUS.OK,
 };
 
 export const SOURCE_DATASET_DRAFT_NO_CROSSREF: TestSourceDataset = {
   doi: "10.123/sd-draft-no-crossref",
+  doiStatus: DOI_STATUS.DOI_NOT_ON_CROSSREF,
   id: "ee67ddcb-e5d8-4240-a8ef-c945657c3321",
   publication: null,
-  publicationStatus: PUBLICATION_STATUS.DOI_NOT_ON_CROSSREF,
 };
 
 export const SOURCE_DATASET_PUBLIC_NO_CROSSREF: TestSourceDataset = {
   doi: "10.123/sd-public-no-crossref",
+  doiStatus: DOI_STATUS.DOI_NOT_ON_CROSSREF,
   id: "dae11387-d0c2-4160-8f2e-0be27a3a551a",
   publication: null,
-  publicationStatus: PUBLICATION_STATUS.DOI_NOT_ON_CROSSREF,
 };
 
 // Source datasets initialized in the database before tests

--- a/testing/entities.ts
+++ b/testing/entities.ts
@@ -1,9 +1,9 @@
 import {
   ATLAS_STATUS,
+  DOI_STATUS,
   IntegrationLead,
   NetworkKey,
   PublicationInfo,
-  PUBLICATION_STATUS,
   Wave,
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 
@@ -29,7 +29,7 @@ export interface TestAtlas {
 
 export interface TestSourceDataset {
   doi: string | null;
+  doiStatus: DOI_STATUS;
   id: string;
   publication: PublicationInfo | null;
-  publicationStatus: PUBLICATION_STATUS;
 }

--- a/testing/global-setup.ts
+++ b/testing/global-setup.ts
@@ -25,6 +25,7 @@ export default async function setup(): Promise<void> {
       doiStatus: dataset.doiStatus,
       hcaProjectId: null,
       publication: dataset.publication,
+      unpublishedInfo: null,
     };
     await pool.query(
       "INSERT INTO hat.source_datasets (doi, id, sd_info) VALUES ($1, $2, $3)",

--- a/testing/global-setup.ts
+++ b/testing/global-setup.ts
@@ -1,4 +1,4 @@
-import { HCAAtlasTrackerDBSourceDatasetInfo } from "app/apis/catalog/hca-atlas-tracker/common/entities";
+import { HCAAtlasTrackerDBPublishedSourceDatasetInfo } from "app/apis/catalog/hca-atlas-tracker/common/entities";
 import pg from "pg";
 import { getPoolConfig } from "../app/utils/__mocks__/pg-app-connect-config";
 import {
@@ -20,7 +20,7 @@ export default async function setup(): Promise<void> {
   }
 
   for (const dataset of INITIAL_TEST_SOURCE_DATASETS) {
-    const sdInfo: HCAAtlasTrackerDBSourceDatasetInfo = {
+    const sdInfo: HCAAtlasTrackerDBPublishedSourceDatasetInfo = {
       cellxgeneCollectionId: null,
       doiStatus: dataset.doiStatus,
       hcaProjectId: null,

--- a/testing/global-setup.ts
+++ b/testing/global-setup.ts
@@ -22,9 +22,9 @@ export default async function setup(): Promise<void> {
   for (const dataset of INITIAL_TEST_SOURCE_DATASETS) {
     const sdInfo: HCAAtlasTrackerDBSourceDatasetInfo = {
       cellxgeneCollectionId: null,
+      doiStatus: dataset.doiStatus,
       hcaProjectId: null,
       publication: dataset.publication,
-      publicationStatus: dataset.publicationStatus,
     };
     await pool.query(
       "INSERT INTO hat.source_datasets (doi, id, sd_info) VALUES ($1, $2, $3)",

--- a/testing/global-setup.ts
+++ b/testing/global-setup.ts
@@ -1,4 +1,3 @@
-import { HCAAtlasTrackerDBPublishedSourceDatasetInfo } from "app/apis/catalog/hca-atlas-tracker/common/entities";
 import pg from "pg";
 import { getPoolConfig } from "../app/utils/__mocks__/pg-app-connect-config";
 import {
@@ -6,7 +5,7 @@ import {
   INITIAL_TEST_SOURCE_DATASETS,
   INITIAL_TEST_USERS,
 } from "./constants";
-import { makeTestAtlasOverview } from "./utils";
+import { makeTestAtlasOverview, makeTestSourceDatasetOverview } from "./utils";
 
 const { Pool } = pg;
 
@@ -20,13 +19,7 @@ export default async function setup(): Promise<void> {
   }
 
   for (const dataset of INITIAL_TEST_SOURCE_DATASETS) {
-    const sdInfo: HCAAtlasTrackerDBPublishedSourceDatasetInfo = {
-      cellxgeneCollectionId: null,
-      doiStatus: dataset.doiStatus,
-      hcaProjectId: null,
-      publication: dataset.publication,
-      unpublishedInfo: null,
-    };
+    const sdInfo = makeTestSourceDatasetOverview(dataset);
     await pool.query(
       "INSERT INTO hat.source_datasets (doi, id, sd_info) VALUES ($1, $2, $3)",
       [dataset.doi, dataset.id, JSON.stringify(sdInfo)]

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -1,6 +1,9 @@
 import { ProjectsResponse } from "../app/apis/azul/hca-dcp/common/responses";
-import { HCAAtlasTrackerDBAtlasOverview } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { TestAtlas, TestUser } from "./entities";
+import {
+  HCAAtlasTrackerDBAtlasOverview,
+  HCAAtlasTrackerDBPublishedSourceDatasetInfo,
+} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { TestAtlas, TestSourceDataset, TestUser } from "./entities";
 
 export function makeTestUser(
   nameId: string,
@@ -26,6 +29,18 @@ export function makeTestAtlasOverview(
     shortName: atlas.shortName,
     version: atlas.version,
     wave: atlas.wave,
+  };
+}
+
+export function makeTestSourceDatasetOverview(
+  dataset: TestSourceDataset
+): HCAAtlasTrackerDBPublishedSourceDatasetInfo {
+  return {
+    cellxgeneCollectionId: null,
+    doiStatus: dataset.doiStatus,
+    hcaProjectId: null,
+    publication: dataset.publication,
+    unpublishedInfo: null,
   };
 }
 


### PR DESCRIPTION
Notes:
- The schema and how it fits in with the form might need some attention
  - Currently (with the new fields and no update to the form) the save button for some reason doesn't do anything
- API response datasets are flat objects with several properties used for both published and unpublished source datasets
- `firstAuthorPrimaryName` is renamed to `referenceAuthor` (does this seem appropriate?)
- Field names for new unpublished source dataset are ~~`author`~~ `referenceAuthor`, `contactEmail`, and `title`
  - Would `authorEmail` be more accurate? (I'm inclined not to use just `email` because I think it should be more specific on the API response and ideally that would be consistent with the request)
- ~~The only API update is the `create` API (do we need an API for updating source datasets for this ticket?)~~
  - There is now an edit API

EDIT: the API schema accepts either an object of the form `{ doi: string }`, or of the form `{ contactEmail: string; referenceAuthor: string; title: string }` (~~though I guess we may change `author` to `referenceAuthor`?~~ done!). If DOI is a string, the other three properties must be `undefined`/omitted, and if DOI is `undefined`/omitted, the other three properties must be strings.