### PR TITLE
feat: add source datasets backend (#274)

### DIFF
--- a/__tests__/api-atlases-id-source-studies-id-source-datasets-create.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id-source-datasets-create.test.ts
@@ -1,0 +1,214 @@
+import { METHOD } from "app/common/entities";
+import { getSourceDataset } from "app/services/source-datasets";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
+import {
+  HCAAtlasTrackerDBSourceDataset,
+  HCAAtlasTrackerDBSourceDatasetWithStudyProperties,
+  HCAAtlasTrackerSourceDataset,
+} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { NewSourceDatasetData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
+import { dbSourceDatasetToApiSourceDataset } from "../app/apis/catalog/hca-atlas-tracker/common/utils";
+import { endPgPool } from "../app/services/database";
+import createHandler from "../pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/create";
+import {
+  ATLAS_NONEXISTENT,
+  ATLAS_WITH_MISC_SOURCE_STUDIES,
+  SOURCE_STUDY_WITH_SOURCE_DATASETS,
+  USER_CONTENT_ADMIN,
+  USER_STAKEHOLDER,
+  USER_UNREGISTERED,
+} from "../testing/constants";
+import { resetDatabase } from "../testing/db-utils";
+import { TestAtlas, TestSourceStudy, TestUser } from "../testing/entities";
+import { withConsoleErrorHiding } from "../testing/utils";
+
+jest.mock("../app/services/user-profile");
+jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/cellxgene");
+jest.mock("../app/utils/pg-app-connect-config");
+
+const NEW_SOURCE_DATASET_DATA: NewSourceDatasetData = {
+  title: "New Source Dataset",
+};
+
+beforeAll(async () => {
+  await resetDatabase();
+});
+
+afterAll(async () => {
+  endPgPool();
+});
+
+describe("/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/create", () => {
+  it("returns error 405 for non-POST request", async () => {
+    expect(
+      (
+        await doCreateTest(
+          undefined,
+          ATLAS_WITH_MISC_SOURCE_STUDIES,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS,
+          NEW_SOURCE_DATASET_DATA,
+          false,
+          METHOD.GET
+        )
+      )._getStatusCode()
+    ).toEqual(405);
+  });
+
+  it("returns error 401 for logged out user", async () => {
+    expect(
+      (
+        await doCreateTest(
+          undefined,
+          ATLAS_WITH_MISC_SOURCE_STUDIES,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS,
+          NEW_SOURCE_DATASET_DATA
+        )
+      )._getStatusCode()
+    ).toEqual(401);
+  });
+
+  it("returns error 403 for unregistered user", async () => {
+    expect(
+      (
+        await doCreateTest(
+          USER_UNREGISTERED,
+          ATLAS_WITH_MISC_SOURCE_STUDIES,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS,
+          NEW_SOURCE_DATASET_DATA
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 for logged in user with STAKEHOLDER role", async () => {
+    expect(
+      (
+        await doCreateTest(
+          USER_STAKEHOLDER,
+          ATLAS_WITH_MISC_SOURCE_STUDIES,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS,
+          NEW_SOURCE_DATASET_DATA
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 404 when specified atlas doesn't exist", async () => {
+    expect(
+      (
+        await doCreateTest(
+          USER_CONTENT_ADMIN,
+          ATLAS_NONEXISTENT,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS,
+          NEW_SOURCE_DATASET_DATA,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(404);
+  });
+
+  it("returns error 400 when title is not a string", async () => {
+    expect(
+      (
+        await doCreateTest(
+          USER_CONTENT_ADMIN,
+          ATLAS_WITH_MISC_SOURCE_STUDIES,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS,
+          {
+            ...NEW_SOURCE_DATASET_DATA,
+            title: 123,
+          },
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+  });
+
+  it("returns error 400 when title is empty string", async () => {
+    expect(
+      (
+        await doCreateTest(
+          USER_CONTENT_ADMIN,
+          ATLAS_WITH_MISC_SOURCE_STUDIES,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS,
+          {
+            ...NEW_SOURCE_DATASET_DATA,
+            title: "",
+          },
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+  });
+
+  it("creates and returns source dataset entry", async () => {
+    await testSuccessfulCreate(
+      ATLAS_WITH_MISC_SOURCE_STUDIES,
+      SOURCE_STUDY_WITH_SOURCE_DATASETS,
+      NEW_SOURCE_DATASET_DATA,
+      NEW_SOURCE_DATASET_DATA.title
+    );
+  });
+});
+
+async function testSuccessfulCreate(
+  atlas: TestAtlas,
+  sourceStudy: TestSourceStudy,
+  newData: Record<string, unknown>,
+  expectedTitle: string
+): Promise<HCAAtlasTrackerDBSourceDataset> {
+  const res = await doCreateTest(
+    USER_CONTENT_ADMIN,
+    atlas,
+    sourceStudy,
+    newData
+  );
+  expect(res._getStatusCode()).toEqual(201);
+  const newSourceDataset: HCAAtlasTrackerSourceDataset = res._getJSONData();
+  const newSourceDatasetFromDb = await getSourceDataset(
+    atlas.id,
+    sourceStudy.id,
+    newSourceDataset.id
+  );
+  expectDbSourceDatasetToMatch(
+    newSourceDatasetFromDb,
+    newSourceDataset,
+    sourceStudy.id,
+    expectedTitle
+  );
+  return newSourceDatasetFromDb;
+}
+
+async function doCreateTest(
+  user: TestUser | undefined,
+  atlas: Pick<TestAtlas, "id">,
+  sourceStudy: TestSourceStudy,
+  newData: Record<string, unknown>,
+  hideConsoleError = false,
+  method = METHOD.POST
+): Promise<httpMocks.MockResponse<NextApiResponse>> {
+  const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>({
+    body: newData,
+    headers: { authorization: user?.authorization },
+    method,
+    query: { atlasId: atlas.id, sourceStudyId: sourceStudy.id },
+  });
+  await withConsoleErrorHiding(() => createHandler(req, res), hideConsoleError);
+  return res;
+}
+
+function expectDbSourceDatasetToMatch(
+  dbSourceDataset: HCAAtlasTrackerDBSourceDatasetWithStudyProperties,
+  apiSourceDataset: HCAAtlasTrackerSourceDataset,
+  sourceStudyId: string,
+  title: string
+): void {
+  expect(dbSourceDataset).toBeDefined();
+  expect(dbSourceDataset.source_study_id).toEqual(sourceStudyId);
+  expect(dbSourceDataset.sd_info.title).toEqual(title);
+  expect(dbSourceDatasetToApiSourceDataset(dbSourceDataset)).toEqual(
+    apiSourceDataset
+  );
+}

--- a/__tests__/api-atlases-id-source-studies-id-source-datasets-id.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id-source-datasets-id.test.ts
@@ -1,0 +1,442 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
+import {
+  HCAAtlasTrackerDBSourceDataset,
+  HCAAtlasTrackerSourceDataset,
+} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { SourceDatasetEditData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
+import { dbSourceDatasetToApiSourceDataset } from "../app/apis/catalog/hca-atlas-tracker/common/utils";
+import { METHOD } from "../app/common/entities";
+import { endPgPool, query } from "../app/services/database";
+import { getSourceDataset } from "../app/services/source-datasets";
+import sourceDatasetHandler from "../pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/[sourceDatasetId]";
+import {
+  ATLAS_PUBLIC,
+  ATLAS_WITH_MISC_SOURCE_STUDIES,
+  SOURCE_DATASET_FOO,
+  SOURCE_STUDY_PUBLIC_WITH_JOURNAL,
+  SOURCE_STUDY_WITH_SOURCE_DATASETS,
+  USER_CONTENT_ADMIN,
+  USER_STAKEHOLDER,
+  USER_UNREGISTERED,
+} from "../testing/constants";
+import { resetDatabase } from "../testing/db-utils";
+import { TestSourceDataset, TestUser } from "../testing/entities";
+import { withConsoleErrorHiding } from "../testing/utils";
+
+jest.mock("../app/services/user-profile");
+jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/cellxgene");
+jest.mock("../app/utils/pg-app-connect-config");
+
+const SOURCE_DATASET_FOO_EDIT: SourceDatasetEditData = {
+  title: "Source Dataset Foo Edited",
+};
+
+beforeAll(async () => {
+  await resetDatabase();
+});
+
+afterAll(async () => {
+  endPgPool();
+});
+
+describe("/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/[sourceDatasetId]", () => {
+  it("returns error 405 for PUT request", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+          SOURCE_DATASET_FOO.id,
+          undefined,
+          METHOD.PUT
+        )
+      )._getStatusCode()
+    ).toEqual(405);
+  });
+
+  it("returns error 401 when source dataset is GET requested from draft atlas by logged out user", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+          SOURCE_DATASET_FOO.id
+        )
+      )._getStatusCode()
+    ).toEqual(401);
+  });
+
+  it("returns error 403 when source dataset is GET requested from draft atlas by unregistered user", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+          SOURCE_DATASET_FOO.id,
+          USER_UNREGISTERED
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 404 when source dataset is GET requested by user with CONTENT_ADMIN role via atlas it doesn't exist on", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_PUBLIC.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+          SOURCE_DATASET_FOO.id,
+          USER_CONTENT_ADMIN,
+          undefined,
+          undefined,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(404);
+  });
+
+  it("returns error 404 when source dataset is GET requested by user with CONTENT_ADMIN role via source study it doesn't exist on", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_PUBLIC_WITH_JOURNAL.id,
+          SOURCE_DATASET_FOO.id,
+          USER_CONTENT_ADMIN,
+          undefined,
+          undefined,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(404);
+  });
+
+  it("returns source dataset from draft atlas when GET requested by logged in user with STAKEHOLDER role", async () => {
+    const res = await doSourceDatasetRequest(
+      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+      SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+      SOURCE_DATASET_FOO.id,
+      USER_STAKEHOLDER
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const sourceDataset = res._getJSONData() as HCAAtlasTrackerSourceDataset;
+    expect(sourceDataset.title).toEqual(SOURCE_DATASET_FOO.title);
+  });
+
+  it("returns source dataset from draft atlas when GET requested by logged in user with CONTENT_ADMIN role", async () => {
+    const res = await doSourceDatasetRequest(
+      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+      SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+      SOURCE_DATASET_FOO.id,
+      USER_CONTENT_ADMIN
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const sourceDataset = res._getJSONData() as HCAAtlasTrackerSourceDataset;
+    expect(sourceDataset.title).toEqual(SOURCE_DATASET_FOO.title);
+  });
+
+  it("returns error 401 when source dataset is PATCH requested from draft atlas by logged out user", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+          SOURCE_DATASET_FOO.id,
+          undefined,
+          METHOD.PATCH,
+          SOURCE_DATASET_FOO_EDIT
+        )
+      )._getStatusCode()
+    ).toEqual(401);
+    expectSourceDatasetToBeUnchanged(SOURCE_DATASET_FOO);
+  });
+
+  it("returns error 403 when source dataset is PATCH requested from draft atlas by unregistered user", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+          SOURCE_DATASET_FOO.id,
+          USER_STAKEHOLDER,
+          METHOD.PATCH,
+          SOURCE_DATASET_FOO_EDIT
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    expectSourceDatasetToBeUnchanged(SOURCE_DATASET_FOO);
+  });
+
+  it("returns error 403 when source dataset is PATCH requested from draft atlas by logged in user with STAKEHOLDER role", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+          SOURCE_DATASET_FOO.id,
+          USER_STAKEHOLDER,
+          METHOD.PATCH,
+          SOURCE_DATASET_FOO_EDIT
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    expectSourceDatasetToBeUnchanged(SOURCE_DATASET_FOO);
+  });
+
+  it("returns error 404 when source dataset is PATCH requested from atlas it doesn't exist on", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_PUBLIC.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+          SOURCE_DATASET_FOO.id,
+          USER_CONTENT_ADMIN,
+          METHOD.PATCH,
+          SOURCE_DATASET_FOO_EDIT,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(404);
+    expectSourceDatasetToBeUnchanged(SOURCE_DATASET_FOO);
+  });
+
+  it("returns error 404 when source dataset is PATCH requested from source study it doesn't exist on", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_PUBLIC_WITH_JOURNAL.id,
+          SOURCE_DATASET_FOO.id,
+          USER_CONTENT_ADMIN,
+          METHOD.PATCH,
+          SOURCE_DATASET_FOO_EDIT,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(404);
+    expectSourceDatasetToBeUnchanged(SOURCE_DATASET_FOO);
+  });
+
+  it("returns error 400 for source dataset PATCH requested with title set to undefined", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+          SOURCE_DATASET_FOO.id,
+          USER_CONTENT_ADMIN,
+          METHOD.PATCH,
+          {
+            ...SOURCE_DATASET_FOO_EDIT,
+            title: undefined,
+          },
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+    expectSourceDatasetToBeUnchanged(SOURCE_DATASET_FOO);
+  });
+
+  it("updates and returns source dataset when PATCH requested", async () => {
+    const res = await doSourceDatasetRequest(
+      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+      SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+      SOURCE_DATASET_FOO.id,
+      USER_CONTENT_ADMIN,
+      METHOD.PATCH,
+      SOURCE_DATASET_FOO_EDIT
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const updatedSourceDataset = res._getJSONData();
+    const sourceDatasetFromDb = await getSourceDataset(
+      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+      SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+      updatedSourceDataset.id
+    );
+    expect(sourceDatasetFromDb).toBeDefined();
+    if (!sourceDatasetFromDb) return;
+    expect(sourceDatasetFromDb.sd_info.title).toEqual(
+      SOURCE_DATASET_FOO_EDIT.title
+    );
+    expect(dbSourceDatasetToApiSourceDataset(sourceDatasetFromDb)).toEqual(
+      updatedSourceDataset
+    );
+
+    await restoreDbSourceDataset(SOURCE_DATASET_FOO);
+  });
+
+  it("returns error 401 when source dataset is DELETE requested from draft atlas by logged out user", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+          SOURCE_DATASET_FOO.id,
+          undefined,
+          METHOD.DELETE
+        )
+      )._getStatusCode()
+    ).toEqual(401);
+    expectSourceDatasetToBeUnchanged(SOURCE_DATASET_FOO);
+  });
+
+  it("returns error 403 when source dataset is DELETE requested from draft atlas by unregistered user", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+          SOURCE_DATASET_FOO.id,
+          USER_STAKEHOLDER,
+          METHOD.DELETE
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    expectSourceDatasetToBeUnchanged(SOURCE_DATASET_FOO);
+  });
+
+  it("returns error 403 when source dataset is DELETE requested from draft atlas by logged in user with STAKEHOLDER role", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+          SOURCE_DATASET_FOO.id,
+          USER_STAKEHOLDER,
+          METHOD.DELETE
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    expectSourceDatasetToBeUnchanged(SOURCE_DATASET_FOO);
+  });
+
+  it("returns error 404 when source dataset is DELETE requested from atlas it doesn't exist on", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_PUBLIC.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+          SOURCE_DATASET_FOO.id,
+          USER_CONTENT_ADMIN,
+          METHOD.DELETE,
+          undefined,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(404);
+    expectSourceDatasetToBeUnchanged(SOURCE_DATASET_FOO);
+  });
+
+  it("returns error 404 when source dataset is DELETE requested from source study it doesn't exist on", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_PUBLIC_WITH_JOURNAL.id,
+          SOURCE_DATASET_FOO.id,
+          USER_CONTENT_ADMIN,
+          METHOD.DELETE,
+          undefined,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(404);
+    expectSourceDatasetToBeUnchanged(SOURCE_DATASET_FOO);
+  });
+
+  it("deletes source dataset", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+          SOURCE_DATASET_FOO.id,
+          USER_CONTENT_ADMIN,
+          METHOD.DELETE
+        )
+      )._getStatusCode()
+    ).toEqual(200);
+    const sourceDatasetQueryResult = await query(
+      "SELECT * FROM hat.source_datasets WHERE id=$1",
+      [SOURCE_DATASET_FOO.id]
+    );
+    expect(sourceDatasetQueryResult.rows[0]).toBeUndefined();
+
+    await query(
+      "INSERT INTO hat.source_datasets (source_study_id, sd_info, id) VALUES ($1, $2, $3)",
+      [
+        SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+        JSON.stringify({
+          cellCount: 0,
+          cellxgeneDatasetId: null,
+          cellxgeneDatasetVersion: null,
+          title: SOURCE_DATASET_FOO.title,
+        }),
+        SOURCE_DATASET_FOO.id,
+      ]
+    );
+  });
+});
+
+async function doSourceDatasetRequest(
+  atlasId: string,
+  sourceStudyId: string,
+  sourceDatasetId: string,
+  user?: TestUser,
+  method = METHOD.GET,
+  updatedData?: Record<string, unknown>,
+  hideConsoleError = false
+): Promise<httpMocks.MockResponse<NextApiResponse>> {
+  const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>({
+    body: updatedData,
+    headers: { authorization: user?.authorization },
+    method,
+    query: { atlasId, sourceDatasetId, sourceStudyId },
+  });
+  await withConsoleErrorHiding(
+    () => sourceDatasetHandler(req, res),
+    hideConsoleError
+  );
+  return res;
+}
+
+async function restoreDbSourceDataset(
+  sourceDataset: TestSourceDataset
+): Promise<void> {
+  await query("UPDATE hat.source_datasets SET sd_info=$1 WHERE id=$2", [
+    JSON.stringify({
+      cellCount: 0,
+      cellxgeneDatasetId: null,
+      cellxgeneDatasetVersion: null,
+      title: sourceDataset.title,
+    }),
+    sourceDataset.id,
+  ]);
+}
+
+async function expectSourceDatasetToBeUnchanged(
+  sourceDataset: TestSourceDataset
+): Promise<void> {
+  const sourceDatasetFromDb = await getSourceDatasetFromDatabase(
+    sourceDataset.id
+  );
+  expect(sourceDatasetFromDb).toBeDefined();
+  if (!sourceDatasetFromDb) return;
+  expect(sourceDatasetFromDb.source_study_id).toEqual(
+    sourceDataset.sourceStudyId
+  );
+  expect(sourceDatasetFromDb.sd_info.title).toEqual(sourceDataset.title);
+}
+
+async function getSourceDatasetFromDatabase(
+  id: string
+): Promise<HCAAtlasTrackerDBSourceDataset | undefined> {
+  return (
+    await query<HCAAtlasTrackerDBSourceDataset>(
+      "SELECT * FROM hat.source_datasets WHERE id=$1",
+      [id]
+    )
+  ).rows[0];
+}

