### PR TITLE
feat: use existing dataset when creating a dataset with an already-used doi (#139, #152)

### DIFF
--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -38,10 +38,16 @@ export async function createSourceDataset(
 
   const existingDataset = await getExistingDataset(inputData);
   if (existingDataset) {
-    await query(
+    const queryResult = await query(
       "UPDATE hat.atlases SET source_datasets=source_datasets||$1 WHERE id=$2 AND NOT source_datasets @> $1",
       [JSON.stringify([existingDataset.id]), atlasId]
     );
+    if (queryResult.rowCount === 0)
+      throw new ValidationError(
+        "DOI already exists in this atlas",
+        undefined,
+        "doi"
+      );
     return existingDataset;
   }
 

--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -36,6 +36,15 @@ export async function createSourceDataset(
     throw new NotFoundError(`Atlas with ID ${atlasId} doesn't exist`);
   }
 
+  const existingDataset = await getExistingDataset(inputData);
+  if (existingDataset) {
+    await query(
+      "UPDATE hat.atlases SET source_datasets=source_datasets||$1 WHERE id=$2 AND NOT source_datasets @> $1",
+      [JSON.stringify([existingDataset.id]), atlasId]
+    );
+    return existingDataset;
+  }
+
   const newInfo = await sourceDatasetInputDataToDbData(inputData);
 
   const client = await getPoolClient();
@@ -61,6 +70,26 @@ export async function createSourceDataset(
   } finally {
     client.release();
   }
+}
+
+/**
+ * Get existing source dataset matching values submitted to create a source dataset.
+ * @param inputData - Source dataset creation values.
+ * @returns existing dataset or null.
+ */
+async function getExistingDataset(
+  inputData: NewSourceDatasetData
+): Promise<HCAAtlasTrackerDBSourceDataset | null> {
+  if (!inputData.doi) return null;
+  const doi = normalizeDoi(inputData.doi);
+  return (
+    (
+      await query<HCAAtlasTrackerDBSourceDataset>(
+        "SELECT * FROM hat.source_datasets WHERE doi=$1 OR sd_info->'publication'->>'preprintOfDoi'=$1 OR sd_info->'publication'->>'hasPreprintDoi'=$1",
+        [doi]
+      )
+    ).rows[0] ?? null
+  );
 }
 
 /**

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -30,96 +30,6 @@ export const INITIAL_TEST_USERS = [
 
 export const TEST_USERS = [...INITIAL_TEST_USERS, USER_NONEXISTENT, USER_NEW];
 
-// SOURCE DATASETS
-
-export const SOURCE_DATASET_DRAFT_OK: TestSourceDataset = {
-  doi: "10.123/sd-draft-ok",
-  doiStatus: DOI_STATUS.OK,
-  id: "d2932506-0af5-4030-920c-07f6beeb817a",
-  publication: {
-    authors: [
-      {
-        name: "draft-ok-author",
-        personalName: null,
-      },
-    ],
-    hasPreprintDoi: null,
-    journal: "draft-ok-journal",
-    preprintOfDoi: null,
-    publicationDate: "2024-04-09",
-    title: "draft-ok-title",
-  },
-};
-
-export const SOURCE_DATASET_DRAFT_NO_CROSSREF: TestSourceDataset = {
-  doi: "10.123/sd-draft-no-crossref",
-  doiStatus: DOI_STATUS.DOI_NOT_ON_CROSSREF,
-  id: "ee67ddcb-e5d8-4240-a8ef-c945657c3321",
-  publication: null,
-};
-
-export const SOURCE_DATASET_PUBLIC_NO_CROSSREF: TestSourceDataset = {
-  doi: "10.123/sd-public-no-crossref",
-  doiStatus: DOI_STATUS.DOI_NOT_ON_CROSSREF,
-  id: "dae11387-d0c2-4160-8f2e-0be27a3a551a",
-  publication: null,
-};
-
-// Source datasets initialized in the database before tests
-export const INITIAL_TEST_SOURCE_DATASETS = [
-  SOURCE_DATASET_DRAFT_OK,
-  SOURCE_DATASET_DRAFT_NO_CROSSREF,
-  SOURCE_DATASET_PUBLIC_NO_CROSSREF,
-];
-
-// ATLASES
-
-export const ATLAS_DRAFT: TestAtlas = {
-  id: "823dcc68-340b-4a61-8883-c61dc4975ce3",
-  integrationLead: null,
-  network: "eye",
-  shortName: "test-draft",
-  sourceDatasets: [
-    SOURCE_DATASET_DRAFT_OK.id,
-    SOURCE_DATASET_DRAFT_NO_CROSSREF.id,
-  ],
-  status: ATLAS_STATUS.DRAFT,
-  version: "1.2",
-  wave: "1",
-};
-
-export const ATLAS_PUBLIC: TestAtlas = {
-  id: "94f62ad0-99cb-4f01-a1cf-cce2d56a8850",
-  integrationLead: null,
-  network: "lung",
-  shortName: "test-public",
-  sourceDatasets: [SOURCE_DATASET_PUBLIC_NO_CROSSREF.id],
-  status: ATLAS_STATUS.PUBLIC,
-  version: "2.3",
-  wave: "1",
-};
-
-export const ATLAS_WITH_IL: TestAtlas = {
-  id: "798b563d-16ff-438a-8e15-77be05b1f8ec",
-  integrationLead: {
-    email: "baz@example.com",
-    name: "Baz",
-  },
-  network: "heart",
-  shortName: "test-with-il",
-  sourceDatasets: [],
-  status: ATLAS_STATUS.DRAFT,
-  version: "2.0",
-  wave: "3",
-};
-
-export const ATLAS_NONEXISTENT = {
-  id: "aa992f01-39ea-4906-ac12-053552561187",
-};
-
-// Atlases initialized in the database before tests
-export const INITIAL_TEST_ATLASES = [ATLAS_DRAFT, ATLAS_PUBLIC, ATLAS_WITH_IL];
-
 // DOIS
 
 export const DOI_NORMAL = "10.123/test";
@@ -142,7 +52,33 @@ export const DOI_JOURNAL_WITH_PREPRINT_COUNTERPART =
 
 export const DOI_PREPRINT_COUNTERPART = "10.123/preprint-counterpart";
 
+export const DOI_PUBLIC_WITH_PREPRINT = "10.123/public-with-preprint";
+
+export const DOI_PUBLIC_WITH_PREPRINT_PREPRINT =
+  "10.123/public-with-preprint-preprint";
+
+export const DOI_PUBLIC_WITH_JOURNAL = "10.123/public-with-journal";
+
+export const DOI_PUBLIC_WITH_JOURNAL_JOURNAL =
+  "10.123/public-with-journal-journal";
+
+export const DOI_DRAFT_OK = "10.123/sd-draft-ok";
+
 // PUBLICATIONS
+
+export const PUBLICATION_DRAFT_OK: PublicationInfo = {
+  authors: [
+    {
+      name: "draft-ok-author",
+      personalName: null,
+    },
+  ],
+  hasPreprintDoi: null,
+  journal: "draft-ok-journal",
+  preprintOfDoi: null,
+  publicationDate: "2024-04-09",
+  title: "draft-ok-title",
+};
 
 export const PUBLICATION_NORMAL: PublicationInfo = {
   authors: [
@@ -267,6 +203,34 @@ export const CROSSREF_WORK_JOURNAL_WITH_PREPRINT_COUNTERPART: CrossrefWork = {
   type: "journal-article",
 };
 
+export const PUBLICATION_PUBLIC_WITH_PREPRINT: PublicationInfo = {
+  authors: [
+    {
+      name: "Bar Foo",
+      personalName: null,
+    },
+  ],
+  hasPreprintDoi: DOI_PUBLIC_WITH_PREPRINT_PREPRINT,
+  journal: "Foo Bar",
+  preprintOfDoi: null,
+  publicationDate: "2024-04-29",
+  title: "Public With Preprint",
+};
+
+export const PUBLICATION_PUBLIC_WITH_JOURNAL: PublicationInfo = {
+  authors: [
+    {
+      name: "Bar Baz",
+      personalName: null,
+    },
+  ],
+  hasPreprintDoi: null,
+  journal: "Baz Bar",
+  preprintOfDoi: DOI_PUBLIC_WITH_JOURNAL_JOURNAL,
+  publicationDate: "2024-04-30",
+  title: "Public With Journal",
+};
+
 export const TEST_DOI_CROSSREF_WORKS = new Map([
   [DOI_NORMAL, CROSSREF_WORK_NORMAL],
   [DOI_PREPRINT_NO_JOURNAL, CROSSREF_WORK_PREPRINT_NO_JOURNAL],
@@ -280,6 +244,100 @@ export const TEST_DOI_CROSSREF_WORKS = new Map([
     CROSSREF_WORK_JOURNAL_WITH_PREPRINT_COUNTERPART,
   ],
 ]);
+
+// SOURCE DATASETS
+
+export const SOURCE_DATASET_DRAFT_OK: TestSourceDataset = {
+  doi: DOI_DRAFT_OK,
+  doiStatus: DOI_STATUS.OK,
+  id: "d2932506-0af5-4030-920c-07f6beeb817a",
+  publication: PUBLICATION_DRAFT_OK,
+};
+
+export const SOURCE_DATASET_DRAFT_NO_CROSSREF: TestSourceDataset = {
+  doi: "10.123/sd-draft-no-crossref",
+  doiStatus: DOI_STATUS.DOI_NOT_ON_CROSSREF,
+  id: "ee67ddcb-e5d8-4240-a8ef-c945657c3321",
+  publication: null,
+};
+
+export const SOURCE_DATASET_PUBLIC_NO_CROSSREF: TestSourceDataset = {
+  doi: "10.123/sd-public-no-crossref",
+  doiStatus: DOI_STATUS.DOI_NOT_ON_CROSSREF,
+  id: "dae11387-d0c2-4160-8f2e-0be27a3a551a",
+  publication: null,
+};
+
+export const SOURCE_DATASET_PUBLIC_WITH_PREPRINT: TestSourceDataset = {
+  doi: DOI_PUBLIC_WITH_PREPRINT,
+  doiStatus: DOI_STATUS.OK,
+  id: "babb7839-cf33-4422-b90f-d9ad53d1133d",
+  publication: PUBLICATION_PUBLIC_WITH_PREPRINT,
+};
+
+export const SOURCE_DATASET_PUBLIC_WITH_JOURNAL: TestSourceDataset = {
+  doi: DOI_PUBLIC_WITH_JOURNAL,
+  doiStatus: DOI_STATUS.OK,
+  id: "815a5b58-ce6e-4578-9210-ffb383e6cf78",
+  publication: PUBLICATION_PUBLIC_WITH_JOURNAL,
+};
+
+// Source datasets initialized in the database before tests
+export const INITIAL_TEST_SOURCE_DATASETS = [
+  SOURCE_DATASET_DRAFT_OK,
+  SOURCE_DATASET_DRAFT_NO_CROSSREF,
+  SOURCE_DATASET_PUBLIC_NO_CROSSREF,
+  SOURCE_DATASET_PUBLIC_WITH_PREPRINT,
+  SOURCE_DATASET_PUBLIC_WITH_JOURNAL,
+];
+
+// ATLASES
+
+export const ATLAS_DRAFT: TestAtlas = {
+  id: "823dcc68-340b-4a61-8883-c61dc4975ce3",
+  integrationLead: null,
+  network: "eye",
+  shortName: "test-draft",
+  sourceDatasets: [
+    SOURCE_DATASET_DRAFT_OK.id,
+    SOURCE_DATASET_DRAFT_NO_CROSSREF.id,
+  ],
+  status: ATLAS_STATUS.DRAFT,
+  version: "1.2",
+  wave: "1",
+};
+
+export const ATLAS_PUBLIC: TestAtlas = {
+  id: "94f62ad0-99cb-4f01-a1cf-cce2d56a8850",
+  integrationLead: null,
+  network: "lung",
+  shortName: "test-public",
+  sourceDatasets: [SOURCE_DATASET_PUBLIC_NO_CROSSREF.id],
+  status: ATLAS_STATUS.PUBLIC,
+  version: "2.3",
+  wave: "1",
+};
+
+export const ATLAS_WITH_IL: TestAtlas = {
+  id: "798b563d-16ff-438a-8e15-77be05b1f8ec",
+  integrationLead: {
+    email: "baz@example.com",
+    name: "Baz",
+  },
+  network: "heart",
+  shortName: "test-with-il",
+  sourceDatasets: [],
+  status: ATLAS_STATUS.DRAFT,
+  version: "2.0",
+  wave: "3",
+};
+
+export const ATLAS_NONEXISTENT = {
+  id: "aa992f01-39ea-4906-ac12-053552561187",
+};
+
+// Atlases initialized in the database before tests
+export const INITIAL_TEST_ATLASES = [ATLAS_DRAFT, ATLAS_PUBLIC, ATLAS_WITH_IL];
 
 // HCA PROJECTS
 


### PR DESCRIPTION
Covers both #139 and #152

Crossref is not called to get DOIs to compare against existing datasets (it'll just compare the given DOI against already-known primary/preprint/journal DOIs) -- do we want to change this and call Crossref to really make sure we don't miss anything?