### PR TITLE
fix: make help and documentation github link open in new tab (#153)

### DIFF
--- a/site-config/hca-atlas-tracker/local/config.ts
+++ b/site-config/hca-atlas-tracker/local/config.ts
@@ -133,6 +133,7 @@ export function makeConfig(browserUrl: string, portalUrl: string): SiteConfig {
               {
                 icon: C.GitHubIcon({ fontSize: "small" }),
                 label: "GitHub",
+                target: ANCHOR_TARGET.BLANK,
                 url: "https://github.com/clevercanary/hca-atlas-tracker",
               },
             ],


### PR DESCRIPTION
Closes #153.