--- a/__tests__/api-atlases-id-source-studies-id-source-datasets-id.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id-source-datasets-id.test.ts
@@ -13,6 +13,7 @@ import sourceDatasetHandler from "../pages/api/atlases/[atlasId]/source-studies/
 import {
   ATLAS_PUBLIC,
   ATLAS_WITH_MISC_SOURCE_STUDIES,
+  SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE,
   SOURCE_DATASET_FOO,
   SOURCE_STUDY_PUBLIC_WITH_JOURNAL,
   SOURCE_STUDY_WITH_SOURCE_DATASETS,
@@ -137,6 +138,20 @@ describe("/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/
     expect(sourceDataset.title).toEqual(SOURCE_DATASET_FOO.title);
   });
 
+  it("returns CELLxGENE source dataset when GET requested by logged in user with CONTENT_ADMIN role", async () => {
+    const res = await doSourceDatasetRequest(
+      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+      SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+      SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE.id,
+      USER_CONTENT_ADMIN
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const sourceDataset = res._getJSONData() as HCAAtlasTrackerSourceDataset;
+    expect(sourceDataset.title).toEqual(
+      SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE.title
+    );
+  });
+
   it("returns error 401 when source dataset is PATCH requested from draft atlas by logged out user", async () => {
     expect(
       (
@@ -237,6 +252,23 @@ describe("/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/
       )._getStatusCode()
     ).toEqual(400);
     expectSourceDatasetToBeUnchanged(SOURCE_DATASET_FOO);
+  });
+
+  it("returns error 400 when CELLxGENE dataset is PATCH requested", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+          SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE.id,
+          USER_CONTENT_ADMIN,
+          METHOD.PATCH,
+          SOURCE_DATASET_FOO_EDIT,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+    expectSourceDatasetToBeUnchanged(SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE);
   });
 
   it("updates and returns source dataset when PATCH requested", async () => {
@@ -344,6 +376,23 @@ describe("/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/
       )._getStatusCode()
     ).toEqual(404);
     expectSourceDatasetToBeUnchanged(SOURCE_DATASET_FOO);
+  });
+
+  it("returns error 400 when CELLxGENE source dataset is DELETE requested", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_PUBLIC_WITH_JOURNAL.id,
+          SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE.id,
+          USER_CONTENT_ADMIN,
+          METHOD.DELETE,
+          undefined,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+    expectSourceDatasetToBeUnchanged(SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE);
   });
 
   it("deletes source dataset", async () => {

--- a/__tests__/api-atlases-id-source-studies-id-source-datasets-id.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id-source-datasets-id.test.ts
@@ -13,6 +13,7 @@ import sourceDatasetHandler from "../pages/api/atlases/[atlasId]/source-studies/
 import {
   ATLAS_PUBLIC,
   ATLAS_WITH_MISC_SOURCE_STUDIES,
+  SOURCE_DATASET_BAR,
   SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE,
   SOURCE_DATASET_FOO,
   SOURCE_STUDY_PUBLIC_WITH_JOURNAL,
@@ -296,6 +297,8 @@ describe("/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/
       updatedSourceDataset
     );
 
+    expectSourceDatasetToBeUnchanged(SOURCE_DATASET_BAR);
+
     await restoreDbSourceDataset(SOURCE_DATASET_FOO);
   });
 
@@ -412,6 +415,8 @@ describe("/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/
       [SOURCE_DATASET_FOO.id]
     );
     expect(sourceDatasetQueryResult.rows[0]).toBeUndefined();
+
+    expectSourceDatasetToBeUnchanged(SOURCE_DATASET_BAR);
 
     await query(
       "INSERT INTO hat.source_datasets (source_study_id, sd_info, id) VALUES ($1, $2, $3)",

--- a/__tests__/api-atlases-id-source-studies-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id-source-datasets.test.ts
@@ -1,0 +1,129 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
+import { HCAAtlasTrackerSourceDataset } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "../app/common/entities";
+import { endPgPool } from "../app/services/database";
+import sourceDatasetsHandler from "../pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets";
+import {
+  ATLAS_WITH_MISC_SOURCE_STUDIES,
+  SOURCE_DATASET_BAR,
+  SOURCE_DATASET_FOO,
+  SOURCE_STUDY_WITH_SOURCE_DATASETS,
+  USER_CONTENT_ADMIN,
+  USER_STAKEHOLDER,
+  USER_UNREGISTERED,
+} from "../testing/constants";
+import { resetDatabase } from "../testing/db-utils";
+import { TestSourceDataset, TestUser } from "../testing/entities";
+
+jest.mock("../app/services/user-profile");
+jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/cellxgene");
+jest.mock("../app/utils/pg-app-connect-config");
+
+beforeAll(async () => {
+  await resetDatabase();
+});
+
+afterAll(async () => {
+  endPgPool();
+});
+
+describe("/api/atlases/[id]/source-studies/[sourceStudyId]/source-datasets", () => {
+  it("returns error 405 for non-GET request", async () => {
+    expect(
+      (
+        await doSourceDatasetsRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+          undefined,
+          METHOD.POST
+        )
+      )._getStatusCode()
+    ).toEqual(405);
+  });
+
+  it("returns error 401 when source datasets are requested by logged out user", async () => {
+    expect(
+      (
+        await doSourceDatasetsRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id
+        )
+      )._getStatusCode()
+    ).toEqual(401);
+  });
+  it("returns error 403 when source datasets are requested by unregistered user", async () => {
+    expect(
+      (
+        await doSourceDatasetsRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+          USER_UNREGISTERED
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns source datasets when requested by logged in user with STAKEHOLDER role", async () => {
+    const res = await doSourceDatasetsRequest(
+      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+      SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+      USER_STAKEHOLDER
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const sourceDatasets = res._getJSONData() as HCAAtlasTrackerSourceDataset[];
+    expect(sourceDatasets).toHaveLength(2);
+    expectSourceDatasetsToMatch(sourceDatasets, [
+      SOURCE_DATASET_FOO,
+      SOURCE_DATASET_BAR,
+    ]);
+  });
+
+  it("returns source datasets when requested by logged in user with CONTENT_ADMIN role", async () => {
+    const res = await doSourceDatasetsRequest(
+      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+      SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+      USER_CONTENT_ADMIN
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const sourceDatasets = res._getJSONData() as HCAAtlasTrackerSourceDataset[];
+    expect(sourceDatasets).toHaveLength(2);
+    expectSourceDatasetsToMatch(sourceDatasets, [
+      SOURCE_DATASET_FOO,
+      SOURCE_DATASET_BAR,
+    ]);
+  });
+});
+
+async function doSourceDatasetsRequest(
+  atlasId: string,
+  sourceStudyId: string,
+  user?: TestUser,
+  method = METHOD.GET
+): Promise<httpMocks.MockResponse<NextApiResponse>> {
+  const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>({
+    headers: { authorization: user?.authorization },
+    method,
+    query: { atlasId, sourceStudyId },
+  });
+  await sourceDatasetsHandler(req, res);
+  return res;
+}
+
+function expectSourceDatasetsToMatch(
+  sourceDatasets: HCAAtlasTrackerSourceDataset[],
+  expectedTestSourceDatasets: TestSourceDataset[]
+): void {
+  for (const testSourceDataset of expectedTestSourceDatasets) {
+    const sourceDataset = sourceDatasets.find(
+      (c) => c.id === testSourceDataset.id
+    );
+    expect(sourceDataset).toBeDefined();
+    if (!sourceDataset) continue;
+    expect(sourceDataset.sourceStudyId).toEqual(
+      testSourceDataset.sourceStudyId
+    );
+    expect(sourceDataset.title).toEqual(testSourceDataset.title);
+  }
+}

--- a/__tests__/api-atlases-id-source-studies-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id-source-datasets.test.ts
@@ -7,6 +7,8 @@ import sourceDatasetsHandler from "../pages/api/atlases/[atlasId]/source-studies
 import {
   ATLAS_WITH_MISC_SOURCE_STUDIES,
   SOURCE_DATASET_BAR,
+  SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE,
+  SOURCE_DATASET_CELLXGENE_WITH_UPDATE,
   SOURCE_DATASET_FOO,
   SOURCE_STUDY_WITH_SOURCE_DATASETS,
   USER_CONTENT_ADMIN,
@@ -73,10 +75,12 @@ describe("/api/atlases/[id]/source-studies/[sourceStudyId]/source-datasets", () 
     );
     expect(res._getStatusCode()).toEqual(200);
     const sourceDatasets = res._getJSONData() as HCAAtlasTrackerSourceDataset[];
-    expect(sourceDatasets).toHaveLength(2);
+    expect(sourceDatasets).toHaveLength(4);
     expectSourceDatasetsToMatch(sourceDatasets, [
       SOURCE_DATASET_FOO,
       SOURCE_DATASET_BAR,
+      SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE,
+      SOURCE_DATASET_CELLXGENE_WITH_UPDATE,
     ]);
   });
 
@@ -88,10 +92,12 @@ describe("/api/atlases/[id]/source-studies/[sourceStudyId]/source-datasets", () 
     );
     expect(res._getStatusCode()).toEqual(200);
     const sourceDatasets = res._getJSONData() as HCAAtlasTrackerSourceDataset[];
-    expect(sourceDatasets).toHaveLength(2);
+    expect(sourceDatasets).toHaveLength(4);
     expectSourceDatasetsToMatch(sourceDatasets, [
       SOURCE_DATASET_FOO,
       SOURCE_DATASET_BAR,
+      SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE,
+      SOURCE_DATASET_CELLXGENE_WITH_UPDATE,
     ]);
   });
 });

