### PR TITLE
feat: add component atlas fields aggregated from source datasets (#350)

### DIFF
--- a/__tests__/api-atlases-id-component-atlases-id-source-datasets-id.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id-source-datasets-id.test.ts
@@ -32,7 +32,11 @@ import {
   TestSourceDataset,
   TestUser,
 } from "../testing/entities";
-import { expectIsDefined, withConsoleErrorHiding } from "../testing/utils";
+import {
+  expectComponentAtlasDatasetsToHaveDifference,
+  expectIsDefined,
+  withConsoleErrorHiding,
+} from "../testing/utils";
 
 jest.mock("../app/services/user-profile");
 jest.mock("../app/services/hca-projects");
@@ -459,44 +463,6 @@ async function doSourceDatasetRequest(
     hideConsoleError
   );
   return res;
-}
-
-function expectComponentAtlasDatasetsToHaveDifference(
-  componentAtlasWithout: HCAAtlasTrackerDBComponentAtlas,
-  componentAtlasWith: HCAAtlasTrackerDBComponentAtlas,
-  sourceDatasets: TestSourceDataset[]
-): void {
-  const infoWithout = componentAtlasWithout.component_info;
-  const infoWith = componentAtlasWith.component_info;
-  const expectedCellCountDiff = sourceDatasets.reduce(
-    (sum, d) => sum + (d.cellCount ?? 0),
-    0
-  );
-  expect(infoWith.cellCount - infoWithout.cellCount).toEqual(
-    expectedCellCountDiff
-  );
-  expectArrayToContainItems(infoWith.assay, infoWithout.assay);
-  expectArrayToContainItems(infoWith.disease, infoWithout.disease);
-  expectArrayToContainItems(
-    infoWith.suspensionType,
-    infoWithout.suspensionType
-  );
-  expectArrayToContainItems(infoWith.tissue, infoWithout.tissue);
-  for (const sourceDataset of sourceDatasets) {
-    expectArrayToContainItems(infoWith.assay, sourceDataset.assay ?? []);
-    expectArrayToContainItems(infoWith.disease, sourceDataset.disease ?? []);
-    expectArrayToContainItems(
-      infoWith.suspensionType,
-      sourceDataset.suspensionType ?? []
-    );
-    expectArrayToContainItems(infoWith.tissue, sourceDataset.tissue ?? []);
-  }
-}
-
-function expectArrayToContainItems(array: unknown[], items: unknown[]): void {
-  for (const item of items) {
-    expect(array).toContain(item);
-  }
 }
 
 async function expectComponentAtlasToBeUnchanged(

--- a/__tests__/revalidate-on-refresh.test.ts
+++ b/__tests__/revalidate-on-refresh.test.ts
@@ -10,6 +10,7 @@ import {
 
 jest.mock("../app/services/source-studies");
 jest.mock("../app/services/source-datasets");
+jest.mock("../app/services/component-atlases");
 jest.mock("../app/services/user-profile");
 jest.mock("../app/utils/pg-app-connect-config");
 

--- a/__tests__/update-cellxgene-source-datasets.test.ts
+++ b/__tests__/update-cellxgene-source-datasets.test.ts
@@ -103,7 +103,17 @@ function expectSourceDatasetToMatch(
   expect(sourceDataset.source_study_id).toEqual(
     testSourceDataset.sourceStudyId
   );
-  expect(sourceDataset.sd_info.cellCount).toEqual(0);
+  expect(sourceDataset.sd_info.assay).toEqual(testSourceDataset.assay ?? []);
+  expect(sourceDataset.sd_info.cellCount).toEqual(
+    testSourceDataset.cellCount ?? 0
+  );
+  expect(sourceDataset.sd_info.disease).toEqual(
+    testSourceDataset.disease ?? []
+  );
+  expect(sourceDataset.sd_info.suspensionType).toEqual(
+    testSourceDataset.suspensionType ?? []
+  );
+  expect(sourceDataset.sd_info.tissue).toEqual(testSourceDataset.tissue ?? []);
   expect(sourceDataset.sd_info.cellxgeneDatasetId).toEqual(
     testSourceDataset.cellxgeneDatasetId ?? null
   );

--- a/__tests__/update-component-atlas-aggregate-fields-on-refresh.test.ts
+++ b/__tests__/update-component-atlas-aggregate-fields-on-refresh.test.ts
@@ -1,0 +1,168 @@
+import { HCAAtlasTrackerDBComponentAtlas } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { endPgPool } from "../app/services/database";
+import { doUpdatesIfRefreshesComplete } from "../app/services/refresh-services";
+import { CellxGeneDataset } from "../app/utils/cellxgene-api";
+import {
+  CELLXGENE_DATASET_WITH_UPDATE_UPDATED,
+  COMPONENT_ATLAS_DRAFT_BAR,
+  COMPONENT_ATLAS_DRAFT_FOO,
+  SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE,
+  SOURCE_DATASET_CELLXGENE_WITH_UPDATE,
+} from "../testing/constants";
+import {
+  getComponentAtlasFromDatabase,
+  resetDatabase,
+} from "../testing/db-utils";
+import { TestSourceDataset } from "../testing/entities";
+import { expectIsDefined } from "../testing/utils";
+
+jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/cellxgene");
+jest.mock("../app/services/user-profile");
+jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("../app/services/source-studies");
+jest.mock("../app/services/validations");
+
+beforeAll(async () => {
+  await resetDatabase();
+});
+
+afterAll(() => {
+  endPgPool();
+});
+
+describe("doUpdatesIfRefreshesComplete", () => {
+  it("updates fields of component atlases that have updated cellxgene source datasets", async () => {
+    const caDraftBarBefore = await getComponentAtlasFromDatabase(
+      COMPONENT_ATLAS_DRAFT_BAR.id
+    );
+    const caDraftFooBefore = await getComponentAtlasFromDatabase(
+      COMPONENT_ATLAS_DRAFT_FOO.id
+    );
+
+    if (!expectIsDefined(caDraftBarBefore)) return;
+
+    expectSourceDatasetValues(
+      caDraftBarBefore,
+      SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE
+    );
+    expectSourceDatasetValues(
+      caDraftBarBefore,
+      SOURCE_DATASET_CELLXGENE_WITH_UPDATE
+    );
+    expectCellxGeneDatasetValues(
+      caDraftBarBefore,
+      CELLXGENE_DATASET_WITH_UPDATE_UPDATED,
+      true
+    );
+
+    await doUpdatesIfRefreshesComplete();
+
+    const caDraftBarAfter = await getComponentAtlasFromDatabase(
+      COMPONENT_ATLAS_DRAFT_BAR.id
+    );
+    const caDraftFooAfter = await getComponentAtlasFromDatabase(
+      COMPONENT_ATLAS_DRAFT_FOO.id
+    );
+
+    if (!expectIsDefined(caDraftBarAfter)) return;
+
+    expectSourceDatasetValues(
+      caDraftBarAfter,
+      SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE
+    );
+    expectSourceDatasetValues(
+      caDraftBarAfter,
+      SOURCE_DATASET_CELLXGENE_WITH_UPDATE,
+      true
+    );
+    expectCellxGeneDatasetValues(
+      caDraftBarAfter,
+      CELLXGENE_DATASET_WITH_UPDATE_UPDATED
+    );
+
+    expect(caDraftBarAfter.component_info.cellCount).toEqual(
+      caDraftBarBefore.component_info.cellCount -
+        (SOURCE_DATASET_CELLXGENE_WITH_UPDATE.cellCount ?? 0) +
+        CELLXGENE_DATASET_WITH_UPDATE_UPDATED.cell_count
+    );
+
+    expect(caDraftFooAfter).toEqual(caDraftFooBefore);
+  });
+});
+
+function expectCellxGeneDatasetValues(
+  componentAtlas: HCAAtlasTrackerDBComponentAtlas,
+  dataset: CellxGeneDataset,
+  expectToNotHave = false
+): void {
+  expectCellxGeneArrayValues(
+    componentAtlas.component_info.assay,
+    dataset.assay,
+    expectToNotHave
+  );
+  expectCellxGeneArrayValues(
+    componentAtlas.component_info.disease,
+    dataset.disease,
+    expectToNotHave
+  );
+  expectArrayValues(
+    componentAtlas.component_info.suspensionType,
+    dataset.suspension_type,
+    expectToNotHave
+  );
+  expectCellxGeneArrayValues(
+    componentAtlas.component_info.tissue,
+    dataset.tissue,
+    expectToNotHave
+  );
+}
+
+function expectSourceDatasetValues(
+  componentAtlas: HCAAtlasTrackerDBComponentAtlas,
+  dataset: TestSourceDataset,
+  expectToNotHave = false
+): void {
+  expectArrayValues(
+    componentAtlas.component_info.assay,
+    dataset.assay ?? [],
+    expectToNotHave
+  );
+  expectArrayValues(
+    componentAtlas.component_info.disease,
+    dataset.disease ?? [],
+    expectToNotHave
+  );
+  expectArrayValues(
+    componentAtlas.component_info.suspensionType,
+    dataset.suspensionType ?? [],
+    expectToNotHave
+  );
+  expectArrayValues(
+    componentAtlas.component_info.tissue,
+    dataset.tissue ?? [],
+    expectToNotHave
+  );
+}
+
+function expectCellxGeneArrayValues(
+  array: string[],
+  values: { label: string }[],
+  expectToNotHave = false
+): void {
+  for (const { label } of values) {
+    if (expectToNotHave) expect(array).not.toContain(label);
+    else expect(array).toContain(label);
+  }
+}
+
+function expectArrayValues(
+  array: string[],
+  values: string[],
+  expectToNotHave = false
+): void {
+  for (const value of values) {
+    if (expectToNotHave) expect(array).not.toContain(value);
+    else expect(array).toContain(value);
+  }
+}

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -45,10 +45,16 @@ export interface HCAAtlasTrackerAtlas {
 }
 
 export interface HCAAtlasTrackerComponentAtlas {
+  assay: string[];
   atlasId: string;
+  cellCount: number;
   cellxgeneDatasetId: string | null;
   cellxgeneDatasetVersion: string | null;
+  disease: string[];
   id: string;
+  sourceDatasetCount: number;
+  suspensionType: string[];
+  tissue: string[];
   title: string;
 }
 
@@ -199,8 +205,13 @@ export interface HCAAtlasTrackerDBComponentAtlas {
 }
 
 export interface HCAAtlasTrackerDBComponentAtlasInfo {
+  assay: string[];
+  cellCount: number;
   cellxgeneDatasetId: string | null;
   cellxgeneDatasetVersion: string | null;
+  disease: string[];
+  suspensionType: string[];
+  tissue: string[];
 }
 
 export interface HCAAtlasTrackerDBPublishedSourceStudy {

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -82,11 +82,17 @@ export function dbComponentAtlasToApiComponentAtlas(
   dbComponentAtlas: HCAAtlasTrackerDBComponentAtlas
 ): HCAAtlasTrackerComponentAtlas {
   return {
+    assay: dbComponentAtlas.component_info.assay,
     atlasId: dbComponentAtlas.atlas_id,
+    cellCount: dbComponentAtlas.component_info.cellCount,
     cellxgeneDatasetId: dbComponentAtlas.component_info.cellxgeneDatasetId,
     cellxgeneDatasetVersion:
       dbComponentAtlas.component_info.cellxgeneDatasetVersion,
+    disease: dbComponentAtlas.component_info.disease,
     id: dbComponentAtlas.id,
+    sourceDatasetCount: dbComponentAtlas.source_datasets.length,
+    suspensionType: dbComponentAtlas.component_info.suspensionType,
+    tissue: dbComponentAtlas.component_info.tissue,
     title: dbComponentAtlas.title,
   };
 }

--- a/app/components/Detail/components/ViewComponentAtlases/viewComponentAtlases.tsx
+++ b/app/components/Detail/components/ViewComponentAtlases/viewComponentAtlases.tsx
@@ -47,7 +47,7 @@ export const ViewComponentAtlases = ({
         {componentAtlases?.length > 0 && (
           <Table
             columns={getAtlasComponentAtlasesTableColumns(pathParameter)}
-            gridTemplateColumns="minmax(260px, 1fr)"
+            gridTemplateColumns="minmax(260px, 1fr) repeat(5, minmax(88px, 128px)) auto"
             items={componentAtlases}
           />
         )}

--- a/app/services/refresh-services.ts
+++ b/app/services/refresh-services.ts
@@ -1,4 +1,8 @@
 import { isCellxGeneRefreshing } from "./cellxgene";
+import {
+  getComponentAtlasIdsHavingSourceDatasets,
+  updateComponentAtlasFieldsFromDatasets,
+} from "./component-atlases";
 import { areProjectsRefreshing } from "./hca-projects";
 import { updateCellxGeneSourceDatasets } from "./source-datasets";
 import { updateSourceStudyExternalIds } from "./source-studies";
@@ -7,7 +11,13 @@ import { refreshValidations } from "./validations";
 export async function doUpdatesIfRefreshesComplete(): Promise<void> {
   if (!isAnyServiceRefreshing()) {
     await updateSourceStudyExternalIds();
-    await updateCellxGeneSourceDatasets();
+
+    const updatedSourceDatasetIds = await updateCellxGeneSourceDatasets();
+
+    await updateComponentAtlasFieldsFromDatasets(
+      await getComponentAtlasIdsHavingSourceDatasets(updatedSourceDatasetIds)
+    );
+
     await refreshValidations();
   }
 }

--- a/app/services/refresh-services.ts
+++ b/app/services/refresh-services.ts
@@ -1,8 +1,4 @@
 import { isCellxGeneRefreshing } from "./cellxgene";
-import {
-  getComponentAtlasIdsHavingSourceDatasets,
-  updateComponentAtlasFieldsFromDatasets,
-} from "./component-atlases";
 import { areProjectsRefreshing } from "./hca-projects";
 import { updateCellxGeneSourceDatasets } from "./source-datasets";
 import { updateSourceStudyExternalIds } from "./source-studies";
@@ -11,13 +7,7 @@ import { refreshValidations } from "./validations";
 export async function doUpdatesIfRefreshesComplete(): Promise<void> {
   if (!isAnyServiceRefreshing()) {
     await updateSourceStudyExternalIds();
-
-    const updatedSourceDatasetIds = await updateCellxGeneSourceDatasets();
-
-    await updateComponentAtlasFieldsFromDatasets(
-      await getComponentAtlasIdsHavingSourceDatasets(updatedSourceDatasetIds)
-    );
-
+    await updateCellxGeneSourceDatasets();
     await refreshValidations();
   }
 }

--- a/app/services/source-studies.ts
+++ b/app/services/source-studies.ts
@@ -25,7 +25,10 @@ import { normalizeDoi } from "../utils/doi";
 import { getCellxGeneIdByDoi } from "./cellxgene";
 import { getPoolClient, query } from "./database";
 import { getProjectIdByDoi } from "./hca-projects";
-import { updateSourceStudyCellxGeneDatasets } from "./source-datasets";
+import {
+  deleteSourceDatasetsOfSourceStudy,
+  updateSourceStudyCellxGeneDatasets,
+} from "./source-datasets";
 import { updateSourceStudyValidations } from "./validations";
 
 export async function getAtlasSourceStudies(
@@ -335,10 +338,7 @@ export async function deleteAtlasSourceStudy(
     if (sourceStudyHasAtlases) {
       await updateSourceStudyValidationsByEntityId(sourceStudyId, client);
     } else {
-      await client.query(
-        "DELETE FROM hat.source_datasets WHERE source_study_id=$1",
-        [sourceStudyId]
-      );
+      await deleteSourceDatasetsOfSourceStudy(sourceStudyId, client);
       await client.query("DELETE FROM hat.source_studies WHERE id=$1", [
         sourceStudyId,
       ]);

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -55,6 +55,20 @@ import {
 } from "./utils";
 
 /**
+ * Build props for the assay cell component.
+ * @param entity - Component atlas or source dataset entity.
+ * @returns Props to be used for the cell.
+ */
+export const buildAssay = (
+  entity: HCAAtlasTrackerComponentAtlas | HCAAtlasTrackerSourceDataset
+): React.ComponentProps<typeof C.NTagCell> => {
+  return {
+    label: getPluralizedMetadataLabel(METADATA_KEY.ASSAY),
+    values: entity.assay,
+  };
+};
+
+/**
  * Build props for the atlas name cell component.
  * @param atlas - Atlas entity.
  * @returns Props to be used for the cell.
@@ -78,6 +92,19 @@ export const buildBioNetwork = (
 ): React.ComponentProps<typeof C.BioNetworkCell> => {
   return {
     networkKey: entity.bioNetwork,
+  };
+};
+
+/**
+ * Build props for the cell count cell component.
+ * @param entity - Component atlas or source dataset entity.
+ * @returns Props to be used for the cell.
+ */
+export const buildCellCount = (
+  entity: HCAAtlasTrackerComponentAtlas | HCAAtlasTrackerSourceDataset
+): React.ComponentProps<typeof C.BasicCell> => {
+  return {
+    value: entity.cellCount.toLocaleString(),
   };
 };
 
@@ -126,6 +153,20 @@ export const buildCreatedAt = (
 ): React.ComponentProps<typeof C.BasicCell> => {
   return {
     value: getDateFromIsoString(task.createdAt),
+  };
+};
+
+/**
+ * Build props for the disease cell component.
+ * @param entity - Component atlas or source dataset entity.
+ * @returns Props to be used for the cell.
+ */
+export const buildDisease = (
+  entity: HCAAtlasTrackerComponentAtlas | HCAAtlasTrackerSourceDataset
+): React.ComponentProps<typeof C.PinnedNTagCell> => {
+  return {
+    label: getPluralizedMetadataLabel(METADATA_KEY.DISEASE),
+    values: partitionMetadataValues(entity.disease, [DISEASE.NORMAL]),
   };
 };
 
@@ -251,6 +292,19 @@ export const buildResolvedAt = (
 // };
 
 /**
+ * Build props for the source dataset count cell component.
+ * @param componentAtlas - Component atlas entity.
+ * @returns Props to be used for the cell.
+ */
+export const buildSourceDatasetCount = (
+  componentAtlas: HCAAtlasTrackerComponentAtlas
+): React.ComponentProps<typeof C.BasicCell> => {
+  return {
+    value: componentAtlas.sourceDatasetCount.toLocaleString(),
+  };
+};
+
+/**
  * Build props for the source study publication Link component.
  * @param sourceStudy - Source study entity.
  * @returns Props to be used for the Link component.
@@ -323,6 +377,20 @@ export const buildStatus = (
   return {
     color,
     label: atlas.status,
+  };
+};
+
+/**
+ * Build props for the suspension type cell component.
+ * @param entity - Component atlas or source dataset entity.
+ * @returns Props to be used for the cell.
+ */
+export const buildSuspensionType = (
+  entity: HCAAtlasTrackerComponentAtlas | HCAAtlasTrackerSourceDataset
+): React.ComponentProps<typeof C.NTagCell> => {
+  return {
+    label: getPluralizedMetadataLabel(METADATA_KEY.SUSPENSION_TYPE),
+    values: entity.suspensionType,
   };
 };
 
@@ -551,6 +619,20 @@ export const buildTaskWaves = (
 };
 
 /**
+ * Build props for the tissue cell component.
+ * @param entity - Component atlas or source dataset entity.
+ * @returns Props to be used for the cell.
+ */
+export const buildTissue = (
+  entity: HCAAtlasTrackerComponentAtlas | HCAAtlasTrackerSourceDataset
+): React.ComponentProps<typeof C.NTagCell> => {
+  return {
+    label: getPluralizedMetadataLabel(METADATA_KEY.TISSUE),
+    values: entity.tissue,
+  };
+};
+
+/**
  * Build props for the BasicCell component.
  * @param task - Task entity.
  * @returns Props to be used for the BasicCell component.
@@ -584,7 +666,15 @@ export const buildWave = (
 export function getAtlasComponentAtlasesTableColumns(
   pathParameter: PathParameter
 ): ColumnDef<HCAAtlasTrackerComponentAtlas>[] {
-  return [getComponentAtlasTitleColumnDef(pathParameter)];
+  return [
+    getComponentAtlasTitleColumnDef(pathParameter),
+    getComponentAtlasSourceDatasetCountColumnDef(),
+    getComponentAtlasAssayColumnDef(),
+    getComponentAtlasSuspensionTypeColumnDef(),
+    getComponentAtlasTissueColumnDef(),
+    getComponentAtlasDiseaseColumnDef(),
+    getCellCountColumnDef(),
+  ];
 }
 
 /**
@@ -623,7 +713,7 @@ export function getAtlasSourceDatasetsTableColumns(
     getSourceDatasetSuspensionTypeColumnDef(),
     getSourceDatasetTissueColumnDef(),
     getSourceDatasetDiseaseColumnDef(),
-    getSourceDatasetCellCountColumnDef(),
+    getCellCountColumnDef(),
   ];
 }
 
@@ -634,8 +724,7 @@ export function getAtlasSourceDatasetsTableColumns(
 function getAtlasSourceStudiesSourceDatasetsCellCountColumnDef(): ColumnDef<HCAAtlasTrackerSourceDataset> {
   return {
     accessorKey: "cellCount",
-    cell: ({ row }) =>
-      C.BasicCell({ value: row.original.cellCount.toLocaleString() }),
+    cell: ({ row }) => C.BasicCell(buildCellCount(row.original)),
     header: "Cell Count",
     meta: { enableSortingInteraction: false },
   };
@@ -738,8 +827,7 @@ export function getBioNetworkName(name: string): string {
 function getComponentAtlasSourceDatasetSourceStudyCellCountColumnDef(): ColumnDef<HCAAtlasTrackerSourceDataset> {
   return {
     accessorKey: "cellCount",
-    cell: ({ row }) =>
-      C.BasicCell({ value: row.original.cellCount.toLocaleString() }),
+    cell: ({ row }) => C.BasicCell(buildCellCount(row.original)),
     header: "Cell count",
     meta: { enableSortingInteraction: false },
   };
@@ -791,6 +879,66 @@ function getComponentAtlasSourceDatasetUnlinkColumnDef(
       }),
     header: "",
     meta: { enableSortingInteraction: false },
+  };
+}
+
+/**
+ * Returns component atlas assay column def.
+ * @returns ColumnDef.
+ */
+function getComponentAtlasAssayColumnDef(): ColumnDef<HCAAtlasTrackerComponentAtlas> {
+  return {
+    accessorKey: "assay",
+    cell: ({ row }) => C.NTagCell(buildAssay(row.original)),
+    header: "Assay",
+  };
+}
+
+/**
+ * Returns component atlas disease column def.
+ * @returns ColumnDef.
+ */
+function getComponentAtlasDiseaseColumnDef(): ColumnDef<HCAAtlasTrackerComponentAtlas> {
+  return {
+    accessorKey: "disease",
+    cell: ({ row }) => C.PinnedNTagCell(buildDisease(row.original)),
+    header: "Disease",
+  };
+}
+
+/**
+ * Returns component atlas suspension type column def.
+ * @returns ColumnDef.
+ */
+function getComponentAtlasSuspensionTypeColumnDef(): ColumnDef<HCAAtlasTrackerComponentAtlas> {
+  return {
+    accessorKey: "suspensionType",
+    cell: ({ row }) => C.NTagCell(buildSuspensionType(row.original)),
+    header: "Suspension Type",
+  };
+}
+
+/**
+ * Returns component atlas source dataset count column def.
+ * @returns ColumnDef.
+ */
+function getComponentAtlasSourceDatasetCountColumnDef(): ColumnDef<HCAAtlasTrackerComponentAtlas> {
+  return {
+    accessorKey: "sourceDatasetCount",
+    cell: ({ row }) => C.BasicCell(buildSourceDatasetCount(row.original)),
+    header: "Source Datasets",
+  };
+}
+
+/**
+ * Returns component atlas tissue column def.
+ * @returns ColumnDef.
+ */
+function getComponentAtlasTissueColumnDef(): ColumnDef<HCAAtlasTrackerComponentAtlas> {
+  return {
+    accessorKey: "tissue",
+    cell: ({ row }) => C.NTagCell(buildTissue(row.original)),
+    header: "Tissue",
   };
 }
 
@@ -866,25 +1014,22 @@ function getSourceDatasetAssayColumnDef(
 ): ColumnDef<HCAAtlasTrackerSourceDataset> {
   return {
     accessorKey: "assay",
-    cell: ({ row }) =>
-      C.NTagCell({
-        label: getPluralizedMetadataLabel(METADATA_KEY.ASSAY),
-        values: row.original.assay,
-      }),
+    cell: ({ row }) => C.NTagCell(buildAssay(row.original)),
     header: "Assay",
     meta: { enableSortingInteraction },
   };
 }
 
 /**
- * Returns source dataset cell count column def.
+ * Returns source dataset or component atlas cell count column def.
  * @returns Column def.
  */
-function getSourceDatasetCellCountColumnDef(): ColumnDef<HCAAtlasTrackerSourceDataset> {
+function getCellCountColumnDef<
+  T extends HCAAtlasTrackerSourceDataset | HCAAtlasTrackerComponentAtlas
+>(): ColumnDef<T> {
   return {
     accessorKey: "cellCount",
-    cell: ({ row }) =>
-      C.BasicCell({ value: row.original.cellCount.toLocaleString() }),
+    cell: ({ row }) => C.BasicCell(buildCellCount(row.original)),
     header: "Cell Count",
   };
 }
@@ -899,11 +1044,7 @@ function getSourceDatasetDiseaseColumnDef(
 ): ColumnDef<HCAAtlasTrackerSourceDataset> {
   return {
     accessorKey: "disease",
-    cell: ({ row }) =>
-      C.PinnedNTagCell({
-        label: getPluralizedMetadataLabel(METADATA_KEY.DISEASE),
-        values: partitionMetadataValues(row.original.disease, [DISEASE.NORMAL]),
-      }),
+    cell: ({ row }) => C.PinnedNTagCell(buildDisease(row.original)),
     header: "Disease",
     meta: { enableSortingInteraction },
   };
@@ -950,11 +1091,7 @@ function getSourceDatasetSuspensionTypeColumnDef(
 ): ColumnDef<HCAAtlasTrackerSourceDataset> {
   return {
     accessorKey: "suspensionType",
-    cell: ({ row }) =>
-      C.NTagCell({
-        label: getPluralizedMetadataLabel(METADATA_KEY.SUSPENSION_TYPE),
-        values: row.original.suspensionType,
-      }),
+    cell: ({ row }) => C.NTagCell(buildSuspensionType(row.original)),
     header: "Suspension Type",
     meta: { enableSortingInteraction },
   };
@@ -970,11 +1107,7 @@ function getSourceDatasetTissueColumnDef(
 ): ColumnDef<HCAAtlasTrackerSourceDataset> {
   return {
     accessorKey: "tissue",
-    cell: ({ row }) =>
-      C.NTagCell({
-        label: getPluralizedMetadataLabel(METADATA_KEY.TISSUE),
-        values: row.original.tissue,
-      }),
+    cell: ({ row }) => C.NTagCell(buildTissue(row.original)),
     header: "Tissue",
     meta: { enableSortingInteraction },
   };

--- a/migrations/1720034230795_component-atlas-dataset-properties.ts
+++ b/migrations/1720034230795_component-atlas-dataset-properties.ts
@@ -1,0 +1,35 @@
+import { MigrationBuilder } from "node-pg-migrate";
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.sql(`
+    UPDATE hat.component_atlases c
+    SET component_info = c.component_info || jsonb_build_object(
+      'assay', cd.assay,
+      'disease', cd.disease,
+      'cellCount', cd.cell_count,
+      'suspensionType', cd.suspension_type,
+      'tissue', cd.tissue
+    )
+    FROM (
+      SELECT
+        csub.id AS id,
+        coalesce(sum((d.sd_info->>'cellCount')::int), 0) AS cell_count,
+        (SELECT coalesce(jsonb_agg(DISTINCT e), '[]'::jsonb) FROM unnest(array_agg(d.sd_info->'assay')) v(x), jsonb_array_elements(x) e) AS assay,
+        (SELECT coalesce(jsonb_agg(DISTINCT e), '[]'::jsonb) FROM unnest(array_agg(d.sd_info->'disease')) v(x), jsonb_array_elements(x) e) AS disease,
+        (SELECT coalesce(jsonb_agg(DISTINCT e), '[]'::jsonb) FROM unnest(array_agg(d.sd_info->'suspensionType')) v(x), jsonb_array_elements(x) e) AS suspension_type,
+        (SELECT coalesce(jsonb_agg(DISTINCT e), '[]'::jsonb) FROM unnest(array_agg(d.sd_info->'tissue')) v(x), jsonb_array_elements(x) e) AS tissue
+      FROM
+        hat.component_atlases csub
+        LEFT JOIN hat.source_datasets d
+      ON d.id=ANY(csub.source_datasets)
+      GROUP BY csub.id
+    ) AS cd
+    WHERE c.id=cd.id
+  `);
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.sql(
+    "UPDATE hat.component_atlases SET component_info=component_info-'assay'-'cellCount'-'disease'-'suspensionType'-'tissue'"
+  );
+}

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -1125,8 +1125,13 @@ export const TEST_SOURCE_STUDIES = [...INITIAL_TEST_SOURCE_STUDIES];
 // SOURCE DATASETS
 
 export const SOURCE_DATASET_FOO: TestSourceDataset = {
+  assay: ["assay foo"],
+  cellCount: 354,
+  disease: ["disease foo"],
   id: "6e1e281d-78cb-462a-ae29-94663c1e5713",
   sourceStudyId: SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+  suspensionType: ["suspension type foo"],
+  tissue: ["tissue foo"],
   title: "Source Dataset Foo",
 };
 
@@ -1143,8 +1148,13 @@ export const SOURCE_DATASET_BAZ: TestSourceDataset = {
 };
 
 export const SOURCE_DATASET_FOOFOO: TestSourceDataset = {
+  assay: ["assay foofoo"],
+  cellCount: 534,
+  disease: ["disease foofoo"],
   id: "5c42bc65-93ad-4191-95bc-a40d56f2bb6b",
   sourceStudyId: SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+  suspensionType: ["suspension type foofoo"],
+  tissue: ["tissue foofoo"],
   title: "Source Dataset Foofoo",
 };
 
@@ -1160,18 +1170,28 @@ export const SOURCE_DATASET_FOOBAZ: TestSourceDataset = {
   title: "Source Dataset Foobar",
 };
 export const SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE: TestSourceDataset = {
+  assay: ["foo"],
+  cellCount: 123,
   cellxgeneDatasetId: CELLXGENE_ID_DATASET_WITHOUT_UPDATE,
   cellxgeneDatasetVersion: CELLXGENE_VERSION_DATASET_WITHOUT_UPDATE,
+  disease: ["bar"],
   id: "afcb9181-5a6b-45a8-89c0-1790def2d7dc",
   sourceStudyId: SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+  suspensionType: ["foobarbaz"],
+  tissue: ["baz"],
   title: "Source Dataset CELLxGENE Without Update",
 };
 
 export const SOURCE_DATASET_CELLXGENE_WITH_UPDATE: TestSourceDataset = {
+  assay: ["foobarfoo"],
+  cellCount: 4567,
   cellxgeneDatasetId: CELLXGENE_ID_DATASET_WITH_UPDATE,
   cellxgeneDatasetVersion: "cellxgene-version-dataset-with-update-a",
+  disease: ["barbarfoo"],
   id: "04ccf7fd-22eb-4236-829c-9a0058580d36",
   sourceStudyId: SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+  suspensionType: ["foobazbarfoo"],
+  tissue: ["bazbarfoo"],
   title: "Source Dataset CELLxGENE With Update",
 };
 
@@ -1338,9 +1358,9 @@ export const COMPONENT_ATLAS_DRAFT_FOO: TestComponentAtlas = {
   atlasId: ATLAS_DRAFT.id,
   id: "b1820416-5886-4585-b0fe-7f70487331d8",
   sourceDatasets: [
-    SOURCE_DATASET_FOOFOO.id,
-    SOURCE_DATASET_FOOBAR.id,
-    SOURCE_DATASET_FOOBAZ.id,
+    SOURCE_DATASET_FOOFOO,
+    SOURCE_DATASET_FOOBAR,
+    SOURCE_DATASET_FOOBAZ,
   ],
   title: "Component Atlas Draft Foo",
 };
@@ -1348,6 +1368,10 @@ export const COMPONENT_ATLAS_DRAFT_FOO: TestComponentAtlas = {
 export const COMPONENT_ATLAS_DRAFT_BAR: TestComponentAtlas = {
   atlasId: ATLAS_DRAFT.id,
   id: "484bc93b-836d-4efe-880a-de90eb1c4dfb",
+  sourceDatasets: [
+    SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE,
+    SOURCE_DATASET_CELLXGENE_WITH_UPDATE,
+  ],
   title: "Component Atlas Draft Bar",
 };
 

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -1092,6 +1092,18 @@ export const SOURCE_STUDY_UNPUBLISHED_WITH_HCA: TestUnpublishedSourceStudy = {
   },
 };
 
+export const SOURCE_STUDY_WITH_OTHER_SOURCE_DATASETS: TestUnpublishedSourceStudy =
+  {
+    cellxgeneCollectionId: null,
+    hcaProjectId: null,
+    id: "3e57fb9a-b2c0-4f5d-9109-62fe18c16891",
+    unpublishedInfo: {
+      contactEmail: "bazfoobar@example.com",
+      referenceAuthor: "Baz Foo Bar",
+      title: "Source Study With Other Source Datasets",
+    },
+  };
+
 // Source studies initialized in the database before tests
 export const INITIAL_TEST_SOURCE_STUDIES = [
   SOURCE_STUDY_DRAFT_OK,
@@ -1118,6 +1130,7 @@ export const INITIAL_TEST_SOURCE_STUDIES = [
   SOURCE_STUDY_PUBLISHED_WITH_REMOVED_CELLXGENE_ID,
   SOURCE_STUDY_PUBLISHED_WITH_CHANGING_IDS,
   SOURCE_STUDY_UNPUBLISHED_WITH_HCA,
+  SOURCE_STUDY_WITH_OTHER_SOURCE_DATASETS,
 ];
 
 export const TEST_SOURCE_STUDIES = [...INITIAL_TEST_SOURCE_STUDIES];
@@ -1169,6 +1182,7 @@ export const SOURCE_DATASET_FOOBAZ: TestSourceDataset = {
   sourceStudyId: SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
   title: "Source Dataset Foobar",
 };
+
 export const SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE: TestSourceDataset = {
   assay: ["foo"],
   cellCount: 123,
@@ -1207,6 +1221,28 @@ export const SOURCE_DATASET_DRAFT_OK_BAR: TestSourceDataset = {
   title: "Source Dataset Draft OK Bar",
 };
 
+export const SOURCE_DATASET_OTHER_FOO: TestSourceDataset = {
+  assay: ["assay other foo"],
+  cellCount: 23424,
+  disease: ["disease other foo"],
+  id: "d85cf1fd-3b70-4f6a-812c-583941362117",
+  sourceStudyId: SOURCE_STUDY_WITH_OTHER_SOURCE_DATASETS.id,
+  suspensionType: ["suspension type other foo"],
+  tissue: ["tissue other foo"],
+  title: "Source Dataset Other Foo",
+};
+
+export const SOURCE_DATASET_OTHER_BAR: TestSourceDataset = {
+  assay: ["assay other bar"],
+  cellCount: 23424,
+  disease: ["disease other bar"],
+  id: "e3878dde-ffe5-4193-9b7f-5a395541ba25",
+  sourceStudyId: SOURCE_STUDY_WITH_OTHER_SOURCE_DATASETS.id,
+  suspensionType: ["suspension type other bar"],
+  tissue: ["tissue other bar"],
+  title: "Source Dataset Other Bar",
+};
+
 // Source datasets intitialized in the database before tests
 export const INITIAL_TEST_SOURCE_DATASETS = [
   SOURCE_DATASET_FOO,
@@ -1219,6 +1255,8 @@ export const INITIAL_TEST_SOURCE_DATASETS = [
   SOURCE_DATASET_CELLXGENE_WITH_UPDATE,
   SOURCE_DATASET_DRAFT_OK_FOO,
   SOURCE_DATASET_DRAFT_OK_BAR,
+  SOURCE_DATASET_OTHER_FOO,
+  SOURCE_DATASET_OTHER_BAR,
 ];
 
 // ATLASES
@@ -1289,6 +1327,7 @@ export const ATLAS_WITH_MISC_SOURCE_STUDIES: TestAtlas = {
     SOURCE_STUDY_PUBLISHED_WITH_REMOVED_CELLXGENE_ID.id,
     SOURCE_STUDY_PUBLISHED_WITH_CHANGING_IDS.id,
     SOURCE_STUDY_UNPUBLISHED_WITH_HCA.id,
+    SOURCE_STUDY_WITH_OTHER_SOURCE_DATASETS.id,
   ],
   status: ATLAS_STATUS.PUBLIC,
   version: "2.3",
@@ -1375,10 +1414,23 @@ export const COMPONENT_ATLAS_DRAFT_BAR: TestComponentAtlas = {
   title: "Component Atlas Draft Bar",
 };
 
+export const COMPONENT_ATLAS_MISC_FOO: TestComponentAtlas = {
+  atlasId: ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+  id: "b95614cc-5356-4f47-b3a2-da05d23e86ce",
+  sourceDatasets: [
+    SOURCE_DATASET_FOO,
+    SOURCE_DATASET_FOOFOO,
+    SOURCE_DATASET_OTHER_FOO,
+    SOURCE_DATASET_OTHER_BAR,
+  ],
+  title: "Component Atlas Misc Foo",
+};
+
 // Component atlases to initialize in the database before tests
 export const INITIAL_TEST_COMPONENT_ATLASES = [
   COMPONENT_ATLAS_DRAFT_FOO,
   COMPONENT_ATLAS_DRAFT_BAR,
+  COMPONENT_ATLAS_MISC_FOO,
 ];
 
 // USERS

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -126,8 +126,13 @@ async function initAtlases(client: pg.PoolClient): Promise<void> {
 async function initComponentAtlases(client: pg.PoolClient): Promise<void> {
   for (const componentAtlas of INITIAL_TEST_COMPONENT_ATLASES) {
     const info: HCAAtlasTrackerDBComponentAtlasInfo = {
+      assay: [],
+      cellCount: 0,
       cellxgeneDatasetId: null,
       cellxgeneDatasetVersion: null,
+      disease: [],
+      suspensionType: [],
+      tissue: [],
     };
     await client.query(
       "INSERT INTO hat.component_atlases (atlas_id, component_info, id, source_datasets, title) VALUES ($1, $2, $3, $4, $5)",

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -224,6 +224,14 @@ export async function getDbUsersByEmail(): Promise<
   );
 }
 
+export async function getExistingComponentAtlasFromDatabase(
+  id: string
+): Promise<HCAAtlasTrackerDBComponentAtlas> {
+  const result = await getComponentAtlasFromDatabase(id);
+  if (!result) throw new Error(`Component atlas ${id} doesn't exist`);
+  return result;
+}
+
 export async function getComponentAtlasFromDatabase(
   id: string
 ): Promise<HCAAtlasTrackerDBComponentAtlas | undefined> {

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -6,7 +6,6 @@ import {
   HCAAtlasTrackerDBComponentAtlas,
   HCAAtlasTrackerDBComponentAtlasInfo,
   HCAAtlasTrackerDBSourceDataset,
-  HCAAtlasTrackerDBSourceDatasetInfo,
   HCAAtlasTrackerDBSourceStudy,
   HCAAtlasTrackerDBUser,
   HCAAtlasTrackerDBValidation,
@@ -26,6 +25,7 @@ import {
 import {
   aggregateSourceDatasetArrayField,
   makeTestAtlasOverview,
+  makeTestSourceDatasetInfo,
   makeTestSourceStudyOverview,
 } from "./utils";
 
@@ -92,19 +92,7 @@ async function initSourceStudies(client: pg.PoolClient): Promise<void> {
 
 async function initSourceDatasets(client: pg.PoolClient): Promise<void> {
   for (const sourceDataset of INITIAL_TEST_SOURCE_DATASETS) {
-    const info: HCAAtlasTrackerDBSourceDatasetInfo = {
-      assay: sourceDataset.assay ?? [],
-      cellCount: sourceDataset.cellCount ?? 0,
-      cellxgeneDatasetId: sourceDataset.cellxgeneDatasetId ?? null,
-      cellxgeneDatasetVersion: sourceDataset.cellxgeneDatasetVersion ?? null,
-      cellxgeneExplorerUrl: sourceDataset.cellxgeneDatasetId
-        ? `explorer-url-${sourceDataset.cellxgeneDatasetId}`
-        : null,
-      disease: sourceDataset.disease ?? [],
-      suspensionType: sourceDataset.suspensionType ?? [],
-      tissue: sourceDataset.tissue ?? [],
-      title: sourceDataset.title,
-    };
+    const info = makeTestSourceDatasetInfo(sourceDataset);
     await client.query(
       "INSERT INTO hat.source_datasets (source_study_id, sd_info, id) VALUES ($1, $2, $3)",
       [sourceDataset.sourceStudyId, info, sourceDataset.id]

--- a/testing/entities.ts
+++ b/testing/entities.ts
@@ -34,7 +34,7 @@ export interface TestAtlas {
 export interface TestComponentAtlas {
   atlasId: string;
   id: string;
-  sourceDatasets?: string[];
+  sourceDatasets?: TestSourceDataset[];
   title: string;
 }
 
@@ -60,10 +60,15 @@ export interface TestUnpublishedSourceStudy {
 }
 
 export interface TestSourceDataset {
+  assay?: string[];
+  cellCount?: number;
   cellxgeneDatasetId?: string;
   cellxgeneDatasetVersion?: string;
+  disease?: string[];
   id: string;
   sourceStudyId: string;
+  suspensionType?: string[];
+  tissue?: string[];
   title: string;
 }
 

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -3,6 +3,7 @@ import {
   DOI_STATUS,
   HCAAtlasTrackerAtlas,
   HCAAtlasTrackerDBAtlasOverview,
+  HCAAtlasTrackerDBComponentAtlas,
   HCAAtlasTrackerDBPublishedSourceStudyInfo,
   HCAAtlasTrackerDBSourceStudy,
   HCAAtlasTrackerDBUnpublishedSourceStudyInfo,
@@ -225,6 +226,44 @@ export function expectSourceStudyToMatch(
       expect(apiStudy.title).toBeNull();
     }
     expect(apiStudy.contactEmail).toBeNull();
+  }
+}
+
+export function expectComponentAtlasDatasetsToHaveDifference(
+  componentAtlasWithout: HCAAtlasTrackerDBComponentAtlas,
+  componentAtlasWith: HCAAtlasTrackerDBComponentAtlas,
+  sourceDatasets: TestSourceDataset[]
+): void {
+  const infoWithout = componentAtlasWithout.component_info;
+  const infoWith = componentAtlasWith.component_info;
+  const expectedCellCountDiff = sourceDatasets.reduce(
+    (sum, d) => sum + (d.cellCount ?? 0),
+    0
+  );
+  expect(infoWith.cellCount - infoWithout.cellCount).toEqual(
+    expectedCellCountDiff
+  );
+  expectArrayToContainItems(infoWith.assay, infoWithout.assay);
+  expectArrayToContainItems(infoWith.disease, infoWithout.disease);
+  expectArrayToContainItems(
+    infoWith.suspensionType,
+    infoWithout.suspensionType
+  );
+  expectArrayToContainItems(infoWith.tissue, infoWithout.tissue);
+  for (const sourceDataset of sourceDatasets) {
+    expectArrayToContainItems(infoWith.assay, sourceDataset.assay ?? []);
+    expectArrayToContainItems(infoWith.disease, sourceDataset.disease ?? []);
+    expectArrayToContainItems(
+      infoWith.suspensionType,
+      sourceDataset.suspensionType ?? []
+    );
+    expectArrayToContainItems(infoWith.tissue, sourceDataset.tissue ?? []);
+  }
+}
+
+function expectArrayToContainItems(array: unknown[], items: unknown[]): void {
+  for (const item of items) {
+    expect(array).toContain(item);
   }
 }
 

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -5,6 +5,7 @@ import {
   HCAAtlasTrackerDBAtlasOverview,
   HCAAtlasTrackerDBComponentAtlas,
   HCAAtlasTrackerDBPublishedSourceStudyInfo,
+  HCAAtlasTrackerDBSourceDatasetInfo,
   HCAAtlasTrackerDBSourceStudy,
   HCAAtlasTrackerDBUnpublishedSourceStudyInfo,
   HCAAtlasTrackerSourceStudy,
@@ -86,6 +87,24 @@ export function makeTestSourceStudyOverview(
         publication: study.publication,
         unpublishedInfo: null,
       };
+}
+
+export function makeTestSourceDatasetInfo(
+  sourceDataset: TestSourceDataset
+): HCAAtlasTrackerDBSourceDatasetInfo {
+  return {
+    assay: sourceDataset.assay ?? [],
+    cellCount: sourceDataset.cellCount ?? 0,
+    cellxgeneDatasetId: sourceDataset.cellxgeneDatasetId ?? null,
+    cellxgeneDatasetVersion: sourceDataset.cellxgeneDatasetVersion ?? null,
+    cellxgeneExplorerUrl: sourceDataset.cellxgeneDatasetId
+      ? `explorer-url-${sourceDataset.cellxgeneDatasetId}`
+      : null,
+    disease: sourceDataset.disease ?? [],
+    suspensionType: sourceDataset.suspensionType ?? [],
+    tissue: sourceDataset.tissue ?? [],
+    title: sourceDataset.title,
+  };
 }
 
 export function makeTestProjectsResponse(

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -13,7 +13,12 @@ import {
   TEST_CELLXGENE_COLLECTIONS_BY_DOI,
   TEST_HCA_PROJECTS_BY_DOI,
 } from "./constants";
-import { TestAtlas, TestSourceStudy, TestUser } from "./entities";
+import {
+  TestAtlas,
+  TestSourceDataset,
+  TestSourceStudy,
+  TestUser,
+} from "./entities";
 
 export function makeTestUser(
   nameId: string,
@@ -130,6 +135,14 @@ export function makeTestProjectsResponse(
   };
 }
 
+export function aggregateSourceDatasetArrayField(
+  sourceDatasets: TestSourceDataset[] | undefined,
+  field: "assay" | "disease" | "suspensionType" | "tissue"
+): string[] {
+  if (!sourceDatasets) return [];
+  return Array.from(new Set(sourceDatasets.map((d) => d[field] ?? []).flat()));
+}
+
 export async function withConsoleErrorHiding<T>(
   fn: () => Promise<T>,
   hideConsoleError = true
@@ -213,4 +226,9 @@ export function expectSourceStudyToMatch(
     }
     expect(apiStudy.contactEmail).toBeNull();
   }
+}
+
+export function expectIsDefined<T>(value: T | undefined): value is T {
+  expect(value).toBeDefined();
+  return value !== undefined;
 }


### PR DESCRIPTION
A component atlas's properties are updated when:
- The new migration is run
- A source dataset is added to it
- A source dataset is removed from it
- One of its CELLxGENE source datasets is updated after a refresh