### PR TITLE
feat: add confidentiality notice (#211)

### DIFF
--- a/app/components/common/MDXContent/confidentialNotice.mdx
+++ b/app/components/common/MDXContent/confidentialNotice.mdx
@@ -1,0 +1,8 @@
+Please note that this tracker contains confidential information that must not be distributed beyond the HCA Operations
+and Ingest Teams and the Atlas Integration Leads. This tracker includes:
+
+- Sensitive details on unpublished studies, publications, and datasets.
+- Provisional lists of potential data contributors who may not have been contacted by the HCA yet and may not be aware that their datasets have been selected for the atlas.
+
+Please email or Slack Ellen Todres ([etodres@humancellatlas.org](mailto:etodres@humancellatlas.org)) with any
+questions.

--- a/app/components/common/MDXContent/confidentialNotice.mdx
+++ b/app/components/common/MDXContent/confidentialNotice.mdx
@@ -2,7 +2,7 @@ Please note that this tracker contains confidential information that must not be
 and Ingest Teams and the Atlas Integration Leads. This tracker includes:
 
 - Sensitive details on unpublished studies, publications, and datasets.
-- Provisional lists of potential data contributors who may not have been contacted by the HCA yet and may not be aware that their datasets have been selected for the atlas.
+- Provisional lists of potential data contributors who may not have been contacted by the HCA and may not be aware that their datasets have been selected for the atlas.
 
 Please email or Slack Ellen Todres ([etodres@humancellatlas.org](mailto:etodres@humancellatlas.org)) with any
 questions.

--- a/app/components/common/MDXContent/index.tsx
+++ b/app/components/common/MDXContent/index.tsx
@@ -1,3 +1,4 @@
 export { RenderComponent } from "@databiosphere/findable-ui/lib/components/ComponentCreator/components/RenderComponent/renderComponent";
+export { default as ConfidentialNotice } from "./confidentialNotice.mdx";
 export { default as LoginTermsOfService } from "./loginTermsOfService.mdx";
 export { default as LoginText } from "./loginText.mdx";

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -1,3 +1,5 @@
+export { FluidAlert } from "@databiosphere/findable-ui/lib/components/common/Alert/alert.styles";
+export { AlertText } from "@databiosphere/findable-ui/lib/components/common/Alert/components/AlertText/alertText.styles";
 export { SessionTimeout } from "@databiosphere/findable-ui/lib/components/common/Banner/components/SessionTimeout/sessionTimeout";
 export { GitHubIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/GitHubIcon/gitHubIcon";
 export { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";

--- a/site-config/hca-atlas-tracker/local/index/atlasEntityConfig.ts
+++ b/site-config/hca-atlas-tracker/local/index/atlasEntityConfig.ts
@@ -16,6 +16,7 @@ import {
   HCA_ATLAS_TRACKER_CATEGORY_KEY,
   HCA_ATLAS_TRACKER_CATEGORY_LABEL,
 } from "../../category";
+import { subTitleHero } from "../viewList/subTitleHero";
 
 /**
  * Entity config object responsible to config anything related to the /atlases route.
@@ -179,6 +180,7 @@ export const atlasEntityConfig: EntityConfig = {
   listView: {
     disablePagination: true,
     enableDownload: true,
+    subTitleHero,
   },
   route: "atlases",
 };

--- a/site-config/hca-atlas-tracker/local/viewList/subTitleHero.ts
+++ b/site-config/hca-atlas-tracker/local/viewList/subTitleHero.ts
@@ -1,0 +1,27 @@
+import {
+  ComponentConfig,
+  ComponentsConfig,
+} from "@databiosphere/findable-ui/lib/config/entities";
+import { HCAAtlasTrackerListAtlas } from "../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
+import * as C from "../../../../app/components";
+import * as MDX from "../../../../app/components/common/MDXContent/index";
+
+export const subTitleHero: ComponentsConfig = [
+  {
+    children: [
+      {
+        children: [
+          {
+            component: MDX.ConfidentialNotice,
+          } as ComponentConfig<typeof MDX.ConfidentialNotice>,
+        ],
+        component: C.AlertText,
+      } as ComponentConfig<typeof C.AlertText>,
+    ],
+    component: C.FluidAlert,
+    props: {
+      severity: "warning",
+      title: "This tracker is confidential.",
+    },
+  } as ComponentConfig<typeof C.FluidAlert, HCAAtlasTrackerListAtlas>,
+];


### PR DESCRIPTION
Closes #211.

<img width="1727" alt="image" src="https://github.com/clevercanary/hca-atlas-tracker/assets/18710366/ccbf243d-f869-4133-99b7-5ae42b77c656">
