### PR TITLE
feat: sort by publication ascending on source dataset list (#154)

### DIFF
--- a/app/components/Detail/components/ViewSourceDatasets/viewSourceDatasets.tsx
+++ b/app/components/Detail/components/ViewSourceDatasets/viewSourceDatasets.tsx
@@ -1,9 +1,12 @@
+import { COLLATOR_CASE_INSENSITIVE } from "@databiosphere/findable-ui/lib/common/constants";
 import { AddIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/AddIcon/addIcon";
 import { GridPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
+import { useMemo } from "react";
 import {
   AtlasId,
   HCAAtlasTrackerSourceDataset,
 } from "../../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { getSourceDatasetCitation } from "../../../../apis/catalog/hca-atlas-tracker/common/utils";
 import { getRouteURL } from "../../../../common/utils";
 import { FormManager } from "../../../../hooks/useFormManager/common/entities";
 import { ROUTE } from "../../../../routes/constants";
@@ -29,6 +32,10 @@ export const ViewSourceDatasets = ({
   const {
     access: { canEdit, canView },
   } = formManager;
+  const sortedSourceDatasets = useMemo(
+    () => sourceDatasets.sort(sortSourceDatasets),
+    [sourceDatasets]
+  );
   if (!canView) return <RequestAccess />;
   return (
     <Paper>
@@ -48,10 +55,30 @@ export const ViewSourceDatasets = ({
           <Table
             columns={getAtlasSourceDatasetsTableColumns(atlasId)}
             gridTemplateColumns="minmax(260px, 1fr) minmax(152px, 0.5fr) 100px 110px 70px"
-            items={sourceDatasets}
+            items={sortedSourceDatasets}
           />
         )}
       </GridPaper>
     </Paper>
   );
 };
+
+/**
+ * Sorts source datasets by citation, then title, ascending.
+ * @param sd0 - First source dataset to compare.
+ * @param sd1 - Second source dataset to compare.
+ * @returns number indicating sort precedence of sd0 vs sd1.
+ */
+function sortSourceDatasets(
+  sd0: HCAAtlasTrackerSourceDataset,
+  sd1: HCAAtlasTrackerSourceDataset
+): number {
+  const sortValue = COLLATOR_CASE_INSENSITIVE.compare(
+    getSourceDatasetCitation(sd0),
+    getSourceDatasetCitation(sd1)
+  );
+  if (sortValue === 0) {
+    return COLLATOR_CASE_INSENSITIVE.compare(sd0.title ?? "", sd1.title ?? "");
+  }
+  return sortValue;
+}


### PR DESCRIPTION
Closes #154.

Sorts source datasets by citation, and then by title (should the citation be the same).

<img width="1910" alt="image" src="https://github.com/clevercanary/hca-atlas-tracker/assets/18710366/38d3bf28-2d93-4a4a-9866-9c058b763f80">
