### PR TITLE
feat: revalidate all source datasets when refresh services finish refreshing (#183)

### DIFF
--- a/__tests__/cellxgene.test.ts
+++ b/__tests__/cellxgene.test.ts
@@ -41,7 +41,7 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
-  globalThis.hcaAtlasTrackerProjectsInfoCache = undefined;
+  globalThis.hcaAtlasTrackerCellxGeneInfoCache = undefined;
 });
 
 describe("getCellxGeneIdByDoi", () => {

--- a/__tests__/cellxgene.test.ts
+++ b/__tests__/cellxgene.test.ts
@@ -10,6 +10,11 @@ import {
 } from "../testing/constants";
 import { delay, promiseWithResolvers } from "../testing/utils";
 
+jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/validations", () => ({
+  revalidateAllSourceDatasets: jest.fn(),
+}));
+
 jest.useFakeTimers({
   doNotFake: ["setTimeout"],
 });

--- a/__tests__/hca-projects.test.ts
+++ b/__tests__/hca-projects.test.ts
@@ -11,6 +11,11 @@ import {
 } from "../testing/constants";
 import { delay, promiseWithResolvers } from "../testing/utils";
 
+jest.mock("../app/services/cellxgene");
+jest.mock("../app/services/validations", () => ({
+  revalidateAllSourceDatasets: jest.fn(),
+}));
+
 let [getAllProjectsBlock, resolveGetAllProjectsBlock] =
   promiseWithResolvers<void>();
 

--- a/__tests__/revalidate-on-refresh.test.ts
+++ b/__tests__/revalidate-on-refresh.test.ts
@@ -1,0 +1,94 @@
+import { delay, promiseWithResolvers } from "testing/utils";
+import { ProjectsResponse } from "../app/apis/azul/hca-dcp/common/responses";
+import { CellxGeneCollection } from "../app/utils/cellxgene-api";
+import {
+  HCA_CATALOG_TEST1,
+  HCA_CATALOG_TEST2,
+  TEST_CELLXGENE_COLLECTIONS_A,
+  TEST_HCA_CATALOGS,
+} from "../testing/constants";
+
+const revalidateAllSourceDatasets = jest.fn();
+jest.mock("../app/services/validations", () => ({
+  revalidateAllSourceDatasets,
+}));
+
+let getAllProjectsBlock: Promise<void>;
+
+const getAllProjects = jest
+  .fn()
+  .mockImplementation(async (catalog: string): Promise<ProjectsResponse[]> => {
+    await getAllProjectsBlock;
+    return TEST_HCA_CATALOGS[catalog];
+  });
+
+const getLatestCatalog = jest.fn().mockResolvedValue(HCA_CATALOG_TEST1);
+
+jest.mock("../app/utils/hca-api", () => ({
+  getAllProjects,
+  getLatestCatalog,
+}));
+
+let hcaService: typeof import("../app/services/hca-projects");
+
+jest.useFakeTimers({
+  doNotFake: ["setTimeout"],
+});
+
+let getCollectionsBlock: Promise<void>;
+
+const getCellxGeneCollections = jest
+  .fn()
+  .mockImplementation(async (): Promise<CellxGeneCollection[]> => {
+    await getCollectionsBlock;
+    return TEST_CELLXGENE_COLLECTIONS_A;
+  });
+
+jest.mock("../app/utils/cellxgene-api", () => ({
+  getCellxGeneCollections,
+}));
+
+let cellxgeneService: typeof import("../app/services/cellxgene");
+
+beforeAll(async () => {
+  hcaService = await import("../app/services/hca-projects");
+  cellxgeneService = await import("../app/services/cellxgene");
+});
+
+afterAll(() => {
+  globalThis.hcaAtlasTrackerProjectsInfoCache = undefined;
+  globalThis.hcaAtlasTrackerCellxGeneInfoCache = undefined;
+});
+
+test("source datasets are not revalidated when no refresh happens", async () => {
+  await delay();
+  expect(revalidateAllSourceDatasets).toHaveBeenCalledTimes(1);
+  hcaService.getProjectIdByDoi([""]);
+  cellxgeneService.getCellxGeneIdByDoi([""]);
+  await delay();
+  expect(hcaService.areProjectsRefreshing()).toBe(false);
+  expect(cellxgeneService.isCellxGeneRefreshing()).toBe(false);
+  expect(revalidateAllSourceDatasets).toHaveBeenCalledTimes(1);
+});
+
+test("source datasets are revalidated when last refresh completes", async () => {
+  const [projectsPromise, resolveProjects] = promiseWithResolvers<void>();
+  getAllProjectsBlock = projectsPromise;
+  const [cellxgenePromise, resolveCellxGene] = promiseWithResolvers<void>();
+  getCollectionsBlock = cellxgenePromise;
+
+  getLatestCatalog.mockResolvedValue(HCA_CATALOG_TEST2);
+  jest.setSystemTime(jest.now() + 14400001);
+
+  hcaService.getProjectIdByDoi([""]);
+  cellxgeneService.getCellxGeneIdByDoi([""]);
+
+  await delay();
+  expect(revalidateAllSourceDatasets).toHaveBeenCalledTimes(1);
+  resolveProjects();
+  await delay();
+  expect(revalidateAllSourceDatasets).toHaveBeenCalledTimes(1);
+  resolveCellxGene();
+  await delay();
+  expect(revalidateAllSourceDatasets).toHaveBeenCalledTimes(2);
+});

