### PR TITLE
feat: add logging and retries to hca/cellxgene refreshes (#140)

### DIFF
--- a/app/services/cellxgene.ts
+++ b/app/services/cellxgene.ts
@@ -15,9 +15,9 @@ const REFRESH_INTERVAL = 4 * 60 * 60 * 1000; // 4 hours
 const KY_OPTIONS: KyOptions = {
   retry: {
     delay: () => 60000,
-    limit: 2,
+    limit: 5,
   },
-  timeout: 240000,
+  timeout: 120000,
 };
 
 const { getData: getCellxGeneData } = makeRefreshService({

--- a/app/services/cellxgene.ts
+++ b/app/services/cellxgene.ts
@@ -1,3 +1,4 @@
+import { Options as KyOptions } from "ky";
 import { getCellxGeneCollections } from "../utils/cellxgene-api";
 import { normalizeDoi } from "../utils/doi";
 import { makeRefreshService, RefreshInfo } from "./common/refresh-service";
@@ -10,6 +11,14 @@ interface CellxGeneData {
 export type CellxGeneInfo = RefreshInfo<CellxGeneData>;
 
 const REFRESH_INTERVAL = 4 * 60 * 60 * 1000; // 4 hours
+
+const KY_OPTIONS: KyOptions = {
+  retry: {
+    delay: () => 60000,
+    limit: 2,
+  },
+  timeout: 240000,
+};
 
 const { getData: getCellxGeneData } = makeRefreshService({
   getRefreshParams: () => undefined,
@@ -53,7 +62,19 @@ export function getCellxGeneIdByDoi(dois: string[]): string | null {
  */
 async function getRefreshedCollectionIdsByDoi(): Promise<Map<string, string>> {
   const idsByDoi = new Map<string, string>();
-  for (const { collection_id, doi } of await getCellxGeneCollections()) {
+  console.log("Requesting CELLxGENE collections");
+  const collections = await getCellxGeneCollections({
+    hooks: {
+      beforeRetry: [
+        (): void => {
+          console.log("Retrying CELLxGENE collections request");
+        },
+      ],
+    },
+    ...KY_OPTIONS,
+  });
+  console.log("Loaded CELLxGENE collections");
+  for (const { collection_id, doi } of collections) {
     if (doi) idsByDoi.set(normalizeDoi(doi), collection_id);
   }
   return idsByDoi;

--- a/app/services/hca-projects.ts
+++ b/app/services/hca-projects.ts
@@ -15,9 +15,9 @@ export type ProjectsInfo = RefreshInfo<ProjectsData>;
 const KY_OPTIONS: KyOptions = {
   retry: {
     delay: () => 60000,
-    limit: 2,
+    limit: 5,
   },
-  timeout: 150000,
+  timeout: 120000,
 };
 
 const { getData: getProjectsData } = makeRefreshService({

--- a/app/utils/cellxgene-api.ts
+++ b/app/utils/cellxgene-api.ts
@@ -1,3 +1,5 @@
+import ky, { Options as KyOptions } from "ky";
+
 export interface CellxGeneCollection {
   collection_id: string;
   doi: string | null;
@@ -6,11 +8,8 @@ export interface CellxGeneCollection {
 const API_URL_COLLECTIONS =
   "https://api.cellxgene.cziscience.com/curation/v1/collections";
 
-export async function getCellxGeneCollections(): Promise<
-  CellxGeneCollection[]
-> {
-  const res = await fetch(API_URL_COLLECTIONS);
-  if (res.status !== 200)
-    throw new Error(`Received status ${res.status} from CELLxGENE`);
-  return await res.json();
+export async function getCellxGeneCollections(
+  kyOptions?: KyOptions
+): Promise<CellxGeneCollection[]> {
+  return await ky(API_URL_COLLECTIONS, kyOptions).json();
 }

--- a/app/utils/hca-api.ts
+++ b/app/utils/hca-api.ts
@@ -2,6 +2,7 @@ import {
   AzulCatalogResponse,
   AzulEntitiesResponse,
 } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
+import ky, { Options as KyOptions } from "ky";
 import { ProjectsResponse } from "../apis/azul/hca-dcp/common/responses";
 
 const API_URL_CATALOGS =
@@ -11,11 +12,13 @@ const API_URL_PROJECTS =
 
 /**
  * Fetch current default HCA catalog name.
+ * @param kyOptions - Options to pass to ky.
  * @returns catalog name.
  */
-export async function getLatestCatalog(): Promise<string> {
-  const catalogs: AzulCatalogResponse = await (
-    await fetch(API_URL_CATALOGS)
+export async function getLatestCatalog(kyOptions?: KyOptions): Promise<string> {
+  const catalogs: AzulCatalogResponse = await ky(
+    API_URL_CATALOGS,
+    kyOptions
   ).json();
   return catalogs.default_catalog;
 }
@@ -23,10 +26,12 @@ export async function getLatestCatalog(): Promise<string> {
 /**
  * Fetch all projects from given catalog.
  * @param catalog - Catalog to fetch projects from.
+ * @param kyOptions - Options to pass to ky.
  * @returns projects responses for all of the catalog's projects.
  */
 export async function getAllProjects(
-  catalog: string
+  catalog: string,
+  kyOptions?: KyOptions
 ): Promise<ProjectsResponse[]> {
   let url:
     | string
@@ -35,8 +40,9 @@ export async function getAllProjects(
   )}&size=100`;
   const hits: ProjectsResponse[] = [];
   while (url) {
-    const responseData: AzulEntitiesResponse<ProjectsResponse> = await (
-      await fetch(url)
+    const responseData: AzulEntitiesResponse<ProjectsResponse> = await ky(
+      url,
+      kyOptions
     ).json();
     hits.push(...responseData.hits);
     url = responseData.pagination.next;

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/mdx": "^2.0.11",
         "google-auth-library": "^9.6.3",
         "isomorphic-dompurify": "0.24.0",
+        "ky": "^1.2.4",
         "next": "^14.1.0",
         "next-compose-plugins": "^2.2.1",
         "react": "^18.2.0",
@@ -20402,6 +20403,17 @@
         "node": ">= 8"
       }
     },
+    "node_modules/ky": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.2.4.tgz",
+      "integrity": "sha512-CfSrf4a0yj1n6WgPT6kQNQOopIGLkQzqSAXo05oKByaH7G3SiqW4a8jGox0p9whMXqO49H7ljgigivrMyycAVA==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
+      }
+    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.22",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
@@ -30620,9 +30632,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/mdx": "^2.0.11",
     "google-auth-library": "^9.6.3",
     "isomorphic-dompurify": "0.24.0",
+    "ky": "^1.2.4",
     "next": "^14.1.0",
     "next-compose-plugins": "^2.2.1",
     "react": "^18.2.0",


### PR DESCRIPTION
Retries are done via `ky`, which is made by the same people as `got` but is supposedly preferable because it uses `fetch`