--- a/__tests__/cellxgene.test.ts
+++ b/__tests__/cellxgene.test.ts
@@ -1,5 +1,8 @@
 import { RefreshDataNotReadyError } from "../app/services/common/refresh-service";
-import { CellxGeneCollection } from "../app/utils/cellxgene-api";
+import {
+  CellxGeneCollection,
+  CellxGeneDataset,
+} from "../app/utils/cellxgene-api";
 import {
   CELLXGENE_ID_NORMAL,
   CELLXGENE_ID_NORMAL2,
@@ -22,6 +25,7 @@ jest.useFakeTimers({
 });
 
 let [getCollectionsBlock, resolveGetCollections] = promiseWithResolvers<void>();
+const [getDatasetsBlock, resolveGetDatasets] = promiseWithResolvers<void>();
 let cellxgeneCollections = TEST_CELLXGENE_COLLECTIONS_A;
 
 const getCellxGeneCollections = jest
@@ -31,9 +35,16 @@ const getCellxGeneCollections = jest
     return cellxgeneCollections;
   });
 
+const getCellxGeneDatasets = jest
+  .fn()
+  .mockImplementation(async (): Promise<CellxGeneDataset[]> => {
+    await getDatasetsBlock;
+    return [];
+  });
+
 jest.mock("../app/utils/cellxgene-api", () => ({
   getCellxGeneCollections,
-  getCellxGeneDatasets: jest.fn().mockResolvedValue([]), // TODO test datasets
+  getCellxGeneDatasets,
 }));
 
 let getCellxGeneIdByDoi: typeof import("../app/services/cellxgene").getCellxGeneIdByDoi;