--- a/app/services/__mocks__/cellxgene.ts
+++ b/app/services/__mocks__/cellxgene.ts
@@ -1,6 +1,10 @@
 import { TEST_CELLXGENE_COLLECTIONS_BY_DOI } from "testing/constants";
 import { CollectionInfo } from "../cellxgene";
 
+export function isCellxGeneRefreshing(): boolean {
+  return false;
+}
+
 export function getCellxGeneIdByDoi(dois: string[]): string | null {
   return getCellxGeneInfoByDoi(dois)?.id ?? null;
 }

--- a/app/services/__mocks__/hca-projects.ts
+++ b/app/services/__mocks__/hca-projects.ts
@@ -1,6 +1,10 @@
 import { TEST_HCA_PROJECTS_BY_DOI } from "../../../testing/constants";
 import { ProjectInfo } from "../hca-projects";
 
+export function areProjectsRefreshing(): boolean {
+  return false;
+}
+
 export function getProjectIdByDoi(dois: string[]): string | null {
   return getProjectInfoByDoi(dois)?.id ?? null;
 }

--- a/app/services/common/refresh-service.ts
+++ b/app/services/common/refresh-service.ts
@@ -11,6 +11,7 @@ export interface RefreshServiceParams<TData, TRefreshParams> {
   getRefreshParams: (data?: TData) => TRefreshParams | Promise<TRefreshParams>;
   getStoredInfo: () => RefreshInfo<TData> | undefined;
   notReadyMessage: string;
+  onRefreshSuccess?: () => void;
   refreshNeeded: (
     data: TData | undefined,
     refreshParams: TRefreshParams
@@ -20,6 +21,7 @@ export interface RefreshServiceParams<TData, TRefreshParams> {
 
 export interface RefreshService<TData> {
   getData: () => TData;
+  isRefreshing: () => boolean;
 }
 
 export class RefreshDataNotReadyError extends Error {
@@ -33,6 +35,7 @@ export class RefreshDataNotReadyError extends Error {
  * @param param0.getRefreshParams - Function taking optional current data value, which gets any values needed to do a refresh and returns them directly or as a promise.
  * @param param0.getStoredInfo - Function that returns the cached info object containing the data (or undefined if it doesn't exist), e.g. from a global variable.
  * @param param0.notReadyMessage - Message to use for an error when an attempt to access the data is made before it's initially retrieved.
+ * @param param0.onRefreshSuccess - Function to call when a refresh successfully completes.
  * @param param0.refreshNeeded - Function taking optional current data value and required refresh params, which returns a boolean indicating whether a refresh is needed.
  * @param param0.setStoredInfo - Function that takes the info object containing the data and stores it as a cache, e.g. in a global variable.
  * @returns object containing `getData` function that returns the current data value and starts a refresh if needed.
@@ -42,6 +45,7 @@ export function makeRefreshService<TData, TRefreshParams>({
   getRefreshParams,
   getStoredInfo,
   notReadyMessage,
+  onRefreshSuccess,
   refreshNeeded,
   setStoredInfo,
 }: RefreshServiceParams<TData, TRefreshParams>): RefreshService<TData> {
@@ -61,6 +65,9 @@ export function makeRefreshService<TData, TRefreshParams>({
         throw new RefreshDataNotReadyError(notReadyMessage);
       return info.data;
     },
+    isRefreshing(): boolean {
+      return Boolean(info.refreshing);
+    },
   };
 
   async function startRefreshIfNeeded(force = false): Promise<void> {
@@ -68,10 +75,13 @@ export function makeRefreshService<TData, TRefreshParams>({
     const isRefreshNeeded = refreshNeeded(info.data, refreshParams);
     if (force || (!info.refreshing && isRefreshNeeded)) {
       info.refreshing = true;
+      let completedSuccessfully = false;
       try {
         info.data = await getRefreshedData(refreshParams, info.data);
+        completedSuccessfully = true;
       } finally {
         info.refreshing = false;
+        if (completedSuccessfully) onRefreshSuccess?.();
       }
     }
   }

--- a/app/services/common/refresh-service.ts
+++ b/app/services/common/refresh-service.ts
@@ -1,5 +1,7 @@
-export interface RefreshInfo<T> {
-  data?: T;
+export interface RefreshInfo<TData, TRefreshParams = undefined> {
+  attemptingRefresh?: boolean;
+  data?: TData;
+  prevRefreshParams?: TRefreshParams;
   refreshing?: boolean;
 }
 
@@ -8,15 +10,18 @@ export interface RefreshServiceParams<TData, TRefreshParams> {
     refreshParams: TRefreshParams,
     prevData?: TData
   ) => TData | Promise<TData>;
-  getRefreshParams: (data?: TData) => TRefreshParams | Promise<TRefreshParams>;
-  getStoredInfo: () => RefreshInfo<TData> | undefined;
+  getRefreshParams: (
+    data?: TData,
+    prevRefreshParams?: TRefreshParams
+  ) => TRefreshParams | Promise<TRefreshParams>;
+  getStoredInfo: () => RefreshInfo<TData, TRefreshParams> | undefined;
   notReadyMessage: string;
   onRefreshSuccess?: () => void;
   refreshNeeded: (
     data: TData | undefined,
     refreshParams: TRefreshParams
   ) => boolean;
-  setStoredInfo: (info: RefreshInfo<TData>) => void;
+  setStoredInfo: (info: RefreshInfo<TData, TRefreshParams>) => void;
 }
 
 export interface RefreshService<TData> {
@@ -30,37 +35,32 @@ export class RefreshDataNotReadyError extends Error {
 
 /**
  * Initialize data that will be refreshed using a given set of functions under a given condition.
- * @param param0 - Object containing parameters that determine the behavior of the refresh service.
- * @param param0.getRefreshedData - Function taking refresh params and optional previous data value, which refreshes the data and returns it directly or as a promise.
- * @param param0.getRefreshParams - Function taking optional current data value, which gets any values needed to do a refresh and returns them directly or as a promise.
- * @param param0.getStoredInfo - Function that returns the cached info object containing the data (or undefined if it doesn't exist), e.g. from a global variable.
- * @param param0.notReadyMessage - Message to use for an error when an attempt to access the data is made before it's initially retrieved.
- * @param param0.onRefreshSuccess - Function to call when a refresh successfully completes.
- * @param param0.refreshNeeded - Function taking optional current data value and required refresh params, which returns a boolean indicating whether a refresh is needed.
- * @param param0.setStoredInfo - Function that takes the info object containing the data and stores it as a cache, e.g. in a global variable.
+ * @param params - Object containing parameters that determine the behavior of the refresh service.
+ * @param params.getRefreshedData - Function taking refresh params and optional previous data value, which refreshes the data and returns it directly or as a promise.
+ * @param params.getRefreshParams - Function taking optional current data value, which gets any values needed to do a refresh and returns them directly or as a promise.
+ * @param params.getStoredInfo - Function that returns the cached info object containing the data (or undefined if it doesn't exist), e.g. from a global variable.
+ * @param params.notReadyMessage - Message to use for an error when an attempt to access the data is made before it's initially retrieved.
+ * @param params.onRefreshSuccess - Function to call when a refresh successfully completes.
+ * @param params.refreshNeeded - Function taking optional current data value and required refresh params, which returns a boolean indicating whether a refresh is needed.
+ * @param params.setStoredInfo - Function that takes the info object containing the data and stores it as a cache, e.g. in a global variable.
  * @returns object containing `getData` function that returns the current data value and starts a refresh if needed.
  */
-export function makeRefreshService<TData, TRefreshParams>({
-  getRefreshedData,
-  getRefreshParams,
-  getStoredInfo,
-  notReadyMessage,
-  onRefreshSuccess,
-  refreshNeeded,
-  setStoredInfo,
-}: RefreshServiceParams<TData, TRefreshParams>): RefreshService<TData> {
+export function makeRefreshService<TData, TRefreshParams>(
+  params: RefreshServiceParams<TData, TRefreshParams>
+): RefreshService<TData> {
+  const { getStoredInfo, notReadyMessage, setStoredInfo } = params;
   const initStoredInfo = getStoredInfo();
-  let info: RefreshInfo<TData>;
+  let info: RefreshInfo<TData, TRefreshParams>;
   if (initStoredInfo) {
     info = initStoredInfo;
   } else {
     setStoredInfo((info = {}));
-    startRefreshIfNeeded(true);
+    startRefreshIfNeeded(params, info, true);
   }
 
   return {
     getData(): TData {
-      startRefreshIfNeeded();
+      startRefreshIfNeeded(params, info);
       if (info.data === undefined)
         throw new RefreshDataNotReadyError(notReadyMessage);
       return info.data;
@@ -69,20 +69,45 @@ export function makeRefreshService<TData, TRefreshParams>({
       return Boolean(info.refreshing);
     },
   };
+}
 
-  async function startRefreshIfNeeded(force = false): Promise<void> {
-    const refreshParams = await getRefreshParams(info.data);
-    const isRefreshNeeded = refreshNeeded(info.data, refreshParams);
-    if (force || (!info.refreshing && isRefreshNeeded)) {
-      info.refreshing = true;
-      let completedSuccessfully = false;
-      try {
-        info.data = await getRefreshedData(refreshParams, info.data);
-        completedSuccessfully = true;
-      } finally {
-        info.refreshing = false;
-        if (completedSuccessfully) onRefreshSuccess?.();
-      }
+async function startRefreshIfNeeded<TData, TRefreshParams>(
+  params: RefreshServiceParams<TData, TRefreshParams>,
+  info: RefreshInfo<TData, TRefreshParams>,
+  force = false
+): Promise<void> {
+  const {
+    getRefreshedData,
+    getRefreshParams,
+    onRefreshSuccess,
+    refreshNeeded,
+  } = params;
+
+  if (info.attemptingRefresh) return;
+  info.attemptingRefresh = true;
+
+  let refreshParams, isRefreshNeeded;
+  try {
+    refreshParams = await getRefreshParams(info.data, info.prevRefreshParams);
+    info.prevRefreshParams = refreshParams;
+    isRefreshNeeded = refreshNeeded(info.data, refreshParams);
+  } catch (e) {
+    info.attemptingRefresh = false;
+    throw e;
+  }
+
+  if (force || (!info.refreshing && isRefreshNeeded)) {
+    info.refreshing = true;
+    let completedSuccessfully = false;
+    try {
+      info.data = await getRefreshedData(refreshParams, info.data);
+      completedSuccessfully = true;
+    } finally {
+      info.refreshing = false;
+      info.attemptingRefresh = false;
+      if (completedSuccessfully) onRefreshSuccess?.();
     }
+  } else {
+    info.attemptingRefresh = false;
   }
 }

--- a/app/services/hca-projects.ts
+++ b/app/services/hca-projects.ts
@@ -17,7 +17,7 @@ interface ProjectsData {
   catalog: string;
 }
 
-export type ProjectsInfo = RefreshInfo<ProjectsData>;
+export type ProjectsInfo = RefreshInfo<ProjectsData, string>;
 
 const KY_OPTIONS: KyOptions = {
   retry: {

--- a/app/services/refresh-services.ts
+++ b/app/services/refresh-services.ts
@@ -1,0 +1,6 @@
+import { isCellxGeneRefreshing } from "./cellxgene";
+import { areProjectsRefreshing } from "./hca-projects";
+
+export function isAnyServiceRefreshing(): boolean {
+  return areProjectsRefreshing() || isCellxGeneRefreshing();
+}

--- a/app/services/validations.ts
+++ b/app/services/validations.ts
@@ -169,6 +169,10 @@ function getValidationResult<T extends ENTITY_TYPE>(
   };
 }
 
+export async function revalidateAllSourceDatasets(): Promise<void> {
+  console.log("revalidate");
+}
+
 /**
  * Update saved validations for the given source dataset.
  * @param sourceDataset - Source dataset to validate.

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -2,9 +2,11 @@
  * Function to run on server start.
  */
 export async function register(): Promise<void> {
-  // Initialize HCA projects
-  await import("./app/services/hca-projects");
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    // Initialize HCA projects
+    await import("./app/services/hca-projects");
 
-  // Initialize CELLxGENE collections
-  await import("./app/services/cellxgene");
+    // Initialize CELLxGENE collections
+    await import("./app/services/cellxgene");
+  }
 }


### PR DESCRIPTION
Notes:
- Revalidation happens when either of the refresh services finishes refreshing and there are no other refreshes in progress -- meaning that when both HCA and CELLxGENE get refreshed at the same time, whichever finishes last will trigger revalidation
- Because the server does an initial refresh, revalidation will always happen when the server is started