### PR TITLE
feat: add comments table and apis (#292)

### DIFF
--- a/__tests__/api-comments-thread-id-comments-comment-id.test.ts
+++ b/__tests__/api-comments-thread-id-comments-comment-id.test.ts
@@ -1,0 +1,572 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
+import {
+  HCAAtlasTrackerComment,
+  HCAAtlasTrackerDBComment,
+  HCAAtlasTrackerDBUser,
+} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { CommentEditData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
+import { METHOD } from "../app/common/entities";
+import { endPgPool, query } from "../app/services/database";
+import commentHandler from "../pages/api/comments/[threadId]/comments/[commentId]";
+import {
+  COMMENT_BY_CONTENT_ADMIN_FOO_REPLY1_STAKEHOLDER,
+  COMMENT_BY_CONTENT_ADMIN_FOO_REPLY2_STAKEHOLDER2,
+  COMMENT_BY_CONTENT_ADMIN_REPLY1_STAKEHOLDER,
+  COMMENT_BY_CONTENT_ADMIN_REPLY2_ADMIN,
+  COMMENT_BY_STAKEHOLDER2_REPLY2_STAKEHOLDER,
+  COMMENT_BY_STAKEHOLDER2_ROOT,
+  COMMENT_BY_STAKEHOLDER_FOO_REPLY1_ADMIN,
+  COMMENT_BY_STAKEHOLDER_FOO_REPLY2_STAKEHOLDER2,
+  COMMENT_BY_STAKEHOLDER_FOO_ROOT,
+  COMMENT_BY_STAKEHOLDER_REPLY1_STAKEHOLDER,
+  COMMENT_BY_STAKEHOLDER_REPLY2_ADMIN,
+  COMMENT_BY_STAKEHOLDER_ROOT,
+  TEST_COMMENTS_BY_THREAD_ID,
+  THREAD_ID_BY_CONTENT_ADMIN,
+  THREAD_ID_BY_CONTENT_ADMIN_FOO,
+  THREAD_ID_BY_STAKEHOLDER,
+  THREAD_ID_BY_STAKEHOLDER2,
+  THREAD_ID_BY_STAKEHOLDER_FOO,
+  USER_CONTENT_ADMIN,
+  USER_STAKEHOLDER,
+  USER_STAKEHOLDER2,
+  USER_UNREGISTERED,
+} from "../testing/constants";
+import { getDbUsersByEmail, resetDatabase } from "../testing/db-utils";
+import { TestComment, TestUser } from "../testing/entities";
+import { withConsoleErrorHiding } from "../testing/utils";
+
+jest.mock("../app/services/user-profile");
+jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/cellxgene");
+jest.mock("../app/utils/pg-app-connect-config");
+
+const COMMENT_BY_STAKEHOLDER_ROOT_EDIT: CommentEditData = {
+  text: "comment by stakeholder root edit",
+};
+
+const COMMENT_BY_CONTENT_ADMIN_REPLY1_STAKEHOLDER_EDIT: CommentEditData = {
+  text: "comment by content admin reply1 edit",
+};
+
+let dbUsersByEmail: Record<string, HCAAtlasTrackerDBUser>;
+
+beforeAll(async () => {
+  await resetDatabase();
+  dbUsersByEmail = await getDbUsersByEmail();
+});
+
+afterAll(async () => {
+  endPgPool();
+});
+
+describe("/api/comments/[threadId]/comments", () => {
+  it("returns error 405 for PUT request", async () => {
+    expect(
+      (
+        await doCommentTest(
+          undefined,
+          THREAD_ID_BY_STAKEHOLDER,
+          COMMENT_BY_STAKEHOLDER_REPLY1_STAKEHOLDER.id,
+          METHOD.PUT,
+          false
+        )
+      )._getStatusCode()
+    ).toEqual(405);
+  });
+
+  it("GET returns error 401 for logged out user", async () => {
+    expect(
+      (
+        await doCommentTest(
+          undefined,
+          THREAD_ID_BY_STAKEHOLDER,
+          COMMENT_BY_STAKEHOLDER_REPLY1_STAKEHOLDER.id
+        )
+      )._getStatusCode()
+    ).toEqual(401);
+  });
+
+  it("GET returns error 403 for unregistered user", async () => {
+    expect(
+      (
+        await doCommentTest(
+          USER_UNREGISTERED,
+          THREAD_ID_BY_STAKEHOLDER,
+          COMMENT_BY_STAKEHOLDER_REPLY1_STAKEHOLDER.id
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("GET returns error 404 when comment is requested via thread it doesn't exist in", async () => {
+    expect(
+      (
+        await doCommentTest(
+          USER_STAKEHOLDER,
+          THREAD_ID_BY_CONTENT_ADMIN,
+          COMMENT_BY_STAKEHOLDER_REPLY1_STAKEHOLDER.id,
+          METHOD.GET,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(404);
+  });
+
+  it("GET returns comment when requested by user with STAKEHOLDER role", async () => {
+    const res = await doCommentTest(
+      USER_STAKEHOLDER,
+      THREAD_ID_BY_STAKEHOLDER,
+      COMMENT_BY_STAKEHOLDER_REPLY1_STAKEHOLDER.id
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const comment = res._getJSONData();
+    expectApiCommentToMatchTest(
+      comment,
+      COMMENT_BY_STAKEHOLDER_REPLY1_STAKEHOLDER
+    );
+  });
+
+  it("GET returns comment when requested by user with CONTENT_ADMIN role", async () => {
+    const res = await doCommentTest(
+      USER_CONTENT_ADMIN,
+      THREAD_ID_BY_STAKEHOLDER,
+      COMMENT_BY_STAKEHOLDER_REPLY1_STAKEHOLDER.id
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const comment = res._getJSONData();
+    expectApiCommentToMatchTest(
+      comment,
+      COMMENT_BY_STAKEHOLDER_REPLY1_STAKEHOLDER
+    );
+  });
+
+  it("PATCH returns error 401 for logged out user", async () => {
+    expect(
+      (
+        await doCommentTest(
+          undefined,
+          THREAD_ID_BY_STAKEHOLDER,
+          COMMENT_BY_STAKEHOLDER_ROOT.id,
+          METHOD.PATCH,
+          false,
+          COMMENT_BY_STAKEHOLDER_ROOT_EDIT
+        )
+      )._getStatusCode()
+    ).toEqual(401);
+    await expectCommentToBeUnchanged(COMMENT_BY_STAKEHOLDER_ROOT);
+  });
+
+  it("PATCH returns error 403 for unregistered user", async () => {
+    expect(
+      (
+        await doCommentTest(
+          USER_UNREGISTERED,
+          THREAD_ID_BY_STAKEHOLDER,
+          COMMENT_BY_STAKEHOLDER_ROOT.id,
+          METHOD.PATCH,
+          false,
+          COMMENT_BY_STAKEHOLDER_ROOT_EDIT
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectCommentToBeUnchanged(COMMENT_BY_STAKEHOLDER_ROOT);
+  });
+
+  it("PATCH returns error 404 when comment is requested via thread it doesn't exist in", async () => {
+    expect(
+      (
+        await doCommentTest(
+          USER_STAKEHOLDER,
+          THREAD_ID_BY_CONTENT_ADMIN,
+          COMMENT_BY_STAKEHOLDER_ROOT.id,
+          METHOD.PATCH,
+          true,
+          COMMENT_BY_STAKEHOLDER_ROOT_EDIT
+        )
+      )._getStatusCode()
+    ).toEqual(404);
+    await expectCommentToBeUnchanged(COMMENT_BY_STAKEHOLDER_ROOT);
+  });
+
+  it("PATCH returns error 400 when text is not a string", async () => {
+    expect(
+      (
+        await doCommentTest(
+          USER_STAKEHOLDER,
+          THREAD_ID_BY_STAKEHOLDER,
+          COMMENT_BY_STAKEHOLDER_ROOT.id,
+          METHOD.PATCH,
+          true,
+          {
+            ...COMMENT_BY_STAKEHOLDER_ROOT_EDIT,
+            text: 123,
+          }
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+    await expectCommentToBeUnchanged(COMMENT_BY_STAKEHOLDER_ROOT);
+  });
+
+  it("PATCH returns error 400 when text is empty", async () => {
+    expect(
+      (
+        await doCommentTest(
+          USER_STAKEHOLDER,
+          THREAD_ID_BY_STAKEHOLDER,
+          COMMENT_BY_STAKEHOLDER_ROOT.id,
+          METHOD.PATCH,
+          true,
+          {
+            ...COMMENT_BY_STAKEHOLDER_ROOT_EDIT,
+            text: "",
+          }
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+    await expectCommentToBeUnchanged(COMMENT_BY_STAKEHOLDER_ROOT);
+  });
+
+  it("PATCH returns error 403 when user with STAKEHOLDER role attempts to edit another user's comment", async () => {
+    expect(
+      (
+        await doCommentTest(
+          USER_STAKEHOLDER,
+          THREAD_ID_BY_STAKEHOLDER,
+          COMMENT_BY_STAKEHOLDER_REPLY2_ADMIN.id,
+          METHOD.PATCH,
+          true,
+          COMMENT_BY_STAKEHOLDER_ROOT_EDIT
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectCommentToBeUnchanged(COMMENT_BY_STAKEHOLDER_REPLY2_ADMIN);
+  });
+
+  it("PATCH updates user's own comment when requested by user with STAKEHOLDER role", async () => {
+    const res = await doCommentTest(
+      USER_STAKEHOLDER,
+      THREAD_ID_BY_STAKEHOLDER,
+      COMMENT_BY_STAKEHOLDER_ROOT.id,
+      METHOD.PATCH,
+      true,
+      COMMENT_BY_STAKEHOLDER_ROOT_EDIT
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const updatedComment = res._getJSONData() as HCAAtlasTrackerComment;
+    expect(updatedComment.text).toEqual(COMMENT_BY_STAKEHOLDER_ROOT_EDIT.text);
+    const updatedCommentFromDb = await getCommentFromDatabase(
+      COMMENT_BY_STAKEHOLDER_ROOT.id
+    );
+    expect(updatedCommentFromDb).toBeDefined();
+    if (updatedCommentFromDb === undefined) return;
+    expectDbCommentToMatch(updatedCommentFromDb, updatedComment);
+    await expectCommentToBeUnchanged(COMMENT_BY_STAKEHOLDER_REPLY2_ADMIN);
+  });
+
+  it("PATCH updates another user's comment when requested by user with CONTENT_ADMIN role", async () => {
+    const res = await doCommentTest(
+      USER_CONTENT_ADMIN,
+      THREAD_ID_BY_CONTENT_ADMIN,
+      COMMENT_BY_CONTENT_ADMIN_REPLY1_STAKEHOLDER.id,
+      METHOD.PATCH,
+      true,
+      COMMENT_BY_CONTENT_ADMIN_REPLY1_STAKEHOLDER_EDIT
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const updatedComment = res._getJSONData() as HCAAtlasTrackerComment;
+    expect(updatedComment.text).toEqual(
+      COMMENT_BY_CONTENT_ADMIN_REPLY1_STAKEHOLDER_EDIT.text
+    );
+    const updatedCommentFromDb = await getCommentFromDatabase(
+      COMMENT_BY_CONTENT_ADMIN_REPLY1_STAKEHOLDER.id
+    );
+    expect(updatedCommentFromDb).toBeDefined();
+    if (updatedCommentFromDb === undefined) return;
+    expectDbCommentToMatch(updatedCommentFromDb, updatedComment);
+    await expectCommentToBeUnchanged(COMMENT_BY_CONTENT_ADMIN_REPLY2_ADMIN);
+  });
+
+  it("DELETE returns error 401 for logged out user", async () => {
+    expect(
+      (
+        await doCommentTest(
+          undefined,
+          THREAD_ID_BY_STAKEHOLDER2,
+          COMMENT_BY_STAKEHOLDER2_REPLY2_STAKEHOLDER.id,
+          METHOD.DELETE
+        )
+      )._getStatusCode()
+    ).toEqual(401);
+    await expectCommentToBeUnchanged(
+      COMMENT_BY_STAKEHOLDER2_REPLY2_STAKEHOLDER
+    );
+  });
+
+  it("DELETE returns error 403 for unregistered user", async () => {
+    expect(
+      (
+        await doCommentTest(
+          USER_UNREGISTERED,
+          THREAD_ID_BY_STAKEHOLDER2,
+          COMMENT_BY_STAKEHOLDER2_REPLY2_STAKEHOLDER.id,
+          METHOD.DELETE
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectCommentToBeUnchanged(
+      COMMENT_BY_STAKEHOLDER2_REPLY2_STAKEHOLDER
+    );
+  });
+
+  it("DELETE returns error 404 when comment is requested via thread it doesn't exist it", async () => {
+    expect(
+      (
+        await doCommentTest(
+          USER_STAKEHOLDER,
+          THREAD_ID_BY_CONTENT_ADMIN,
+          COMMENT_BY_STAKEHOLDER2_REPLY2_STAKEHOLDER.id,
+          METHOD.DELETE,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(404);
+    await expectCommentToBeUnchanged(
+      COMMENT_BY_STAKEHOLDER2_REPLY2_STAKEHOLDER
+    );
+  });
+
+  it("DELETE returns error 403 when user with STAKEHOLDER role attempts to delete their own root comment", async () => {
+    expect(
+      (
+        await doCommentTest(
+          USER_STAKEHOLDER2,
+          THREAD_ID_BY_STAKEHOLDER2,
+          COMMENT_BY_STAKEHOLDER2_ROOT.id,
+          METHOD.DELETE,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectCommentToBeUnchanged(COMMENT_BY_STAKEHOLDER2_ROOT);
+  });
+
+  it("DELETE returns error 403 when user with STAKEHOLDER role attempts to delete another user's non-root comment", async () => {
+    expect(
+      (
+        await doCommentTest(
+          USER_STAKEHOLDER2,
+          THREAD_ID_BY_STAKEHOLDER2,
+          COMMENT_BY_STAKEHOLDER2_REPLY2_STAKEHOLDER.id,
+          METHOD.DELETE,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectCommentToBeUnchanged(
+      COMMENT_BY_STAKEHOLDER2_REPLY2_STAKEHOLDER
+    );
+  });
+
+  it("DELETE returns error 403 when user with STAKEHOLDER role attempts to delete another user's root comment", async () => {
+    expect(
+      (
+        await doCommentTest(
+          USER_STAKEHOLDER2,
+          THREAD_ID_BY_STAKEHOLDER_FOO,
+          COMMENT_BY_STAKEHOLDER_FOO_ROOT.id,
+          METHOD.DELETE,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectCommentToBeUnchanged(COMMENT_BY_STAKEHOLDER_FOO_ROOT);
+  });
+
+  it("DELETE deletes user's own non-root comment when requested by user with STAKEHOLDER role", async () => {
+    await expectCommentToBeUnchanged(
+      COMMENT_BY_STAKEHOLDER_FOO_REPLY2_STAKEHOLDER2
+    );
+    expect(
+      (
+        await doCommentTest(
+          USER_STAKEHOLDER2,
+          THREAD_ID_BY_STAKEHOLDER_FOO,
+          COMMENT_BY_STAKEHOLDER_FOO_REPLY2_STAKEHOLDER2.id,
+          METHOD.DELETE,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(200);
+    expect(
+      await getCommentFromDatabase(
+        COMMENT_BY_STAKEHOLDER_FOO_REPLY2_STAKEHOLDER2.id
+      )
+    ).toBeUndefined();
+    await expectCommentToBeUnchanged(COMMENT_BY_STAKEHOLDER_FOO_REPLY1_ADMIN);
+  });
+
+  it("DELETE deletes another user's non-root comment when requested by user with CONTENT_ADMIN role", async () => {
+    await expectCommentToBeUnchanged(
+      COMMENT_BY_CONTENT_ADMIN_FOO_REPLY1_STAKEHOLDER
+    );
+    expect(
+      (
+        await doCommentTest(
+          USER_CONTENT_ADMIN,
+          THREAD_ID_BY_CONTENT_ADMIN_FOO,
+          COMMENT_BY_CONTENT_ADMIN_FOO_REPLY1_STAKEHOLDER.id,
+          METHOD.DELETE,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(200);
+    expect(
+      await getCommentFromDatabase(
+        COMMENT_BY_CONTENT_ADMIN_FOO_REPLY1_STAKEHOLDER.id
+      )
+    ).toBeUndefined();
+    await expectCommentToBeUnchanged(
+      COMMENT_BY_CONTENT_ADMIN_FOO_REPLY2_STAKEHOLDER2
+    );
+  });
+
+  it("DELETE deletes another user's thread via root comment when requested by user with CONTENT_ADMIN role", async () => {
+    await expectThreadToBeUnchanged(THREAD_ID_BY_STAKEHOLDER2);
+    expect(
+      (
+        await doCommentTest(
+          USER_CONTENT_ADMIN,
+          THREAD_ID_BY_STAKEHOLDER2,
+          COMMENT_BY_STAKEHOLDER2_ROOT.id,
+          METHOD.DELETE,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(200);
+    expect(
+      await getThreadCommentsFromDatabase(THREAD_ID_BY_STAKEHOLDER2)
+    ).toHaveLength(0);
+    expectCommentToBeUnchanged(COMMENT_BY_STAKEHOLDER_ROOT);
+  });
+});
+
+async function expectThreadToBeUnchanged(threadId: string): Promise<void> {
+  expectDbCommentsToMatchTest(
+    await getThreadCommentsFromDatabase(threadId),
+    TEST_COMMENTS_BY_THREAD_ID[threadId]
+  );
+}
+
+async function expectCommentToBeUnchanged(
+  testComment: TestComment
+): Promise<void> {
+  const dbComment = await getCommentFromDatabase(testComment.id);
+  expect(dbComment).toBeDefined();
+  if (dbComment === undefined) return;
+  expectDbCommentToMatchTest(dbComment, testComment);
+}
+
+function expectApiCommentToMatchTest(
+  dbComment: HCAAtlasTrackerComment,
+  testComment: TestComment
+): void {
+  expect(dbComment.createdAt).toEqual(testComment.createdAt);
+  expect(dbComment.createdBy).toEqual(
+    dbUsersByEmail[testComment.createdBy.email].id
+  );
+  expect(dbComment.id).toEqual(testComment.id);
+  expect(dbComment.text).toEqual(testComment.text);
+  expect(dbComment.threadId).toEqual(testComment.threadId);
+  expect(dbComment.updatedAt).toEqual(testComment.createdAt);
+  expect(dbComment.updatedBy).toEqual(
+    dbUsersByEmail[testComment.createdBy.email].id
+  );
+}
+
+function expectDbCommentsToMatchTest(
+  dbComments: HCAAtlasTrackerDBComment[],
+  testComments: TestComment[]
+): void {
+  expect(dbComments).toHaveLength(testComments.length);
+  for (const [i, dbComment] of dbComments.entries()) {
+    expectDbCommentToMatchTest(dbComment, testComments[i]);
+  }
+}
+
+function expectDbCommentToMatchTest(
+  dbComment: HCAAtlasTrackerDBComment,
+  testComment: TestComment
+): void {
+  expect(dbComment.created_at).toEqual(new Date(testComment.createdAt));
+  expect(dbComment.created_by).toEqual(
+    dbUsersByEmail[testComment.createdBy.email].id
+  );
+  expect(dbComment.id).toEqual(testComment.id);
+  expect(dbComment.text).toEqual(testComment.text);
+  expect(dbComment.thread_id).toEqual(testComment.threadId);
+  expect(dbComment.updated_at).toEqual(new Date(testComment.createdAt));
+  expect(dbComment.updated_by).toEqual(
+    dbUsersByEmail[testComment.createdBy.email].id
+  );
+}
+
+function expectDbCommentToMatch(
+  dbComment: HCAAtlasTrackerDBComment,
+  apiComment: HCAAtlasTrackerComment
+): void {
+  expect(dbComment.created_at.toISOString()).toEqual(apiComment.createdAt);
+  expect(dbComment.created_by).toEqual(apiComment.createdBy);
+  expect(dbComment.id).toEqual(apiComment.id);
+  expect(dbComment.text).toEqual(apiComment.text);
+  expect(dbComment.thread_id).toEqual(apiComment.threadId);
+  expect(dbComment.updated_at.toISOString()).toEqual(apiComment.updatedAt);
+  expect(dbComment.updated_by).toEqual(apiComment.updatedBy);
+}
+
+async function doCommentTest(
+  user: TestUser | undefined,
+  threadId: string,
+  commentId: string,
+  method = METHOD.GET,
+  hideConsoleError = false,
+  editData?: Record<string, unknown>
+): Promise<httpMocks.MockResponse<NextApiResponse>> {
+  const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>({
+    body: editData,
+    headers: { authorization: user?.authorization },
+    method,
+    query: {
+      commentId,
+      threadId,
+    },
+  });
+  await withConsoleErrorHiding(
+    () => commentHandler(req, res),
+    hideConsoleError
+  );
+  return res;
+}
+
+async function getThreadCommentsFromDatabase(
+  threadId: string
+): Promise<HCAAtlasTrackerDBComment[]> {
+  return (
+    await query<HCAAtlasTrackerDBComment>(
+      "SELECT * FROM hat.comments WHERE thread_id=$1",
+      [threadId]
+    )
+  ).rows;
+}
+
+async function getCommentFromDatabase(
+  commentId: string
+): Promise<HCAAtlasTrackerDBComment | undefined> {
+  return (
+    await query<HCAAtlasTrackerDBComment>(
+      "SELECT * FROM hat.comments WHERE id=$1",
+      [commentId]
+    )
+  ).rows[0];
+}

--- a/__tests__/api-comments-thread-id-comments-comment-id.test.ts
+++ b/__tests__/api-comments-thread-id-comments-comment-id.test.ts
@@ -266,6 +266,12 @@ describe("/api/comments/[threadId]/comments", () => {
   });
 
   it("PATCH updates another user's comment when requested by user with CONTENT_ADMIN role", async () => {
+    const commentBefore = await getCommentFromDatabase(
+      COMMENT_BY_CONTENT_ADMIN_REPLY1_STAKEHOLDER.id
+    );
+    expect(commentBefore?.updated_by).toEqual(
+      dbUsersByEmail[USER_STAKEHOLDER.email].id
+    );
     const res = await doCommentTest(
       USER_CONTENT_ADMIN,
       THREAD_ID_BY_CONTENT_ADMIN,
@@ -285,6 +291,14 @@ describe("/api/comments/[threadId]/comments", () => {
     expect(updatedCommentFromDb).toBeDefined();
     if (updatedCommentFromDb === undefined) return;
     expectDbCommentToMatch(updatedCommentFromDb, updatedComment);
+
+    expect(updatedCommentFromDb.updated_by).toEqual(
+      dbUsersByEmail[USER_CONTENT_ADMIN.email].id
+    );
+    expect(updatedCommentFromDb.created_by).toEqual(
+      dbUsersByEmail[USER_STAKEHOLDER.email].id
+    );
+
     await expectCommentToBeUnchanged(COMMENT_BY_CONTENT_ADMIN_REPLY2_ADMIN);
   });
 

--- a/__tests__/api-comments-thread-id-comments.test.ts
+++ b/__tests__/api-comments-thread-id-comments.test.ts
@@ -1,0 +1,297 @@
+import { METHOD } from "app/common/entities";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
+import {
+  HCAAtlasTrackerComment,
+  HCAAtlasTrackerDBComment,
+  HCAAtlasTrackerDBUser,
+} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { NewCommentData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
+import { endPgPool, query } from "../app/services/database";
+import commentsHandler from "../pages/api/comments/[threadId]/comments";
+import {
+  TEST_COMMENTS_BY_THREAD_ID,
+  THREAD_ID_BY_CONTENT_ADMIN,
+  THREAD_ID_BY_STAKEHOLDER,
+  USER_CONTENT_ADMIN,
+  USER_STAKEHOLDER,
+  USER_UNREGISTERED,
+} from "../testing/constants";
+import { getDbUsersByEmail, resetDatabase } from "../testing/db-utils";
+import { TestComment, TestUser } from "../testing/entities";
+import { withConsoleErrorHiding } from "../testing/utils";
+
+jest.mock("../app/services/user-profile");
+jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/cellxgene");
+jest.mock("../app/utils/pg-app-connect-config");
+
+const NEW_COMMENT_FOO_DATA: NewCommentData = {
+  text: "New comment foo",
+};
+
+const NEW_COMMENT_BAR_DATA: NewCommentData = {
+  text: "New comment bar",
+};
+
+let dbUsersByEmail: Record<string, HCAAtlasTrackerDBUser>;
+
+beforeAll(async () => {
+  await resetDatabase();
+  dbUsersByEmail = await getDbUsersByEmail();
+});
+
+afterAll(async () => {
+  endPgPool();
+});
+
+describe("/api/comments/[threadId]/comments", () => {
+  it("returns error 405 for non-GET, non-POST request", async () => {
+    expect(
+      (
+        await doCommentsTest(
+          undefined,
+          THREAD_ID_BY_STAKEHOLDER,
+          NEW_COMMENT_FOO_DATA,
+          false,
+          METHOD.PUT
+        )
+      )._getStatusCode()
+    ).toEqual(405);
+  });
+
+  it("GET returns error 401 for logged out user", async () => {
+    expect(
+      (
+        await doCommentsTest(undefined, THREAD_ID_BY_STAKEHOLDER)
+      )._getStatusCode()
+    ).toEqual(401);
+  });
+
+  it("GET returns error 403 for unregistered user", async () => {
+    expect(
+      (
+        await doCommentsTest(USER_UNREGISTERED, THREAD_ID_BY_STAKEHOLDER)
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("GET returns thread comments when requested by user with STAKEHOLDER role", async () => {
+    const res = await doCommentsTest(
+      USER_STAKEHOLDER,
+      THREAD_ID_BY_CONTENT_ADMIN
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const comments = res._getJSONData();
+    expectApiCommentsToMatchTest(
+      comments,
+      TEST_COMMENTS_BY_THREAD_ID[THREAD_ID_BY_CONTENT_ADMIN]
+    );
+  });
+
+  it("GET returns thread comments when requested by user with CONTENT_ADMIN role", async () => {
+    const res = await doCommentsTest(
+      USER_CONTENT_ADMIN,
+      THREAD_ID_BY_CONTENT_ADMIN
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const comments = res._getJSONData();
+    expectApiCommentsToMatchTest(
+      comments,
+      TEST_COMMENTS_BY_THREAD_ID[THREAD_ID_BY_CONTENT_ADMIN]
+    );
+  });
+
+  it("POST returns error 401 for logged out user", async () => {
+    expect(
+      (
+        await doCommentsTest(
+          undefined,
+          THREAD_ID_BY_STAKEHOLDER,
+          NEW_COMMENT_FOO_DATA,
+          false,
+          METHOD.POST
+        )
+      )._getStatusCode()
+    ).toEqual(401);
+  });
+
+  it("POST returns error 403 for unregistered user", async () => {
+    expect(
+      (
+        await doCommentsTest(
+          USER_UNREGISTERED,
+          THREAD_ID_BY_STAKEHOLDER,
+          NEW_COMMENT_FOO_DATA,
+          false,
+          METHOD.POST
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("POST returns error 400 when text is not a string", async () => {
+    expect(
+      (
+        await doCommentsTest(
+          USER_CONTENT_ADMIN,
+          THREAD_ID_BY_STAKEHOLDER,
+          {
+            ...NEW_COMMENT_FOO_DATA,
+            text: 123,
+          },
+          true,
+          METHOD.POST
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+  });
+
+  it("POST returns error 400 when text is empty string", async () => {
+    expect(
+      (
+        await doCommentsTest(
+          USER_CONTENT_ADMIN,
+          THREAD_ID_BY_STAKEHOLDER,
+          {
+            ...NEW_COMMENT_FOO_DATA,
+            text: "",
+          },
+          true,
+          METHOD.POST
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+  });
+
+  it("POST creates and returns comment for user with STAKEHOLDER role", async () => {
+    await testSuccessfulCreate(
+      THREAD_ID_BY_CONTENT_ADMIN,
+      NEW_COMMENT_FOO_DATA,
+      USER_STAKEHOLDER
+    );
+  });
+
+  it("POST creates and returns comment for user with CONTENT_ADMIN role", async () => {
+    await testSuccessfulCreate(
+      THREAD_ID_BY_STAKEHOLDER,
+      NEW_COMMENT_BAR_DATA,
+      USER_CONTENT_ADMIN
+    );
+  });
+});
+
+async function testSuccessfulCreate(
+  threadId: string,
+  newData: NewCommentData,
+  user: TestUser
+): Promise<HCAAtlasTrackerDBComment> {
+  const res = await doCommentsTest(user, threadId, newData, false, METHOD.POST);
+  expect(res._getStatusCode()).toEqual(201);
+  const newComment: HCAAtlasTrackerComment = res._getJSONData();
+  expect(newComment.text).toEqual(newData.text);
+  const threadCommentsFromDb = (
+    await query<HCAAtlasTrackerDBComment>(
+      "SELECT * FROM hat.comments WHERE thread_id=$1",
+      [newComment.threadId]
+    )
+  ).rows;
+  expectDbCommentsToMatchTest(
+    threadCommentsFromDb.slice(0, threadCommentsFromDb.length - 1),
+    TEST_COMMENTS_BY_THREAD_ID[threadId]
+  );
+  const newCommentFromDb =
+    threadCommentsFromDb[threadCommentsFromDb.length - 1];
+  expect(newCommentFromDb.id).toEqual(newComment.id);
+  expectDbCommentToMatch(newCommentFromDb, newComment);
+  return newCommentFromDb;
+}
+
+function expectApiCommentsToMatchTest(
+  apiComments: HCAAtlasTrackerComment[],
+  testComments: TestComment[]
+): void {
+  expect(apiComments).toHaveLength(testComments.length);
+  for (const [i, apiComment] of apiComments.entries()) {
+    expectApiCommentToMatchTest(apiComment, testComments[i]);
+  }
+}
+
+function expectApiCommentToMatchTest(
+  dbComment: HCAAtlasTrackerComment,
+  testComment: TestComment
+): void {
+  expect(dbComment.createdAt).toEqual(testComment.createdAt);
+  expect(dbComment.createdBy).toEqual(
+    dbUsersByEmail[testComment.createdBy.email].id
+  );
+  expect(dbComment.id).toEqual(testComment.id);
+  expect(dbComment.text).toEqual(testComment.text);
+  expect(dbComment.threadId).toEqual(testComment.threadId);
+  expect(dbComment.updatedAt).toEqual(testComment.createdAt);
+  expect(dbComment.updatedBy).toEqual(
+    dbUsersByEmail[testComment.createdBy.email].id
+  );
+}
+
+function expectDbCommentsToMatchTest(
+  dbComments: HCAAtlasTrackerDBComment[],
+  testComments: TestComment[]
+): void {
+  expect(dbComments).toHaveLength(testComments.length);
+  for (const [i, dbComment] of dbComments.entries()) {
+    expectDbCommentToMatchTest(dbComment, testComments[i]);
+  }
+}
+
+function expectDbCommentToMatchTest(
+  dbComment: HCAAtlasTrackerDBComment,
+  testComment: TestComment
+): void {
+  expect(dbComment.created_at).toEqual(new Date(testComment.createdAt));
+  expect(dbComment.created_by).toEqual(
+    dbUsersByEmail[testComment.createdBy.email].id
+  );
+  expect(dbComment.id).toEqual(testComment.id);
+  expect(dbComment.text).toEqual(testComment.text);
+  expect(dbComment.thread_id).toEqual(testComment.threadId);
+  expect(dbComment.updated_at).toEqual(new Date(testComment.createdAt));
+  expect(dbComment.updated_by).toEqual(
+    dbUsersByEmail[testComment.createdBy.email].id
+  );
+}
+
+function expectDbCommentToMatch(
+  dbComment: HCAAtlasTrackerDBComment,
+  apiComment: HCAAtlasTrackerComment
+): void {
+  expect(dbComment.created_at.toISOString()).toEqual(apiComment.createdAt);
+  expect(dbComment.created_by).toEqual(apiComment.createdBy);
+  expect(dbComment.id).toEqual(apiComment.id);
+  expect(dbComment.text).toEqual(apiComment.text);
+  expect(dbComment.thread_id).toEqual(apiComment.threadId);
+  expect(dbComment.updated_at.toISOString()).toEqual(apiComment.updatedAt);
+  expect(dbComment.updated_by).toEqual(apiComment.updatedBy);
+}
+
+async function doCommentsTest(
+  user: TestUser | undefined,
+  threadId: string,
+  newData?: Record<string, unknown>,
+  hideConsoleError = false,
+  method = METHOD.GET
+): Promise<httpMocks.MockResponse<NextApiResponse>> {
+  const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>({
+    body: newData,
+    headers: { authorization: user?.authorization },
+    method,
+    query: {
+      threadId,
+    },
+  });
+  await withConsoleErrorHiding(
+    () => commentsHandler(req, res),
+    hideConsoleError
+  );
+  return res;
+}

--- a/__tests__/api-comments-thread-id-comments.test.ts
+++ b/__tests__/api-comments-thread-id-comments.test.ts
@@ -26,6 +26,8 @@ jest.mock("../app/services/hca-projects");
 jest.mock("../app/services/cellxgene");
 jest.mock("../app/utils/pg-app-connect-config");
 
+const THREAD_ID_NONEXISTENT = "f1d7ee3c-34ac-4d2e-86bb-d45f86d84fe4";
+
 const NEW_COMMENT_FOO_DATA: NewCommentData = {
   text: "New comment foo",
 };
@@ -74,6 +76,19 @@ describe("/api/comments/[threadId]/comments", () => {
         await doCommentsTest(USER_UNREGISTERED, THREAD_ID_BY_STAKEHOLDER)
       )._getStatusCode()
     ).toEqual(403);
+  });
+
+  it("GET returns error 404 for nonexistent thread", async () => {
+    expect(
+      (
+        await doCommentsTest(
+          USER_STAKEHOLDER,
+          THREAD_ID_NONEXISTENT,
+          undefined,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(404);
   });
 
   it("GET returns thread comments when requested by user with STAKEHOLDER role", async () => {
@@ -128,6 +143,20 @@ describe("/api/comments/[threadId]/comments", () => {
         )
       )._getStatusCode()
     ).toEqual(403);
+  });
+
+  it("POST returns error 404 for nonexistent thread", async () => {
+    expect(
+      (
+        await doCommentsTest(
+          USER_STAKEHOLDER,
+          THREAD_ID_NONEXISTENT,
+          NEW_COMMENT_FOO_DATA,
+          true,
+          METHOD.POST
+        )
+      )._getStatusCode()
+    ).toEqual(404);
   });
 
   it("POST returns error 400 when text is not a string", async () => {

--- a/__tests__/api-comments.test.ts
+++ b/__tests__/api-comments.test.ts
@@ -1,0 +1,153 @@
+import { METHOD } from "app/common/entities";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
+import {
+  HCAAtlasTrackerComment,
+  HCAAtlasTrackerDBComment,
+} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { NewCommentThreadData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
+import { endPgPool, query } from "../app/services/database";
+import commentsHandler from "../pages/api/comments";
+import {
+  USER_CONTENT_ADMIN,
+  USER_STAKEHOLDER,
+  USER_UNREGISTERED,
+} from "../testing/constants";
+import { resetDatabase } from "../testing/db-utils";
+import { TestUser } from "../testing/entities";
+import { withConsoleErrorHiding } from "../testing/utils";
+
+jest.mock("../app/services/user-profile");
+jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/cellxgene");
+jest.mock("../app/utils/pg-app-connect-config");
+
+const NEW_COMMENT_FOO_DATA: NewCommentThreadData = {
+  text: "New comment foo",
+};
+
+const NEW_COMMENT_BAR_DATA: NewCommentThreadData = {
+  text: "New comment bar",
+};
+
+beforeAll(async () => {
+  await resetDatabase();
+});
+
+afterAll(async () => {
+  endPgPool();
+});
+
+describe("/api/comments", () => {
+  it("returns error 405 for non-POST request", async () => {
+    expect(
+      (
+        await doCommentsTest(undefined, NEW_COMMENT_FOO_DATA, false, METHOD.GET)
+      )._getStatusCode()
+    ).toEqual(405);
+  });
+
+  it("returns error 401 for logged out user", async () => {
+    expect(
+      (await doCommentsTest(undefined, NEW_COMMENT_FOO_DATA))._getStatusCode()
+    ).toEqual(401);
+  });
+
+  it("returns error 403 for unregistered user", async () => {
+    expect(
+      (
+        await doCommentsTest(USER_UNREGISTERED, NEW_COMMENT_FOO_DATA)
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 400 when text is not a string", async () => {
+    expect(
+      (
+        await doCommentsTest(
+          USER_CONTENT_ADMIN,
+          {
+            ...NEW_COMMENT_FOO_DATA,
+            text: 123,
+          },
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+  });
+
+  it("returns error 400 when text is empty string", async () => {
+    expect(
+      (
+        await doCommentsTest(
+          USER_CONTENT_ADMIN,
+          {
+            ...NEW_COMMENT_FOO_DATA,
+            text: "",
+          },
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+  });
+
+  it("creates and returns comment for user with STAKEHOLDER role", async () => {
+    await testSuccessfulCreate(NEW_COMMENT_FOO_DATA, USER_STAKEHOLDER);
+  });
+
+  it("creates and returns comment for user with CONTENT_ADMIN role", async () => {
+    await testSuccessfulCreate(NEW_COMMENT_BAR_DATA, USER_CONTENT_ADMIN);
+  });
+});
+
+async function testSuccessfulCreate(
+  newData: NewCommentThreadData,
+  user: TestUser
+): Promise<HCAAtlasTrackerDBComment> {
+  const res = await doCommentsTest(user, newData);
+  expect(res._getStatusCode()).toEqual(201);
+  const newComment: HCAAtlasTrackerComment = res._getJSONData();
+  expect(newComment.text).toEqual(newData.text);
+  const threadCommentsFromDb = (
+    await query<HCAAtlasTrackerDBComment>(
+      "SELECT * FROM hat.comments WHERE thread_id=$1",
+      [newComment.threadId]
+    )
+  ).rows;
+  expect(threadCommentsFromDb).toHaveLength(1);
+  const newCommentFromDb = threadCommentsFromDb[0];
+  expect(newCommentFromDb.id).toEqual(newComment.id);
+  expectDbCommentToMatch(newCommentFromDb, newComment);
+  return newCommentFromDb;
+}
+
+function expectDbCommentToMatch(
+  dbComment: HCAAtlasTrackerDBComment,
+  apiComment: HCAAtlasTrackerComment
+): void {
+  expect(dbComment.created_at.toISOString()).toEqual(apiComment.createdAt);
+  expect(dbComment.created_by).toEqual(apiComment.createdBy);
+  expect(dbComment.id).toEqual(apiComment.id);
+  expect(dbComment.text).toEqual(apiComment.text);
+  expect(dbComment.thread_id).toEqual(apiComment.threadId);
+  expect(dbComment.updated_at.toISOString()).toEqual(apiComment.updatedAt);
+  expect(dbComment.updated_by).toEqual(apiComment.updatedBy);
+}
+
+async function doCommentsTest(
+  user: TestUser | undefined,
+  newData: Record<string, unknown>,
+  hideConsoleError = false,
+  method = METHOD.POST
+): Promise<httpMocks.MockResponse<NextApiResponse>> {
+  const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>({
+    body: newData,
+    headers: { authorization: user?.authorization },
+    method,
+  });
+  await withConsoleErrorHiding(
+    () => commentsHandler(req, res),
+    hideConsoleError
+  );
+  return res;
+}

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -139,6 +139,16 @@ export interface HCAAtlasTrackerValidationRecord
   waves: Wave[];
 }
 
+export interface HCAAtlasTrackerComment {
+  createdAt: string;
+  createdBy: number;
+  id: string;
+  text: string;
+  threadId: string;
+  updatedAt: string;
+  updatedBy: number;
+}
+
 export interface HCAAtlasTrackerActiveUser {
   email: string;
   fullName: string;
@@ -314,6 +324,16 @@ export interface HCAAtlasTrackerDBValidationWithAtlasProperties
   atlas_short_names: string[];
   networks: NetworkKey[];
   waves: Wave[];
+}
+
+export interface HCAAtlasTrackerDBComment {
+  created_at: Date;
+  created_by: number;
+  id: string;
+  text: string;
+  thread_id: string;
+  updated_at: Date;
+  updated_by: number;
 }
 
 export interface HCAAtlasTrackerDBUser {

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -257,6 +257,29 @@ export const sourceDatasetEditSchema = object({
 export type SourceDatasetEditData = InferType<typeof sourceDatasetEditSchema>;
 
 /**
+ * Schema for data used to create a comment.
+ */
+export const newCommentSchema = object({
+  text: string().required(),
+}).strict();
+
+export type NewCommentSchema = InferType<typeof newCommentSchema>;
+
+/**
+ * Schema for data used to edit a comment.
+ */
+export const commentEditSchema = newCommentSchema;
+
+export type CommentEditSchema = InferType<typeof commentEditSchema>;
+
+/**
+ * Schema for data used to create a comment thread.
+ */
+export const newCommentThreadSchema = newCommentSchema;
+
+export type NewCommentThreadSchema = InferType<typeof newCommentThreadSchema>;
+
+/**
  * Schema for data used to create a new user.
  */
 export const newUserSchema = object({

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -263,21 +263,21 @@ export const newCommentSchema = object({
   text: string().required(),
 }).strict();
 
-export type NewCommentSchema = InferType<typeof newCommentSchema>;
+export type NewCommentData = InferType<typeof newCommentSchema>;
 
 /**
  * Schema for data used to edit a comment.
  */
 export const commentEditSchema = newCommentSchema;
 
-export type CommentEditSchema = InferType<typeof commentEditSchema>;
+export type CommentEditData = InferType<typeof commentEditSchema>;
 
 /**
  * Schema for data used to create a comment thread.
  */
 export const newCommentThreadSchema = newCommentSchema;
 
-export type NewCommentThreadSchema = InferType<typeof newCommentThreadSchema>;
+export type NewCommentThreadData = InferType<typeof newCommentThreadSchema>;
 
 /**
  * Schema for data used to create a new user.

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -3,8 +3,10 @@ import { NETWORK_KEYS, WAVES } from "./constants";
 import {
   DOI_STATUS,
   HCAAtlasTrackerAtlas,
+  HCAAtlasTrackerComment,
   HCAAtlasTrackerComponentAtlas,
   HCAAtlasTrackerDBAtlasWithComponentAtlases,
+  HCAAtlasTrackerDBComment,
   HCAAtlasTrackerDBComponentAtlas,
   HCAAtlasTrackerDBSourceDatasetWithStudyProperties,
   HCAAtlasTrackerDBSourceStudy,
@@ -182,6 +184,20 @@ export function dbValidationToApiValidation(
     validationStatus: validationInfo.validationStatus,
     validationType: validationInfo.validationType,
     waves: validation.waves,
+  };
+}
+
+export function dbCommentToApiComment(
+  dbComment: HCAAtlasTrackerDBComment
+): HCAAtlasTrackerComment {
+  return {
+    createdAt: dbComment.created_at.toISOString(),
+    createdBy: dbComment.created_by,
+    id: dbComment.id,
+    text: dbComment.text,
+    threadId: dbComment.thread_id,
+    updatedAt: dbComment.updated_at.toISOString(),
+    updatedBy: dbComment.updated_by,
   };
 }
 

--- a/app/services/comments.ts
+++ b/app/services/comments.ts
@@ -1,0 +1,202 @@
+import {
+  HCAAtlasTrackerDBComment,
+  HCAAtlasTrackerDBUser,
+} from "../../app/apis/catalog/hca-atlas-tracker/common/entities";
+import {
+  NewCommentSchema,
+  NewCommentThreadSchema,
+} from "../../app/apis/catalog/hca-atlas-tracker/common/schema";
+import { ForbiddenError, NotFoundError } from "../../app/utils/api-handler";
+import { doTransaction, query } from "./database";
+
+/**
+ * Get comments in a given thread.
+ * @param threadId - ID of the thread to get comments from.
+ * @returns comments from the thread, ordered by ascending creation date.
+ */
+export async function getThreadComments(
+  threadId: string
+): Promise<HCAAtlasTrackerDBComment[]> {
+  const queryResult = await query<HCAAtlasTrackerDBComment>(
+    "SELECT * FROM hat.comments WHERE thread_id=$1 ORDER BY created_at ASC",
+    [threadId]
+  );
+
+  if (queryResult.rows.length === 0)
+    throw new NotFoundError(`Comment thread with ID ${threadId} doesn't exist`);
+
+  return queryResult.rows;
+}
+
+/**
+ * Get a comment.
+ * @param threadId - ID of the thread that the comment is accessed through.
+ * @param commentId - ID of the comment to get.
+ * @returns comment.
+ */
+export async function getComment(
+  threadId: string,
+  commentId: string
+): Promise<HCAAtlasTrackerDBComment> {
+  const queryResult = await query<HCAAtlasTrackerDBComment>(
+    "SELECT * FROM hat.comments WHERE id=$1 AND thread_id=$2",
+    [commentId, threadId]
+  );
+
+  if (queryResult.rows.length === 0)
+    throw getCommentNotFoundError(threadId, commentId);
+
+  return queryResult.rows[0];
+}
+
+/**
+ * Create a comment thread.
+ * @param inputData - Values for the new comment thread.
+ * @param user - User creating the comment thread.
+ * @returns database model of new comment.
+ */
+export async function createCommentThread(
+  inputData: NewCommentThreadSchema,
+  user: HCAAtlasTrackerDBUser
+): Promise<HCAAtlasTrackerDBComment> {
+  const newRowFields: Pick<
+    HCAAtlasTrackerDBComment,
+    "created_by" | "text" | "updated_by"
+  > = {
+    created_by: user.id,
+    text: inputData.text,
+    updated_by: user.id,
+  };
+
+  const queryResult = await query<HCAAtlasTrackerDBComment>(
+    "INSERT INTO hat.comments (created_by, text, updated_by) VALUES ($1, $2, $3) RETURNING *",
+    [newRowFields.created_by, newRowFields.text, newRowFields.updated_by]
+  );
+
+  return queryResult.rows[0];
+}
+
+/**
+ * Create a comment.
+ * @param threadId - ID of the thread to add the comment to.
+ * @param inputData - Values for the new comment.
+ * @param user - User creating the comment.
+ * @returns database model of new comment.
+ */
+export async function createComment(
+  threadId: string,
+  inputData: NewCommentSchema,
+  user: HCAAtlasTrackerDBUser
+): Promise<HCAAtlasTrackerDBComment> {
+  const newRowFields: Pick<
+    HCAAtlasTrackerDBComment,
+    "created_by" | "text" | "thread_id" | "updated_by"
+  > = {
+    created_by: user.id,
+    text: inputData.text,
+    thread_id: threadId,
+    updated_by: user.id,
+  };
+
+  const queryResult = await query<HCAAtlasTrackerDBComment>(
+    "INSERT INTO hat.comments (created_by, text, thread_id, updated_by) VALUES ($1, $2, $3, $4) RETURNING *",
+    [
+      newRowFields.created_by,
+      newRowFields.text,
+      newRowFields.thread_id,
+      newRowFields.updated_by,
+    ]
+  );
+
+  return queryResult.rows[0];
+}
+
+/**
+ * Update a comment.
+ * @param threadId - ID of the thread that the comment is accessed through.
+ * @param commentId - ID of the comment to update.
+ * @param inputData - Values to update the comment with.
+ * @param user - User updating the comment.
+ * @param limitToOwnComments - Whether the comment must be one created by the user who's editing it.
+ * @returns database model of updated comment.
+ */
+export async function updateComment(
+  threadId: string,
+  commentId: string,
+  inputData: NewCommentSchema,
+  user: HCAAtlasTrackerDBUser,
+  limitToOwnComments: boolean
+): Promise<HCAAtlasTrackerDBComment> {
+  const updatedRowFields: Pick<
+    HCAAtlasTrackerDBComment,
+    "text" | "updated_by"
+  > = {
+    text: inputData.text,
+    updated_by: user.id,
+  };
+
+  return await doTransaction(async (client) => {
+    const queryResult = await client.query<HCAAtlasTrackerDBComment>(
+      "UPDATE hat.comments SET text=$1, updated_by=$2 WHERE id=$3 AND thread_id=$4 RETURNING *",
+      [updatedRowFields.text, updatedRowFields.updated_by, commentId, threadId]
+    );
+
+    if (queryResult.rows.length === 0)
+      throw getCommentNotFoundError(threadId, commentId);
+
+    const updatedComment = queryResult.rows[0];
+
+    if (limitToOwnComments && updatedComment.created_by !== user.id)
+      throw new ForbiddenError(`Must be user's own comment`);
+
+    return updatedComment;
+  });
+}
+
+/**
+ * Delete a comment.
+ * @param threadId - ID of the thread that the comment is accessed through.
+ * @param commentId - ID of the comment to delete.
+ * @param user - User deleting the comment.
+ * @param limitToOwnNonRootComments - Whether the comment must be one created by the user who's deleting it and not the first in a thread.
+ */
+export async function deleteComment(
+  threadId: string,
+  commentId: string,
+  user: HCAAtlasTrackerDBUser,
+  limitToOwnNonRootComments: boolean
+): Promise<void> {
+  const commentResult = await query<
+    HCAAtlasTrackerDBComment & { is_root: boolean }
+  >(
+    "SELECT *, (created_at = (SELECT MIN(created_at) FROM hat.comments WHERE thread_id=$1)) AS is_root FROM hat.comments WHERE id=$2 AND thread_id=$1",
+    [threadId, commentId]
+  );
+
+  if (commentResult.rows.length === 0)
+    throw getCommentNotFoundError(threadId, commentId);
+
+  const comment = commentResult.rows[0];
+
+  if (
+    limitToOwnNonRootComments &&
+    (comment.created_by !== user.id || comment.is_root)
+  ) {
+    throw new ForbiddenError("Must be user's own non-root comment");
+  }
+
+  if (comment.is_root) {
+    await query("DELETE FROM hat.comments WHERE thread_id=$1", [threadId]);
+  } else {
+    await query("DELETE FROM hat.comments WHERE id=$1", [commentId]);
+  }
+}
+
+function getCommentNotFoundError(
+  threadId: string,
+  commentId: string
+): NotFoundError {
+  return new NotFoundError(
+    `Comment with ID ${commentId} doesn't exist on thread with ID ${threadId}`
+  );
+}

--- a/app/services/comments.ts
+++ b/app/services/comments.ts
@@ -3,8 +3,8 @@ import {
   HCAAtlasTrackerDBUser,
 } from "../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import {
-  NewCommentSchema,
-  NewCommentThreadSchema,
+  NewCommentData,
+  NewCommentThreadData,
 } from "../../app/apis/catalog/hca-atlas-tracker/common/schema";
 import { ForbiddenError, NotFoundError } from "../../app/utils/api-handler";
 import { doTransaction, query } from "./database";
@@ -56,7 +56,7 @@ export async function getComment(
  * @returns database model of new comment.
  */
 export async function createCommentThread(
-  inputData: NewCommentThreadSchema,
+  inputData: NewCommentThreadData,
   user: HCAAtlasTrackerDBUser
 ): Promise<HCAAtlasTrackerDBComment> {
   const newRowFields: Pick<
@@ -85,7 +85,7 @@ export async function createCommentThread(
  */
 export async function createComment(
   threadId: string,
-  inputData: NewCommentSchema,
+  inputData: NewCommentData,
   user: HCAAtlasTrackerDBUser
 ): Promise<HCAAtlasTrackerDBComment> {
   const newRowFields: Pick<
@@ -123,7 +123,7 @@ export async function createComment(
 export async function updateComment(
   threadId: string,
   commentId: string,
-  inputData: NewCommentSchema,
+  inputData: NewCommentData,
   user: HCAAtlasTrackerDBUser,
   limitToOwnComments: boolean
 ): Promise<HCAAtlasTrackerDBComment> {

--- a/app/services/comments.ts
+++ b/app/services/comments.ts
@@ -88,6 +88,16 @@ export async function createComment(
   inputData: NewCommentData,
   user: HCAAtlasTrackerDBUser
 ): Promise<HCAAtlasTrackerDBComment> {
+  const { exists: threadExists } = (
+    await query<{ exists: boolean }>(
+      "SELECT EXISTS(SELECT 1 FROM hat.comments WHERE thread_id=$1)",
+      [threadId]
+    )
+  ).rows[0];
+
+  if (!threadExists)
+    throw new NotFoundError(`Thread with id ${threadId} doesn't exist`);
+
   const newRowFields: Pick<
     HCAAtlasTrackerDBComment,
     "created_by" | "text" | "thread_id" | "updated_by"

--- a/app/utils/api-handler.ts
+++ b/app/utils/api-handler.ts
@@ -111,7 +111,10 @@ export function method(methodName: METHOD): MiddlewareFunction {
 export const registeredUser: MiddlewareFunction = async (req, res, next) => {
   const user = await getUserFromAuthorization(req.headers.authorization);
   if (!user) {
-    res.status(401).json({ message: "User must be registered" });
+    const userProfile = await getProvidedUserProfile(req.headers.authorization);
+    res
+      .status(userProfile ? 403 : 401)
+      .json({ message: "User must be registered" });
   } else {
     next();
   }

--- a/migrations/1719273460285_comment-table.ts
+++ b/migrations/1719273460285_comment-table.ts
@@ -1,0 +1,74 @@
+import { MigrationBuilder } from "node-pg-migrate";
+
+export const up = (pgm: MigrationBuilder): void => {
+  pgm.createTable(
+    { name: "comments", schema: "hat" },
+    {
+      created_at: {
+        default: pgm.func("CURRENT_TIMESTAMP"),
+        notNull: true,
+        type: "timestamp",
+      },
+      created_by: {
+        notNull: true,
+        type: "integer",
+      },
+      id: {
+        default: pgm.func("gen_random_uuid ()"),
+        notNull: true,
+        type: "uuid",
+      },
+      text: {
+        notNull: true,
+        type: "text",
+      },
+      thread_id: {
+        default: pgm.func("gen_random_uuid ()"),
+        notNull: true,
+        type: "uuid",
+      },
+      updated_at: {
+        default: pgm.func("CURRENT_TIMESTAMP"),
+        notNull: true,
+        type: "timestamp",
+      },
+      updated_by: {
+        notNull: true,
+        type: "integer",
+      },
+    }
+  );
+
+  pgm.addConstraint({ name: "comments", schema: "hat" }, "pk_comments_id", {
+    primaryKey: "id",
+  });
+
+  pgm.addConstraint(
+    { name: "comments", schema: "hat" },
+    "fk_comments_created_by_user_id",
+    {
+      foreignKeys: {
+        columns: "created_by",
+        references: { name: "users", schema: "hat" },
+      },
+    }
+  );
+
+  pgm.addConstraint(
+    { name: "comments", schema: "hat" },
+    "fk_comments_updated_by_user_id",
+    {
+      foreignKeys: {
+        columns: "updated_by",
+        references: { name: "users", schema: "hat" },
+      },
+    }
+  );
+
+  pgm.createTrigger({ name: "comments", schema: "hat" }, "update_updated_at", {
+    function: { name: "update_updated_at_column", schema: "hat" },
+    level: "ROW",
+    operation: "UPDATE",
+    when: "BEFORE",
+  });
+};

--- a/pages/api/comments.ts
+++ b/pages/api/comments.ts
@@ -1,0 +1,27 @@
+import { newCommentThreadSchema } from "../../app/apis/catalog/hca-atlas-tracker/common/schema";
+import { dbCommentToApiComment } from "../../app/apis/catalog/hca-atlas-tracker/common/utils";
+import { METHOD } from "../../app/common/entities";
+import { createCommentThread } from "../../app/services/comments";
+import {
+  getRegisteredUserFromAuthorization,
+  handler,
+  method,
+  registeredUser,
+} from "../../app/utils/api-handler";
+
+export default handler(
+  method(METHOD.POST),
+  registeredUser,
+  async (req, res) => {
+    res
+      .status(201)
+      .json(
+        dbCommentToApiComment(
+          await createCommentThread(
+            await newCommentThreadSchema.validate(req.body),
+            await getRegisteredUserFromAuthorization(req.headers.authorization)
+          )
+        )
+      );
+  }
+);

--- a/pages/api/comments/[threadId]/comments.ts
+++ b/pages/api/comments/[threadId]/comments.ts
@@ -1,0 +1,40 @@
+import { newCommentSchema } from "../../../../app/apis/catalog/hca-atlas-tracker/common/schema";
+import { dbCommentToApiComment } from "../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
+import { METHOD } from "../../../../app/common/entities";
+import {
+  createComment,
+  getThreadComments,
+} from "../../../../app/services/comments";
+import {
+  getRegisteredUserFromAuthorization,
+  handleByMethod,
+  handler,
+  registeredUser,
+} from "../../../../app/utils/api-handler";
+
+const getHandler = handler(registeredUser, async (req, res) => {
+  const threadId = req.query.threadId as string;
+  res
+    .status(200)
+    .json((await getThreadComments(threadId)).map(dbCommentToApiComment));
+});
+
+const postHandler = handler(registeredUser, async (req, res) => {
+  const threadId = req.query.threadId as string;
+  res
+    .status(201)
+    .json(
+      dbCommentToApiComment(
+        await createComment(
+          threadId,
+          await newCommentSchema.validate(req.body),
+          await getRegisteredUserFromAuthorization(req.headers.authorization)
+        )
+      )
+    );
+});
+
+export default handleByMethod({
+  [METHOD.GET]: getHandler,
+  [METHOD.POST]: postHandler,
+});

--- a/pages/api/comments/[threadId]/comments/[commentId].ts
+++ b/pages/api/comments/[threadId]/comments/[commentId].ts
@@ -1,0 +1,65 @@
+import { ROLE } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { commentEditSchema } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/schema";
+import { dbCommentToApiComment } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
+import { METHOD } from "../../../../../app/common/entities";
+import {
+  deleteComment,
+  getComment,
+  updateComment,
+} from "../../../../../app/services/comments";
+import {
+  getRegisteredUserFromAuthorization,
+  handleByMethod,
+  handler,
+  registeredUser,
+} from "../../../../../app/utils/api-handler";
+
+const getHandler = handler(registeredUser, async (req, res) => {
+  const threadId = req.query.threadId as string;
+  const commentId = req.query.commentId as string;
+  res
+    .status(200)
+    .json(dbCommentToApiComment(await getComment(threadId, commentId)));
+});
+
+const patchHandler = handler(registeredUser, async (req, res) => {
+  const threadId = req.query.threadId as string;
+  const commentId = req.query.commentId as string;
+  const user = await getRegisteredUserFromAuthorization(
+    req.headers.authorization
+  );
+  res
+    .status(200)
+    .json(
+      dbCommentToApiComment(
+        await updateComment(
+          threadId,
+          commentId,
+          await commentEditSchema.validate(req.body),
+          user,
+          user.role !== ROLE.CONTENT_ADMIN
+        )
+      )
+    );
+});
+
+const deleteHandler = handler(registeredUser, async (req, res) => {
+  const threadId = req.query.threadId as string;
+  const commentId = req.query.commentId as string;
+  const user = await getRegisteredUserFromAuthorization(
+    req.headers.authorization
+  );
+  await deleteComment(
+    threadId,
+    commentId,
+    user,
+    user.role !== ROLE.CONTENT_ADMIN
+  );
+  res.status(200).end();
+});
+
+export default handleByMethod({
+  [METHOD.DELETE]: deleteHandler,
+  [METHOD.GET]: getHandler,
+  [METHOD.PATCH]: patchHandler,
+});

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -27,6 +27,10 @@ export const USER_STAKEHOLDER = makeTestUser(
   "test-stakeholder",
   ROLE.STAKEHOLDER
 );
+export const USER_STAKEHOLDER2 = makeTestUser(
+  "test-stakeholder2",
+  ROLE.STAKEHOLDER
+);
 export const USER_DISABLED = makeTestUser(
   "test-disabled",
   ROLE.STAKEHOLDER,
@@ -44,6 +48,7 @@ export const USER_NEW = makeTestUser("test-new");
 export const INITIAL_TEST_USERS = [
   USER_DISABLED,
   USER_STAKEHOLDER,
+  USER_STAKEHOLDER2,
   USER_CONTENT_ADMIN,
 ];
 
@@ -1402,6 +1407,14 @@ export const THREAD_ID_BY_STAKEHOLDER = "5eaf0a40-e603-46d6-b38d-45f0f1664295";
 export const THREAD_ID_BY_CONTENT_ADMIN =
   "48cb0273-7a3b-449b-9f61-5418be01d6cf";
 
+export const THREAD_ID_BY_STAKEHOLDER_FOO =
+  "590f3a6a-68d8-457d-a6a2-c43b26a083be";
+
+export const THREAD_ID_BY_CONTENT_ADMIN_FOO =
+  "2bf5ac46-4e9e-4b5d-b507-9cd3103cf7f8";
+
+export const THREAD_ID_BY_STAKEHOLDER2 = "3e5a735e-b055-410d-a8d4-5ce9ef64352d";
+
 export const COMMENT_BY_STAKEHOLDER_ROOT: TestComment = {
   createdAt: "2024-06-25T21:13:49.725Z",
   createdBy: USER_STAKEHOLDER,
@@ -1410,7 +1423,7 @@ export const COMMENT_BY_STAKEHOLDER_ROOT: TestComment = {
   threadId: THREAD_ID_BY_STAKEHOLDER,
 };
 
-export const COMMENT_BY_STAKEHOLDER_REPLY1: TestComment = {
+export const COMMENT_BY_STAKEHOLDER_REPLY1_STAKEHOLDER: TestComment = {
   createdAt: "2024-06-25T21:14:11.153Z",
   createdBy: USER_STAKEHOLDER,
   id: "9925b9ab-2e4c-45c5-b0b0-40dd0043f0f3",
@@ -1418,7 +1431,7 @@ export const COMMENT_BY_STAKEHOLDER_REPLY1: TestComment = {
   threadId: THREAD_ID_BY_STAKEHOLDER,
 };
 
-export const COMMENT_BY_STAKEHOLDER_REPLY2: TestComment = {
+export const COMMENT_BY_STAKEHOLDER_REPLY2_ADMIN: TestComment = {
   createdAt: "2024-06-25T21:15:24.460Z",
   createdBy: USER_CONTENT_ADMIN,
   id: "816e4a41-cc56-4232-9bf7-35401b91370c",
@@ -1434,7 +1447,7 @@ export const COMMENT_BY_CONTENT_ADMIN_ROOT: TestComment = {
   threadId: THREAD_ID_BY_CONTENT_ADMIN,
 };
 
-export const COMMENT_BY_CONTENT_ADMIN_REPLY1: TestComment = {
+export const COMMENT_BY_CONTENT_ADMIN_REPLY1_STAKEHOLDER: TestComment = {
   createdAt: "2024-06-26T05:18:29.875Z",
   createdBy: USER_STAKEHOLDER,
   id: "f031b429-0234-4798-aaaf-2a5743e30c17",
@@ -1442,7 +1455,7 @@ export const COMMENT_BY_CONTENT_ADMIN_REPLY1: TestComment = {
   threadId: THREAD_ID_BY_CONTENT_ADMIN,
 };
 
-export const COMMENT_BY_CONTENT_ADMIN_REPLY2: TestComment = {
+export const COMMENT_BY_CONTENT_ADMIN_REPLY2_ADMIN: TestComment = {
   createdAt: "2024-06-26T05:19:13.480Z",
   createdBy: USER_CONTENT_ADMIN,
   id: "7c6b6e70-883f-4256-8b94-3c4fc863fdb2",
@@ -1450,14 +1463,95 @@ export const COMMENT_BY_CONTENT_ADMIN_REPLY2: TestComment = {
   threadId: THREAD_ID_BY_CONTENT_ADMIN,
 };
 
+export const COMMENT_BY_STAKEHOLDER_FOO_ROOT: TestComment = {
+  createdAt: "2024-06-26T19:59:13.734Z",
+  createdBy: USER_STAKEHOLDER,
+  id: "54c3ecdb-63b0-49eb-ba70-e06e7fe4817f",
+  text: "baz foobaz bazbar",
+  threadId: THREAD_ID_BY_STAKEHOLDER_FOO,
+};
+
+export const COMMENT_BY_STAKEHOLDER_FOO_REPLY1_ADMIN: TestComment = {
+  createdAt: "2024-06-26T19:59:54.303Z",
+  createdBy: USER_CONTENT_ADMIN,
+  id: "2a748245-08bb-4ddb-adf5-1514ec915eb3",
+  text: "foobar foo bar baz",
+  threadId: THREAD_ID_BY_STAKEHOLDER_FOO,
+};
+
+export const COMMENT_BY_STAKEHOLDER_FOO_REPLY2_STAKEHOLDER2: TestComment = {
+  createdAt: "2024-06-26T20:00:28.019Z",
+  createdBy: USER_STAKEHOLDER2,
+  id: "0a1203c3-0b03-46f1-b55d-8309e21b3581",
+  text: "barfoo foobarbaz bazbar",
+  threadId: THREAD_ID_BY_STAKEHOLDER_FOO,
+};
+
+export const COMMENT_BY_CONTENT_ADMIN_FOO_ROOT: TestComment = {
+  createdAt: "2024-06-26T20:01:05.629Z",
+  createdBy: USER_CONTENT_ADMIN,
+  id: "a9f4ac87-4760-49d2-bafb-a86c245e0772",
+  text: "baz baz foo barfoo",
+  threadId: THREAD_ID_BY_CONTENT_ADMIN_FOO,
+};
+
+export const COMMENT_BY_CONTENT_ADMIN_FOO_REPLY1_STAKEHOLDER: TestComment = {
+  createdAt: "2024-06-26T20:01:38.746Z",
+  createdBy: USER_STAKEHOLDER,
+  id: "c0c4f831-d5d1-4020-b778-75208a88b150",
+  text: "barfoofoo foo",
+  threadId: THREAD_ID_BY_CONTENT_ADMIN_FOO,
+};
+
+export const COMMENT_BY_CONTENT_ADMIN_FOO_REPLY2_STAKEHOLDER2: TestComment = {
+  createdAt: "2024-06-26T20:02:15.665Z",
+  createdBy: USER_STAKEHOLDER2,
+  id: "30353723-cf92-4262-a73b-b3fc02993de5",
+  text: "baz foo barbar",
+  threadId: THREAD_ID_BY_CONTENT_ADMIN_FOO,
+};
+
+export const COMMENT_BY_STAKEHOLDER2_ROOT: TestComment = {
+  createdAt: "2024-06-26T20:02:45.374Z",
+  createdBy: USER_STAKEHOLDER2,
+  id: "eed98c8d-bc18-4f9c-88c4-41086c11b85a",
+  text: "baz barfoo bar barbar",
+  threadId: THREAD_ID_BY_STAKEHOLDER2,
+};
+
+export const COMMENT_BY_STAKEHOLDER2_REPLY1_ADMIN: TestComment = {
+  createdAt: "2024-06-26T20:03:28.628Z",
+  createdBy: USER_CONTENT_ADMIN,
+  id: "48056eb8-e6c5-4e95-9abb-3f9824af758a",
+  text: "foo barbazfoo bar",
+  threadId: THREAD_ID_BY_STAKEHOLDER2,
+};
+
+export const COMMENT_BY_STAKEHOLDER2_REPLY2_STAKEHOLDER: TestComment = {
+  createdAt: "2024-06-26T20:04:03.038Z",
+  createdBy: USER_STAKEHOLDER,
+  id: "0b55a00a-aede-455f-97be-0f948fd43a81",
+  text: "bar foo foo barfoo",
+  threadId: THREAD_ID_BY_STAKEHOLDER2,
+};
+
 // Comments to initialize in the database before tests
 export const INITIAL_TEST_COMMENTS = [
   COMMENT_BY_STAKEHOLDER_ROOT,
-  COMMENT_BY_STAKEHOLDER_REPLY1,
-  COMMENT_BY_STAKEHOLDER_REPLY2,
+  COMMENT_BY_STAKEHOLDER_REPLY1_STAKEHOLDER,
+  COMMENT_BY_STAKEHOLDER_REPLY2_ADMIN,
   COMMENT_BY_CONTENT_ADMIN_ROOT,
-  COMMENT_BY_CONTENT_ADMIN_REPLY1,
-  COMMENT_BY_CONTENT_ADMIN_REPLY2,
+  COMMENT_BY_CONTENT_ADMIN_REPLY1_STAKEHOLDER,
+  COMMENT_BY_CONTENT_ADMIN_REPLY2_ADMIN,
+  COMMENT_BY_STAKEHOLDER_FOO_ROOT,
+  COMMENT_BY_STAKEHOLDER_FOO_REPLY1_ADMIN,
+  COMMENT_BY_STAKEHOLDER_FOO_REPLY2_STAKEHOLDER2,
+  COMMENT_BY_CONTENT_ADMIN_FOO_ROOT,
+  COMMENT_BY_CONTENT_ADMIN_FOO_REPLY1_STAKEHOLDER,
+  COMMENT_BY_CONTENT_ADMIN_FOO_REPLY2_STAKEHOLDER2,
+  COMMENT_BY_STAKEHOLDER2_ROOT,
+  COMMENT_BY_STAKEHOLDER2_REPLY1_ADMIN,
+  COMMENT_BY_STAKEHOLDER2_REPLY2_STAKEHOLDER,
 ];
 
 export const TEST_COMMENTS = [...INITIAL_TEST_COMMENTS];

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -12,6 +12,7 @@ import {
 import { CrossrefWork } from "../app/utils/crossref/crossref";
 import {
   TestAtlas,
+  TestComment,
   TestComponentAtlas,
   TestPublishedSourceStudy,
   TestSourceDataset,
@@ -1393,3 +1394,80 @@ export const INITIAL_TEST_COMPONENT_ATLASES = [
   COMPONENT_ATLAS_DRAFT_FOO,
   COMPONENT_ATLAS_DRAFT_BAR,
 ];
+
+// COMMENTS
+
+export const THREAD_ID_BY_STAKEHOLDER = "5eaf0a40-e603-46d6-b38d-45f0f1664295";
+
+export const THREAD_ID_BY_CONTENT_ADMIN =
+  "48cb0273-7a3b-449b-9f61-5418be01d6cf";
+
+export const COMMENT_BY_STAKEHOLDER_ROOT: TestComment = {
+  createdAt: "2024-06-25T21:13:49.725Z",
+  createdBy: USER_STAKEHOLDER,
+  id: "9b0a28a3-1fed-4f02-9850-39d60e2d88b2",
+  text: "foo barfoo baz",
+  threadId: THREAD_ID_BY_STAKEHOLDER,
+};
+
+export const COMMENT_BY_STAKEHOLDER_REPLY1: TestComment = {
+  createdAt: "2024-06-25T21:14:11.153Z",
+  createdBy: USER_STAKEHOLDER,
+  id: "9925b9ab-2e4c-45c5-b0b0-40dd0043f0f3",
+  text: "barbar foo baz foo",
+  threadId: THREAD_ID_BY_STAKEHOLDER,
+};
+
+export const COMMENT_BY_STAKEHOLDER_REPLY2: TestComment = {
+  createdAt: "2024-06-25T21:15:24.460Z",
+  createdBy: USER_CONTENT_ADMIN,
+  id: "816e4a41-cc56-4232-9bf7-35401b91370c",
+  text: "foo baz bar bazbaz",
+  threadId: THREAD_ID_BY_STAKEHOLDER,
+};
+
+export const COMMENT_BY_CONTENT_ADMIN_ROOT: TestComment = {
+  createdAt: "2024-06-26T05:17:42.555Z",
+  createdBy: USER_CONTENT_ADMIN,
+  id: "ce7437eb-db21-497a-b1d3-cef333097b8c",
+  text: "bar foobar barbazbaz",
+  threadId: THREAD_ID_BY_CONTENT_ADMIN,
+};
+
+export const COMMENT_BY_CONTENT_ADMIN_REPLY1: TestComment = {
+  createdAt: "2024-06-26T05:18:29.875Z",
+  createdBy: USER_STAKEHOLDER,
+  id: "f031b429-0234-4798-aaaf-2a5743e30c17",
+  text: "barfoofoo foobar baz foo",
+  threadId: THREAD_ID_BY_CONTENT_ADMIN,
+};
+
+export const COMMENT_BY_CONTENT_ADMIN_REPLY2: TestComment = {
+  createdAt: "2024-06-26T05:19:13.480Z",
+  createdBy: USER_CONTENT_ADMIN,
+  id: "7c6b6e70-883f-4256-8b94-3c4fc863fdb2",
+  text: "baz foofoo foo",
+  threadId: THREAD_ID_BY_CONTENT_ADMIN,
+};
+
+// Comments to initialize in the database before tests
+export const INITIAL_TEST_COMMENTS = [
+  COMMENT_BY_STAKEHOLDER_ROOT,
+  COMMENT_BY_STAKEHOLDER_REPLY1,
+  COMMENT_BY_STAKEHOLDER_REPLY2,
+  COMMENT_BY_CONTENT_ADMIN_ROOT,
+  COMMENT_BY_CONTENT_ADMIN_REPLY1,
+  COMMENT_BY_CONTENT_ADMIN_REPLY2,
+];
+
+export const TEST_COMMENTS = [...INITIAL_TEST_COMMENTS];
+
+export const TEST_COMMENTS_BY_THREAD_ID = TEST_COMMENTS.reduce(
+  (byThread, comment) => {
+    (byThread[comment.threadId] || (byThread[comment.threadId] = [])).push(
+      comment
+    );
+    return byThread;
+  },
+  {} as Record<string, TestComment[]>
+);

--- a/testing/entities.ts
+++ b/testing/entities.ts
@@ -65,3 +65,11 @@ export interface TestSourceDataset {
   sourceStudyId: string;
   title: string;
 }
+
+export interface TestComment {
+  createdAt: string;
+  createdBy: TestUser;
+  id: string;
+  text: string;
+  threadId: string;
+}


### PR DESCRIPTION
APIs added:
- `/api/comments`
  - POST to create a thread, with body of shape `{ text: string }`, specifying the text of the root comment
- `/api/comments/[threadId]/comments`
  - GET to get all comments in the thread, ordered by timestamp
  - POST to create a new comment in the thread, with body of shape `{ text: string }`
- `/api/comments/[threadId]/comments/[commentId]`
  - GET to get a comment
  - PATCH to update a comment, with body of shape `{ text: string }`; only content admins can update other users' comments
  - DELETE to delete a comment, or an entire thread if the root comment is requested; only content admins can delete other users' comments or delete root comments

All are restricted to registered users