### PR TITLE
feat: add api to update target completion dates for tasks (#207)

### DIFF
--- a/__tests__/api-tasks-completion-dates.test.ts
+++ b/__tests__/api-tasks-completion-dates.test.ts
@@ -136,6 +136,15 @@ describe("/api/tasks/completion-dates", () => {
     await expectValidationsToBeUnchanged();
   });
 
+  it("returns error 400 when an empty ID array is provided", async () => {
+    expect(
+      (
+        await doCompletionDatesRequest(USER_CONTENT_ADMIN, DATE_VALID, [])
+      )._getStatusCode()
+    ).toEqual(400);
+    await expectValidationsToBeUnchanged();
+  });
+
   it("updates target completion dates for specified validations and returns updated validations", async () => {
     const res = await doCompletionDatesRequest(
       USER_CONTENT_ADMIN,

--- a/__tests__/api-tasks-completion-dates.test.ts
+++ b/__tests__/api-tasks-completion-dates.test.ts
@@ -1,0 +1,202 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
+import {
+  HCAAtlasTrackerDBValidation,
+  HCAAtlasTrackerValidationRecord,
+} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "../app/common/entities";
+import { endPgPool, query } from "../app/services/database";
+import completionDatesHandler from "../pages/api/tasks/completion-dates";
+import {
+  SOURCE_DATASET_PUBLISHED_WITH_HCA,
+  USER_CONTENT_ADMIN,
+  USER_STAKEHOLDER,
+  USER_UNREGISTERED,
+} from "../testing/constants";
+import { resetDatabase } from "../testing/db-utils";
+import { TestUser } from "../testing/entities";
+
+jest.mock("../app/services/user-profile");
+jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/cellxgene");
+jest.mock("../app/utils/pg-app-connect-config");
+
+const DATE_VALID = "2024-05-20T01:16:42.761Z";
+
+const DATE_NON_UTC = "2024-05-19T18:16:42.761-0700";
+
+const VALIDATION_ID_NONEXISTENT = "8fb38ac8-78fe-4d47-a858-145175819dfe";
+
+let validations: HCAAtlasTrackerDBValidation[];
+let validationIds: string[];
+let otherValidation: HCAAtlasTrackerDBValidation;
+
+beforeAll(async () => {
+  await resetDatabase();
+  validations = (
+    await query<HCAAtlasTrackerDBValidation>(
+      "SELECT * FROM hat.validations WHERE entity_id=$1",
+      [SOURCE_DATASET_PUBLISHED_WITH_HCA.id]
+    )
+  ).rows;
+  if (validations.length < 2) throw new Error("Missing test validations");
+  otherValidation = validations[0];
+  validations.shift();
+  validationIds = validations.map(({ id }) => id);
+});
+
+afterAll(async () => {
+  endPgPool();
+});
+
+describe("/api/tasks/completion-dates", () => {
+  it("returns error 405 for non-PATCH request", async () => {
+    expect(
+      (
+        await doCompletionDatesRequest(
+          USER_CONTENT_ADMIN,
+          DATE_VALID,
+          validationIds,
+          METHOD.GET
+        )
+      )._getStatusCode()
+    ).toEqual(405);
+    await expectValidationsToBeUnchanged();
+  });
+
+  it("returns error 401 for logged out user", async () => {
+    expect(
+      (
+        await doCompletionDatesRequest(undefined, DATE_VALID, validationIds)
+      )._getStatusCode()
+    ).toEqual(401);
+    await expectValidationsToBeUnchanged();
+  });
+
+  it("returns error 403 for unregistered user", async () => {
+    expect(
+      (
+        await doCompletionDatesRequest(
+          USER_UNREGISTERED,
+          DATE_VALID,
+          validationIds
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectValidationsToBeUnchanged();
+  });
+
+  it("returns error 403 for logged in user with STAKEHOLDER role", async () => {
+    expect(
+      (
+        await doCompletionDatesRequest(
+          USER_STAKEHOLDER,
+          DATE_VALID,
+          validationIds
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectValidationsToBeUnchanged();
+  });
+
+  it("returns error 400 when date is non-UTC", async () => {
+    expect(
+      (
+        await doCompletionDatesRequest(
+          USER_CONTENT_ADMIN,
+          DATE_NON_UTC,
+          validationIds
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+    await expectValidationsToBeUnchanged();
+  });
+
+  it("returns error 400 when one of the IDs is not a UUID", async () => {
+    expect(
+      (
+        await doCompletionDatesRequest(USER_CONTENT_ADMIN, DATE_NON_UTC, [
+          ...validationIds,
+          "notauuid",
+        ])
+      )._getStatusCode()
+    ).toEqual(400);
+    await expectValidationsToBeUnchanged();
+  });
+
+  it("returns error 404 when one of the IDs doesn't exist", async () => {
+    expect(
+      (
+        await doCompletionDatesRequest(USER_CONTENT_ADMIN, DATE_VALID, [
+          ...validationIds,
+          VALIDATION_ID_NONEXISTENT,
+        ])
+      )._getStatusCode()
+    ).toEqual(404);
+    await expectValidationsToBeUnchanged();
+  });
+
+  it("updates target completion dates for specified validations and returns updated validations", async () => {
+    const res = await doCompletionDatesRequest(
+      USER_CONTENT_ADMIN,
+      DATE_VALID,
+      validationIds
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const updatedValidations: HCAAtlasTrackerValidationRecord[] =
+      res._getJSONData();
+    expect(updatedValidations).toHaveLength(validationIds.length);
+    for (const { id, targetCompletionDate } of updatedValidations) {
+      expect(targetCompletionDate).toEqual(DATE_VALID);
+      expect(validationIds).toContain(id);
+    }
+    const updatedValidationsFromDb = (
+      await query<HCAAtlasTrackerDBValidation>(
+        "SELECT * FROM hat.validations WHERE id=ANY($1)",
+        [validationIds]
+      )
+    ).rows;
+    for (const validation of updatedValidationsFromDb) {
+      expect(validation.target_completion?.toISOString()).toEqual(DATE_VALID);
+    }
+    const otherValidationFromDb = (
+      await query<HCAAtlasTrackerDBValidation>(
+        "SELECT * FROM hat.validations WHERE id=$1",
+        [otherValidation.id]
+      )
+    ).rows[0];
+    expect(otherValidationFromDb).toEqual(otherValidation);
+  });
+});
+
+async function expectValidationsToBeUnchanged(): Promise<void> {
+  const currentValidations = (
+    await query<HCAAtlasTrackerDBValidation>(
+      "SELECT * FROM hat.validations WHERE id=ANY($1)",
+      [validationIds]
+    )
+  ).rows;
+  for (const currentValidation of currentValidations) {
+    expect(currentValidation).toEqual(
+      validations.find((v) => v.id === currentValidation.id)
+    );
+  }
+}
+
+async function doCompletionDatesRequest(
+  user: TestUser | undefined,
+  targetCompletion: string,
+  taskIds: string[],
+  method = METHOD.PATCH
+): Promise<httpMocks.MockResponse<NextApiResponse>> {
+  const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>({
+    body: {
+      targetCompletion,
+      taskIds,
+    },
+    headers: { authorization: user?.authorization },
+    method,
+  });
+  await completionDatesHandler(req, res);
+  return res;
+}

--- a/__tests__/source-dataset-validation-results.test.ts
+++ b/__tests__/source-dataset-validation-results.test.ts
@@ -32,6 +32,7 @@ type ExpectedValidationProperties = Pick<
 jest.mock("../app/utils/pg-app-connect-config");
 jest.mock("../app/services/hca-projects");
 jest.mock("../app/services/cellxgene");
+jest.mock("../app/services/user-profile");
 
 const VALIDATIONS_UNPUBLISHED_WITH_CELLXGENE: ExpectedValidationProperties[] = [
   {

--- a/__tests__/update-validations.test.ts
+++ b/__tests__/update-validations.test.ts
@@ -13,6 +13,7 @@ import { endPgPool, getPoolClient, query } from "../app/services/database";
 import { resetDatabase } from "../testing/db-utils";
 
 jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/user-profile");
 jest.mock("../app/utils/pg-app-connect-config");
 
 const ENTITY_TYPE_TEST = "ENTITY_TYPE_TEST" as ENTITY_TYPE;

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -139,7 +139,7 @@ export type NewUserData = InferType<typeof newUserSchema>;
 
 export const taskCompletionDatesSchema = object({
   targetCompletion: string().datetime().required(),
-  taskIds: array(string().uuid().required()).required(),
+  taskIds: array(string().uuid().required()).required().min(1),
 }).strict(true);
 
 export type TaskCompletionDatesData = InferType<

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -1,4 +1,4 @@
-import { boolean, InferType, mixed, object, string } from "yup";
+import { array, boolean, InferType, mixed, object, string } from "yup";
 import { isDoi } from "../../../../utils/doi";
 import { NETWORK_KEYS, WAVES } from "./constants";
 
@@ -136,3 +136,12 @@ export const newUserSchema = object({
 }).strict(true);
 
 export type NewUserData = InferType<typeof newUserSchema>;
+
+export const taskCompletionDatesSchema = object({
+  targetCompletion: string().datetime().required(),
+  taskIds: array(string().required()).required(),
+}).strict(true);
+
+export type TaskCompletionDatesData = InferType<
+  typeof taskCompletionDatesSchema
+>;

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -139,7 +139,7 @@ export type NewUserData = InferType<typeof newUserSchema>;
 
 export const taskCompletionDatesSchema = object({
   targetCompletion: string().datetime().required(),
-  taskIds: array(string().required()).required(),
+  taskIds: array(string().uuid().required()).required(),
 }).strict(true);
 
 export type TaskCompletionDatesData = InferType<

--- a/app/common/entities.ts
+++ b/app/common/entities.ts
@@ -8,6 +8,7 @@ export enum FETCH_STATUS {
 export enum METHOD {
   DELETE = "DELETE",
   GET = "GET",
+  PATCH = "PATCH",
   POST = "POST",
   PUT = "PUT",
 }

--- a/app/services/database.ts
+++ b/app/services/database.ts
@@ -7,9 +7,12 @@ const pool = new Pool(getPoolConfig());
 
 export function query<T extends pg.QueryResultRow>(
   queryTextOrConfig: string | pg.QueryConfig<unknown[]>,
-  values?: unknown[] | undefined
+  values?: unknown[] | undefined,
+  client?: pg.PoolClient
 ): Promise<pg.QueryResult<T>> {
-  return pool.query<T>(queryTextOrConfig, values);
+  return client
+    ? client.query<T>(queryTextOrConfig, values)
+    : pool.query<T>(queryTextOrConfig, values);
 }
 
 export function getPoolClient(): Promise<pg.PoolClient> {

--- a/pages/api/tasks/completion-dates.ts
+++ b/pages/api/tasks/completion-dates.ts
@@ -1,0 +1,20 @@
+import { ROLE } from "app/apis/catalog/hca-atlas-tracker/common/entities";
+import { taskCompletionDatesSchema } from "app/apis/catalog/hca-atlas-tracker/common/schema";
+import { dbValidationToApiValidation } from "app/apis/catalog/hca-atlas-tracker/common/utils";
+import { METHOD } from "app/common/entities";
+import { updateTargetCompletions } from "app/services/validations";
+import { handler, method, role } from "app/utils/api-handler";
+
+export default handler(
+  method(METHOD.PATCH),
+  role(ROLE.CONTENT_ADMIN),
+  async (req, res) => {
+    const { targetCompletion, taskIds } =
+      await taskCompletionDatesSchema.validate(req.body);
+    const updatedValidations = await updateTargetCompletions(
+      new Date(targetCompletion),
+      taskIds
+    );
+    res.json(updatedValidations.map(dbValidationToApiValidation));
+  }
+);


### PR DESCRIPTION
The endpoint is `/api/tasks/completion-dates` rather than the `/api/tasks/completionDates` specified in the ticket, in order to follow the established naming patterns