@@ -52,14 +63,22 @@ afterAll(() => {
 });
 
 describe("getCellxGeneIdByDoi", () => {
-  it("Throws RefreshDataNotReadyError when called before CELLxGENE collections are initially fetched", () => {
+  it("Throws RefreshDataNotReadyError when called before CELLxGENE data is initially fetched", () => {
+    expect(() => getCellxGeneIdByDoi([DOI_NORMAL])).toThrow(
+      RefreshDataNotReadyError
+    );
+  });
+
+  it("Throws RefreshDataNotReadyError when called after collections initially resolve but datasets have not resolved", async () => {
+    resolveGetCollections();
+    await delay();
     expect(() => getCellxGeneIdByDoi([DOI_NORMAL])).toThrow(
       RefreshDataNotReadyError
     );
   });
 
   it("Returns ID for project in initial catalog", async () => {
-    resolveGetCollections();
+    resolveGetDatasets();
     await delay();
     expect(getCellxGeneIdByDoi([DOI_NORMAL])).toEqual(CELLXGENE_ID_NORMAL);
   });

--- a/__tests__/cellxgene.test.ts
+++ b/__tests__/cellxgene.test.ts
@@ -10,9 +10,11 @@ import {
 } from "../testing/constants";
 import { delay, promiseWithResolvers } from "../testing/utils";
 
+jest.mock("../app/services/user-profile");
 jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/validations", () => ({
-  refreshValidations: jest.fn(),
+jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("../app/services/refresh-services", () => ({
+  doUpdatesIfRefreshesComplete: jest.fn(),
 }));
 
 jest.useFakeTimers({
@@ -31,6 +33,7 @@ const getCellxGeneCollections = jest
 
 jest.mock("../app/utils/cellxgene-api", () => ({
   getCellxGeneCollections,
+  getCellxGeneDatasets: jest.fn().mockResolvedValue([]), // TODO test datasets
 }));
 
 let getCellxGeneIdByDoi: typeof import("../app/services/cellxgene").getCellxGeneIdByDoi;

--- a/__tests__/hca-projects.test.ts
+++ b/__tests__/hca-projects.test.ts
@@ -1,5 +1,6 @@
 import { ProjectsResponse } from "../app/apis/azul/hca-dcp/common/responses";
 import { RefreshDataNotReadyError } from "../app/services/common/refresh-service";
+import { endPgPool } from "../app/services/database";
 import {
   DOI_NORMAL,
   DOI_NORMAL2,
@@ -11,7 +12,9 @@ import {
 } from "../testing/constants";
 import { delay, promiseWithResolvers } from "../testing/utils";
 
+jest.mock("../app/services/user-profile");
 jest.mock("../app/services/cellxgene");
+jest.mock("../app/utils/pg-app-connect-config");
 jest.mock("../app/services/validations", () => ({
   refreshValidations: jest.fn(),
 }));
@@ -50,6 +53,7 @@ beforeAll(async () => {
 afterAll(() => {
   consoleLogSpy.mockRestore();
   globalThis.hcaAtlasTrackerProjectsInfoCache = undefined;
+  endPgPool();
 });
 
 describe("getProjectIdByDoi", () => {

--- a/__tests__/revalidate-on-refresh.test.ts
+++ b/__tests__/revalidate-on-refresh.test.ts
@@ -8,6 +8,10 @@ import {
   TEST_HCA_CATALOGS,
 } from "../testing/constants";
 
+jest.mock("../app/services/source-datasets");
+jest.mock("../app/services/user-profile");
+jest.mock("../app/utils/pg-app-connect-config");
+
 const refreshValidations = jest.fn();
 jest.mock("../app/services/validations", () => ({
   refreshValidations,
@@ -46,6 +50,7 @@ const getCellxGeneCollections = jest
 
 jest.mock("../app/utils/cellxgene-api", () => ({
   getCellxGeneCollections,
+  getCellxGeneDatasets: jest.fn().mockResolvedValue([]),
 }));
 
 let cellxgeneService: typeof import("../app/services/cellxgene");
@@ -54,8 +59,17 @@ let consoleLogSpy: jest.SpyInstance;
 
 beforeAll(async () => {
   consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
+
+  const [projectsPromise, resolveProjects] = promiseWithResolvers<void>();
+  getAllProjectsBlock = projectsPromise;
+  const [cellxgenePromise, resolveCellxGene] = promiseWithResolvers<void>();
+  getCollectionsBlock = cellxgenePromise;
+
   hcaService = await import("../app/services/hca-projects");
   cellxgeneService = await import("../app/services/cellxgene");
+
+  resolveProjects();
+  resolveCellxGene();
 });
 
 afterAll(() => {

--- a/__tests__/update-cellxgene-source-datasets.test.ts
+++ b/__tests__/update-cellxgene-source-datasets.test.ts
@@ -1,0 +1,157 @@
+import {
+  CELLXGENE_DATASET_NEW,
+  CELLXGENE_DATASET_WITH_UPDATE_UPDATED,
+  SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE,
+  SOURCE_DATASET_CELLXGENE_WITH_UPDATE,
+  SOURCE_DATASET_FOO,
+  SOURCE_STUDY_WITH_SOURCE_DATASETS,
+} from "testing/constants";
+import { HCAAtlasTrackerDBSourceDataset } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { endPgPool, query } from "../app/services/database";
+import { updateCellxGeneSourceDatasets } from "../app/services/source-datasets";
+import { CellxGeneDataset } from "../app/utils/cellxgene-api";
+import { resetDatabase } from "../testing/db-utils";
+import { TestSourceDataset } from "../testing/entities";
+
+jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/cellxgene");
+jest.mock("../app/services/user-profile");
+jest.mock("../app/utils/pg-app-connect-config");
+
+beforeAll(async () => {
+  await resetDatabase();
+});
+
+afterAll(() => {
+  endPgPool();
+});
+
+describe("updateCellxGeneSourceDatasets", () => {
+  it("updates and adds source datasets as appropriate", async () => {
+    const sourceDatasetsBefore = await getStudySourceDatasets(
+      SOURCE_STUDY_WITH_SOURCE_DATASETS.id
+    );
+
+    expect(sourceDatasetsBefore).toHaveLength(4);
+
+    expectSourceDatasetToMatch(
+      findSourceDatasetById(
+        sourceDatasetsBefore,
+        SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE.id
+      ),
+      SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE
+    );
+    expectSourceDatasetToMatch(
+      findSourceDatasetById(
+        sourceDatasetsBefore,
+        SOURCE_DATASET_CELLXGENE_WITH_UPDATE.id
+      ),
+      SOURCE_DATASET_CELLXGENE_WITH_UPDATE
+    );
+    expect(
+      findSourceDatasetByCellxGeneId(
+        sourceDatasetsBefore,
+        CELLXGENE_DATASET_NEW.dataset_id
+      )
+    ).toBeUndefined();
+
+    await updateCellxGeneSourceDatasets();
+
+    const sourceDatasetsAfter = await getStudySourceDatasets(
+      SOURCE_STUDY_WITH_SOURCE_DATASETS.id
+    );
+
+    expect(sourceDatasetsAfter).toHaveLength(5);
+
+    expectSourceDatasetToMatch(
+      findSourceDatasetById(
+        sourceDatasetsAfter,
+        SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE.id
+      ),
+      SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE
+    );
+    expectSourceDatasetToMatchCellxGeneDataset(
+      findSourceDatasetById(
+        sourceDatasetsAfter,
+        SOURCE_DATASET_CELLXGENE_WITH_UPDATE.id
+      ),
+      CELLXGENE_DATASET_WITH_UPDATE_UPDATED,
+      SOURCE_STUDY_WITH_SOURCE_DATASETS.id
+    );
+    expectSourceDatasetToMatchCellxGeneDataset(
+      findSourceDatasetByCellxGeneId(
+        sourceDatasetsAfter,
+        CELLXGENE_DATASET_NEW.dataset_id
+      ),
+      CELLXGENE_DATASET_NEW,
+      SOURCE_STUDY_WITH_SOURCE_DATASETS.id
+    );
+
+    expectSourceDatasetToMatch(
+      findSourceDatasetById(sourceDatasetsAfter, SOURCE_DATASET_FOO.id),
+      SOURCE_DATASET_FOO
+    );
+  });
+});
+
+function expectSourceDatasetToMatch(
+  sourceDataset: HCAAtlasTrackerDBSourceDataset | undefined,
+  testSourceDataset: TestSourceDataset
+): void {
+  expect(sourceDataset).toBeDefined();
+  if (!sourceDataset) return;
+  expect(sourceDataset.source_study_id).toEqual(
+    testSourceDataset.sourceStudyId
+  );
+  expect(sourceDataset.sd_info.cellCount).toEqual(0);
+  expect(sourceDataset.sd_info.cellxgeneDatasetId).toEqual(
+    testSourceDataset.cellxgeneDatasetId ?? null
+  );
+  expect(sourceDataset.sd_info.cellxgeneDatasetVersion).toEqual(
+    testSourceDataset.cellxgeneDatasetVersion ?? null
+  );
+  expect(sourceDataset.sd_info.title).toEqual(testSourceDataset.title);
+}
+
+function expectSourceDatasetToMatchCellxGeneDataset(
+  sourceDataset: HCAAtlasTrackerDBSourceDataset | undefined,
+  cxgDataset: CellxGeneDataset,
+  expectedSourceStudyId: string
+): void {
+  expect(sourceDataset).toBeDefined();
+  if (!sourceDataset) return;
+  expect(sourceDataset.source_study_id).toEqual(expectedSourceStudyId);
+  expect(sourceDataset.sd_info.cellCount).toEqual(cxgDataset.cell_count);
+  expect(sourceDataset.sd_info.cellxgeneDatasetId).toEqual(
+    cxgDataset.dataset_id
+  );
+  expect(sourceDataset.sd_info.cellxgeneDatasetVersion).toEqual(
+    cxgDataset.dataset_version_id
+  );
+  expect(sourceDataset.sd_info.title).toEqual(cxgDataset.title);
+}
+
+function findSourceDatasetById(
+  sourceDatasets: HCAAtlasTrackerDBSourceDataset[],
+  id: string
+): HCAAtlasTrackerDBSourceDataset | undefined {
+  return sourceDatasets.find((d) => d.id === id);
+}
+
+function findSourceDatasetByCellxGeneId(
+  sourceDatasets: HCAAtlasTrackerDBSourceDataset[],
+  id: string
+): HCAAtlasTrackerDBSourceDataset | undefined {
+  return sourceDatasets.find((d) => d.sd_info.cellxgeneDatasetId === id);
+}
+
+async function getStudySourceDatasets(
+  studyId: string
+): Promise<HCAAtlasTrackerDBSourceDataset[]> {
+  return (
+    await query<HCAAtlasTrackerDBSourceDataset>(
+      "SELECT * FROM hat.source_datasets WHERE source_study_id=$1",
+      [studyId]
+    )
+  ).rows;
+}

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -83,6 +83,20 @@ export interface HCAAtlasTrackerUnpublishedSourceStudy
   title: string;
 }
 
+export interface HCAAtlasTrackerSourceDataset {
+  cellCount: number;
+  cellxgeneDatasetId: string | null;
+  cellxgeneDatasetVersion: string | null;
+  createdAt: string;
+  doi: string | null;
+  id: string;
+  publicationString: string;
+  sourceStudyId: string;
+  sourceStudyTitle: string | null;
+  title: string;
+  updatedAt: string;
+}
+
 export interface HCAAtlasTrackerValidationResult {
   atlasIds: string[];
   description: string;
@@ -199,12 +213,30 @@ export interface HCAAtlasTrackerDBUnpublishedSourceStudyInfo {
   doiStatus: DOI_STATUS;
   hcaProjectId: string | null;
   publication: null;
-  unpublishedInfo: {
-    contactEmail: string | null;
-    referenceAuthor: string;
-    title: string;
-  };
+  unpublishedInfo: UnpublishedInfo;
 }
+
+export interface HCAAtlasTrackerDBSourceDataset {
+  created_at: Date;
+  id: string;
+  sd_info: HCAAtlasTrackerDBSourceDatasetInfo;
+  source_study_id: string;
+  updated_at: Date;
+}
+
+export interface HCAAtlasTrackerDBSourceDatasetInfo {
+  cellCount: number;
+  cellxgeneDatasetId: string | null;
+  cellxgeneDatasetVersion: string | null;
+  title: string;
+}
+
+export type HCAAtlasTrackerDBSourceDatasetWithStudyProperties =
+  HCAAtlasTrackerDBSourceDataset &
+    (
+      | Pick<HCAAtlasTrackerDBPublishedSourceStudy, "doi" | "study_info">
+      | Pick<HCAAtlasTrackerDBUnpublishedSourceStudy, "doi" | "study_info">
+    );
 
 export interface HCAAtlasTrackerListValidationRecord
   extends Omit<HCAAtlasTrackerValidationRecord, "targetCompletion" | "doi"> {
@@ -290,6 +322,12 @@ export interface PublicationInfo {
   journal: string;
   preprintOfDoi: string | null;
   publicationDate: string;
+  title: string;
+}
+
+export interface UnpublishedInfo {
+  contactEmail: string | null;
+  referenceAuthor: string;
   title: string;
 }
 

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -221,6 +221,21 @@ export type SourceStudyEditData =
   | UnpublishedSourceStudyEditData;
 
 /**
+ * Schema for data used to create a new source dataset.
+ */
+export const newSourceDatasetSchema = object({
+  title: string().required(),
+}).strict();
+
+export type NewSourceDatasetData = InferType<typeof newSourceDatasetSchema>;
+
+export const sourceDatasetEditSchema = object({
+  title: string().required(),
+}).strict();
+
+export type SourceDatasetEditData = InferType<typeof sourceDatasetEditSchema>;
+
+/**
  * Schema for data used to create a new user.
  */
 export const newUserSchema = object({

--- a/app/services/__mocks__/cellxgene.ts
+++ b/app/services/__mocks__/cellxgene.ts
@@ -1,4 +1,8 @@
-import { TEST_CELLXGENE_COLLECTIONS_BY_DOI } from "testing/constants";
+import { CellxGeneDataset } from "../../../app/utils/cellxgene-api";
+import {
+  TEST_CELLXGENE_COLLECTIONS_BY_DOI,
+  TEST_CELLXGENE_DATASETS_BY_COLLECTION_ID,
+} from "../../../testing/constants";
 import { CollectionInfo } from "../cellxgene";
 
 export function isCellxGeneRefreshing(): boolean {
@@ -19,4 +23,10 @@ export function getCellxGeneInfoByDoi(dois: string[]): CollectionInfo | null {
       };
   }
   return null;
+}
+
+export function getCellxGeneDatasetsByCollectionId(
+  id: string
+): CellxGeneDataset[] | undefined {
+  return TEST_CELLXGENE_DATASETS_BY_COLLECTION_ID.get(id);
 }

--- a/app/services/cellxgene.ts
+++ b/app/services/cellxgene.ts
@@ -1,9 +1,8 @@
 import { Options as KyOptions } from "ky";
-import { getCellxGeneCollections } from "../utils/cellxgene-api";
+import { CellxGeneDataset, getCellxGeneCollections } from "../utils/cellxgene-api";
 import { normalizeDoi } from "../utils/doi";
 import { makeRefreshService, RefreshInfo } from "./common/refresh-service";
-import { isAnyServiceRefreshing } from "./refresh-services";
-import { refreshValidations } from "./validations";
+import { doUpdatesIfRefreshesComplete } from "./refresh-services";
 
 export interface CollectionInfo {
   id: string;
@@ -41,7 +40,7 @@ const refreshService = makeRefreshService({
   },
   notReadyMessage: "DOI to CELLxGENE collection ID mapping not initialized",
   onRefreshSuccess() {
-    if (!isAnyServiceRefreshing()) refreshValidations();
+    doUpdatesIfRefreshesComplete();
   },
   refreshNeeded(data) {
     if (!data) return true;
@@ -61,6 +60,10 @@ export const isCellxGeneRefreshing = refreshService.isRefreshing;
  */
 export function getCellxGeneIdByDoi(dois: string[]): string | null {
   return getCellxGeneInfoByDoi(dois)?.id ?? null;
+}
+
+export function getCellxGeneDatasetsByCollectionId(): Map<string, CellxGeneDataset[]> {
+
 }
 
 /**

--- a/app/services/cellxgene.ts
+++ b/app/services/cellxgene.ts
@@ -1,5 +1,9 @@
 import { Options as KyOptions } from "ky";
-import { CellxGeneDataset, getCellxGeneCollections } from "../utils/cellxgene-api";
+import {
+  CellxGeneDataset,
+  getCellxGeneCollections,
+  getCellxGeneDatasets,
+} from "../utils/cellxgene-api";
 import { normalizeDoi } from "../utils/doi";
 import { makeRefreshService, RefreshInfo } from "./common/refresh-service";
 import { doUpdatesIfRefreshesComplete } from "./refresh-services";
@@ -11,6 +15,7 @@ export interface CollectionInfo {
 
 interface CellxGeneData {
   collectionInfoByDoi: Map<string, CollectionInfo>;
+  datasetsByCollectionId: Map<string, CellxGeneDataset[]>;
   lastRefreshTime: number;
 }
 
@@ -30,8 +35,13 @@ const refreshService = makeRefreshService({
   getRefreshParams: () => undefined,
   async getRefreshedData() {
     const time = Date.now();
+    const [collectionInfoByDoi, datasetsByCollectionId] = await Promise.all([
+      getRefreshedCollectionIdsByDoi(),
+      getRefreshedDatasetsByCollectionId(),
+    ]);
     return {
-      collectionInfoByDoi: await getRefreshedCollectionIdsByDoi(),
+      collectionInfoByDoi,
+      datasetsByCollectionId,
       lastRefreshTime: time,
     };
   },
@@ -62,8 +72,10 @@ export function getCellxGeneIdByDoi(dois: string[]): string | null {
   return getCellxGeneInfoByDoi(dois)?.id ?? null;
 }
 
-export function getCellxGeneDatasetsByCollectionId(): Map<string, CellxGeneDataset[]> {
-
+export function getCellxGeneDatasetsByCollectionId(
+  collectionId: string
+): CellxGeneDataset[] | undefined {
+  return refreshService.getData().datasetsByCollectionId.get(collectionId);
 }
 
 /**
@@ -108,4 +120,32 @@ async function getRefreshedCollectionIdsByDoi(): Promise<
       });
   }
   return idsByDoi;
+}
+
+async function getRefreshedDatasetsByCollectionId(): Promise<
+  Map<string, CellxGeneDataset[]>
+> {
+  console.log("Requesting CELLxGENE datasets");
+  const datasets = await getCellxGeneDatasets({
+    hooks: {
+      beforeRetry: [
+        (): void => {
+          console.log("Retrying CELLxGENE datasets request");
+        },
+      ],
+    },
+    ...KY_OPTIONS,
+  });
+  console.log("Loaded CELLxGENE datasets");
+  const datasetsByCollectionId = new Map<string, CellxGeneDataset[]>();
+  for (const dataset of datasets) {
+    let collectionDatasets = datasetsByCollectionId.get(dataset.collection_id);
+    if (!collectionDatasets)
+      datasetsByCollectionId.set(
+        dataset.collection_id,
+        (collectionDatasets = [])
+      );
+    collectionDatasets.push(dataset);
+  }
+  return datasetsByCollectionId;
 }

--- a/app/services/database.ts
+++ b/app/services/database.ts
@@ -15,6 +15,34 @@ export function query<T extends pg.QueryResultRow>(
     : pool.query<T>(queryTextOrConfig, values);
 }
 
+/**
+ * Perform a database transaction, with automatic client management and rollback on error.
+ * @param func - Function to receive a Postgres client and perform queries.
+ * @param catchFunc - Function to handle thrown errors; if present, errors will not be automatically re-thrown.
+ * @param finallyFunc - Function to call after the client is released, whether or not an error was thrown.
+ * @returns result of evaluating the functions.
+ */
+export async function doTransaction<T>(
+  func: (client: pg.PoolClient) => Promise<T>,
+  catchFunc?: (e: unknown) => T | Promise<T>,
+  finallyFunc?: () => void | Promise<void>
+): Promise<T> {
+  const client = await getPoolClient();
+  try {
+    await client.query("BEGIN");
+    const result = await func(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (e) {
+    await client.query("ROLLBACK");
+    if (catchFunc) return await catchFunc(e);
+    else throw e;
+  } finally {
+    client.release();
+    await finallyFunc?.();
+  }
+}
+
 export function getPoolClient(): Promise<pg.PoolClient> {
   return pool.connect();
 }

--- a/app/services/hca-projects.ts
+++ b/app/services/hca-projects.ts
@@ -2,8 +2,7 @@ import { Options as KyOptions } from "ky";
 import { getAllProjects, getLatestCatalog } from "../utils/hca-api";
 import { getProjectsInfo, ProjectInfo } from "../utils/hca-projects";
 import { makeRefreshService, RefreshInfo } from "./common/refresh-service";
-import { isAnyServiceRefreshing } from "./refresh-services";
-import { refreshValidations } from "./validations";
+import { doUpdatesIfRefreshesComplete } from "./refresh-services";
 
 type ProjectInfoByDoi = Map<string, ProjectInfo>;
 
@@ -69,7 +68,7 @@ const refreshService = makeRefreshService({
   },
   notReadyMessage: "DOI to HCA project ID mapping not initialized",
   onRefreshSuccess() {
-    if (!isAnyServiceRefreshing()) refreshValidations();
+    doUpdatesIfRefreshesComplete();
   },
   refreshNeeded(data, { catalog }) {
     return data?.catalog !== catalog;

--- a/app/services/refresh-services.ts
+++ b/app/services/refresh-services.ts
@@ -1,5 +1,14 @@
 import { isCellxGeneRefreshing } from "./cellxgene";
 import { areProjectsRefreshing } from "./hca-projects";
+import { updateCellxGeneSourceDatasets } from "./source-datasets";
+import { refreshValidations } from "./validations";
+
+export async function doUpdatesIfRefreshesComplete(): Promise<void> {
+  if (!isAnyServiceRefreshing()) {
+    await updateCellxGeneSourceDatasets();
+    await refreshValidations();
+  }
+}
 
 export function isAnyServiceRefreshing(): boolean {
   return areProjectsRefreshing() || isCellxGeneRefreshing();

--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -1,0 +1,169 @@
+import pg from "pg";
+import {
+  HCAAtlasTrackerDBSourceDataset,
+  HCAAtlasTrackerDBSourceDatasetInfo,
+  HCAAtlasTrackerDBSourceDatasetWithStudyProperties,
+} from "../apis/catalog/hca-atlas-tracker/common/entities";
+import {
+  NewSourceDatasetData,
+  SourceDatasetEditData,
+} from "../apis/catalog/hca-atlas-tracker/common/schema";
+import { NotFoundError } from "../utils/api-handler";
+import { doTransaction, query } from "./database";
+import { confirmSourceStudyExistsOnAtlas } from "./source-studies";
+
+/**
+ * Get all source datasets of the given source study.
+ * @param atlasId - ID of the atlas that the source study is accesed through.
+ * @param sourceStudyId - Source study ID.
+ * @returns database-model source datasets.
+ */
+export async function getSourceStudyDatasets(
+  atlasId: string,
+  sourceStudyId: string
+): Promise<HCAAtlasTrackerDBSourceDatasetWithStudyProperties[]> {
+  await confirmSourceStudyExistsOnAtlas(sourceStudyId, atlasId);
+  const queryResult =
+    await query<HCAAtlasTrackerDBSourceDatasetWithStudyProperties>(
+      "SELECT d.*, s.doi, s.study_info FROM hat.source_datasets d JOIN hat.source_studies s ON d.study_id = s.id WHERE s.id = $1",
+      [sourceStudyId]
+    );
+  return queryResult.rows;
+}
+
+/**
+ * Get a source dataset.
+ * @param atlasId - ID of the atlas that the source dataset is accessed through.
+ * @param sourceStudyId - ID of the source study that the source dataset is accessed through.
+ * @param sourceDatasetId - Source dataset ID.
+ * @param client - Postgres client to use.
+ * @returns database model of the source dataset.
+ */
+export async function getSourceDataset(
+  atlasId: string,
+  sourceStudyId: string,
+  sourceDatasetId: string,
+  client?: pg.PoolClient
+): Promise<HCAAtlasTrackerDBSourceDatasetWithStudyProperties> {
+  await confirmSourceStudyExistsOnAtlas(
+    sourceStudyId,
+    atlasId,
+    undefined,
+    client
+  );
+  const queryResult =
+    await query<HCAAtlasTrackerDBSourceDatasetWithStudyProperties>(
+      "SELECT d.*, s.doi, s.study_info FROM hat.source_datasets d JOIN hat.source_studies s ON d.study_id = s.id WHERE d.id = $1",
+      [sourceDatasetId],
+      client
+    );
+  if (queryResult.rows.length === 0)
+    throw getSourceDatasetNotFoundError(sourceStudyId, sourceDatasetId);
+  return queryResult.rows[0];
+}
+
+/**
+ * Create a source dataset for the given source study.
+ * @param atlasId - ID of the atlas that the source study is accessed through.
+ * @param sourceStudyId - Source study ID.
+ * @param inputData - Values for the new source dataset.
+ * @returns database model of the new source dataset.
+ */
+export async function createSourceDataset(
+  atlasId: string,
+  sourceStudyId: string,
+  inputData: NewSourceDatasetData
+): Promise<HCAAtlasTrackerDBSourceDatasetWithStudyProperties> {
+  await confirmSourceStudyExistsOnAtlas(sourceStudyId, atlasId);
+  const info = sourceDatasetInputDataToDbData(inputData);
+  return await doTransaction(async (client) => {
+    const insertResult = await client.query<
+      Pick<HCAAtlasTrackerDBSourceDataset, "id">
+    >(
+      "INSERT INTO hat.source_datasets (sd_info, source_study_id) VALUES ($1, $2) RETURNING id",
+      [JSON.stringify(info), sourceStudyId]
+    );
+    return await getSourceDataset(
+      atlasId,
+      sourceStudyId,
+      insertResult.rows[0].id,
+      client
+    );
+  });
+}
+
+/**
+ * Update a source dataset.
+ * @param atlasId - ID of the atlas that the source dataset is accessed through.
+ * @param sourceStudyId - ID of the source study that the source dataset is accessed through.
+ * @param sourceDatasetId - Source dataset ID.
+ * @param inputData - Values to update the source dataset with.
+ * @returns database model of the updated source dataset.
+ */
+export async function updateSourceDataset(
+  atlasId: string,
+  sourceStudyId: string,
+  sourceDatasetId: string,
+  inputData: SourceDatasetEditData
+): Promise<HCAAtlasTrackerDBSourceDatasetWithStudyProperties> {
+  // TODO disallow for CELLxGENE datasets
+  await confirmSourceStudyExistsOnAtlas(sourceStudyId, atlasId);
+  const info = sourceDatasetInputDataToDbData(inputData);
+  return await doTransaction(async (client) => {
+    const updateResult = await client.query<
+      Pick<HCAAtlasTrackerDBSourceDataset, "id">
+    >("UPDATE hat.source_datasets SET sd_info=$1 WHERE id=$2 RETURNING id", [
+      JSON.stringify(info),
+      sourceDatasetId,
+    ]);
+    if (updateResult.rows.length === 0)
+      throw getSourceDatasetNotFoundError(sourceStudyId, sourceDatasetId);
+    return await getSourceDataset(
+      atlasId,
+      sourceStudyId,
+      updateResult.rows[0].id,
+      client
+    );
+  });
+}
+
+function sourceDatasetInputDataToDbData(
+  inputData: NewSourceDatasetData | SourceDatasetEditData
+): HCAAtlasTrackerDBSourceDatasetInfo {
+  return {
+    cellCount: 0,
+    cellxgeneDatasetId: null,
+    cellxgeneDatasetVersion: null,
+    title: inputData.title,
+  };
+}
+
+/**
+ * Delete a source dataset.
+ * @param atlasId - ID of the atlas that the source dataset is accessed through.
+ * @param sourceStudyId - ID of the source study that the source dataset is accessed through.
+ * @param sourceDatasetId - Source dataset ID.
+ */
+export async function deleteSourceDataset(
+  atlasId: string,
+  sourceStudyId: string,
+  sourceDatasetId: string
+): Promise<void> {
+  // TODO disallow for CELLxGENE datasets
+  await confirmSourceStudyExistsOnAtlas(sourceStudyId, atlasId);
+  const queryResult = await query(
+    "DELETE FROM hat.source_datasets WHERE id=$1 AND source_study_id=$2",
+    [sourceDatasetId, sourceStudyId]
+  );
+  if (queryResult.rowCount === 0)
+    throw getSourceDatasetNotFoundError(sourceStudyId, sourceDatasetId);
+}
+
+function getSourceDatasetNotFoundError(
+  sourceStudyId: string,
+  sourceDatasetId: string
+): NotFoundError {
+  return new NotFoundError(
+    `Source dataset with ID ${sourceDatasetId} doesn't exist on source study with ID ${sourceStudyId}`
+  );
+}

--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -55,8 +55,8 @@ export async function getSourceDataset(
   );
   const queryResult =
     await query<HCAAtlasTrackerDBSourceDatasetWithStudyProperties>(
-      "SELECT d.*, s.doi, s.study_info FROM hat.source_datasets d JOIN hat.source_studies s ON d.source_study_id = s.id WHERE d.id = $1",
-      [sourceDatasetId],
+      "SELECT d.*, s.doi, s.study_info FROM hat.source_datasets d JOIN hat.source_studies s ON d.source_study_id = s.id WHERE d.id = $1 AND s.id = $2",
+      [sourceDatasetId, sourceStudyId],
       client
     );
   if (queryResult.rows.length === 0)

--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -25,7 +25,7 @@ export async function getSourceStudyDatasets(
   await confirmSourceStudyExistsOnAtlas(sourceStudyId, atlasId);
   const queryResult =
     await query<HCAAtlasTrackerDBSourceDatasetWithStudyProperties>(
-      "SELECT d.*, s.doi, s.study_info FROM hat.source_datasets d JOIN hat.source_studies s ON d.study_id = s.id WHERE s.id = $1",
+      "SELECT d.*, s.doi, s.study_info FROM hat.source_datasets d JOIN hat.source_studies s ON d.source_study_id = s.id WHERE s.id = $1",
       [sourceStudyId]
     );
   return queryResult.rows;
@@ -53,7 +53,7 @@ export async function getSourceDataset(
   );
   const queryResult =
     await query<HCAAtlasTrackerDBSourceDatasetWithStudyProperties>(
-      "SELECT d.*, s.doi, s.study_info FROM hat.source_datasets d JOIN hat.source_studies s ON d.study_id = s.id WHERE d.id = $1",
+      "SELECT d.*, s.doi, s.study_info FROM hat.source_datasets d JOIN hat.source_studies s ON d.source_study_id = s.id WHERE d.id = $1",
       [sourceDatasetId],
       client
     );

--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -4,7 +4,6 @@ import {
   HCAAtlasTrackerDBSourceDataset,
   HCAAtlasTrackerDBSourceDatasetInfo,
   HCAAtlasTrackerDBSourceDatasetWithStudyProperties,
-  HCAAtlasTrackerDBSourceStudy,
 } from "../apis/catalog/hca-atlas-tracker/common/entities";
 import {
   NewSourceDatasetData,
@@ -179,15 +178,13 @@ export async function updateCellxGeneSourceDatasets(): Promise<void> {
   );
 
   const sourceStudies = (
-    await query<HCAAtlasTrackerDBSourceStudy>(
-      "SELECT * FROM hat.source_studies WHEREN NOT study_info->'cellxgeneCollectionId' = 'null'"
+    await query<{ id: string; study_info: { cellxgeneCollectionId: string } }>(
+      "SELECT id, study_info FROM hat.source_studies WHEREN NOT study_info->'cellxgeneCollectionId' = 'null'"
     )
   ).rows;
 
-  const cxgDatasetsByCollectionId = getCellxGeneDatasetsByCollectionId();
-
   for (const sourceStudy of sourceStudies) {
-    const collectionDatasets = cxgDatasetsByCollectionId.get(
+    const collectionDatasets = getCellxGeneDatasetsByCollectionId(
       sourceStudy.study_info.cellxgeneCollectionId
     );
 

--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -179,7 +179,7 @@ export async function updateCellxGeneSourceDatasets(): Promise<void> {
 
   const sourceStudies = (
     await query<{ id: string; study_info: { cellxgeneCollectionId: string } }>(
-      "SELECT id, study_info FROM hat.source_studies WHEREN NOT study_info->'cellxgeneCollectionId' = 'null'"
+      "SELECT id, study_info FROM hat.source_studies WHERE NOT study_info->'cellxgeneCollectionId' = 'null'"
     )
   ).rows;
 
@@ -201,7 +201,6 @@ export async function updateCellxGeneSourceDatasets(): Promise<void> {
       ) {
         continue;
       }
-
       const infoJson = JSON.stringify(
         getCellxGeneSourceDatasetInfo(cxgDataset)
       );
@@ -218,9 +217,9 @@ export async function updateCellxGeneSourceDatasets(): Promise<void> {
   }
 }
 
-async function getCellxGeneSourceDatasetInfo(
+function getCellxGeneSourceDatasetInfo(
   cxgDataset: CellxGeneDataset
-): Promise<HCAAtlasTrackerDBSourceDatasetInfo> {
+): HCAAtlasTrackerDBSourceDatasetInfo {
   return {
     cellCount: cxgDataset.cell_count,
     cellxgeneDatasetId: cxgDataset.dataset_id,

--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -204,7 +204,10 @@ export async function updateCellxGeneSourceDatasets(): Promise<void> {
       );
 
       if (existingDataset) {
-        await query("UPDATE hat.source_datasets SET sd_info=$1", [infoJson]);
+        await query("UPDATE hat.source_datasets SET sd_info=$1 WHERE id=$2", [
+          infoJson,
+          existingDataset.id,
+        ]);
       } else {
         await query(
           "INSERT INTO hat.source_datasets (sd_info, source_study_id) VALUES ($1, $2)",

--- a/app/services/source-studies.ts
+++ b/app/services/source-studies.ts
@@ -303,15 +303,21 @@ export async function updateSourceStudyValidationsByEntityId(
  * @param sourceStudyId - Source study ID.
  * @param atlasId - Atlas ID.
  * @param limitToStatuses - If specified, statuses that the atlas must have.
+ * @param client - Postgres client to use.
  */
 export async function confirmSourceStudyExistsOnAtlas(
   sourceStudyId: string,
   atlasId: string,
-  limitToStatuses?: ATLAS_STATUS[]
+  limitToStatuses?: ATLAS_STATUS[],
+  client?: pg.PoolClient
 ): Promise<void> {
   const queryResult = await query<
     Pick<HCAAtlasTrackerDBAtlas, "source_studies" | "status">
-  >("SELECT source_studies, status FROM hat.atlases WHERE id=$1", [atlasId]);
+  >(
+    "SELECT source_studies, status FROM hat.atlases WHERE id=$1",
+    [atlasId],
+    client
+  );
   if (queryResult.rows.length === 0)
     throw new NotFoundError(`Atlas with ID ${atlasId} doesn't exist`);
   const { source_studies, status } = queryResult.rows[0];

--- a/app/utils/api-handler.ts
+++ b/app/utils/api-handler.ts
@@ -18,6 +18,10 @@ export type MiddlewareFunction = (
 
 type Handler = (req: NextApiRequest, res: NextApiResponse) => Promise<void>;
 
+export class InvalidOperationError extends Error {
+  name = "InvalidOperationError";
+}
+
 export class AccessError extends Error {
   name = "AccessError";
 }
@@ -169,7 +173,9 @@ export async function getUserFromAuthorization(
  * @param error - Error or other thrown value.
  */
 function respondError(res: NextApiResponse, error: unknown): void {
-  if (error instanceof NotFoundError)
+  if (error instanceof InvalidOperationError)
+    res.status(400).json({ message: error.message });
+  else if (error instanceof NotFoundError)
     res.status(404).json({ message: error.message });
   else if (error instanceof ValidationError) respondValidationError(res, error);
   else if (error instanceof RefreshDataNotReadyError)

--- a/app/utils/cellxgene-api.ts
+++ b/app/utils/cellxgene-api.ts
@@ -6,6 +6,14 @@ export interface CellxGeneCollection {
   name: string;
 }
 
+export interface CellxGeneDataset {
+  cell_count: number;
+  collection_id: string;
+  dataset_id: string;
+  dataset_version_id: string;
+  title: string;
+}
+
 const API_URL_COLLECTIONS =
   "https://api.cellxgene.cziscience.com/curation/v1/collections";
 

--- a/app/utils/cellxgene-api.ts
+++ b/app/utils/cellxgene-api.ts
@@ -16,9 +16,17 @@ export interface CellxGeneDataset {
 
 const API_URL_COLLECTIONS =
   "https://api.cellxgene.cziscience.com/curation/v1/collections";
+const API_URL_DATASETS =
+  "https://api.cellxgene.cziscience.com/curation/v1/datasets";
 
 export async function getCellxGeneCollections(
   kyOptions?: KyOptions
 ): Promise<CellxGeneCollection[]> {
   return await ky(API_URL_COLLECTIONS, kyOptions).json();
+}
+
+export async function getCellxGeneDatasets(
+  kyOptions?: KyOptions
+): Promise<CellxGeneDataset[]> {
+  return await ky(API_URL_DATASETS, kyOptions).json();
 }

--- a/migrations/1717735890311_source-dataset-table.ts
+++ b/migrations/1717735890311_source-dataset-table.ts
@@ -1,0 +1,59 @@
+import { MigrationBuilder } from "node-pg-migrate";
+
+export const up = (pgm: MigrationBuilder): void => {
+  pgm.createTable(
+    { name: "source_datasets", schema: "hat" },
+    {
+      created_at: {
+        default: pgm.func("CURRENT_TIMESTAMP"),
+        notNull: true,
+        type: "timestamp",
+      },
+      id: {
+        default: pgm.func("gen_random_uuid ()"),
+        notNull: true,
+        type: "uuid",
+      },
+      sd_info: { notNull: true, type: "jsonb" },
+      source_study_id: {
+        notNull: true,
+        type: "uuid",
+      },
+      updated_at: {
+        default: pgm.func("CURRENT_TIMESTAMP"),
+        notNull: true,
+        type: "timestamp",
+      },
+    }
+  );
+
+  pgm.addConstraint(
+    { name: "source_datasets", schema: "hat" },
+    "pk_source_datasets_id",
+    {
+      primaryKey: "id",
+    }
+  );
+
+  pgm.addConstraint(
+    { name: "source_datasets", schema: "hat" },
+    "fk_source_datasets_source_study_id",
+    {
+      foreignKeys: {
+        columns: "source_study_id",
+        references: { name: "source_studies", schema: "hat" },
+      },
+    }
+  );
+
+  pgm.createTrigger(
+    { name: "source_datasets", schema: "hat" },
+    "update_updated_at",
+    {
+      function: { name: "update_updated_at_column", schema: "hat" },
+      level: "ROW",
+      operation: "UPDATE",
+      when: "BEFORE",
+    }
+  );
+};

--- a/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets.ts
+++ b/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets.ts
@@ -1,0 +1,24 @@
+import { ROLE_GROUP } from "../../../../../../app/apis/catalog/hca-atlas-tracker/common/constants";
+import { dbSourceDatasetToApiSourceDataset } from "../../../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
+import { METHOD } from "../../../../../../app/common/entities";
+import { getSourceStudyDatasets } from "../../../../../../app/services/source-datasets";
+import { handler, method, role } from "../../../../../../app/utils/api-handler";
+
+/**
+ * API route for getting a source study's source datasets.
+ */
+export default handler(
+  method(METHOD.GET),
+  role(ROLE_GROUP.READ),
+  async (req, res) => {
+    const atlasId = req.query.atlasId as string;
+    const sourceStudyId = req.query.sourceStudyId as string;
+    res
+      .status(200)
+      .json(
+        (await getSourceStudyDatasets(atlasId, sourceStudyId)).map(
+          dbSourceDatasetToApiSourceDataset
+        )
+      );
+  }
+);

--- a/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/[sourceDatasetId].ts
+++ b/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/[sourceDatasetId].ts
@@ -1,0 +1,64 @@
+import { ROLE } from "app/apis/catalog/hca-atlas-tracker/common/entities";
+import { sourceDatasetEditSchema } from "app/apis/catalog/hca-atlas-tracker/common/schema";
+import { ROLE_GROUP } from "../../../../../../../app/apis/catalog/hca-atlas-tracker/common/constants";
+import { dbSourceDatasetToApiSourceDataset } from "../../../../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
+import { METHOD } from "../../../../../../../app/common/entities";
+import {
+  deleteSourceDataset,
+  getSourceDataset,
+  updateSourceDataset,
+} from "../../../../../../../app/services/source-datasets";
+import {
+  handleByMethod,
+  handler,
+  role,
+} from "../../../../../../../app/utils/api-handler";
+
+const getHandler = handler(role(ROLE_GROUP.READ), async (req, res) => {
+  const atlasId = req.query.atlasId as string;
+  const sourceStudyId = req.query.sourceStudyId as string;
+  const sourceDatasetId = req.query.sourceDatasetId as string;
+  res
+    .status(200)
+    .json(
+      dbSourceDatasetToApiSourceDataset(
+        await getSourceDataset(atlasId, sourceStudyId, sourceDatasetId)
+      )
+    );
+});
+
+const patchHandler = handler(role(ROLE.CONTENT_ADMIN), async (req, res) => {
+  const atlasId = req.query.atlasId as string;
+  const sourceStudyId = req.query.sourceStudyId as string;
+  const sourceDatasetId = req.query.sourceDatasetId as string;
+  const inputData = await sourceDatasetEditSchema.validate(req.body);
+  res
+    .status(200)
+    .json(
+      dbSourceDatasetToApiSourceDataset(
+        await updateSourceDataset(
+          atlasId,
+          sourceStudyId,
+          sourceDatasetId,
+          inputData
+        )
+      )
+    );
+});
+
+const deleteHandler = handler(role(ROLE.CONTENT_ADMIN), async (req, res) => {
+  const atlasId = req.query.atlasId as string;
+  const sourceStudyId = req.query.sourceStudyId as string;
+  const sourceDatasetId = req.query.sourceDatasetId as string;
+  await deleteSourceDataset(atlasId, sourceStudyId, sourceDatasetId);
+  res.status(200).end();
+});
+
+/**
+ * API route for getting, updating, or deleting a source dataset.
+ */
+export default handleByMethod({
+  [METHOD.GET]: getHandler,
+  [METHOD.PATCH]: patchHandler,
+  [METHOD.DELETE]: deleteHandler,
+});

--- a/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/create.ts
+++ b/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/create.ts
@@ -1,0 +1,26 @@
+import { ROLE } from "app/apis/catalog/hca-atlas-tracker/common/entities";
+import { newSourceDatasetSchema } from "app/apis/catalog/hca-atlas-tracker/common/schema";
+import { dbSourceDatasetToApiSourceDataset } from "app/apis/catalog/hca-atlas-tracker/common/utils";
+import { METHOD } from "app/common/entities";
+import { createSourceDataset } from "app/services/source-datasets";
+import { handler, method, role } from "app/utils/api-handler";
+
+/**
+ * API route for creating a source dataset.
+ */
+export default handler(
+  method(METHOD.POST),
+  role(ROLE.CONTENT_ADMIN),
+  async (req, res) => {
+    const atlasId = req.query.atlasId as string;
+    const sourceStudyId = req.query.sourceStudyId as string;
+    const inputData = await newSourceDatasetSchema.validate(req.body);
+    res
+      .status(201)
+      .json(
+        dbSourceDatasetToApiSourceDataset(
+          await createSourceDataset(atlasId, sourceStudyId, inputData)
+        )
+      );
+  }
+);

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -5,7 +5,10 @@ import {
   PublicationInfo,
   ROLE,
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { CellxGeneCollection } from "../app/utils/cellxgene-api";
+import {
+  CellxGeneCollection,
+  CellxGeneDataset,
+} from "../app/utils/cellxgene-api";
 import { CrossrefWork } from "../app/utils/crossref/crossref";
 import {
   TestAtlas,
@@ -410,6 +413,9 @@ export const CELLXGENE_ID_UNPUBLISHED_WITH_CELLXGENE =
 export const CELLXGENE_ID_PUBLISHED_WITH_CAP_AND_CELLXGENE =
   "cellxgene-collection-published-with-cap-and-cellxgene";
 
+export const CELLXGENE_ID_WITH_SOURCE_DATASETS =
+  "cellxgene-collection-with-source-datasets";
+
 export const TEST_CELLXGENE_COLLECTION_NORMAL: CellxGeneCollection = {
   collection_id: CELLXGENE_ID_NORMAL,
   doi: DOI_NORMAL,
@@ -443,6 +449,13 @@ export const TEST_CELLXGENE_COLLECTION_PUBLISHED_WITH_CAP_AND_CELLXGENE: CellxGe
     name: "Published With CAP And CELLxGENE",
   };
 
+export const TEST_CELLXGENE_COLLECTION_WITH_SOURCE_DATASETS: CellxGeneCollection =
+  {
+    collection_id: CELLXGENE_ID_WITH_SOURCE_DATASETS,
+    doi: null,
+    name: "With Source Datasets",
+  };
+
 export const TEST_CELLXGENE_COLLECTIONS_BY_DOI = new Map([
   [DOI_NORMAL, TEST_CELLXGENE_COLLECTION_NORMAL],
   [DOI_JOURNAL_COUNTERPART, TEST_CELLXGENE_COLLECTION_JOURNAL_COUNTERPART],
@@ -459,6 +472,39 @@ export const TEST_CELLXGENE_COLLECTIONS_B = [
   TEST_CELLXGENE_COLLECTION_NORMAL,
   TEST_CELLXGENE_COLLECTION_NORMAL2,
 ];
+
+// CELLXGENE DATASETS
+
+export const CELLXGENE_ID_DATASET_WITHOUT_UPDATE =
+  "cellxgene-dataset-without-update";
+
+export const CELLXGENE_VERSION_DATASET_WITHOUT_UPDATE =
+  "cellxgene-version-dataset-without-update";
+
+export const CELLXGENE_ID_DATASET_WITH_UPDATE = "cellxgene-dataset-with-update";
+
+export const CELLXGENE_DATASET_WITHOUT_UPDATE: CellxGeneDataset = {
+  cell_count: 123,
+  collection_id: CELLXGENE_ID_WITH_SOURCE_DATASETS,
+  dataset_id: CELLXGENE_ID_DATASET_WITHOUT_UPDATE,
+  dataset_version_id: CELLXGENE_VERSION_DATASET_WITHOUT_UPDATE,
+  title: "Dataset Without Update",
+};
+
+export const CELLXGENE_DATASET_WITH_UPDATE_UPDATED: CellxGeneDataset = {
+  cell_count: 456,
+  collection_id: CELLXGENE_ID_WITH_SOURCE_DATASETS,
+  dataset_id: CELLXGENE_ID_DATASET_WITH_UPDATE,
+  dataset_version_id: "cellxgene-version-dataset-with-update-b",
+  title: "Dataset With Update Updated",
+};
+
+export const TEST_CELLXGENE_DATASETS_BY_COLLECTION_ID = new Map([
+  [
+    CELLXGENE_ID_WITH_SOURCE_DATASETS,
+    [CELLXGENE_DATASET_WITHOUT_UPDATE, CELLXGENE_DATASET_WITH_UPDATE_UPDATED],
+  ],
+]);
 
 // SOURCE STUDIES
 
@@ -657,7 +703,7 @@ export const SOURCE_STUDY_PUBLISHED_WITH_CAP_AND_CELLXGENE: TestPublishedSourceS
   };
 
 export const SOURCE_STUDY_WITH_SOURCE_DATASETS: TestUnpublishedSourceStudy = {
-  cellxgeneCollectionId: null,
+  cellxgeneCollectionId: CELLXGENE_ID_WITH_SOURCE_DATASETS,
   hcaProjectId: null,
   id: "aa6a5a69-7d68-4dc1-b5ac-7ef0d55fc125",
   unpublishedInfo: {
@@ -700,10 +746,28 @@ export const SOURCE_DATASET_BAR: TestSourceDataset = {
   title: "Source Dataset Bar",
 };
 
+export const SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE: TestSourceDataset = {
+  cellxgeneDatasetId: CELLXGENE_ID_DATASET_WITHOUT_UPDATE,
+  cellxgeneDatasetVersion: CELLXGENE_VERSION_DATASET_WITHOUT_UPDATE,
+  id: "afcb9181-5a6b-45a8-89c0-1790def2d7dc",
+  sourceStudyId: SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+  title: "Source Dataset CELLxGENE Without Update",
+};
+
+export const SOURCE_DATASET_CELLXGENE_WITH_UPDATE: TestSourceDataset = {
+  cellxgeneDatasetId: CELLXGENE_ID_DATASET_WITH_UPDATE,
+  cellxgeneDatasetVersion: "cellxgene-version-dataset-with-update-a",
+  id: "04ccf7fd-22eb-4236-829c-9a0058580d36",
+  sourceStudyId: SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+  title: "Source Dataset CELLxGENE Without Update",
+};
+
 // Source datasets intitialized in the database before tests
 export const INITIAL_TEST_SOURCE_DATASETS = [
   SOURCE_DATASET_FOO,
   SOURCE_DATASET_BAR,
+  SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE,
+  SOURCE_DATASET_CELLXGENE_WITH_UPDATE,
 ];
 
 // ATLASES

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -11,6 +11,7 @@ import {
   TestAtlas,
   TestComponentAtlas,
   TestPublishedSourceStudy,
+  TestSourceDataset,
   TestUnpublishedSourceStudy,
 } from "./entities";
 import { makeTestProjectsResponse, makeTestUser } from "./utils";
@@ -655,6 +656,17 @@ export const SOURCE_STUDY_PUBLISHED_WITH_CAP_AND_CELLXGENE: TestPublishedSourceS
     },
   };
 
+export const SOURCE_STUDY_WITH_SOURCE_DATASETS: TestUnpublishedSourceStudy = {
+  cellxgeneCollectionId: null,
+  hcaProjectId: null,
+  id: "aa6a5a69-7d68-4dc1-b5ac-7ef0d55fc125",
+  unpublishedInfo: {
+    contactEmail: "bazfoo@example.com",
+    referenceAuthor: "Baz Foo",
+    title: "Source Study With Source Datasets",
+  },
+};
+
 // Source studies initialized in the database before tests
 export const INITIAL_TEST_SOURCE_STUDIES = [
   SOURCE_STUDY_DRAFT_OK,
@@ -671,6 +683,27 @@ export const INITIAL_TEST_SOURCE_STUDIES = [
   SOURCE_STUDY_PUBLISHED_WITH_NO_HCA_OR_CELLXGENE,
   SOURCE_STUDY_PUBLISHED_WITH_CAP_AND_NO_CELLXGENE,
   SOURCE_STUDY_PUBLISHED_WITH_CAP_AND_CELLXGENE,
+  SOURCE_STUDY_WITH_SOURCE_DATASETS,
+];
+
+// SOURCE DATASETS
+
+export const SOURCE_DATASET_FOO: TestSourceDataset = {
+  id: "6e1e281d-78cb-462a-ae29-94663c1e5713",
+  sourceStudyId: SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+  title: "Source Dataset Foo",
+};
+
+export const SOURCE_DATASET_BAR: TestSourceDataset = {
+  id: "cd053619-8b50-4e2d-ba62-96fbbcad6011",
+  sourceStudyId: SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+  title: "Source Dataset Bar",
+};
+
+// Source datasets intitialized in the database before tests
+export const INITIAL_TEST_SOURCE_DATASETS = [
+  SOURCE_DATASET_FOO,
+  SOURCE_DATASET_BAR,
 ];
 
 // ATLASES
@@ -731,6 +764,7 @@ export const ATLAS_WITH_MISC_SOURCE_STUDIES: TestAtlas = {
   sourceStudies: [
     SOURCE_STUDY_PUBLIC_WITH_JOURNAL.id,
     SOURCE_STUDY_PUBLIC_WITH_PREPRINT.id,
+    SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
   ],
   status: ATLAS_STATUS.PUBLIC,
   version: "2.3",

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -483,6 +483,8 @@ export const CELLXGENE_VERSION_DATASET_WITHOUT_UPDATE =
 
 export const CELLXGENE_ID_DATASET_WITH_UPDATE = "cellxgene-dataset-with-update";
 
+export const CELLXGENE_ID_DATASET_NEW = "cellxgene-dataset-new";
+
 export const CELLXGENE_DATASET_WITHOUT_UPDATE: CellxGeneDataset = {
   cell_count: 123,
   collection_id: CELLXGENE_ID_WITH_SOURCE_DATASETS,
@@ -499,10 +501,22 @@ export const CELLXGENE_DATASET_WITH_UPDATE_UPDATED: CellxGeneDataset = {
   title: "Dataset With Update Updated",
 };
 
+export const CELLXGENE_DATASET_NEW: CellxGeneDataset = {
+  cell_count: 789,
+  collection_id: CELLXGENE_ID_WITH_SOURCE_DATASETS,
+  dataset_id: CELLXGENE_ID_DATASET_NEW,
+  dataset_version_id: "cellxgene-version-dataset-new",
+  title: "Dataset New",
+};
+
 export const TEST_CELLXGENE_DATASETS_BY_COLLECTION_ID = new Map([
   [
     CELLXGENE_ID_WITH_SOURCE_DATASETS,
-    [CELLXGENE_DATASET_WITHOUT_UPDATE, CELLXGENE_DATASET_WITH_UPDATE_UPDATED],
+    [
+      CELLXGENE_DATASET_WITHOUT_UPDATE,
+      CELLXGENE_DATASET_WITH_UPDATE_UPDATED,
+      CELLXGENE_DATASET_NEW,
+    ],
   ],
 ]);
 
@@ -759,7 +773,7 @@ export const SOURCE_DATASET_CELLXGENE_WITH_UPDATE: TestSourceDataset = {
   cellxgeneDatasetVersion: "cellxgene-version-dataset-with-update-a",
   id: "04ccf7fd-22eb-4236-829c-9a0058580d36",
   sourceStudyId: SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
-  title: "Source Dataset CELLxGENE Without Update",
+  title: "Source Dataset CELLxGENE With Update",
 };
 
 // Source datasets intitialized in the database before tests

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -3,6 +3,7 @@ import { MigrationDirection } from "node-pg-migrate/dist/types";
 import pg from "pg";
 import {
   HCAAtlasTrackerDBComponentAtlasInfo,
+  HCAAtlasTrackerDBSourceDatasetInfo,
   HCAAtlasTrackerDBSourceStudy,
   HCAAtlasTrackerDBValidation,
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
@@ -13,6 +14,7 @@ import { getPoolConfig } from "../app/utils/__mocks__/pg-app-connect-config";
 import {
   INITIAL_TEST_ATLASES,
   INITIAL_TEST_COMPONENT_ATLASES,
+  INITIAL_TEST_SOURCE_DATASETS,
   INITIAL_TEST_SOURCE_STUDIES,
   INITIAL_TEST_USERS,
 } from "./constants";
@@ -44,6 +46,19 @@ async function initDatabaseEntries(client: pg.PoolClient): Promise<void> {
     await client.query(
       "INSERT INTO hat.source_studies (doi, id, study_info) VALUES ($1, $2, $3)",
       ["doi" in study ? study.doi : null, study.id, JSON.stringify(sdInfo)]
+    );
+  }
+
+  for (const sourceDataset of INITIAL_TEST_SOURCE_DATASETS) {
+    const info: HCAAtlasTrackerDBSourceDatasetInfo = {
+      cellCount: 0,
+      cellxgeneDatasetId: null,
+      cellxgeneDatasetVersion: null,
+      title: sourceDataset.title,
+    };
+    await client.query(
+      "INSERT INTO hat.source_datasets (source_study_id, sd_info, id) VALUES ($1, $2, $3)",
+      [sourceDataset.sourceStudyId, info, sourceDataset.id]
     );
   }
 

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -52,8 +52,8 @@ async function initDatabaseEntries(client: pg.PoolClient): Promise<void> {
   for (const sourceDataset of INITIAL_TEST_SOURCE_DATASETS) {
     const info: HCAAtlasTrackerDBSourceDatasetInfo = {
       cellCount: 0,
-      cellxgeneDatasetId: null,
-      cellxgeneDatasetVersion: null,
+      cellxgeneDatasetId: sourceDataset.cellxgeneDatasetId ?? null,
+      cellxgeneDatasetVersion: sourceDataset.cellxgeneDatasetVersion ?? null,
       title: sourceDataset.title,
     };
     await client.query(

--- a/testing/entities.ts
+++ b/testing/entities.ts
@@ -54,3 +54,9 @@ export interface TestUnpublishedSourceStudy {
   id: string;
   unpublishedInfo: HCAAtlasTrackerDBUnpublishedSourceStudyInfo["unpublishedInfo"];
 }
+
+export interface TestSourceDataset {
+  id: string;
+  sourceStudyId: string;
+  title: string;
+}

--- a/testing/entities.ts
+++ b/testing/entities.ts
@@ -56,6 +56,8 @@ export interface TestUnpublishedSourceStudy {
 }
 
 export interface TestSourceDataset {
+  cellxgeneDatasetId?: string;
+  cellxgeneDatasetVersion?: string;
   id: string;
   sourceStudyId: string;
   title: string;


### PR DESCRIPTION
Should updating CELLxGENE source datasets be done with transactions of any sort? Currently each dataset is inserted/updated individually