### PR TITLE
feat: add cap url to source dataset edit page (#255)

### DIFF
--- a/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/common/constants.ts
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/common/constants.ts
@@ -1,4 +1,8 @@
 export const DEFAULT_INPUT_PROPS = {
+  CAP_ID: {
+    isFullWidth: true,
+    label: "CAP ID",
+  },
   CELLXGENE_COLLECTION_ID: {
     isFullWidth: true,
     label: "CELLxGENE collection ID",

--- a/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/View/components/Identifiers/identifiers.tsx
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/View/components/Identifiers/identifiers.tsx
@@ -7,6 +7,7 @@ import { FIELD_NAME } from "../../../../../../../../../../../../views/SourceData
 import { SourceDatasetEditData } from "../../../../../../../../../../../../views/SourceDatasetView/common/entities";
 import { Input } from "../../../../../../../../../../../common/Form/components/Input/input";
 import { TypographyNoWrap } from "../../../../../../../../../../../common/Typography/components/TypographyNoWrap/typographyNoWrap";
+import { CapId } from "../../../../../../../../../../../Form/components/Input/components/CapId/capId";
 import {
   Section,
   SectionCard,
@@ -50,26 +51,35 @@ export const Identifiers = ({ formMethod }: IdentifiersProps): JSX.Element => {
         <Controller
           control={control}
           name={FIELD_NAME.CELLXGENE_COLLECTION_ID}
-          render={({ field }): JSX.Element => {
-            return (
-              <Input
-                {...field}
-                {...DEFAULT_INPUT_PROPS.CELLXGENE_COLLECTION_ID}
-                isFilled={Boolean(field.value)}
-                label={
-                  <Fragment>
-                    <TypographyNoWrap>
-                      {DEFAULT_INPUT_PROPS.CELLXGENE_COLLECTION_ID.label}
-                    </TypographyNoWrap>
-                    {field.value && (
-                      <Link label="Visit link" url={field.value} />
-                    )}
-                  </Fragment>
-                }
-                readOnly={true}
-              />
-            );
-          }}
+          render={({ field }): JSX.Element => (
+            <Input
+              {...field}
+              {...DEFAULT_INPUT_PROPS.CELLXGENE_COLLECTION_ID}
+              isFilled={Boolean(field.value)}
+              label={
+                <Fragment>
+                  <TypographyNoWrap>
+                    {DEFAULT_INPUT_PROPS.CELLXGENE_COLLECTION_ID.label}
+                  </TypographyNoWrap>
+                  {field.value && <Link label="Visit link" url={field.value} />}
+                </Fragment>
+              }
+              readOnly={true}
+            />
+          )}
+        />
+        <Controller
+          control={control}
+          name={FIELD_NAME.CAP_ID}
+          render={({ field, fieldState: { error, invalid } }): JSX.Element => (
+            <CapId
+              {...field}
+              {...DEFAULT_INPUT_PROPS.CAP_ID}
+              error={invalid}
+              helperText={error?.message}
+              isFilled={Boolean(field.value)}
+            />
+          )}
         />
       </SectionCard>
     </Section>

--- a/app/components/Form/common/entities.ts
+++ b/app/components/Form/common/entities.ts
@@ -1,0 +1,1 @@
+export type NonEmpty<T = string> = T extends "" ? never : T;

--- a/app/components/Form/common/utils.ts
+++ b/app/components/Form/common/utils.ts
@@ -1,0 +1,10 @@
+import { NonEmpty } from "./entities";
+
+/**
+ * Returns true if the value is a non-empty string.
+ * @param value - Value.
+ * @returns value is a non-empty string.
+ */
+export function isNonEmptyString(value: unknown): value is NonEmpty {
+  return typeof value === "string" && value.trim() !== "";
+}

--- a/app/components/Form/components/Input/components/CapId/capId.tsx
+++ b/app/components/Form/components/Input/components/CapId/capId.tsx
@@ -1,0 +1,34 @@
+import { Link } from "@databiosphere/findable-ui/lib/components/Links/components/Link/link";
+import { forwardRef, Fragment } from "react";
+import {
+  Input,
+  InputProps,
+} from "../../../../../common/Form/components/Input/input";
+import { TypographyNoWrap } from "../../../../../common/Typography/components/TypographyNoWrap/typographyNoWrap";
+import { isNonEmptyString } from "../../../../common/utils";
+import { CAP_ID_REGEXP } from "./common/constants";
+
+export const CapId = forwardRef<HTMLInputElement, InputProps>(function CapId(
+  {
+    className,
+    ...props /* Spread props to allow for Mui InputProps specific prop overrides and controller related props e.g. "field". */
+  }: InputProps,
+  ref
+): JSX.Element {
+  const { label, value } = props;
+  return (
+    <Input
+      {...props}
+      className={className}
+      label={
+        <Fragment>
+          <TypographyNoWrap>{label}</TypographyNoWrap>
+          {isNonEmptyString(value) && CAP_ID_REGEXP.test(value) && (
+            <Link label="Visit link" url={value} />
+          )}
+        </Fragment>
+      }
+      ref={ref}
+    />
+  );
+});

--- a/app/components/Form/components/Input/components/CapId/common/constants.ts
+++ b/app/components/Form/components/Input/components/CapId/common/constants.ts
@@ -1,0 +1,5 @@
+import { escapeRegExp } from "@databiosphere/findable-ui/lib/common/utils";
+
+export const CAP_ID_REGEXP = new RegExp(
+  `^(?:${escapeRegExp("https://celltype.info/project/")}\\d+/dataset/\\d+)?$`
+);

--- a/app/components/common/Form/components/FormHelperText/formHelperText.styles.ts
+++ b/app/components/common/Form/components/FormHelperText/formHelperText.styles.ts
@@ -10,6 +10,10 @@ export const FormHelperText = styled(MFormHelperText)`
 
   &.Mui-error {
     color: ${warningMain};
+
+    .MuiSvgIcon-root {
+      color: inherit;
+    }
   }
 }
 `;

--- a/app/views/AddNewSourceDatasetView/hooks/useAddSourceDatasetFormManager.tsx
+++ b/app/views/AddNewSourceDatasetView/hooks/useAddSourceDatasetFormManager.tsx
@@ -43,7 +43,7 @@ export const useAddSourceDatasetFormManager = (
       onSubmit(
         getRequestURL(API.CREATE_ATLAS_SOURCE_DATASET, atlasId),
         METHOD.POST,
-        payload,
+        filterPayload(payload),
         {
           onSuccess: (data) => onSuccess(atlasId, data.id, url),
         }
@@ -54,6 +54,20 @@ export const useAddSourceDatasetFormManager = (
 
   return useFormManager(formMethod, { onDiscard, onSave }, isDirty);
 };
+
+/**
+ * Filters the payload to exclude the publication status.
+ * @param payload - Payload.
+ * @returns filtered payload (payload without the publication status).
+ */
+function filterPayload(payload: NewSourceDatasetData): NewSourceDatasetData {
+  return Object.entries(payload).reduce((acc, [key, value]) => {
+    if (key !== FIELD_NAME.PUBLICATION_STATUS) {
+      return { ...acc, [key]: value };
+    }
+    return acc;
+  }, {} as NewSourceDatasetData);
+}
 
 /**
  * Returns schema fields relating to the publication status.
@@ -110,6 +124,5 @@ function unregisterSchemaFields(
   } else {
     fieldKeys.push(...PUBLISHED_FIELDS);
   }
-  fieldKeys.push(FIELD_NAME.PUBLICATION_STATUS);
   return fieldKeys;
 }

--- a/app/views/SourceDatasetView/common/constants.ts
+++ b/app/views/SourceDatasetView/common/constants.ts
@@ -7,12 +7,14 @@ import { SourceDatasetEditDataKeys } from "./entities";
 
 export const FIELD_NAME = {
   ...NEW_SOURCE_DATASET_FIELD_NAME,
+  CAP_ID: "capId",
   CELLXGENE_COLLECTION_ID: "cellxgeneCollectionId",
   HCA_PROJECT_ID: "hcaProjectId",
 } as const;
 
 export const PUBLISHED_FIELDS: SourceDatasetEditDataKeys[] = [
   ...NEW_SOURCE_DATASET_PUBLISHED_FIELDS,
+  FIELD_NAME.CAP_ID,
   FIELD_NAME.CELLXGENE_COLLECTION_ID,
   FIELD_NAME.HCA_PROJECT_ID,
 ];

--- a/app/views/SourceDatasetView/common/schema.ts
+++ b/app/views/SourceDatasetView/common/schema.ts
@@ -1,9 +1,14 @@
 import { object, string } from "yup";
+import { CAP_ID_REGEXP } from "../../../components/Form/components/Input/components/CapId/common/constants";
 import { newSourceDatasetSchema } from "../../AddNewSourceDatasetView/common/schema";
 import { FIELD_NAME } from "./constants";
 
 export const sourceDatasetEditSchema = newSourceDatasetSchema.concat(
   object({
+    [FIELD_NAME.CAP_ID]: string()
+      .matches(CAP_ID_REGEXP, "Invalid CAP ID")
+      .default("")
+      .notRequired(),
     [FIELD_NAME.CELLXGENE_COLLECTION_ID]: string().default("").notRequired(),
     [FIELD_NAME.HCA_PROJECT_ID]: string().default("").notRequired(),
   })

--- a/app/views/SourceDatasetView/hooks/useEditSourceDatasetForm.tsx
+++ b/app/views/SourceDatasetView/hooks/useEditSourceDatasetForm.tsx
@@ -70,6 +70,7 @@ function mapSchemaValues(
 ): SourceDatasetEditData | undefined {
   if (!sourceDataset) return;
   return {
+    [FIELD_NAME.CAP_ID]: sourceDataset.capId ?? "",
     [FIELD_NAME.CELLXGENE_COLLECTION_ID]: mapCELLxGENECollectionId(
       sourceDataset.cellxgeneCollectionId
     ),

--- a/app/views/SourceDatasetView/hooks/useEditSourceDatasetFormManager.tsx
+++ b/app/views/SourceDatasetView/hooks/useEditSourceDatasetFormManager.tsx
@@ -61,7 +61,7 @@ export const useEditSourceDatasetFormManager = (
       onSubmit(
         getRequestURL(API.ATLAS_SOURCE_DATASET, atlasId, sdId),
         METHOD.PUT,
-        payload,
+        filterPayload(payload),
         {
           onReset: reset,
           onSuccess: (data) => onSuccess(atlasId, data.id, url),
@@ -73,6 +73,20 @@ export const useEditSourceDatasetFormManager = (
 
   return useFormManager(formMethod, { onDelete, onDiscard, onSave }, isDirty);
 };
+
+/**
+ * Filters the payload to exclude the publication status.
+ * @param payload - Payload.
+ * @returns filtered payload (payload without the publication status).
+ */
+function filterPayload(payload: SourceDatasetEditData): SourceDatasetEditData {
+  return Object.entries(payload).reduce((acc, [key, value]) => {
+    if (key !== FIELD_NAME.PUBLICATION_STATUS) {
+      return { ...acc, [key]: value };
+    }
+    return acc;
+  }, {} as SourceDatasetEditData);
+}
 
 /**
  * Returns schema fields relating to the publication status.
@@ -137,6 +151,5 @@ function unregisterSchemaFields(
   } else {
     fieldKeys.push(...PUBLISHED_FIELDS);
   }
-  fieldKeys.push(FIELD_NAME.PUBLICATION_STATUS);
   return fieldKeys;
 }


### PR DESCRIPTION
Closes #255.

<img width="1631" alt="image" src="https://github.com/clevercanary/hca-atlas-tracker/assets/18710366/d8bd4042-76a2-443e-bfa0-811933f42262">
