### PR TITLE
feat: allow integration leads to use source dataset apis for their atlases (#370)

### DIFF
--- a/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/[sourceDatasetId].ts
+++ b/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/[sourceDatasetId].ts
@@ -11,6 +11,7 @@ import {
 import {
   handleByMethod,
   handler,
+  integrationLeadAssociatedAtlasOnly,
   role,
 } from "../../../../../../../app/utils/api-handler";
 
@@ -27,32 +28,40 @@ const getHandler = handler(role(ROLE_GROUP.READ), async (req, res) => {
     );
 });
 
-const patchHandler = handler(role(ROLE.CONTENT_ADMIN), async (req, res) => {
-  const atlasId = req.query.atlasId as string;
-  const sourceStudyId = req.query.sourceStudyId as string;
-  const sourceDatasetId = req.query.sourceDatasetId as string;
-  const inputData = await sourceDatasetEditSchema.validate(req.body);
-  res
-    .status(200)
-    .json(
-      dbSourceDatasetToApiSourceDataset(
-        await updateSourceDataset(
-          atlasId,
-          sourceStudyId,
-          sourceDatasetId,
-          inputData
+const patchHandler = handler(
+  role([ROLE.INTEGRATION_LEAD, ROLE.CONTENT_ADMIN]),
+  integrationLeadAssociatedAtlasOnly,
+  async (req, res) => {
+    const atlasId = req.query.atlasId as string;
+    const sourceStudyId = req.query.sourceStudyId as string;
+    const sourceDatasetId = req.query.sourceDatasetId as string;
+    const inputData = await sourceDatasetEditSchema.validate(req.body);
+    res
+      .status(200)
+      .json(
+        dbSourceDatasetToApiSourceDataset(
+          await updateSourceDataset(
+            atlasId,
+            sourceStudyId,
+            sourceDatasetId,
+            inputData
+          )
         )
-      )
-    );
-});
+      );
+  }
+);
 
-const deleteHandler = handler(role(ROLE.CONTENT_ADMIN), async (req, res) => {
-  const atlasId = req.query.atlasId as string;
-  const sourceStudyId = req.query.sourceStudyId as string;
-  const sourceDatasetId = req.query.sourceDatasetId as string;
-  await deleteSourceDataset(atlasId, sourceStudyId, sourceDatasetId);
-  res.status(200).end();
-});
+const deleteHandler = handler(
+  role([ROLE.INTEGRATION_LEAD, ROLE.CONTENT_ADMIN]),
+  integrationLeadAssociatedAtlasOnly,
+  async (req, res) => {
+    const atlasId = req.query.atlasId as string;
+    const sourceStudyId = req.query.sourceStudyId as string;
+    const sourceDatasetId = req.query.sourceDatasetId as string;
+    await deleteSourceDataset(atlasId, sourceStudyId, sourceDatasetId);
+    res.status(200).end();
+  }
+);
 
 /**
  * API route for getting, updating, or deleting a source dataset.

--- a/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/create.ts
+++ b/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/create.ts
@@ -1,16 +1,22 @@
-import { ROLE } from "app/apis/catalog/hca-atlas-tracker/common/entities";
-import { newSourceDatasetSchema } from "app/apis/catalog/hca-atlas-tracker/common/schema";
-import { dbSourceDatasetToApiSourceDataset } from "app/apis/catalog/hca-atlas-tracker/common/utils";
-import { METHOD } from "app/common/entities";
-import { createSourceDataset } from "app/services/source-datasets";
-import { handler, method, role } from "app/utils/api-handler";
+import { ROLE } from "../../../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { newSourceDatasetSchema } from "../../../../../../../app/apis/catalog/hca-atlas-tracker/common/schema";
+import { dbSourceDatasetToApiSourceDataset } from "../../../../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
+import { METHOD } from "../../../../../../../app/common/entities";
+import { createSourceDataset } from "../../../../../../../app/services/source-datasets";
+import {
+  handler,
+  integrationLeadAssociatedAtlasOnly,
+  method,
+  role,
+} from "../../../../../../../app/utils/api-handler";
 
 /**
  * API route for creating a source dataset.
  */
 export default handler(
   method(METHOD.POST),
-  role(ROLE.CONTENT_ADMIN),
+  role([ROLE.INTEGRATION_LEAD, ROLE.CONTENT_ADMIN]),
+  integrationLeadAssociatedAtlasOnly,
   async (req, res) => {
     const atlasId = req.query.atlasId as string;
     const sourceStudyId = req.query.sourceStudyId as string;


### PR DESCRIPTION
In addition to allowing creating and deleting source datasets as specified in the ticket, also allows editing source datasets (i.e. editing their titles)