### PR TITLE
feat: add task counts to atlases (#212)

### DIFF
--- a/__tests__/api-atlases-create.test.ts
+++ b/__tests__/api-atlases-create.test.ts
@@ -181,7 +181,7 @@ describe("/api/atlases/create", () => {
         [newAtlas.id]
       )
     ).rows[0];
-    expect(newAtlasFromDb.overview).toEqual(NEW_ATLAS_DATA);
+    expect(newAtlasFromDb.overview).toMatchObject(NEW_ATLAS_DATA);
     expect(dbAtlasToApiAtlas(newAtlasFromDb)).toEqual(newAtlas);
   });
 
@@ -195,7 +195,7 @@ describe("/api/atlases/create", () => {
         [newAtlas.id]
       )
     ).rows[0];
-    expect(newAtlasFromDb.overview).toEqual(NEW_ATLAS_WITH_IL_DATA);
+    expect(newAtlasFromDb.overview).toMatchObject(NEW_ATLAS_WITH_IL_DATA);
     expect(dbAtlasToApiAtlas(newAtlasFromDb)).toEqual(newAtlas);
   });
 });

--- a/__tests__/api-atlases-id.test.ts
+++ b/__tests__/api-atlases-id.test.ts
@@ -233,7 +233,7 @@ describe("/api/atlases/[id]", () => {
         [ATLAS_PUBLIC.id]
       )
     ).rows[0];
-    expect(updatedAtlasFromDb.overview).toEqual(ATLAS_PUBLIC_EDIT);
+    expect(updatedAtlasFromDb.overview).toMatchObject(ATLAS_PUBLIC_EDIT);
     expect(dbAtlasToApiAtlas(updatedAtlasFromDb)).toEqual(updatedAtlas);
   });
 
@@ -252,7 +252,7 @@ describe("/api/atlases/[id]", () => {
         [ATLAS_WITH_IL.id]
       )
     ).rows[0];
-    expect(updatedAtlasFromDb.overview).toEqual(ATLAS_WITH_IL_EDIT);
+    expect(updatedAtlasFromDb.overview).toMatchObject(ATLAS_WITH_IL_EDIT);
     expect(dbAtlasToApiAtlas(updatedAtlasFromDb)).toEqual(updatedAtlas);
   });
 });

