### PR TITLE
feat: trim whitespace from normalized dois (#305)

### DIFF
--- a/app/utils/doi.ts
+++ b/app/utils/doi.ts
@@ -8,12 +8,13 @@ export function isDoi(value: string): boolean {
 }
 
 export function normalizeDoi(doi: string): string {
+  doi = doi.trim();
   const urlMatch = /^(?:https?:\/\/)?(doi\.org\/.*$)/i.exec(doi);
   if (urlMatch) {
     const [, nonProtocolPart] = urlMatch;
     doi = decodeURIComponent(
       new URL("https://" + nonProtocolPart).pathname.replace(/^\//, "")
-    );
+    ).trim();
   }
   return doi.toLowerCase();
 }

--- a/migrations/1718484744990_trim-doi-whitespace.ts
+++ b/migrations/1718484744990_trim-doi-whitespace.ts
@@ -1,0 +1,12 @@
+import { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.sql(
+    "UPDATE hat.source_studies SET doi=regexp_replace(doi, '^\\s+|\\s+$', '', 'g') WHERE NOT doi IS NULL"
+  );
+  pgm.sql(
+    "UPDATE hat.validations SET validation_info=validation_info||jsonb_build_object('doi', regexp_replace(validation_info->>'doi', '^\\s+|\\s+$', '', 'g')) WHERE NOT validation_info->'doi'='null'"
+  );
+}
+
+export const down = (): void => undefined;


### PR DESCRIPTION
(This will not cause HCA/CELLxGENE IDs to be recalculated, as they're only updated when the source study is edited)