### PR TITLE
feat: create/edit unpublished source datasets ui (#130)

### DIFF
--- a/app/apis/catalog/hca-atlas-tracker/common/api.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/api.ts
@@ -1,5 +1,6 @@
 export enum API {
   ATLAS = "/api/atlases/[atlasId]",
+  ATLAS_SOURCE_DATASET = "/api/atlases/[atlasId]/source-datasets/[sdId]",
   ATLAS_SOURCE_DATASETS = "/api/atlases/[atlasId]/source-datasets",
   CREATE_ATLAS = "/api/atlases/create",
   CREATE_ATLAS_SOURCE_DATASET = "/api/atlases/[atlasId]/source-datasets/create",

--- a/app/common/utils.ts
+++ b/app/common/utils.ts
@@ -70,12 +70,20 @@ export function isFetchStatusOk(status: number): boolean {
 }
 
 /**
- * Replaces [atlasId] in the API URL with the given atlas ID.
+ * Replaces [atlasId] in the API URL with the given atlas ID and optionally replaces [sdId] with the given source dataset ID.
  * @param apiURL - Request URL.
  * @param atlasId - Atlas ID.
+ * @param sdId - Source dataset ID.
  * @returns request URL with Atlas ID.
  */
-export function getRequestURL(apiURL: API, atlasId: string): string {
+export function getRequestURL(
+  apiURL: API,
+  atlasId: string,
+  sdId?: string
+): string {
+  if (/\[sdId]/.test(apiURL) && sdId) {
+    return apiURL.replace(/\[atlasId]/, atlasId).replace(/\[sdId]/, sdId);
+  }
   return apiURL.replace(/\[atlasId]/, atlasId);
 }
 

--- a/app/components/Detail/components/AddSourceDataset/addSourceDataset.tsx
+++ b/app/components/Detail/components/AddSourceDataset/addSourceDataset.tsx
@@ -9,7 +9,10 @@ import { getRequestURL, getRouteURL } from "../../../../common/utils";
 import { FormMethod } from "../../../../hooks/useForm/common/entities";
 import { ROUTE } from "../../../../routes/constants";
 import { NewSourceDatasetData } from "../../../../views/AddNewSourceDatasetView/common/entities";
-import { onSuccess } from "../../../../views/AddNewSourceDatasetView/hooks/useAddSourceDatasetForm";
+import {
+  onSuccess,
+  unregisterSourceDatasetFields,
+} from "../../../../views/AddNewSourceDatasetView/hooks/useAddSourceDatasetForm";
 import {
   ButtonLink,
   BUTTON_COLOR,
@@ -30,15 +33,11 @@ export const AddSourceDataset = ({
   formMethod,
 }: AddSourceDatasetProps): JSX.Element => {
   const { isAuthenticated } = useAuthentication();
-  const {
-    disabled,
-    formState: { isDirty },
-    handleSubmit,
-    onSubmit,
-  } = formMethod;
+  const { disabled, handleSubmit, onSubmit, unregister } = formMethod;
 
   const onFormSubmit = useCallback(
     (payload: NewSourceDatasetData): void => {
+      unregister(unregisterSourceDatasetFields(payload));
       onSubmit(
         getRequestURL(API.CREATE_ATLAS_SOURCE_DATASET, atlasId),
         METHOD.POST,
@@ -48,7 +47,7 @@ export const AddSourceDataset = ({
         }
       );
     },
-    [atlasId, onSubmit]
+    [atlasId, onSubmit, unregister]
   );
 
   return isAuthenticated ? (
@@ -63,7 +62,7 @@ export const AddSourceDataset = ({
         >
           Discard
         </ButtonLink>
-        <ButtonPrimary disabled={disabled || !isDirty} type="submit">
+        <ButtonPrimary disabled={disabled} type="submit">
           Save
         </ButtonPrimary>
       </FormActions>

--- a/app/components/Detail/components/EditSourceDataset/editSourceDataset.tsx
+++ b/app/components/Detail/components/EditSourceDataset/editSourceDataset.tsx
@@ -2,14 +2,22 @@ import { Link } from "@databiosphere/findable-ui/lib/components/Links/components
 import { useAuthentication } from "@databiosphere/findable-ui/lib/hooks/useAuthentication/useAuthentication";
 import Router from "next/router";
 import { useCallback } from "react";
+import { API } from "../../../../apis/catalog/hca-atlas-tracker/common/api";
 import {
   AtlasId,
   HCAAtlasTrackerSourceDataset,
+  SourceDatasetId,
 } from "../../../../apis/catalog/hca-atlas-tracker/common/entities";
-import { getRouteURL } from "../../../../common/utils";
+import { METHOD } from "../../../../common/entities";
+import { getRequestURL, getRouteURL } from "../../../../common/utils";
 import { FormMethod } from "../../../../hooks/useForm/common/entities";
 import { ROUTE } from "../../../../routes/constants";
+import { PUBLICATION_STATUS } from "../../../../views/AddNewSourceDatasetView/common/entities";
 import { SourceDatasetEditData } from "../../../../views/EditSourceDatasetView/common/entities";
+import {
+  onSuccess,
+  unregisterSourceDatasetFields,
+} from "../../../../views/EditSourceDatasetView/hooks/useEditSourceDatasetForm";
 import {
   getFormDiscardProps,
   getFormSaveProps,
@@ -24,30 +32,55 @@ import { TrackerForm } from "../TrackerForm/trackerForm";
 interface EditSourceDatasetProps {
   atlasId: AtlasId;
   formMethod: FormMethod<SourceDatasetEditData, HCAAtlasTrackerSourceDataset>;
+  sdId: SourceDatasetId;
+  sdPublicationStatus: PUBLICATION_STATUS;
 }
 
 export const EditSourceDataset = ({
   atlasId,
   formMethod,
+  sdId,
+  sdPublicationStatus,
 }: EditSourceDatasetProps): JSX.Element => {
   const { isAuthenticated } = useAuthentication();
   const {
     formState: { isDirty },
+    handleSubmit,
+    onSubmit,
+    unregister,
   } = formMethod;
 
   const onDiscard = useCallback(() => {
     Router.push(getRouteURL(ROUTE.VIEW_SOURCE_DATASETS, atlasId));
   }, [atlasId]);
 
+  const onFormSubmit = useCallback(
+    (payload: SourceDatasetEditData): void => {
+      unregister(unregisterSourceDatasetFields(payload));
+      onSubmit(
+        getRequestURL(API.ATLAS_SOURCE_DATASET, atlasId, sdId),
+        METHOD.PUT,
+        payload,
+        {
+          onSuccess: (id) => onSuccess(atlasId, id),
+        }
+      );
+    },
+    [atlasId, onSubmit, sdId, unregister]
+  );
+
   return isAuthenticated ? (
     <TrackerForm>
       <FormManagement
         formDiscardProps={getFormDiscardProps(onDiscard)}
-        formSaveProps={getFormSaveProps(formMethod)}
+        formSaveProps={getFormSaveProps(formMethod, handleSubmit(onFormSubmit))} // TODO fix disable form save between published and unpublished states.
         isDirty={isDirty}
       />
       <Divider />
-      <GeneralInfo formMethod={formMethod} />
+      <GeneralInfo
+        formMethod={formMethod}
+        sdPublicationStatus={sdPublicationStatus}
+      />
       <Divider />
       <Identifiers formMethod={formMethod} />
       <Divider />

--- a/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/common/constants.ts
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/common/constants.ts
@@ -2,30 +2,24 @@ export const DEFAULT_INPUT_PROPS = {
   CELLXGENE_COLLECTION_ID: {
     isFullWidth: true,
     label: "CELLxGENE collection ID",
-    readOnly: false,
+  },
+  CONTACT_EMAIL: {
+    label: "Email",
   },
   DOI: {
     isFullWidth: true,
     label: "Publication DOI no.",
     placeholder: "e.g. 10.1038/s41591-023-02327-2",
-    readOnly: false,
   },
   HCA_PROJECT_ID: {
     isFullWidth: true,
     label: "HCA repository project ID",
-    readOnly: false,
+  },
+  REFERENCE_AUTHOR: {
+    label: "First author",
   },
   TITLE: {
     isFullWidth: true,
     label: "Title",
-    readOnly: false,
   },
 };
-export const FIELD_NAME = {
-  AUTHOR: "referenceAuthor",
-  CELLXGENE_COLLECTION_ID: "cellxgeneCollectionId",
-  CONTACT_EMAIL: "contactEmail",
-  DOI: "doi",
-  HCA_PROJECT_ID: "hcaProjectId",
-  TITLE: "title",
-} as const;

--- a/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Add/components/GeneralInfo/common/utils.ts
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Add/components/GeneralInfo/common/utils.ts
@@ -1,0 +1,22 @@
+import { PUBLICATION_STATUS } from "../../../../../../../../../../../../../views/AddNewSourceDatasetView/common/entities";
+import { TabsProps } from "../../../../../../../../Tabs/tabs";
+
+/**
+ * Returns tabs for the general info section.
+ * @param hasDoi - Whether the source dataset has a DOI.
+ * @returns tabs.
+ */
+export function getSectionTabs(hasDoi: boolean): TabsProps["tabs"] {
+  return [
+    {
+      disabled: false,
+      label: "Published",
+      value: PUBLICATION_STATUS.PUBLISHED,
+    },
+    {
+      disabled: hasDoi, // Unpublished tab is disabled if the source dataset has a DOI.
+      label: "Unpublished",
+      value: PUBLICATION_STATUS.UNPUBLISHED,
+    },
+  ];
+}

--- a/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Add/components/GeneralInfo/generalInfo.styles.ts
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Add/components/GeneralInfo/generalInfo.styles.ts
@@ -1,0 +1,28 @@
+import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
+import { sectionPadding } from "@databiosphere/findable-ui/lib/components/common/Section/section.styles";
+import {
+  mediaDesktopSmallUp,
+  mediaTabletUp,
+} from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
+import styled from "@emotion/styled";
+
+export const SectionCard = styled(FluidPaper)`
+  ${mediaTabletUp} {
+    grid-column: 6 / span 7;
+  }
+
+  ${mediaDesktopSmallUp} {
+    grid-template-columns: 1fr 1fr;
+  }
+`;
+
+export const SectionContent = styled.div`
+  ${sectionPadding};
+  display: grid;
+  gap: 20px;
+  grid-template-columns: 1fr;
+
+  ${mediaDesktopSmallUp} {
+    grid-template-columns: 1fr 1fr;
+  }
+`;

--- a/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Add/components/GeneralInfo/generalInfo.tsx
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Add/components/GeneralInfo/generalInfo.tsx
@@ -1,41 +1,118 @@
+import { Fragment, useCallback, useState } from "react";
 import { Controller } from "react-hook-form";
 import { FormMethod } from "../../../../../../../../../../../../hooks/useForm/common/entities";
-import { NewSourceDatasetData } from "../../../../../../../../../../../../views/AddNewSourceDatasetView/common/entities";
+import { FIELD_NAME } from "../../../../../../../../../../../../views/AddNewSourceDatasetView/common/constants";
+import {
+  NewSourceDatasetData,
+  PUBLICATION_STATUS,
+} from "../../../../../../../../../../../../views/AddNewSourceDatasetView/common/entities";
 import { Input } from "../../../../../../../../../../../common/Form/components/Input/input";
+import { Tabs } from "../../../../../../../Tabs/tabs";
 import {
   Section,
-  SectionCard,
   SectionHero,
   SectionTitle,
 } from "../../../../../../section.styles";
-import { DEFAULT_INPUT_PROPS, FIELD_NAME } from "../../../../common/constants";
+import { DEFAULT_INPUT_PROPS } from "../../../../common/constants";
+import { getSectionTabs } from "./common/utils";
+import { SectionCard, SectionContent } from "./generalInfo.styles";
 
 export interface GeneralInfoProps {
   formMethod: FormMethod<NewSourceDatasetData>;
 }
 
 export const GeneralInfo = ({ formMethod }: GeneralInfoProps): JSX.Element => {
-  const { control, formState } = formMethod;
+  const [publicationStatus, setPublicationStatus] =
+    useState<PUBLICATION_STATUS>(PUBLICATION_STATUS.PUBLISHED);
+  const { clearErrors, control, formState, setValue, watch } = formMethod;
   const { errors } = formState;
+  const hasDoi = Boolean(watch(FIELD_NAME.DOI));
+
+  // Callback to handle tab change; clears errors, sets publication status, and updates form value.
+  const onTabChange = useCallback(
+    (value: PUBLICATION_STATUS): void => {
+      clearErrors();
+      setPublicationStatus(value);
+      setValue(FIELD_NAME.PUBLICATION_STATUS, value);
+    },
+    [clearErrors, setValue]
+  );
+
   return (
     <Section>
       <SectionHero>
         <SectionTitle>General info</SectionTitle>
       </SectionHero>
       <SectionCard>
-        <Controller
-          control={control}
-          name={FIELD_NAME.DOI}
-          render={({ field }): JSX.Element => (
-            <Input
-              {...field}
-              {...DEFAULT_INPUT_PROPS.DOI}
-              error={Boolean(errors[FIELD_NAME.DOI])}
-              helperText={errors[FIELD_NAME.DOI]?.message}
-              isFilled={Boolean(field.value)}
-            />
-          )}
+        <Tabs
+          onTabChange={onTabChange}
+          tabs={getSectionTabs(hasDoi)}
+          value={publicationStatus}
         />
+        <SectionContent>
+          {publicationStatus === PUBLICATION_STATUS.PUBLISHED ? (
+            <Controller
+              control={control}
+              key={FIELD_NAME.DOI}
+              name={FIELD_NAME.DOI}
+              render={({ field }): JSX.Element => (
+                <Input
+                  {...field}
+                  {...DEFAULT_INPUT_PROPS.DOI}
+                  error={Boolean(errors[FIELD_NAME.DOI])}
+                  helperText={errors[FIELD_NAME.DOI]?.message}
+                  isFilled={Boolean(field.value)}
+                />
+              )}
+            />
+          ) : (
+            <Fragment>
+              <Controller
+                control={control}
+                key={FIELD_NAME.REFERENCE_AUTHOR}
+                name={FIELD_NAME.REFERENCE_AUTHOR}
+                render={({ field }): JSX.Element => (
+                  <Input
+                    {...field}
+                    {...DEFAULT_INPUT_PROPS.REFERENCE_AUTHOR}
+                    error={Boolean(errors[FIELD_NAME.REFERENCE_AUTHOR])}
+                    helperText={errors[FIELD_NAME.REFERENCE_AUTHOR]?.message}
+                    isFilled={Boolean(field.value)}
+                  />
+                )}
+              />
+              <Controller
+                control={control}
+                key={FIELD_NAME.CONTACT_EMAIL}
+                name={FIELD_NAME.CONTACT_EMAIL}
+                render={({ field }): JSX.Element => (
+                  <Input
+                    {...field}
+                    {...DEFAULT_INPUT_PROPS.CONTACT_EMAIL}
+                    error={Boolean(errors[FIELD_NAME.CONTACT_EMAIL])}
+                    helperText={errors[FIELD_NAME.CONTACT_EMAIL]?.message}
+                    isFilled={Boolean(field.value)}
+                  />
+                )}
+              />
+              <Controller
+                control={control}
+                key={FIELD_NAME.TITLE}
+                name={FIELD_NAME.TITLE}
+                render={({ field }): JSX.Element => (
+                  <Input
+                    {...field}
+                    {...DEFAULT_INPUT_PROPS.TITLE}
+                    error={Boolean(errors[FIELD_NAME.TITLE])}
+                    helperText={errors[FIELD_NAME.TITLE]?.message}
+                    isFilled={Boolean(field.value)}
+                    label="Working title"
+                  />
+                )}
+              />
+            </Fragment>
+          )}
+        </SectionContent>
       </SectionCard>
     </Section>
   );

--- a/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Edit/components/GeneralInfo/common/utils.ts
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Edit/components/GeneralInfo/common/utils.ts
@@ -1,0 +1,26 @@
+import { PUBLICATION_STATUS } from "../../../../../../../../../../../../../views/AddNewSourceDatasetView/common/entities";
+import { TabsProps } from "../../../../../../../../Tabs/tabs";
+
+/**
+ * Returns tabs for the general info section.
+ * @param isPublished - Whether the source dataset is published.
+ * @param hasDoi - Whether the source dataset has a DOI.
+ * @returns tabs.
+ */
+export function getSectionTabs(
+  isPublished: boolean,
+  hasDoi: boolean
+): TabsProps["tabs"] {
+  return [
+    {
+      disabled: false,
+      label: "Published",
+      value: PUBLICATION_STATUS.PUBLISHED,
+    },
+    {
+      disabled: isPublished || hasDoi, // Unpublished tab is disabled if the source dataset is published or is edited with a DOI.
+      label: "Unpublished",
+      value: PUBLICATION_STATUS.UNPUBLISHED,
+    },
+  ];
+}

--- a/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Edit/components/GeneralInfo/generalInfo.styles.ts
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Edit/components/GeneralInfo/generalInfo.styles.ts
@@ -1,0 +1,28 @@
+import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
+import { sectionPadding } from "@databiosphere/findable-ui/lib/components/common/Section/section.styles";
+import {
+  mediaDesktopSmallUp,
+  mediaTabletUp,
+} from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
+import styled from "@emotion/styled";
+
+export const SectionCard = styled(FluidPaper)`
+  ${mediaTabletUp} {
+    grid-column: 6 / span 7;
+  }
+
+  ${mediaDesktopSmallUp} {
+    grid-template-columns: 1fr 1fr;
+  }
+`;
+
+export const SectionContent = styled.div`
+  ${sectionPadding};
+  display: grid;
+  gap: 20px;
+  grid-template-columns: 1fr;
+
+  ${mediaDesktopSmallUp} {
+    grid-template-columns: 1fr 1fr;
+  }
+`;

--- a/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Edit/components/GeneralInfo/generalInfo.tsx
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Edit/components/GeneralInfo/generalInfo.tsx
@@ -1,5 +1,6 @@
 import { ErrorIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/ErrorIcon/errorIcon";
 import { SuccessIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/SuccessIcon/successIcon";
+import { Fragment, useCallback, useEffect, useState } from "react";
 import { Controller } from "react-hook-form";
 import {
   DOI_STATUS,
@@ -7,63 +8,156 @@ import {
 } from "../../../../../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { FormMethod } from "../../../../../../../../../../../../hooks/useForm/common/entities";
 import { getSourceDatasetCitation } from "../../../../../../../../../../../../viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders";
+import { PUBLICATION_STATUS } from "../../../../../../../../../../../../views/AddNewSourceDatasetView/common/entities";
+import { FIELD_NAME } from "../../../../../../../../../../../../views/EditSourceDatasetView/common/constants";
 import { SourceDatasetEditData } from "../../../../../../../../../../../../views/EditSourceDatasetView/common/entities";
 import { Input } from "../../../../../../../../../../../common/Form/components/Input/input";
+import { Tabs } from "../../../../../../../Tabs/tabs";
 import {
   Section,
-  SectionCard,
   SectionHero,
   SectionTitle,
 } from "../../../../../../section.styles";
-import { DEFAULT_INPUT_PROPS, FIELD_NAME } from "../../../../common/constants";
+import { DEFAULT_INPUT_PROPS } from "../../../../common/constants";
+import { getSectionTabs } from "./common/utils";
+import { SectionCard, SectionContent } from "./generalInfo.styles";
 
 export interface GeneralInfoProps {
   formMethod: FormMethod<SourceDatasetEditData, HCAAtlasTrackerSourceDataset>;
+  sdPublicationStatus: PUBLICATION_STATUS;
 }
 
-export const GeneralInfo = ({ formMethod }: GeneralInfoProps): JSX.Element => {
-  const { control, data: sourceDataset, formState } = formMethod;
+export const GeneralInfo = ({
+  formMethod,
+  sdPublicationStatus,
+}: GeneralInfoProps): JSX.Element => {
+  const [publicationStatus, setPublicationStatus] =
+    useState<PUBLICATION_STATUS>(PUBLICATION_STATUS.PUBLISHED);
+  const {
+    clearErrors,
+    control,
+    data: sourceDataset,
+    formState,
+    setValue,
+    watch,
+  } = formMethod;
   const { errors } = formState;
+  const hasDoi = Boolean(watch(FIELD_NAME.DOI));
+  const isPublished = sdPublicationStatus === PUBLICATION_STATUS.PUBLISHED;
+
+  // Callback to handle tab change; clears errors, sets publication status, and updates form value.
+  const onTabChange = useCallback(
+    (value: PUBLICATION_STATUS): void => {
+      clearErrors();
+      setPublicationStatus(value);
+      setValue(FIELD_NAME.PUBLICATION_STATUS, value);
+    },
+    [clearErrors, setValue]
+  );
+
+  useEffect(() => {
+    setPublicationStatus(sdPublicationStatus);
+  }, [sdPublicationStatus]);
+
   return (
     <Section>
       <SectionHero>
         <SectionTitle>General info</SectionTitle>
       </SectionHero>
       <SectionCard>
-        <Controller
-          control={control}
-          name={FIELD_NAME.DOI}
-          render={({ field }): JSX.Element => (
-            <Input
-              {...field}
-              {...DEFAULT_INPUT_PROPS.DOI}
-              endAdornment={renderDoiEndAdornment(sourceDataset)}
-              error={Boolean(errors[FIELD_NAME.DOI])}
-              helperText={renderDoiHelperText(
-                sourceDataset,
-                errors[FIELD_NAME.DOI]?.message
-              )}
-              isFilled={Boolean(field.value)}
-              readOnly={true}
-            />
-          )}
+        <Tabs
+          onTabChange={onTabChange}
+          tabs={getSectionTabs(isPublished, hasDoi)}
+          value={publicationStatus}
         />
-        <Controller
-          control={control}
-          name={FIELD_NAME.TITLE}
-          render={({ field }): JSX.Element => {
-            return (
-              <Input
-                {...field}
-                {...DEFAULT_INPUT_PROPS.TITLE}
-                error={Boolean(errors[FIELD_NAME.TITLE])}
-                helperText={errors[FIELD_NAME.TITLE]?.message}
-                isFilled={Boolean(field.value)}
-                readOnly={true}
+        <SectionContent>
+          {publicationStatus ? (
+            <Fragment>
+              <Controller
+                control={control}
+                key={FIELD_NAME.DOI}
+                name={FIELD_NAME.DOI}
+                render={({ field }): JSX.Element => (
+                  <Input
+                    {...field}
+                    {...DEFAULT_INPUT_PROPS.DOI}
+                    endAdornment={renderDoiEndAdornment(sourceDataset)}
+                    error={Boolean(errors[FIELD_NAME.DOI])}
+                    helperText={renderDoiHelperText(
+                      sourceDataset,
+                      errors[FIELD_NAME.DOI]?.message
+                    )}
+                    isFilled={Boolean(field.value)}
+                    readOnly={isPublished}
+                  />
+                )}
               />
-            );
-          }}
-        />
+              <Controller
+                control={control}
+                key={FIELD_NAME.TITLE}
+                name={FIELD_NAME.TITLE}
+                render={({ field }): JSX.Element => {
+                  return (
+                    <Input
+                      {...field}
+                      {...DEFAULT_INPUT_PROPS.TITLE}
+                      error={Boolean(errors[FIELD_NAME.TITLE])}
+                      helperText={errors[FIELD_NAME.TITLE]?.message}
+                      isFilled={Boolean(field.value)}
+                      readOnly={true}
+                    />
+                  );
+                }}
+              />
+            </Fragment>
+          ) : (
+            <Fragment>
+              <Controller
+                control={control}
+                key={FIELD_NAME.REFERENCE_AUTHOR}
+                name={FIELD_NAME.REFERENCE_AUTHOR}
+                render={({ field }): JSX.Element => (
+                  <Input
+                    {...field}
+                    {...DEFAULT_INPUT_PROPS.REFERENCE_AUTHOR}
+                    error={Boolean(errors[FIELD_NAME.REFERENCE_AUTHOR])}
+                    helperText={errors[FIELD_NAME.REFERENCE_AUTHOR]?.message}
+                    isFilled={Boolean(field.value)}
+                  />
+                )}
+              />
+              <Controller
+                control={control}
+                key={FIELD_NAME.CONTACT_EMAIL}
+                name={FIELD_NAME.CONTACT_EMAIL}
+                render={({ field }): JSX.Element => (
+                  <Input
+                    {...field}
+                    {...DEFAULT_INPUT_PROPS.CONTACT_EMAIL}
+                    error={Boolean(errors[FIELD_NAME.CONTACT_EMAIL])}
+                    helperText={errors[FIELD_NAME.CONTACT_EMAIL]?.message}
+                    isFilled={Boolean(field.value)}
+                  />
+                )}
+              />
+              <Controller
+                control={control}
+                key={FIELD_NAME.TITLE}
+                name={FIELD_NAME.TITLE}
+                render={({ field }): JSX.Element => (
+                  <Input
+                    {...field}
+                    {...DEFAULT_INPUT_PROPS.TITLE}
+                    error={Boolean(errors[FIELD_NAME.TITLE])}
+                    helperText={errors[FIELD_NAME.TITLE]?.message}
+                    isFilled={Boolean(field.value)}
+                    label="Working title"
+                  />
+                )}
+              />
+            </Fragment>
+          )}
+        </SectionContent>
       </SectionCard>
     </Section>
   );
@@ -76,11 +170,17 @@ export const GeneralInfo = ({ formMethod }: GeneralInfoProps): JSX.Element => {
  */
 function renderDoiEndAdornment(
   sourceDataset: HCAAtlasTrackerSourceDataset | undefined
-): JSX.Element {
-  if (sourceDataset?.doiStatus === DOI_STATUS.OK) {
-    return <SuccessIcon color="success" fontSize="small" />;
+): JSX.Element | undefined {
+  switch (sourceDataset?.doiStatus) {
+    case DOI_STATUS.DOI_NOT_ON_CROSSREF:
+      return <ErrorIcon color="error" fontSize="small" />;
+    case DOI_STATUS.NA:
+      return;
+    case DOI_STATUS.OK:
+      return <SuccessIcon color="success" fontSize="small" />;
+    default:
+      return;
   }
-  return <ErrorIcon color="error" fontSize="small" />;
 }
 
 /**

--- a/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Edit/components/Identifiers/identifiers.tsx
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/Edit/components/Identifiers/identifiers.tsx
@@ -1,6 +1,7 @@
 import { Controller } from "react-hook-form";
 import { HCAAtlasTrackerSourceDataset } from "../../../../../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { FormMethod } from "../../../../../../../../../../../../hooks/useForm/common/entities";
+import { FIELD_NAME } from "../../../../../../../../../../../../views/EditSourceDatasetView/common/constants";
 import { SourceDatasetEditData } from "../../../../../../../../../../../../views/EditSourceDatasetView/common/entities";
 import { Input } from "../../../../../../../../../../../common/Form/components/Input/input";
 import {
@@ -9,7 +10,7 @@ import {
   SectionHero,
   SectionTitle,
 } from "../../../../../../section.styles";
-import { DEFAULT_INPUT_PROPS, FIELD_NAME } from "../../../../common/constants";
+import { DEFAULT_INPUT_PROPS } from "../../../../common/constants";
 
 export interface IdentifiersProps {
   formMethod: FormMethod<SourceDatasetEditData, HCAAtlasTrackerSourceDataset>;

--- a/app/components/Detail/components/TrackerForm/components/Tabs/tabs.styles.ts
+++ b/app/components/Detail/components/TrackerForm/components/Tabs/tabs.styles.ts
@@ -1,0 +1,20 @@
+import { mediaTabletUp } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
+import styled from "@emotion/styled";
+import { Tabs as MTabs } from "@mui/material";
+
+export const Tabs = styled(MTabs)`
+  &.MuiTabs-root {
+    .MuiTabs-scroller {
+      margin-top: 2px;
+      padding: 0 16px;
+
+      ${mediaTabletUp} {
+        padding: 0 20px;
+      }
+
+      .MuiTab-root {
+        flex: 1;
+      }
+    }
+  }
+`;

--- a/app/components/Detail/components/TrackerForm/components/Tabs/tabs.tsx
+++ b/app/components/Detail/components/TrackerForm/components/Tabs/tabs.tsx
@@ -1,0 +1,30 @@
+import {
+  OnTabChangeFn,
+  Tab as DXTab,
+  TabsProps as DXTabsProps,
+} from "@databiosphere/findable-ui/lib/components/common/Tabs/tabs";
+import { Tab as MTab } from "@mui/material";
+import { Tabs as SectionTabs } from "./tabs.styles";
+
+interface Tab extends DXTab {
+  disabled?: boolean;
+}
+
+export interface TabsProps extends Omit<DXTabsProps, "tabs" | "onTabChange"> {
+  onTabChange?: OnTabChangeFn;
+  tabs: Tab[];
+}
+
+export const Tabs = ({ onTabChange, tabs, value }: TabsProps): JSX.Element => {
+  return (
+    <SectionTabs
+      onChange={(_, tabValue): void => onTabChange?.(tabValue)}
+      scrollButtons={false}
+      value={value}
+    >
+      {tabs.map((tab, t) => (
+        <MTab key={t} {...tab} />
+      ))}
+    </SectionTabs>
+  );
+};

--- a/app/hooks/useFetchSourceDataset.ts
+++ b/app/hooks/useFetchSourceDataset.ts
@@ -22,21 +22,19 @@ export const useFetchSourceDataset = (
   atlasId: AtlasId,
   sdId: string
 ): UseFetchSourceDataset => {
-  const { token } = useAuthentication();
-  const {
-    data: sourceDatasets, // TODO rename to source dataset.
-    isIdle,
-    isLoading,
-    run,
-  } = useAsync<HCAAtlasTrackerSourceDataset[] | undefined>(); // TODO update to singular dataset here and elsewhere.
+  const { isAuthenticated, token } = useAuthentication();
+  const { data: sourceDataset, run } = useAsync<
+    HCAAtlasTrackerSourceDataset | undefined
+  >();
 
   const fetchSourceDataset = useCallback(
     async (
       atlasId: AtlasId,
+      sdId: string,
       accessToken: string
-    ): Promise<HCAAtlasTrackerSourceDataset[] | undefined> => {
+    ): Promise<HCAAtlasTrackerSourceDataset | undefined> => {
       const res = await fetch(
-        getRequestURL(API.ATLAS_SOURCE_DATASETS, atlasId), // TODO update API.
+        getRequestURL(API.ATLAS_SOURCE_DATASET, atlasId, sdId),
         getFetchOptions(METHOD.GET, accessToken)
       );
       if (isFetchStatusOk(res.status)) {
@@ -55,11 +53,11 @@ export const useFetchSourceDataset = (
 
   useEffect(() => {
     if (!token) return;
-    run(fetchSourceDataset(atlasId, token));
-  }, [atlasId, fetchSourceDataset, run, token]);
+    run(fetchSourceDataset(atlasId, sdId, token));
+  }, [atlasId, fetchSourceDataset, run, sdId, token]);
 
   return {
-    isLoading: isIdle || isLoading,
-    sourceDataset: sourceDatasets?.find(({ id }) => id === sdId),
+    isLoading: isAuthenticated ? !sourceDataset : false,
+    sourceDataset,
   };
 };

--- a/app/hooks/useForm/common/entities.ts
+++ b/app/hooks/useForm/common/entities.ts
@@ -3,9 +3,8 @@ import { InferType, ObjectSchema } from "yup";
 import { METHOD } from "../../../common/entities";
 import { UseForm } from "../useForm";
 
-export type CustomUseFormReturn<T extends FieldValues> = Pick<
-  UseFormReturn<YupValidatedFormValues<T>>,
-  "control" | "formState" | "handleSubmit"
+export type CustomUseFormReturn<T extends FieldValues> = UseFormReturn<
+  YupValidatedFormValues<T>
 >;
 
 export type FormMethod<T extends FieldValues, R = undefined> = UseForm<T, R>;

--- a/app/views/AddNewSourceDatasetView/common/constants.ts
+++ b/app/views/AddNewSourceDatasetView/common/constants.ts
@@ -1,0 +1,7 @@
+export const FIELD_NAME = {
+  CONTACT_EMAIL: "contactEmail",
+  DOI: "doi",
+  PUBLICATION_STATUS: "publicationStatus",
+  REFERENCE_AUTHOR: "referenceAuthor",
+  TITLE: "title",
+} as const;

--- a/app/views/AddNewSourceDatasetView/common/entities.ts
+++ b/app/views/AddNewSourceDatasetView/common/entities.ts
@@ -2,3 +2,8 @@ import { InferType } from "yup";
 import { newSourceDatasetSchema } from "./schema";
 
 export type NewSourceDatasetData = InferType<typeof newSourceDatasetSchema>;
+
+export enum PUBLICATION_STATUS {
+  PUBLISHED = 1,
+  UNPUBLISHED = 0,
+}

--- a/app/views/AddNewSourceDatasetView/common/schema.ts
+++ b/app/views/AddNewSourceDatasetView/common/schema.ts
@@ -1,11 +1,46 @@
-import { object, string } from "yup";
+import { mixed, object, string } from "yup";
 import { isDoi } from "../../../utils/doi";
+import { FIELD_NAME } from "./constants";
+import { PUBLICATION_STATUS } from "./entities";
 
 export const newSourceDatasetSchema = object({
-  doi: string()
+  [FIELD_NAME.CONTACT_EMAIL]: string()
     .default("")
-    .required("DOI is required")
-    .test("is-doi", "DOI must be a syntactically-valid DOI", (value) =>
-      isDoi(value)
-    ),
+    .when(FIELD_NAME.PUBLICATION_STATUS, {
+      is: PUBLICATION_STATUS.PUBLISHED,
+      otherwise: (schema) =>
+        schema
+          .email("Email must be a valid email address")
+          .required("Email is required"),
+      then: (schema) => schema.notRequired(),
+    }),
+  [FIELD_NAME.DOI]: string()
+    .default("")
+    .when(FIELD_NAME.PUBLICATION_STATUS, {
+      is: PUBLICATION_STATUS.PUBLISHED,
+      otherwise: (schema) => schema.notRequired(),
+      then: (schema) =>
+        schema
+          .required("DOI is required")
+          .test("is-doi", "DOI must be a syntactically-valid DOI", (value) =>
+            isDoi(value)
+          ),
+    }),
+  [FIELD_NAME.PUBLICATION_STATUS]: mixed<PUBLICATION_STATUS>().default(
+    PUBLICATION_STATUS.PUBLISHED
+  ),
+  [FIELD_NAME.REFERENCE_AUTHOR]: string()
+    .default("")
+    .when(FIELD_NAME.PUBLICATION_STATUS, {
+      is: PUBLICATION_STATUS.PUBLISHED,
+      otherwise: (schema) => schema.required("Author is required"),
+      then: (schema) => schema.notRequired(),
+    }),
+  [FIELD_NAME.TITLE]: string()
+    .default("")
+    .when(FIELD_NAME.PUBLICATION_STATUS, {
+      is: PUBLICATION_STATUS.PUBLISHED,
+      otherwise: (schema) => schema.required("Title is required"),
+      then: (schema) => schema.notRequired(),
+    }),
 }).strict(true);

--- a/app/views/AddNewSourceDatasetView/hooks/useAddSourceDatasetForm.tsx
+++ b/app/views/AddNewSourceDatasetView/hooks/useAddSourceDatasetForm.tsx
@@ -3,7 +3,8 @@ import { getRouteURL } from "../../../common/utils";
 import { FormMethod } from "../../../hooks/useForm/common/entities";
 import { useForm } from "../../../hooks/useForm/useForm";
 import { ROUTE } from "../../../routes/constants";
-import { NewSourceDatasetData } from "../common/entities";
+import { FIELD_NAME } from "../common/constants";
+import { NewSourceDatasetData, PUBLICATION_STATUS } from "../common/entities";
 import { newSourceDatasetSchema } from "../common/schema";
 
 const SCHEMA = newSourceDatasetSchema;
@@ -19,4 +20,23 @@ export const useAddSourceDatasetForm = (): FormMethod<NewSourceDatasetData> => {
  */
 export function onSuccess(atlasId: string, sdId: string): void {
   Router.push(getRouteURL(ROUTE.EDIT_ATLAS_SOURCE_DATASET, atlasId, sdId));
+}
+
+/**
+ * Returns a list of source dataset fields to be unregistered prior to submission.
+ * @param payload - Source dataset data.
+ * @returns fields to be unregistered.
+ */
+export function unregisterSourceDatasetFields(
+  payload: NewSourceDatasetData
+): (keyof NewSourceDatasetData)[] {
+  if (payload.publicationStatus === PUBLICATION_STATUS.PUBLISHED) {
+    return [
+      FIELD_NAME.CONTACT_EMAIL,
+      FIELD_NAME.PUBLICATION_STATUS,
+      FIELD_NAME.REFERENCE_AUTHOR,
+      FIELD_NAME.TITLE,
+    ];
+  }
+  return [FIELD_NAME.DOI, FIELD_NAME.PUBLICATION_STATUS];
 }

--- a/app/views/EditSourceDatasetView/common/constants.ts
+++ b/app/views/EditSourceDatasetView/common/constants.ts
@@ -1,0 +1,7 @@
+import { FIELD_NAME as NEW_SOURCE_DATASET_FIELD_NAME } from "../../AddNewSourceDatasetView/common/constants";
+
+export const FIELD_NAME = {
+  ...NEW_SOURCE_DATASET_FIELD_NAME,
+  CELLXGENE_COLLECTION_ID: "cellxgeneCollectionId",
+  HCA_PROJECT_ID: "hcaProjectId",
+} as const;

--- a/app/views/EditSourceDatasetView/common/schema.ts
+++ b/app/views/EditSourceDatasetView/common/schema.ts
@@ -5,6 +5,5 @@ export const sourceDatasetEditSchema = newSourceDatasetSchema.concat(
   object({
     cellxgeneCollectionId: string().default("").notRequired(),
     hcaProjectId: string().default("").notRequired(),
-    title: string().default("").required("Title is required"),
   })
 );

--- a/app/views/EditSourceDatasetView/editSourceDatasetView.tsx
+++ b/app/views/EditSourceDatasetView/editSourceDatasetView.tsx
@@ -7,7 +7,10 @@ import { EditSourceDataset } from "../../components/Detail/components/EditSource
 import { DetailView } from "../../components/Layout/components/Detail/detailView";
 import { useFetchAtlas } from "../../hooks/useFetchAtlas";
 import { getBreadcrumbs } from "./common/utils";
-import { useEditSourceDatasetForm } from "./hooks/useEditSourceDatasetForm";
+import {
+  mapPublicationStatus,
+  useEditSourceDatasetForm,
+} from "./hooks/useEditSourceDatasetForm";
 
 interface EditSourceDatasetViewProps {
   atlasId: AtlasId;
@@ -21,6 +24,7 @@ export const EditSourceDatasetView = ({
   const { atlas } = useFetchAtlas(atlasId);
   const formMethod = useEditSourceDatasetForm(atlasId, sdId);
   const { data: sourceDataset } = formMethod;
+  const { doi } = sourceDataset || {};
   return (
     <DetailView
       breadcrumbs={
@@ -29,7 +33,12 @@ export const EditSourceDatasetView = ({
         />
       }
       mainColumn={
-        <EditSourceDataset atlasId={atlasId} formMethod={formMethod} />
+        <EditSourceDataset
+          atlasId={atlasId}
+          formMethod={formMethod}
+          sdId={sdId}
+          sdPublicationStatus={mapPublicationStatus(doi)}
+        />
       }
       title={sourceDataset?.title || "Edit Source Dataset"}
     />

--- a/app/views/EditSourceDatasetView/hooks/useEditSourceDatasetForm.tsx
+++ b/app/views/EditSourceDatasetView/hooks/useEditSourceDatasetForm.tsx
@@ -1,3 +1,4 @@
+import Router from "next/router";
 import {
   ALTAS_ECOSYSTEM_PATHS,
   ATLAS_ECOSYSTEM_URLS,
@@ -7,10 +8,13 @@ import {
   HCAAtlasTrackerSourceDataset,
   SourceDatasetId,
 } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
-import { FIELD_NAME } from "../../../components/Detail/components/TrackerForm/components/Section/components/SourceDataset/common/constants";
+import { getRouteURL } from "../../../common/utils";
 import { useFetchSourceDataset } from "../../../hooks/useFetchSourceDataset";
 import { FormMethod } from "../../../hooks/useForm/common/entities";
 import { useForm } from "../../../hooks/useForm/useForm";
+import { ROUTE } from "../../../routes/constants";
+import { PUBLICATION_STATUS } from "../../AddNewSourceDatasetView/common/entities";
+import { FIELD_NAME } from "../common/constants";
 import { SourceDatasetEditData } from "../common/entities";
 import { sourceDatasetEditSchema } from "../common/schema";
 
@@ -27,6 +31,15 @@ export const useEditSourceDatasetForm = (
     mapSchemaValues
   );
 };
+
+/**
+ * Side effect "onSuccess"; redirects to the edit source dataset page.
+ * @param atlasId - Atlas ID.
+ * @param sdId - Source dataset ID.
+ */
+export function onSuccess(atlasId: string, sdId: string): void {
+  Router.push(getRouteURL(ROUTE.EDIT_ATLAS_SOURCE_DATASET, atlasId, sdId));
+}
 
 /**
  * Maps CELLxGENE collection ID to URL.
@@ -51,6 +64,15 @@ function mapHCAProjectId(hcaProjectId: string | null): string {
 }
 
 /**
+ * Maps publication status.
+ * @param doi - DOI.
+ * @returns publication status.
+ */
+export function mapPublicationStatus(doi?: string | null): PUBLICATION_STATUS {
+  return doi ? PUBLICATION_STATUS.PUBLISHED : PUBLICATION_STATUS.UNPUBLISHED;
+}
+
+/**
  * Returns schema default values mapped from source dataset.
  * @param sourceDataset - Source dataset.
  * @returns schema default values.
@@ -63,8 +85,37 @@ function mapSchemaValues(
     [FIELD_NAME.CELLXGENE_COLLECTION_ID]: mapCELLxGENECollectionId(
       sourceDataset.cellxgeneCollectionId
     ),
+    [FIELD_NAME.CONTACT_EMAIL]: sourceDataset.contactEmail ?? "",
     [FIELD_NAME.DOI]: sourceDataset.doi ?? "",
     [FIELD_NAME.HCA_PROJECT_ID]: mapHCAProjectId(sourceDataset.hcaProjectId),
+    [FIELD_NAME.PUBLICATION_STATUS]: mapPublicationStatus(sourceDataset.doi),
+    [FIELD_NAME.REFERENCE_AUTHOR]: sourceDataset.referenceAuthor ?? "",
     [FIELD_NAME.TITLE]: sourceDataset.title ?? "",
   };
+}
+
+/**
+ * Returns a list of source dataset fields to be unregistered prior to submission.
+ * @param payload - Source dataset data.
+ * @returns fields to be unregistered.
+ */
+export function unregisterSourceDatasetFields(
+  payload: SourceDatasetEditData
+): (keyof SourceDatasetEditData)[] {
+  if (payload.publicationStatus === PUBLICATION_STATUS.PUBLISHED) {
+    return [
+      FIELD_NAME.CELLXGENE_COLLECTION_ID,
+      FIELD_NAME.CONTACT_EMAIL,
+      FIELD_NAME.HCA_PROJECT_ID,
+      FIELD_NAME.PUBLICATION_STATUS,
+      FIELD_NAME.REFERENCE_AUTHOR,
+      FIELD_NAME.TITLE,
+    ];
+  }
+  return [
+    FIELD_NAME.CELLXGENE_COLLECTION_ID,
+    FIELD_NAME.DOI,
+    FIELD_NAME.HCA_PROJECT_ID,
+    FIELD_NAME.PUBLICATION_STATUS,
+  ];
 }


### PR DESCRIPTION
Closes #130.

TODOs:

- Should only render form if authenticated with fetched data: should resolve things like the initial tab state ("Published" versus "Unpublished"),
- UI updates to Identifiers section,
- Updates to the disabling of "Save" button (see https://github.com/clevercanary/hca-atlas-tracker/issues/133).