--- a/__tests__/cellxgene.test.ts
+++ b/__tests__/cellxgene.test.ts
@@ -12,7 +12,7 @@ import { delay, promiseWithResolvers } from "../testing/utils";
 
 jest.mock("../app/services/hca-projects");
 jest.mock("../app/services/validations", () => ({
-  revalidateAllSourceDatasets: jest.fn(),
+  refreshValidations: jest.fn(),
 }));
 
 jest.useFakeTimers({

--- a/__tests__/hca-projects.test.ts
+++ b/__tests__/hca-projects.test.ts
@@ -13,7 +13,7 @@ import { delay, promiseWithResolvers } from "../testing/utils";
 
 jest.mock("../app/services/cellxgene");
 jest.mock("../app/services/validations", () => ({
-  revalidateAllSourceDatasets: jest.fn(),
+  refreshValidations: jest.fn(),
 }));
 
 jest.useFakeTimers({

--- a/__tests__/refresh-validations.test.ts
+++ b/__tests__/refresh-validations.test.ts
@@ -1,0 +1,195 @@
+import { refreshValidations } from "app/services/validations";
+import {
+  HCAAtlasTrackerDBAtlas,
+  HCAAtlasTrackerDBAtlasOverview,
+  HCAAtlasTrackerDBValidation,
+  VALIDATION_ID,
+  VALIDATION_STATUS,
+} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { endPgPool, query } from "../app/services/database";
+import {
+  ATLAS_WITH_SOURCE_DATASET_VALIDATIONS_A,
+  ATLAS_WITH_SOURCE_DATASET_VALIDATIONS_B,
+  SOURCE_DATASET_PUBLISHED_WITH_HCA,
+  SOURCE_DATASET_PUBLISHED_WITH_HCA_TITLE_MISMATCH,
+  SOURCE_DATASET_UNPUBLISHED_WITH_CELLXGENE,
+} from "../testing/constants";
+import { resetDatabase } from "../testing/db-utils";
+import { TestAtlas, TestSourceDataset } from "../testing/entities";
+
+jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/user-profile");
+jest.mock("../app/utils/pg-app-connect-config");
+
+beforeAll(async () => {
+  await resetDatabase();
+});
+
+afterAll(async () => {
+  endPgPool();
+});
+
+describe("refreshValidations", () => {
+  it("updates source dataset validations and atlas task counts", async () => {
+    const aExpectedSubjectTasksBefore = 5;
+    const aExpectedSubjectCompletedTasksBefore = 4;
+    const aExpectedSubjectTasksAfter = 3;
+    const aExpectedSubjectCompletedTasksAfter = 1;
+
+    const bExpectedSubjectTasksBefore = 1;
+    const bExpectedSubjectCompletedTasksBefore = 1;
+    const bExpectedSubjectTasksAfter = 1;
+    const bExpectedSubjectCompletedTasksAfter = 0;
+
+    const unpublishedWithCellxGeneInCellxGeneBefore = await getSavedValidation(
+      SOURCE_DATASET_UNPUBLISHED_WITH_CELLXGENE,
+      VALIDATION_ID.SOURCE_DATASET_IN_CELLXGENE
+    );
+    const publishedWithHcaInHcaBefore = await getSavedValidation(
+      SOURCE_DATASET_PUBLISHED_WITH_HCA,
+      VALIDATION_ID.SOURCE_DATASET_IN_HCA_DATA_REPOSITORY
+    );
+    const publishedWithHcaHcaTitleBefore = await getSavedValidation(
+      SOURCE_DATASET_PUBLISHED_WITH_HCA,
+      VALIDATION_ID.SOURCE_DATASET_TITLE_MATCHES_HCA_DATA_REPOSITORY
+    );
+    const publishedWithHcaPrimaryDataBefore = await getSavedValidation(
+      SOURCE_DATASET_PUBLISHED_WITH_HCA,
+      VALIDATION_ID.SOURCE_DATASET_HCA_PROJECT_HAS_PRIMARY_DATA
+    );
+    const publishedWithHcaTitleMismatchHcaTitleBefore =
+      await getSavedValidation(
+        SOURCE_DATASET_PUBLISHED_WITH_HCA_TITLE_MISMATCH,
+        VALIDATION_ID.SOURCE_DATASET_TITLE_MATCHES_HCA_DATA_REPOSITORY
+      );
+
+    const {
+      completedTaskCount: aCompletedTaskCountBefore,
+      taskCount: aTaskCountBefore,
+    } = await getSavedAtlasOverview(ATLAS_WITH_SOURCE_DATASET_VALIDATIONS_A);
+    const {
+      completedTaskCount: bCompletedTaskCountBefore,
+      taskCount: bTaskCountBefore,
+    } = await getSavedAtlasOverview(ATLAS_WITH_SOURCE_DATASET_VALIDATIONS_B);
+
+    expect(
+      unpublishedWithCellxGeneInCellxGeneBefore?.validation_info
+        .validationStatus
+    ).toEqual(VALIDATION_STATUS.PASSED);
+    expect(
+      publishedWithHcaInHcaBefore?.validation_info.validationStatus
+    ).toEqual(VALIDATION_STATUS.PASSED);
+    expect(
+      publishedWithHcaHcaTitleBefore?.validation_info.validationStatus
+    ).toEqual(VALIDATION_STATUS.PASSED);
+    expect(
+      publishedWithHcaPrimaryDataBefore?.validation_info.validationStatus
+    ).toEqual(VALIDATION_STATUS.PASSED);
+    expect(
+      publishedWithHcaTitleMismatchHcaTitleBefore?.validation_info
+        .validationStatus
+    ).toEqual(VALIDATION_STATUS.FAILED);
+
+    await query(
+      `UPDATE hat.source_datasets SET sd_info=sd_info||'{"cellxgeneCollectionId":null}' WHERE id=$1`,
+      [SOURCE_DATASET_UNPUBLISHED_WITH_CELLXGENE.id]
+    );
+    await query(
+      `UPDATE hat.source_datasets SET sd_info=sd_info||'{"hcaProjectId":null}' WHERE id=$1`,
+      [SOURCE_DATASET_PUBLISHED_WITH_HCA.id]
+    );
+    await query(
+      `UPDATE hat.source_datasets SET sd_info=jsonb_set(sd_info, '{publication, title}', '"Published With HCA Title Mismatch MISMATCHED"') WHERE id=$1`,
+      [SOURCE_DATASET_PUBLISHED_WITH_HCA_TITLE_MISMATCH.id]
+    );
+
+    await refreshValidations();
+
+    const unpublishedWithCellxGeneInCellxGeneAfter = await getSavedValidation(
+      SOURCE_DATASET_UNPUBLISHED_WITH_CELLXGENE,
+      VALIDATION_ID.SOURCE_DATASET_IN_CELLXGENE
+    );
+    const publishedWithHcaInHcaAfter = await getSavedValidation(
+      SOURCE_DATASET_PUBLISHED_WITH_HCA,
+      VALIDATION_ID.SOURCE_DATASET_IN_HCA_DATA_REPOSITORY
+    );
+    const publishedWithHcaHcaTitleAfter = await getSavedValidation(
+      SOURCE_DATASET_PUBLISHED_WITH_HCA,
+      VALIDATION_ID.SOURCE_DATASET_TITLE_MATCHES_HCA_DATA_REPOSITORY
+    );
+    const publishedWithHcaPrimaryDataAfter = await getSavedValidation(
+      SOURCE_DATASET_PUBLISHED_WITH_HCA,
+      VALIDATION_ID.SOURCE_DATASET_HCA_PROJECT_HAS_PRIMARY_DATA
+    );
+    const publishedWithHcaTitleMismatchHcaTitleAfter = await getSavedValidation(
+      SOURCE_DATASET_PUBLISHED_WITH_HCA_TITLE_MISMATCH,
+      VALIDATION_ID.SOURCE_DATASET_TITLE_MATCHES_HCA_DATA_REPOSITORY
+    );
+
+    const {
+      completedTaskCount: aCompletedTaskCountAfter,
+      taskCount: aTaskCountAfter,
+    } = await getSavedAtlasOverview(ATLAS_WITH_SOURCE_DATASET_VALIDATIONS_A);
+    const {
+      completedTaskCount: bCompletedTaskCountAfter,
+      taskCount: bTaskCountAfter,
+    } = await getSavedAtlasOverview(ATLAS_WITH_SOURCE_DATASET_VALIDATIONS_B);
+
+    expect(
+      unpublishedWithCellxGeneInCellxGeneAfter?.validation_info.validationStatus
+    ).toEqual(VALIDATION_STATUS.FAILED);
+    expect(
+      publishedWithHcaInHcaAfter?.validation_info.validationStatus
+    ).toEqual(VALIDATION_STATUS.FAILED);
+    expect(publishedWithHcaHcaTitleAfter).toBeUndefined();
+    expect(publishedWithHcaPrimaryDataAfter).toBeUndefined();
+    expect(
+      publishedWithHcaTitleMismatchHcaTitleAfter?.validation_info
+        .validationStatus
+    ).toEqual(VALIDATION_STATUS.PASSED);
+
+    expect(aTaskCountAfter).toEqual(
+      aTaskCountBefore -
+        aExpectedSubjectTasksBefore +
+        aExpectedSubjectTasksAfter
+    );
+    expect(aCompletedTaskCountAfter).toEqual(
+      aCompletedTaskCountBefore -
+        aExpectedSubjectCompletedTasksBefore +
+        aExpectedSubjectCompletedTasksAfter
+    );
+    expect(bTaskCountAfter).toEqual(
+      bTaskCountBefore -
+        bExpectedSubjectTasksBefore +
+        bExpectedSubjectTasksAfter
+    );
+    expect(bCompletedTaskCountAfter).toEqual(
+      bCompletedTaskCountBefore -
+        bExpectedSubjectCompletedTasksBefore +
+        bExpectedSubjectCompletedTasksAfter
+    );
+  });
+});
+
+async function getSavedAtlasOverview(
+  atlas: TestAtlas
+): Promise<HCAAtlasTrackerDBAtlasOverview> {
+  return (
+    await query<Pick<HCAAtlasTrackerDBAtlas, "overview">>(
+      "SELECT overview FROM hat.atlases WHERE id=$1",
+      [atlas.id]
+    )
+  ).rows[0].overview;
+}
+
+async function getSavedValidation(
+  dataset: TestSourceDataset,
+  validationId: VALIDATION_ID
+): Promise<HCAAtlasTrackerDBValidation | undefined> {
+  return (
+    await query<HCAAtlasTrackerDBValidation>(
+      "SELECT * FROM hat.validations WHERE entity_id=$1 AND validation_id=$2",
+      [dataset.id, validationId]
+    )
+  ).rows[0];
+}

--- a/__tests__/revalidate-on-refresh.test.ts
+++ b/__tests__/revalidate-on-refresh.test.ts
@@ -8,9 +8,9 @@ import {
   TEST_HCA_CATALOGS,
 } from "../testing/constants";
 
-const revalidateAllSourceDatasets = jest.fn();
+const refreshValidations = jest.fn();
 jest.mock("../app/services/validations", () => ({
-  revalidateAllSourceDatasets,
+  refreshValidations,
 }));
 
 let getAllProjectsBlock: Promise<void>;
@@ -66,13 +66,13 @@ afterAll(() => {
 
 test("source datasets are not revalidated when no refresh happens", async () => {
   await delay();
-  expect(revalidateAllSourceDatasets).toHaveBeenCalledTimes(1);
+  expect(refreshValidations).toHaveBeenCalledTimes(1);
   hcaService.getProjectIdByDoi([""]);
   cellxgeneService.getCellxGeneIdByDoi([""]);
   await delay();
   expect(hcaService.areProjectsRefreshing()).toBe(false);
   expect(cellxgeneService.isCellxGeneRefreshing()).toBe(false);
-  expect(revalidateAllSourceDatasets).toHaveBeenCalledTimes(1);
+  expect(refreshValidations).toHaveBeenCalledTimes(1);
 });
 
 test("source datasets are revalidated when last refresh completes", async () => {
@@ -88,11 +88,11 @@ test("source datasets are revalidated when last refresh completes", async () => 
   cellxgeneService.getCellxGeneIdByDoi([""]);
 
   await delay();
-  expect(revalidateAllSourceDatasets).toHaveBeenCalledTimes(1);
+  expect(refreshValidations).toHaveBeenCalledTimes(1);
   resolveProjects();
   await delay();
-  expect(revalidateAllSourceDatasets).toHaveBeenCalledTimes(1);
+  expect(refreshValidations).toHaveBeenCalledTimes(1);
   resolveCellxGene();
   await delay();
-  expect(revalidateAllSourceDatasets).toHaveBeenCalledTimes(2);
+  expect(refreshValidations).toHaveBeenCalledTimes(2);
 });

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -2,6 +2,7 @@ import { NETWORK_KEYS, WAVES } from "./constants";
 
 export interface HCAAtlasTrackerListAtlas {
   bioNetwork: NetworkKey;
+  completedTaskCount: number;
   id: string;
   integrationLeadEmail: IntegrationLead["email"] | null;
   integrationLeadName: IntegrationLead["name"] | null;
@@ -10,6 +11,7 @@ export interface HCAAtlasTrackerListAtlas {
   publicationPubString: string;
   shortName: string;
   status: ATLAS_STATUS;
+  taskCount: number;
   title: string;
   version: string;
   wave: Wave;
@@ -17,6 +19,7 @@ export interface HCAAtlasTrackerListAtlas {
 
 export interface HCAAtlasTrackerAtlas {
   bioNetwork: NetworkKey;
+  completedTaskCount: number;
   id: string;
   integrationLead: IntegrationLead | null;
   publication: {
@@ -26,6 +29,7 @@ export interface HCAAtlasTrackerAtlas {
   shortName: string;
   sourceDatasetCount: number;
   status: ATLAS_STATUS;
+  taskCount: number;
   title: string;
   version: string;
   wave: Wave;
@@ -129,9 +133,11 @@ export interface HCAAtlasTrackerDBAtlas {
 }
 
 export interface HCAAtlasTrackerDBAtlasOverview {
+  completedTaskCount: number;
   integrationLead: IntegrationLead | null;
   network: NetworkKey;
   shortName: string;
+  taskCount: number;
   version: string;
   wave: Wave;
 }

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -28,6 +28,7 @@ export function atlasInputMapper(
 ): HCAAtlasTrackerListAtlas {
   return {
     bioNetwork: apiAtlas.bioNetwork,
+    completedTaskCount: apiAtlas.completedTaskCount,
     id: apiAtlas.id,
     integrationLeadEmail: apiAtlas.integrationLead?.email ?? null,
     integrationLeadName: apiAtlas.integrationLead?.name ?? null,
@@ -36,6 +37,7 @@ export function atlasInputMapper(
     publicationPubString: apiAtlas.publication.pubString,
     shortName: apiAtlas.shortName,
     status: apiAtlas.status,
+    taskCount: apiAtlas.taskCount,
     title: apiAtlas.title,
     version: apiAtlas.version,
     wave: apiAtlas.wave,
@@ -47,6 +49,7 @@ export function dbAtlasToApiAtlas(
 ): HCAAtlasTrackerAtlas {
   return {
     bioNetwork: dbAtlas.overview.network,
+    completedTaskCount: dbAtlas.overview.completedTaskCount,
     id: dbAtlas.id,
     integrationLead: dbAtlas.overview.integrationLead,
     publication: {
@@ -56,6 +59,7 @@ export function dbAtlasToApiAtlas(
     shortName: dbAtlas.overview.shortName,
     sourceDatasetCount: dbAtlas.source_datasets.length,
     status: dbAtlas.status,
+    taskCount: dbAtlas.overview.taskCount,
     title: "",
     version: dbAtlas.overview.version,
     wave: dbAtlas.overview.wave,

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -1,0 +1,22 @@
+import { query } from "./database";
+
+export async function updateTaskCounts(): Promise<void> {
+  await query(`
+    UPDATE hat.atlases a
+    SET
+      overview = a.overview || jsonb_build_object('taskCount', counts.task_count, 'completedTaskCount', counts.completed_task_count)
+    FROM (
+      SELECT
+        a.id AS atlas_id,
+        COUNT(v.id) AS task_count,
+        COUNT(CASE WHEN v.validation_info->>'validationStatus' = 'PASSED' THEN 1 END) AS completed_task_count
+      FROM
+        hat.atlases a
+      LEFT JOIN
+        hat.validations v ON a.id = ANY(v.atlas_ids)
+      GROUP BY
+        a.id
+    ) AS counts
+    WHERE a.id = counts.atlas_id;
+  `);
+}

--- a/app/services/cellxgene.ts
+++ b/app/services/cellxgene.ts
@@ -3,7 +3,7 @@ import { getCellxGeneCollections } from "../utils/cellxgene-api";
 import { normalizeDoi } from "../utils/doi";
 import { makeRefreshService, RefreshInfo } from "./common/refresh-service";
 import { isAnyServiceRefreshing } from "./refresh-services";
-import { revalidateAllSourceDatasets } from "./validations";
+import { refreshValidations } from "./validations";
 
 export interface CollectionInfo {
   id: string;
@@ -41,7 +41,7 @@ const refreshService = makeRefreshService({
   },
   notReadyMessage: "DOI to CELLxGENE collection ID mapping not initialized",
   onRefreshSuccess() {
-    if (!isAnyServiceRefreshing()) revalidateAllSourceDatasets();
+    if (!isAnyServiceRefreshing()) refreshValidations();
   },
   refreshNeeded(data) {
     if (!data) return true;

--- a/app/services/hca-projects.ts
+++ b/app/services/hca-projects.ts
@@ -3,7 +3,7 @@ import { getAllProjects, getLatestCatalog } from "../utils/hca-api";
 import { getProjectsInfo, ProjectInfo } from "../utils/hca-projects";
 import { makeRefreshService, RefreshInfo } from "./common/refresh-service";
 import { isAnyServiceRefreshing } from "./refresh-services";
-import { revalidateAllSourceDatasets } from "./validations";
+import { refreshValidations } from "./validations";
 
 type ProjectInfoByDoi = Map<string, ProjectInfo>;
 
@@ -69,7 +69,7 @@ const refreshService = makeRefreshService({
   },
   notReadyMessage: "DOI to HCA project ID mapping not initialized",
   onRefreshSuccess() {
-    if (!isAnyServiceRefreshing()) revalidateAllSourceDatasets();
+    if (!isAnyServiceRefreshing()) refreshValidations();
   },
   refreshNeeded(data, { catalog }) {
     return data?.catalog !== catalog;

--- a/app/services/validations.ts
+++ b/app/services/validations.ts
@@ -25,6 +25,7 @@ import {
 } from "../apis/catalog/hca-atlas-tracker/common/utils";
 import { NotFoundError } from "../utils/api-handler";
 import { ProjectInfo } from "../utils/hca-projects";
+import { updateTaskCounts } from "./atlases";
 import { getPoolClient, query } from "./database";
 import { getProjectInfoByDoi } from "./hca-projects";
 
@@ -247,9 +248,17 @@ function getValidationResult<T extends ENTITY_TYPE>(
 }
 
 /**
+ * Revalidate all source datasets and update atlas task counts.
+ */
+export async function refreshValidations(): Promise<void> {
+  await revalidateAllSourceDatasets();
+  await updateTaskCounts();
+}
+
+/**
  * Update validations for all source datasets in the database.
  */
-export async function revalidateAllSourceDatasets(): Promise<void> {
+async function revalidateAllSourceDatasets(): Promise<void> {
   const client = await getPoolClient();
   const sourceDatasets = (
     await client.query<HCAAtlasTrackerDBSourceDataset>(

--- a/migrations/1716345988615_atlas-task-counts.ts
+++ b/migrations/1716345988615_atlas-task-counts.ts
@@ -1,0 +1,28 @@
+import { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(`
+    UPDATE hat.atlases a
+    SET
+      overview = a.overview || jsonb_build_object('taskCount', counts.task_count, 'completedTaskCount', counts.completed_task_count)
+    FROM (
+      SELECT
+        a.id AS atlas_id,
+        COUNT(v.id) AS task_count,
+        COUNT(CASE WHEN v.validation_info->>'validationStatus' = 'PASSED' THEN 1 END) AS completed_task_count
+      FROM
+        hat.atlases a
+      LEFT JOIN
+        hat.validations v ON a.id = ANY(v.atlas_ids)
+      GROUP BY
+        a.id
+    ) AS counts
+    WHERE a.id = counts.atlas_id;
+  `);
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(
+    `UPDATE hat.atlases SET overview=overview-'taskCount'-'completedTaskCount'`
+  );
+}

--- a/pages/api/atlases/[atlasId].ts
+++ b/pages/api/atlases/[atlasId].ts
@@ -53,7 +53,10 @@ const putHandler = handler(role(ROLE.CONTENT_ADMIN), async (req, res) => {
       throw e;
     }
   }
-  const newOverviewValues: HCAAtlasTrackerDBAtlasOverview = {
+  const newOverviewValues: Omit<
+    HCAAtlasTrackerDBAtlasOverview,
+    "completedTaskCount" | "taskCount"
+  > = {
     integrationLead: newInfo.integrationLead,
     network: newInfo.network,
     shortName: newInfo.shortName,

--- a/pages/api/atlases/create.ts
+++ b/pages/api/atlases/create.ts
@@ -38,9 +38,11 @@ export default handler(
       }
     }
     const newOverview: HCAAtlasTrackerDBAtlasOverview = {
+      completedTaskCount: 0,
       integrationLead: newInfo.integrationLead,
       network: newInfo.network,
       shortName: newInfo.shortName,
+      taskCount: 0,
       version: newInfo.version,
       wave: newInfo.wave,
     };

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -5,6 +5,7 @@ import {
   HCAAtlasTrackerDBSourceDataset,
   HCAAtlasTrackerDBValidation,
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { updateTaskCounts } from "../app/services/atlases";
 import { query } from "../app/services/database";
 import { updateSourceDatasetValidations } from "../app/services/validations";
 import { getPoolConfig } from "../app/utils/__mocks__/pg-app-connect-config";
@@ -69,6 +70,8 @@ async function initDatabaseEntries(client: pg.PoolClient): Promise<void> {
   for (const dataset of dbSourceDatasets) {
     await updateSourceDatasetValidations(dataset, client);
   }
+
+  await updateTaskCounts();
 }
 
 async function runMigrations(

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -31,9 +31,11 @@ export function makeTestAtlasOverview(
   atlas: TestAtlas
 ): HCAAtlasTrackerDBAtlasOverview {
   return {
+    completedTaskCount: 0,
     integrationLead: atlas.integrationLead,
     network: atlas.network,
     shortName: atlas.shortName,
+    taskCount: 0,
     version: atlas.version,
     wave: atlas.wave,
   };


### PR DESCRIPTION
Task counts are updated in the migration and after a full revalidation