### PR TITLE
feat: on tasks page add "expected" and "actual" titles to the "task type" text for update project title to match publication title in hca data repository tasks (#283)

### DIFF
--- a/app/components/Table/components/TableCell/components/TaskDescriptionSystemCell/components/TitleValidation/titleValidation.tsx
+++ b/app/components/Table/components/TableCell/components/TaskDescriptionSystemCell/components/TitleValidation/titleValidation.tsx
@@ -1,0 +1,39 @@
+import { Fragment } from "react";
+import {
+  HCAAtlasTrackerListValidationRecord,
+  ValidationDifference,
+  VALIDATION_STATUS,
+  VALIDATION_VARIABLE,
+} from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
+
+interface TitleValidationProps {
+  task: HCAAtlasTrackerListValidationRecord;
+}
+
+export const TitleValidation = ({
+  task,
+}: TitleValidationProps): JSX.Element | null => {
+  const { validationStatus } = task;
+  const titleValidation = findTitleValidationVariable(task);
+  if (!titleValidation) return null;
+  if (validationStatus !== VALIDATION_STATUS.FAILED) return null;
+  return (
+    <Fragment>
+      <span>Expected: {titleValidation.expected}</span>
+      <span>Actual: {titleValidation.actual}</span>
+    </Fragment>
+  );
+};
+
+/**
+ * Finds the validation difference with the title variable.
+ * @param task - Task.
+ * @returns validation difference with the title variable.
+ */
+function findTitleValidationVariable(
+  task: HCAAtlasTrackerListValidationRecord
+): ValidationDifference | undefined {
+  return task.differences.find(
+    ({ variable }) => variable === VALIDATION_VARIABLE.TITLE
+  );
+}

--- a/app/components/Table/components/TableCell/components/TaskDescriptionSystemCell/taskDescriptionSystemCell.tsx
+++ b/app/components/Table/components/TableCell/components/TaskDescriptionSystemCell/taskDescriptionSystemCell.tsx
@@ -1,0 +1,31 @@
+import { Grid } from "@databiosphere/findable-ui/lib/components/common/Grid/grid";
+import { SYSTEM_DISPLAY_NAMES } from "../../../../../../apis/catalog/hca-atlas-tracker/common/constants";
+import { HCAAtlasTrackerListValidationRecord } from "../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { TitleValidation } from "./components/TitleValidation/titleValidation";
+
+interface TaskDescriptionSystemCellProps {
+  task: HCAAtlasTrackerListValidationRecord;
+}
+
+export const TaskDescriptionSystemCell = ({
+  task,
+}: TaskDescriptionSystemCellProps): JSX.Element => {
+  return (
+    <Grid gridSx={{ gap: 1 }}>
+      <span>{getTaskDescription(task)}</span>
+      <TitleValidation task={task} />
+    </Grid>
+  );
+};
+
+/**
+ * Returns the task description.
+ * @param task - Task.
+ * @returns task description.
+ */
+function getTaskDescription(task: HCAAtlasTrackerListValidationRecord): string {
+  const { description, system } = task;
+  return `${description.trim().slice(0, -1)} in ${
+    SYSTEM_DISPLAY_NAMES[system]
+  }.`;
+}

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -26,3 +26,4 @@ export { BioNetworkCell } from "./Table/components/TableCell/components/BioNetwo
 export { AtlasCell } from "./Table/components/TableCell/components/Cell/AtlasCell/atlasCell";
 export { SourceStudyStatusCell } from "./Table/components/TableCell/components/SourceStudyStatusCell/sourceStudyStatusCell";
 export { TaskCountsCell } from "./Table/components/TableCell/components/TaskCountsCell/taskCountsCell";
+export { TaskDescriptionSystemCell } from "./Table/components/TableCell/components/TaskDescriptionSystemCell/taskDescriptionSystemCell";

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -1,10 +1,7 @@
 import { STATUS_BADGE_COLOR } from "@databiosphere/findable-ui/lib/components/common/StatusBadge/statusBadge";
 import { LinkProps } from "@databiosphere/findable-ui/lib/components/Links/components/Link/link";
 import { ColumnDef, Row } from "@tanstack/react-table";
-import {
-  NETWORKS,
-  SYSTEM_DISPLAY_NAMES,
-} from "app/apis/catalog/hca-atlas-tracker/common/constants";
+import { NETWORKS } from "app/apis/catalog/hca-atlas-tracker/common/constants";
 import { HCA_ATLAS_TRACKER_CATEGORY_LABEL } from "../../../../../site-config/hca-atlas-tracker/category";
 import {
   AtlasId,
@@ -340,17 +337,15 @@ export const buildTaskCounts = (
 };
 
 /**
- * Build props for the Cell component.
+ * Build props for the TaskDescriptionSystemCell component.
  * @param task - Task entity.
- * @returns Props to be used for the Cell component.
+ * @returns Props to be used for the TaskDescriptionSystemCell component.
  */
 export const buildTaskDescriptionSystem = (
   task: HCAAtlasTrackerListValidationRecord
-): React.ComponentProps<typeof C.Cell> => {
+): React.ComponentProps<typeof C.TaskDescriptionSystemCell> => {
   return {
-    value: `${task.description.trim().slice(0, -1)} in ${
-      SYSTEM_DISPLAY_NAMES[task.system]
-    }.`,
+    task,
   };
 };
 

--- a/site-config/hca-atlas-tracker/local/index/tasksEntityConfig.ts
+++ b/site-config/hca-atlas-tracker/local/index/tasksEntityConfig.ts
@@ -290,10 +290,10 @@ export const tasksEntityConfig: EntityConfig = {
       {
         columnPinned: true,
         componentConfig: {
-          component: C.Cell,
+          component: C.TaskDescriptionSystemCell,
           viewBuilder: V.buildTaskDescriptionSystem,
         } as ComponentConfig<
-          typeof C.Cell,
+          typeof C.TaskDescriptionSystemCell,
           HCAAtlasTrackerListValidationRecord
         >,
         header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.DESCRIPTION, // Task.


### PR DESCRIPTION
Closes #283.