### PR TITLE
feat: rename tasks list to reports (#377)

### DIFF
--- a/app/routes/constants.ts
+++ b/app/routes/constants.ts
@@ -9,12 +9,12 @@ export const ROUTE = {
   LOGIN: "/login",
   OVERVIEW: "/overview",
   REGISTRATION_REQUIRED: "/registration-required",
+  REPORTS: "/reports",
   REQUESTING_ACCESS: "/requesting-access",
   ROADMAP: "/roadmap",
   SOURCE_DATASETS:
     "/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets",
   SOURCE_STUDIES: "/atlases/[atlasId]/source-studies",
   SOURCE_STUDY: "/atlases/[atlasId]/source-studies/[sourceStudyId]",
-  TASKS: "/tasks",
   VALIDATIONS_AND_TASKS: "/validations-and-tasks",
 } as const;

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -1312,7 +1312,7 @@ function getTaskCountUrlObject(
     ],
   };
   return {
-    href: ROUTE.TASKS,
+    href: ROUTE.REPORTS,
     query: encodeURIComponent(JSON.stringify(params)),
   };
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -32,6 +32,15 @@ export default withPlugins(
       unoptimized: true,
     },
     reactStrictMode: true,
+    async redirects() {
+      return [
+        {
+          destination: "/reports",
+          permanent: true,
+          source: "/tasks",
+        },
+      ];
+    },
     transpilePackages: [...ESM_PACKAGES],
     webpack: (config) => {
       // Add the alias for the peer dependency

--- a/site-config/hca-atlas-tracker/local/config.ts
+++ b/site-config/hca-atlas-tracker/local/config.ts
@@ -59,7 +59,7 @@ export function makeConfig(browserUrl: string, portalUrl: string): SiteConfig {
               label: "Atlases",
               url: ROUTE.ATLASES,
             },
-            { label: "Tasks", url: ROUTE.TASKS },
+            { label: "Reports", url: ROUTE.REPORTS },
           ],
           [
             {

--- a/site-config/hca-atlas-tracker/local/index/tasks/tasksEntityConfig.ts
+++ b/site-config/hca-atlas-tracker/local/index/tasks/tasksEntityConfig.ts
@@ -27,7 +27,7 @@ import { SAVED_FILTERS_SORTING_TARGET_COMPLETION_DATE } from "../common/constant
 import { COLUMNS, ROW_PREVIEW_COLUMNS } from "./common/columns";
 
 /**
- * Entity config object responsible to config anything related to the /tasks route.
+ * Entity config object responsible to config anything related to the /reports route.
  */
 export const tasksEntityConfig: EntityConfig = {
   apiPath: "api/tasks",
@@ -214,9 +214,9 @@ export const tasksEntityConfig: EntityConfig = {
   },
   entityMapper: taskInputMapper,
   exploreMode: EXPLORE_MODE.SS_FETCH_CS_FILTERING,
-  explorerTitle: "Tasks",
+  explorerTitle: "Reports",
   getId: getTaskId,
-  label: "Tasks",
+  label: "Reports",
   list: {
     columns: COLUMNS,
     defaultSort: {
@@ -252,5 +252,5 @@ export const tasksEntityConfig: EntityConfig = {
       } as ComponentConfig<typeof C.EditTasks>,
     ],
   },
-  route: "tasks",
+  route: "reports",
 };


### PR DESCRIPTION
It doesn't seem to be possible to change the label of the saved filters