### PR TITLE
feat: add api and page to update integration lead users from atlases (#376)

### DIFF
--- a/__tests__/api-users-integration-leads-from-atlases.test.ts
+++ b/__tests__/api-users-integration-leads-from-atlases.test.ts
@@ -1,0 +1,203 @@
+import { HCAAtlasTrackerDBUser } from "app/apis/catalog/hca-atlas-tracker/common/entities";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
+import { METHOD } from "../app/common/entities";
+import { endPgPool, query } from "../app/services/database";
+import integrationLeadsFromAtlasesHandler from "../pages/api/users/integration-leads-from-atlases";
+import {
+  ATLAS_DRAFT,
+  ATLAS_PUBLIC,
+  ATLAS_WITH_IL,
+  ATLAS_WITH_MISC_SOURCE_STUDIES,
+  INTEGRATION_LEAD_BAZ,
+  INTEGRATION_LEAD_BAZ_BAZ,
+  STAKEHOLDER_ANALOGOUS_ROLES,
+  USER_CONTENT_ADMIN,
+  USER_INTEGRATION_LEAD_DRAFT,
+  USER_INTEGRATION_LEAD_PUBLIC,
+  USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
+  USER_INTEGRATION_LEAD_WITH_NEW_ATLAS,
+  USER_UNREGISTERED,
+} from "../testing/constants";
+import { resetDatabase } from "../testing/db-utils";
+import { TestUser } from "../testing/entities";
+import {
+  expectIsDefined,
+  testApiRole,
+  withConsoleErrorHiding,
+} from "../testing/utils";
+
+jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("../app/services/user-profile");
+jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/cellxgene");
+
+const TEST_ROUTE = "/api/users/integration-leads-from-atlases";
+
+beforeAll(async () => {
+  await resetDatabase();
+});
+
+afterAll(() => {
+  endPgPool();
+});
+
+describe(TEST_ROUTE, () => {
+  it("returns error 405 for non-PATCH request", async () => {
+    expect(
+      (
+        await doIntegrationLeadsRequest(USER_CONTENT_ADMIN, false, METHOD.GET)
+      )._getStatusCode()
+    ).toEqual(405);
+  });
+
+  it("returns error 401 for logged out user", async () => {
+    expect((await doIntegrationLeadsRequest())._getStatusCode()).toEqual(401);
+  });
+
+  it("returns error 403 for unregistered user", async () => {
+    expect(
+      (await doIntegrationLeadsRequest(USER_UNREGISTERED))._getStatusCode()
+    ).toEqual(403);
+  });
+
+  for (const role of STAKEHOLDER_ANALOGOUS_ROLES) {
+    testApiRole(
+      TEST_ROUTE,
+      "returns error 403",
+      integrationLeadsFromAtlasesHandler,
+      METHOD.PATCH,
+      role,
+      undefined,
+      undefined,
+      false,
+      (res) => {
+        expect(res._getStatusCode()).toEqual(403);
+      }
+    );
+  }
+
+  it("creates and updates users when requested by user with CONTENT_ADMIN role", async () => {
+    await testSuccessfulRequest();
+  });
+});
+
+async function testSuccessfulRequest(): Promise<void> {
+  const integrationLeadDraftBefore = await getUserFromDatabase(
+    USER_INTEGRATION_LEAD_DRAFT.email
+  );
+  const integrationLeadPublicBefore = await getUserFromDatabase(
+    USER_INTEGRATION_LEAD_PUBLIC.email
+  );
+  const integrationLeadMiscStudiesBefore = await getUserFromDatabase(
+    USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES.email
+  );
+  const integrationLeadNewAtlasBefore = await getUserFromDatabase(
+    USER_INTEGRATION_LEAD_WITH_NEW_ATLAS.email
+  );
+  const bazBefore = await getUserFromDatabase(INTEGRATION_LEAD_BAZ.email);
+  const bazBazBefore = await getUserFromDatabase(
+    INTEGRATION_LEAD_BAZ_BAZ.email
+  );
+
+  if (expectIsDefined(integrationLeadDraftBefore))
+    expectItemsToBe(integrationLeadDraftBefore.role_associated_resource_ids, [
+      ATLAS_DRAFT.id,
+    ]);
+  if (expectIsDefined(integrationLeadPublicBefore))
+    expectItemsToBe(integrationLeadPublicBefore.role_associated_resource_ids, [
+      ATLAS_PUBLIC.id,
+    ]);
+  if (expectIsDefined(integrationLeadMiscStudiesBefore))
+    expectItemsToBe(
+      integrationLeadMiscStudiesBefore.role_associated_resource_ids,
+      [ATLAS_WITH_MISC_SOURCE_STUDIES.id]
+    );
+  if (expectIsDefined(integrationLeadNewAtlasBefore))
+    expectItemsToBe(
+      integrationLeadNewAtlasBefore.role_associated_resource_ids,
+      [ATLAS_DRAFT.id]
+    );
+  expect(bazBefore).toBeUndefined();
+  expect(bazBazBefore).toBeUndefined();
+
+  expect(
+    (
+      await doIntegrationLeadsRequest(USER_CONTENT_ADMIN, false, METHOD.PATCH)
+    )._getStatusCode()
+  ).toEqual(200);
+
+  const integrationLeadDraftAfter = await getUserFromDatabase(
+    USER_INTEGRATION_LEAD_DRAFT.email
+  );
+  const integrationLeadPublicAfter = await getUserFromDatabase(
+    USER_INTEGRATION_LEAD_PUBLIC.email
+  );
+  const integrationLeadMiscStudiesAfter = await getUserFromDatabase(
+    USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES.email
+  );
+  const integrationLeadNewAtlasAfter = await getUserFromDatabase(
+    USER_INTEGRATION_LEAD_WITH_NEW_ATLAS.email
+  );
+  const bazAfter = await getUserFromDatabase(INTEGRATION_LEAD_BAZ.email);
+  const bazBazAfter = await getUserFromDatabase(INTEGRATION_LEAD_BAZ_BAZ.email);
+
+  if (expectIsDefined(integrationLeadDraftAfter))
+    expectItemsToBe(integrationLeadDraftAfter.role_associated_resource_ids, [
+      ATLAS_DRAFT.id,
+    ]);
+  if (expectIsDefined(integrationLeadPublicAfter))
+    expectItemsToBe(integrationLeadPublicAfter.role_associated_resource_ids, [
+      ATLAS_PUBLIC.id,
+    ]);
+  if (expectIsDefined(integrationLeadMiscStudiesAfter))
+    expectItemsToBe(
+      integrationLeadMiscStudiesAfter.role_associated_resource_ids,
+      [ATLAS_WITH_MISC_SOURCE_STUDIES.id]
+    );
+  if (expectIsDefined(integrationLeadNewAtlasAfter))
+    expectItemsToBe(integrationLeadNewAtlasAfter.role_associated_resource_ids, [
+      ATLAS_DRAFT.id,
+      ATLAS_PUBLIC.id,
+    ]);
+  if (expectIsDefined(bazAfter))
+    expectItemsToBe(bazAfter.role_associated_resource_ids, [ATLAS_WITH_IL.id]);
+  if (expectIsDefined(bazBazAfter))
+    expectItemsToBe(bazBazAfter.role_associated_resource_ids, [
+      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+    ]);
+}
+
+async function doIntegrationLeadsRequest(
+  user?: TestUser,
+  hideConsoleError = false,
+  method = METHOD.PATCH
+): Promise<httpMocks.MockResponse<NextApiResponse>> {
+  const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>({
+    headers: { authorization: user?.authorization },
+    method,
+  });
+  await withConsoleErrorHiding(
+    () => integrationLeadsFromAtlasesHandler(req, res),
+    hideConsoleError
+  );
+  return res;
+}
+
+function expectItemsToBe(items: unknown[], expectedItems: unknown[]): void {
+  expect(items).toHaveLength(expectedItems.length);
+  for (const item of expectedItems) {
+    expect(items).toContain(item);
+  }
+}
+
+async function getUserFromDatabase(
+  email: string
+): Promise<HCAAtlasTrackerDBUser | undefined> {
+  return (
+    await query<HCAAtlasTrackerDBUser>(
+      "SELECT * FROM hat.users WHERE email=$1",
+      [email]
+    )
+  ).rows[0];
+}

--- a/app/components/Forms/components/IntegrationLeadsFromAtlases/integrationLeadsFromAtlases.tsx
+++ b/app/components/Forms/components/IntegrationLeadsFromAtlases/integrationLeadsFromAtlases.tsx
@@ -1,0 +1,82 @@
+import { ButtonPrimary } from "@databiosphere/findable-ui/lib/components/common/Button/components/ButtonPrimary/buttonPrimary";
+import { useAuthentication } from "@databiosphere/findable-ui/lib/hooks/useAuthentication/useAuthentication";
+import { useCallback, useState } from "react";
+import { METHOD } from "../../../../../app/common/entities";
+import {
+  fetchResource,
+  isFetchStatusOk,
+} from "../../../../../app/common/utils";
+import { FormResponseErrors } from "../../../../../app/hooks/useForm/common/entities";
+
+export const IntegrationLeadsFromAtlasesForm = (): JSX.Element => {
+  const [isDisabled, setIsDisabled] = useState(false);
+  const [responseErrors, setResponseErrors] = useState<FormResponseErrors>();
+  const [didUpdate, setDidUpdate] = useState(false);
+
+  const { token } = useAuthentication();
+
+  const onSave = useCallback(() => {
+    (async (): Promise<void> => {
+      try {
+        setIsDisabled(true);
+        const res = await fetchResource(
+          "/api/users/integration-leads-from-atlases",
+          METHOD.PATCH,
+          token
+        );
+        if (isFetchStatusOk(res.status)) {
+          setResponseErrors(undefined);
+          setDidUpdate(true);
+        } else {
+          setResponseErrors(
+            await res.json().catch(() => ({
+              message: `Received ${res.status} ${res.statusText} response`,
+            }))
+          );
+        }
+      } catch (e) {
+        setResponseErrors({
+          message: e instanceof Error ? e.message : String(e),
+        });
+      } finally {
+        setIsDisabled(false);
+      }
+    })();
+  }, [token]);
+
+  return (
+    <>
+      <div>
+        <ButtonPrimary disabled={isDisabled} onClick={onSave} size="small">
+          Update
+        </ButtonPrimary>
+      </div>
+      {responseErrors || didUpdate ? (
+        <div style={{ marginTop: "1em" }}>
+          {responseErrors
+            ? buildResponseErrors(responseErrors)
+            : didUpdate
+            ? "Updated"
+            : ""}
+        </div>
+      ) : (
+        ""
+      )}
+    </>
+  );
+};
+
+function buildResponseErrors(responseErrors: FormResponseErrors): JSX.Element {
+  return "message" in responseErrors ? (
+    <div>Error: {responseErrors.message}</div>
+  ) : (
+    <>
+      <div>Error:</div>
+      {Object.entries(responseErrors.errors).map(([field, message]) => (
+        <div key={field}>
+          {field}: {message}
+        </div>
+      ))}
+    </>
+  );
+}

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -1,4 +1,5 @@
-import { NotFoundError } from "app/utils/api-handler";
+import pg from "pg";
+import { NotFoundError } from "../../app/utils/api-handler";
 import {
   ATLAS_STATUS,
   HCAAtlasTrackerDBAtlas,
@@ -19,11 +20,13 @@ interface AtlasInputDbData {
   targetCompletion: HCAAtlasTrackerDBAtlas["target_completion"];
 }
 
-export async function getAllAtlases(): Promise<
-  HCAAtlasTrackerDBAtlasWithComponentAtlases[]
-> {
+export async function getAllAtlases(
+  client?: pg.PoolClient
+): Promise<HCAAtlasTrackerDBAtlasWithComponentAtlases[]> {
   const queryResult = await query<HCAAtlasTrackerDBAtlasWithComponentAtlases>(
-    "SELECT a.*, COUNT(c.*)::int AS component_atlas_count FROM hat.atlases a LEFT JOIN hat.component_atlases c ON c.atlas_id=a.id GROUP BY a.id"
+    "SELECT a.*, COUNT(c.*)::int AS component_atlas_count FROM hat.atlases a LEFT JOIN hat.component_atlases c ON c.atlas_id=a.id GROUP BY a.id",
+    undefined,
+    client
   );
   return queryResult.rows;
 }

--- a/app/services/users.ts
+++ b/app/services/users.ts
@@ -1,5 +1,10 @@
-import { NotFoundError } from "app/utils/api-handler";
-import { query } from "./database";
+import {
+  HCAAtlasTrackerDBUser,
+  ROLE,
+} from "../apis/catalog/hca-atlas-tracker/common/entities";
+import { NotFoundError } from "../utils/api-handler";
+import { getAllAtlases } from "./atlases";
+import { doTransaction, query } from "./database";
 
 /**
  * Update the last login of the specified user to the current time.
@@ -11,4 +16,89 @@ export async function updateLastLogin(userId: number): Promise<void> {
     [new Date(), userId]
   );
   if (queryResult.rowCount === 0) throw new NotFoundError("User not found");
+}
+
+/**
+ * Add new INTEGRATION_LEAD users and update existing users' associated atlases, based on integration leads specified on atlases.
+ */
+export async function addIntegrationLeadsFromAtlases(): Promise<void> {
+  await doTransaction(async (client) => {
+    const existingUsersInfo = (
+      await client.query<Pick<HCAAtlasTrackerDBUser, "email" | "role">>(
+        "SELECT * FROM hat.users"
+      )
+    ).rows;
+    const existingUserRolesByEmail = new Map(
+      existingUsersInfo.map((u) => [u.email, u.role])
+    );
+    const atlases = await getAllAtlases(client);
+    const integrationLeadInfoFromAtlases = new Map<
+      string,
+      { atlasIds: string[]; name: string }
+    >();
+    for (const atlas of atlases) {
+      for (const integrationLead of atlas.overview.integrationLead) {
+        let integrationLeadInfo = integrationLeadInfoFromAtlases.get(
+          integrationLead.email
+        );
+        if (!integrationLeadInfo)
+          integrationLeadInfoFromAtlases.set(
+            integrationLead.email,
+            (integrationLeadInfo = {
+              atlasIds: [],
+              name: integrationLead.name,
+            })
+          );
+        integrationLeadInfo.atlasIds.push(atlas.id);
+      }
+    }
+
+    const newUsersInfoFromAtlases: Pick<
+      HCAAtlasTrackerDBUser,
+      "email" | "full_name" | "role_associated_resource_ids"
+    >[] = [];
+    const existingUsersInfoFromAtlases: Pick<
+      HCAAtlasTrackerDBUser,
+      "email" | "role_associated_resource_ids"
+    >[] = [];
+    for (const [
+      email,
+      { atlasIds, name },
+    ] of integrationLeadInfoFromAtlases.entries()) {
+      const existingRole = existingUserRolesByEmail.get(email);
+      if (existingRole === undefined) {
+        newUsersInfoFromAtlases.push({
+          email,
+          full_name: name,
+          role_associated_resource_ids: atlasIds,
+        });
+      } else if (existingRole === ROLE.INTEGRATION_LEAD) {
+        existingUsersInfoFromAtlases.push({
+          email,
+          role_associated_resource_ids: atlasIds,
+        });
+      }
+    }
+
+    if (newUsersInfoFromAtlases.length)
+      await client.query(
+        `
+          INSERT INTO hat.users (disabled, email, full_name, role, role_associated_resource_ids)
+          SELECT FALSE, email, full_name, 'INTEGRATION_LEAD', role_associated_resource_ids
+          FROM jsonb_to_recordset($1) AS d(email text, full_name text, role_associated_resource_ids uuid[])
+        `,
+        [JSON.stringify(newUsersInfoFromAtlases)]
+      );
+
+    if (existingUsersInfoFromAtlases.length)
+      await client.query(
+        `
+          UPDATE hat.users u
+          SET role_associated_resource_ids = ARRAY(SELECT DISTINCT UNNEST(u.role_associated_resource_ids || d.role_associated_resource_ids))
+          FROM jsonb_to_recordset($1) AS d(email text, role_associated_resource_ids uuid[])
+          WHERE u.email = d.email AND NOT u.role_associated_resource_ids @> d.role_associated_resource_ids
+        `,
+        [JSON.stringify(existingUsersInfoFromAtlases)]
+      );
+  });
 }

--- a/app/views/IntegrationLeadsFromAtlasesView/integrationLeadsFromAtlasesView.tsx
+++ b/app/views/IntegrationLeadsFromAtlasesView/integrationLeadsFromAtlasesView.tsx
@@ -1,0 +1,26 @@
+import { useAuthentication } from "@databiosphere/findable-ui/lib/hooks/useAuthentication/useAuthentication";
+import { ContentView } from "@databiosphere/findable-ui/lib/views/ContentView/contentView";
+import { AccessPrompt } from "../../../app/components/common/Form/components/FormManager/components/AccessPrompt/accessPrompt";
+import { Divider } from "../../../app/components/Detail/components/TrackerForm/components/Divider/divider.styles";
+import { IntegrationLeadsFromAtlasesForm } from "../../../app/components/Forms/components/IntegrationLeadsFromAtlases/integrationLeadsFromAtlases";
+import { Content } from "../../../app/components/Layout/components/Content/content";
+import { LAYOUT_STYLE_NO_CONTRAST_DEFAULT } from "../../../app/content/common/constants";
+
+export const IntegrationLeadsFromAtlasesView = (): JSX.Element => {
+  const { isAuthenticated } = useAuthentication();
+  return (
+    <ContentView
+      content={
+        <Content>
+          <h1>Update Integration Lead Users</h1>
+          {isAuthenticated ? (
+            <IntegrationLeadsFromAtlasesForm />
+          ) : (
+            <AccessPrompt divider={<Divider />} text="to update users" />
+          )}
+        </Content>
+      }
+      layoutStyle={LAYOUT_STYLE_NO_CONTRAST_DEFAULT}
+    />
+  );
+};

--- a/pages/api/users/integration-leads-from-atlases.ts
+++ b/pages/api/users/integration-leads-from-atlases.ts
@@ -1,0 +1,13 @@
+import { ROLE } from "../../../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "../../../app/common/entities";
+import { addIntegrationLeadsFromAtlases } from "../../../app/services/users";
+import { handler, method, role } from "../../../app/utils/api-handler";
+
+export default handler(
+  method(METHOD.PATCH),
+  role(ROLE.CONTENT_ADMIN),
+  async (req, res) => {
+    await addIntegrationLeadsFromAtlases();
+    res.status(200).end();
+  }
+);

--- a/pages/integration-leads-from-atlases/index.tsx
+++ b/pages/integration-leads-from-atlases/index.tsx
@@ -1,0 +1,19 @@
+import { Main } from "@databiosphere/findable-ui/lib/components/Layout/components/ContentLayout/components/Main/main";
+import { GetStaticProps } from "next";
+import { IntegrationLeadsFromAtlasesView } from "../../app/views/IntegrationLeadsFromAtlasesView/integrationLeadsFromAtlasesView";
+
+export const getStaticProps: GetStaticProps = async () => {
+  return {
+    props: {
+      pageTitle: "Update Integration Lead Users",
+    },
+  };
+};
+
+const OverviewPage = (): JSX.Element => {
+  return <IntegrationLeadsFromAtlasesView />;
+};
+
+OverviewPage.Main = Main;
+
+export default OverviewPage;

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -17,6 +17,7 @@ import {
   TestPublishedSourceStudy,
   TestSourceDataset,
   TestUnpublishedSourceStudy,
+  TestUser,
 } from "./entities";
 import { makeTestProjectsResponse, makeTestUser } from "./utils";
 
@@ -1429,11 +1430,124 @@ export const INITIAL_TEST_SOURCE_DATASETS = [
   SOURCE_DATASET_PUBLISHED_WITHOUT_CELLXGENE_ID_BAR,
 ];
 
+// ATLAS IDS
+
+const ATLAS_ID_DRAFT = "823dcc68-340b-4a61-8883-c61dc4975ce3";
+const ATLAS_ID_PUBLIC = "94f62ad0-99cb-4f01-a1cf-cce2d56a8850";
+const ATLAS_ID_WITH_MISC_SOURCE_STUDIES =
+  "8259a9b1-c149-4310-83a5-d126b675c0f1";
+
+// USERS
+
+export const USER_NONEXISTENT = makeTestUser("test-nonexistant");
+export const USER_NEW = makeTestUser("test-new");
+
+export const USER_UNREGISTERED = makeTestUser("test-unregistered");
+export const USER_STAKEHOLDER = makeTestUser(
+  "test-stakeholder",
+  ROLE.STAKEHOLDER
+);
+export const USER_STAKEHOLDER2 = makeTestUser(
+  "test-stakeholder2",
+  ROLE.STAKEHOLDER
+);
+export const USER_DISABLED = makeTestUser(
+  "test-disabled",
+  ROLE.STAKEHOLDER,
+  true
+);
+export const USER_CONTENT_ADMIN = makeTestUser(
+  "test-content-admin",
+  ROLE.CONTENT_ADMIN
+);
+export const USER_INTEGRATION_LEAD_DRAFT = makeTestUser(
+  "test-integration-lead-draft",
+  ROLE.INTEGRATION_LEAD,
+  false,
+  [ATLAS_ID_DRAFT]
+);
+export const USER_INTEGRATION_LEAD_PUBLIC = makeTestUser(
+  "test-integration-lead-public",
+  ROLE.INTEGRATION_LEAD,
+  false,
+  [ATLAS_ID_PUBLIC]
+);
+export const USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES = makeTestUser(
+  "test-integration-lead-with-misc-source-studies",
+  ROLE.INTEGRATION_LEAD,
+  false,
+  [ATLAS_ID_WITH_MISC_SOURCE_STUDIES]
+);
+export const USER_INTEGRATION_LEAD_WITH_NEW_ATLAS = makeTestUser(
+  "test-integration-lead-with-new-atlas",
+  ROLE.INTEGRATION_LEAD,
+  false,
+  [ATLAS_ID_DRAFT]
+);
+export const USER_CELLXGENE_ADMIN = makeTestUser(
+  "test-cellxgene-admin",
+  ROLE.CELLXGENE_ADMIN
+);
+
+// Users initialized in the database before tests
+export const INITIAL_TEST_USERS = [
+  USER_DISABLED,
+  USER_STAKEHOLDER,
+  USER_STAKEHOLDER2,
+  USER_CONTENT_ADMIN,
+  USER_INTEGRATION_LEAD_DRAFT,
+  USER_INTEGRATION_LEAD_PUBLIC,
+  USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
+  USER_INTEGRATION_LEAD_WITH_NEW_ATLAS,
+  USER_CELLXGENE_ADMIN,
+];
+
+export const TEST_USERS = [
+  ...INITIAL_TEST_USERS,
+  USER_UNREGISTERED,
+  USER_NONEXISTENT,
+  USER_NEW,
+];
+
+export const DEFAULT_USERS_BY_ROLE = {
+  [ROLE.CELLXGENE_ADMIN]: USER_CELLXGENE_ADMIN,
+  [ROLE.CONTENT_ADMIN]: USER_CONTENT_ADMIN,
+  [ROLE.INTEGRATION_LEAD]: USER_INTEGRATION_LEAD_DRAFT,
+  [ROLE.STAKEHOLDER]: USER_STAKEHOLDER,
+  [ROLE.UNREGISTERED]: USER_UNREGISTERED,
+};
+
+export const INTEGRATION_LEADS_BY_ATLAS_ID: Record<string, TestUser> = {
+  [ATLAS_ID_DRAFT]: USER_INTEGRATION_LEAD_DRAFT,
+  [ATLAS_ID_PUBLIC]: USER_INTEGRATION_LEAD_PUBLIC,
+  [ATLAS_ID_WITH_MISC_SOURCE_STUDIES]:
+    USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
+};
+
 // ATLASES
 
+export const INTEGRATION_LEAD_BAZ = {
+  email: "baz@example.com",
+  name: "Baz",
+};
+
+export const INTEGRATION_LEAD_BAZ_BAZ = {
+  email: "bazbaz@example.com",
+  name: "Baz Baz",
+};
+
 export const ATLAS_DRAFT: TestAtlas = {
-  id: "823dcc68-340b-4a61-8883-c61dc4975ce3",
-  integrationLead: [],
+  id: ATLAS_ID_DRAFT,
+  integrationLead: [
+    {
+      email: USER_INTEGRATION_LEAD_DRAFT.email,
+      name: USER_INTEGRATION_LEAD_DRAFT.name,
+    },
+    {
+      email: USER_INTEGRATION_LEAD_WITH_NEW_ATLAS.email,
+      name: USER_INTEGRATION_LEAD_WITH_NEW_ATLAS.name,
+    },
+  ],
   network: "eye",
   shortName: "test-draft",
   sourceStudies: [
@@ -1447,8 +1561,17 @@ export const ATLAS_DRAFT: TestAtlas = {
 };
 
 export const ATLAS_PUBLIC: TestAtlas = {
-  id: "94f62ad0-99cb-4f01-a1cf-cce2d56a8850",
-  integrationLead: [],
+  id: ATLAS_ID_PUBLIC,
+  integrationLead: [
+    {
+      email: USER_INTEGRATION_LEAD_PUBLIC.email,
+      name: USER_INTEGRATION_LEAD_PUBLIC.name,
+    },
+    {
+      email: USER_INTEGRATION_LEAD_WITH_NEW_ATLAS.email,
+      name: USER_INTEGRATION_LEAD_WITH_NEW_ATLAS.name,
+    },
+  ],
   network: "lung",
   shortName: "test-public",
   sourceStudies: [SOURCE_STUDY_PUBLIC_NO_CROSSREF.id, SOURCE_STUDY_SHARED.id],
@@ -1460,12 +1583,7 @@ export const ATLAS_PUBLIC: TestAtlas = {
 
 export const ATLAS_WITH_IL: TestAtlas = {
   id: "798b563d-16ff-438a-8e15-77be05b1f8ec",
-  integrationLead: [
-    {
-      email: "baz@example.com",
-      name: "Baz",
-    },
-  ],
+  integrationLead: [INTEGRATION_LEAD_BAZ],
   network: "heart",
   shortName: "test-with-il",
   sourceStudies: [],
@@ -1475,13 +1593,8 @@ export const ATLAS_WITH_IL: TestAtlas = {
 };
 
 export const ATLAS_WITH_MISC_SOURCE_STUDIES: TestAtlas = {
-  id: "8259a9b1-c149-4310-83a5-d126b675c0f1",
-  integrationLead: [
-    {
-      email: "bazbaz@example.com",
-      name: "Baz Baz",
-    },
-  ],
+  id: ATLAS_ID_WITH_MISC_SOURCE_STUDIES,
+  integrationLead: [INTEGRATION_LEAD_BAZ_BAZ],
   network: "adipose",
   shortName: "test-with-misc-source-studies",
   sourceStudies: [
@@ -1603,86 +1716,6 @@ export const INITIAL_TEST_COMPONENT_ATLASES = [
   COMPONENT_ATLAS_DRAFT_BAR,
   COMPONENT_ATLAS_MISC_FOO,
 ];
-
-// USERS
-
-export const USER_NONEXISTENT = makeTestUser("test-nonexistant");
-export const USER_NEW = makeTestUser("test-new");
-
-export const USER_UNREGISTERED = makeTestUser("test-unregistered");
-export const USER_STAKEHOLDER = makeTestUser(
-  "test-stakeholder",
-  ROLE.STAKEHOLDER
-);
-export const USER_STAKEHOLDER2 = makeTestUser(
-  "test-stakeholder2",
-  ROLE.STAKEHOLDER
-);
-export const USER_DISABLED = makeTestUser(
-  "test-disabled",
-  ROLE.STAKEHOLDER,
-  true
-);
-export const USER_CONTENT_ADMIN = makeTestUser(
-  "test-content-admin",
-  ROLE.CONTENT_ADMIN
-);
-export const USER_INTEGRATION_LEAD_DRAFT = makeTestUser(
-  "test-integration-lead-draft",
-  ROLE.INTEGRATION_LEAD,
-  false,
-  [ATLAS_DRAFT.id]
-);
-export const USER_INTEGRATION_LEAD_PUBLIC = makeTestUser(
-  "test-integration-lead-public",
-  ROLE.INTEGRATION_LEAD,
-  false,
-  [ATLAS_PUBLIC.id]
-);
-export const USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES = makeTestUser(
-  "test-integration-lead-with-misc-source-studies",
-  ROLE.INTEGRATION_LEAD,
-  false,
-  [ATLAS_WITH_MISC_SOURCE_STUDIES.id]
-);
-export const USER_CELLXGENE_ADMIN = makeTestUser(
-  "test-cellxgene-admin",
-  ROLE.CELLXGENE_ADMIN
-);
-
-// Users initialized in the database before tests
-export const INITIAL_TEST_USERS = [
-  USER_DISABLED,
-  USER_STAKEHOLDER,
-  USER_STAKEHOLDER2,
-  USER_CONTENT_ADMIN,
-  USER_INTEGRATION_LEAD_DRAFT,
-  USER_INTEGRATION_LEAD_PUBLIC,
-  USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
-  USER_CELLXGENE_ADMIN,
-];
-
-export const TEST_USERS = [
-  ...INITIAL_TEST_USERS,
-  USER_UNREGISTERED,
-  USER_NONEXISTENT,
-  USER_NEW,
-];
-
-export const DEFAULT_USERS_BY_ROLE = {
-  [ROLE.CELLXGENE_ADMIN]: USER_CELLXGENE_ADMIN,
-  [ROLE.CONTENT_ADMIN]: USER_CONTENT_ADMIN,
-  [ROLE.INTEGRATION_LEAD]: USER_INTEGRATION_LEAD_DRAFT,
-  [ROLE.STAKEHOLDER]: USER_STAKEHOLDER,
-  [ROLE.UNREGISTERED]: USER_UNREGISTERED,
-};
-
-export const INTEGRATION_LEADS_BY_ATLAS_ID = {
-  [ATLAS_DRAFT.id]: USER_INTEGRATION_LEAD_DRAFT,
-  [ATLAS_PUBLIC.id]: USER_INTEGRATION_LEAD_PUBLIC,
-  [ATLAS_WITH_MISC_SOURCE_STUDIES.id]:
-    USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
-};
 
 // COMMENTS
 


### PR DESCRIPTION
New API is PATCH `/api/users/integration-leads-from-atlases`, useable by content admins

New page `/integration-leads-from-atlases` allows calling the API