### PR TITLE
feat: add count of component atlases to component atlas tab similar to source study count (#288)

### DIFF
--- a/app/components/Detail/components/ViewAtlas/components/Tabs/tabs.tsx
+++ b/app/components/Detail/components/ViewAtlas/components/Tabs/tabs.tsx
@@ -24,7 +24,7 @@ export const Tabs = ({
   pathParameter,
 }: TabsProps): JSX.Element => {
   const { route } = useRouter();
-  const { sourceStudyCount } = atlas || {};
+  const { componentAtlasCount, sourceStudyCount } = atlas || {};
 
   const onChange = useCallback(
     (tabValue: TabValue): void => {
@@ -43,7 +43,7 @@ export const Tabs = ({
           value: ROUTE.SOURCE_STUDIES,
         },
         {
-          label: getTabLabelWithCount("Component Atlases", 0),
+          label: getTabLabelWithCount("Component Atlases", componentAtlasCount),
           value: ROUTE.COMPONENT_ATLASES,
         },
       ]}


### PR DESCRIPTION
Closes #288.