### PR TITLE
feat: derive source study status columns from validations (#386)

### DIFF
--- a/__tests__/api-atlases-id-source-studies-create.test.ts
+++ b/__tests__/api-atlases-id-source-studies-create.test.ts
@@ -263,7 +263,7 @@ describe(TEST_ROUTE, () => {
     );
     const validations = await getValidationsByEntityId(dbStudy.id);
     expect(validations).not.toHaveLength(0);
-    expectApiValidationsToMatchDb(apiStudy.validations, validations);
+    expectApiValidationsToMatchDb(apiStudy.tasks, validations);
   });
 
   it("creates and returns source study entry for preprint without journal value", async () => {

--- a/__tests__/api-atlases-id-source-studies-create.test.ts
+++ b/__tests__/api-atlases-id-source-studies-create.test.ts
@@ -54,6 +54,7 @@ import {
 } from "../testing/db-utils";
 import { TestAtlas, TestUser } from "../testing/entities";
 import {
+  expectApiValidationsToMatchDb,
   expectSourceStudyToMatch,
   testApiRole,
   withConsoleErrorHiding,
@@ -252,8 +253,8 @@ describe(TEST_ROUTE, () => {
     ).toEqual(400);
   });
 
-  it("creates, validates, and returns source study entry for journal publication", async () => {
-    const { dbStudy } = await testSuccessfulCreate(
+  it("creates, validates, and returns source study entry, including validations, for journal publication", async () => {
+    const { apiStudy, dbStudy } = await testSuccessfulCreate(
       ATLAS_DRAFT,
       NEW_STUDY_DATA,
       PUBLICATION_NORMAL,
@@ -262,6 +263,7 @@ describe(TEST_ROUTE, () => {
     );
     const validations = await getValidationsByEntityId(dbStudy.id);
     expect(validations).not.toHaveLength(0);
+    expectApiValidationsToMatchDb(apiStudy.validations, validations);
   });
 
   it("creates and returns source study entry for preprint without journal value", async () => {

--- a/__tests__/api-atlases-id-source-studies-id.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id.test.ts
@@ -417,7 +417,7 @@ describe(TEST_ROUTE, () => {
       SOURCE_STUDY_PUBLIC_NO_CROSSREF_EDIT.doi
     );
 
-    expectApiValidationsToMatchDb(updatedStudy.validations, validationsAfter);
+    expectApiValidationsToMatchDb(updatedStudy.tasks, validationsAfter);
 
     await restoreDbStudy(SOURCE_STUDY_PUBLIC_NO_CROSSREF);
   });

--- a/__tests__/api-atlases-id-source-studies.test.ts
+++ b/__tests__/api-atlases-id-source-studies.test.ts
@@ -15,7 +15,10 @@ import {
   USER_CONTENT_ADMIN,
   USER_UNREGISTERED,
 } from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
+import {
+  expectApiSourceStudyToHaveMatchingDbValidations,
+  resetDatabase,
+} from "../testing/db-utils";
 import { TestPublishedSourceStudy, TestUser } from "../testing/entities";
 import { testApiRole } from "../testing/utils";
 
@@ -124,7 +127,7 @@ describe(TEST_ROUTE, () => {
     );
   }
 
-  it("returns draft atlas studies when requested by logged in user with CONTENT_ADMIN role", async () => {
+  it("returns draft atlas studies, including validations, when requested by logged in user with CONTENT_ADMIN role", async () => {
     const res = await doStudiesRequest(ATLAS_DRAFT.id, USER_CONTENT_ADMIN);
     expect(res._getStatusCode()).toEqual(200);
     const studies = res._getJSONData() as HCAAtlasTrackerSourceStudy[];
@@ -141,6 +144,9 @@ describe(TEST_ROUTE, () => {
       studies.find((d) => d.id === SOURCE_STUDY_DRAFT_NO_CROSSREF.id),
       SOURCE_STUDY_DRAFT_NO_CROSSREF
     );
+    for (const study of studies) {
+      await expectApiSourceStudyToHaveMatchingDbValidations(study);
+    }
   });
 });
 

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -74,6 +74,7 @@ interface HCAAtlasTrackerSourceStudyCommon {
   hcaProjectId: string | null;
   id: string;
   sourceDatasetCount: number;
+  validations: HCAAtlasTrackerValidationRecordWithoutAtlases[];
 }
 
 export interface HCAAtlasTrackerPublishedSourceStudy
@@ -146,6 +147,16 @@ export interface HCAAtlasTrackerValidationRecord
   updatedAt: string;
   waves: Wave[];
 }
+
+export type HCAAtlasTrackerValidationRecordWithoutAtlases = Omit<
+  HCAAtlasTrackerValidationRecord,
+  | "atlasIds"
+  | "atlasNames"
+  | "atlasShortNames"
+  | "atlasVersions"
+  | "networks"
+  | "waves"
+>;
 
 export interface HCAAtlasTrackerComment {
   createdAt: string;
@@ -266,6 +277,11 @@ export interface HCAAtlasTrackerDBUnpublishedSourceStudyInfo {
 export type HCAAtlasTrackerDBSourceStudyWithSourceDatasets =
   HCAAtlasTrackerDBSourceStudy & {
     source_dataset_count: number;
+  };
+
+export type HCAAtlasTrackerDBSourceStudyWithRelatedEntities =
+  HCAAtlasTrackerDBSourceStudyWithSourceDatasets & {
+    validations: HCAAtlasTrackerDBValidation[];
   };
 
 export interface HCAAtlasTrackerDBSourceDataset {

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -74,7 +74,7 @@ interface HCAAtlasTrackerSourceStudyCommon {
   hcaProjectId: string | null;
   id: string;
   sourceDatasetCount: number;
-  validations: HCAAtlasTrackerValidationRecordWithoutAtlases[];
+  tasks: HCAAtlasTrackerValidationRecordWithoutAtlases[];
 }
 
 export interface HCAAtlasTrackerPublishedSourceStudy

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -105,7 +105,7 @@ export function dbSourceStudyToApiSourceStudy(
   const {
     study_info: { capId, cellxgeneCollectionId, hcaProjectId, publication },
   } = dbSourceStudy;
-  const validations = dbSourceStudy.validations.map(
+  const tasks = dbSourceStudy.validations.map(
     dbValidationToApiValidationWithoutAtlasProperties
   );
   if (dbSourceStudy.doi === null) {
@@ -122,8 +122,8 @@ export function dbSourceStudyToApiSourceStudy(
       publicationDate: null,
       referenceAuthor: unpublishedInfo.referenceAuthor,
       sourceDatasetCount: dbSourceStudy.source_dataset_count,
+      tasks,
       title: unpublishedInfo.title,
-      validations,
     };
   } else {
     return {
@@ -138,8 +138,8 @@ export function dbSourceStudyToApiSourceStudy(
       publicationDate: publication?.publicationDate ?? null,
       referenceAuthor: publication?.authors[0]?.name ?? null,
       sourceDatasetCount: dbSourceStudy.source_dataset_count,
+      tasks,
       title: publication?.title ?? null,
-      validations,
     };
   }
 }

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -10,13 +10,15 @@ import {
   HCAAtlasTrackerDBComponentAtlas,
   HCAAtlasTrackerDBSourceDatasetWithStudyProperties,
   HCAAtlasTrackerDBSourceStudy,
-  HCAAtlasTrackerDBSourceStudyWithSourceDatasets,
+  HCAAtlasTrackerDBSourceStudyWithRelatedEntities,
+  HCAAtlasTrackerDBValidation,
   HCAAtlasTrackerDBValidationWithAtlasProperties,
   HCAAtlasTrackerListAtlas,
   HCAAtlasTrackerListValidationRecord,
   HCAAtlasTrackerSourceDataset,
   HCAAtlasTrackerSourceStudy,
   HCAAtlasTrackerValidationRecord,
+  HCAAtlasTrackerValidationRecordWithoutAtlases,
   NetworkKey,
   PublicationInfo,
   Wave,
@@ -98,11 +100,14 @@ export function dbComponentAtlasToApiComponentAtlas(
 }
 
 export function dbSourceStudyToApiSourceStudy(
-  dbSourceStudy: HCAAtlasTrackerDBSourceStudyWithSourceDatasets
+  dbSourceStudy: HCAAtlasTrackerDBSourceStudyWithRelatedEntities
 ): HCAAtlasTrackerSourceStudy {
   const {
     study_info: { capId, cellxgeneCollectionId, hcaProjectId, publication },
   } = dbSourceStudy;
+  const validations = dbSourceStudy.validations.map(
+    dbValidationToApiValidationWithoutAtlasProperties
+  );
   if (dbSourceStudy.doi === null) {
     const unpublishedInfo = dbSourceStudy.study_info.unpublishedInfo;
     return {
@@ -118,6 +123,7 @@ export function dbSourceStudyToApiSourceStudy(
       referenceAuthor: unpublishedInfo.referenceAuthor,
       sourceDatasetCount: dbSourceStudy.source_dataset_count,
       title: unpublishedInfo.title,
+      validations,
     };
   } else {
     return {
@@ -133,6 +139,7 @@ export function dbSourceStudyToApiSourceStudy(
       referenceAuthor: publication?.authors[0]?.name ?? null,
       sourceDatasetCount: dbSourceStudy.source_dataset_count,
       title: publication?.title ?? null,
+      validations,
     };
   }
 }
@@ -165,12 +172,22 @@ export function dbSourceDatasetToApiSourceDataset(
 export function dbValidationToApiValidation(
   validation: HCAAtlasTrackerDBValidationWithAtlasProperties
 ): HCAAtlasTrackerValidationRecord {
-  const validationInfo = validation.validation_info;
   return {
+    ...dbValidationToApiValidationWithoutAtlasProperties(validation),
     atlasIds: validation.atlas_ids,
     atlasNames: validation.atlas_names,
     atlasShortNames: validation.atlas_short_names,
     atlasVersions: validation.atlas_versions,
+    networks: validation.networks,
+    waves: validation.waves,
+  };
+}
+
+function dbValidationToApiValidationWithoutAtlasProperties(
+  validation: HCAAtlasTrackerDBValidation
+): HCAAtlasTrackerValidationRecordWithoutAtlases {
+  const validationInfo = validation.validation_info;
+  return {
     commentThreadId: validation.comment_thread_id,
     createdAt: validation.created_at.toISOString(),
     description: validationInfo.description,
@@ -180,7 +197,6 @@ export function dbValidationToApiValidation(
     entityTitle: validationInfo.entityTitle,
     entityType: validationInfo.entityType,
     id: validation.id,
-    networks: validation.networks,
     publicationString: validationInfo.publicationString,
     relatedEntityUrl: validationInfo.relatedEntityUrl,
     resolvedAt: validation.resolved_at?.toISOString() ?? null,
@@ -191,7 +207,6 @@ export function dbValidationToApiValidation(
     validationId: validation.validation_id,
     validationStatus: validationInfo.validationStatus,
     validationType: validationInfo.validationType,
-    waves: validation.waves,
   };
 }
 

--- a/app/components/Table/components/TableCell/components/SourceStudyStatusCell/sourceStudyStatusCell.tsx
+++ b/app/components/Table/components/TableCell/components/SourceStudyStatusCell/sourceStudyStatusCell.tsx
@@ -4,6 +4,7 @@ import { RequiredIcon } from "../../../../../common/CustomIcon/components/Requir
 
 export enum SOURCE_STUDY_STATUS {
   DONE = "Yes",
+  IN_PROGRESS = "In progress",
   REQUIRED = "No",
 }
 
@@ -26,6 +27,8 @@ function switchStatusIcon(value: string): JSX.Element {
   switch (value) {
     case SOURCE_STUDY_STATUS.DONE:
       return <SuccessIcon color="success" fontSize="small" />;
+    case SOURCE_STUDY_STATUS.IN_PROGRESS:
+      return <SuccessIcon color="warning" fontSize="small" />;
     case SOURCE_STUDY_STATUS.REQUIRED:
       return <RequiredIcon />;
     default:

--- a/app/services/database.ts
+++ b/app/services/database.ts
@@ -43,6 +43,20 @@ export async function doTransaction<T>(
   }
 }
 
+/**
+ * Call a given function using the given client if specified, or in a new transaction otherwise.
+ * @param client - Postgres client or undefined.
+ * @param func - Function to call.
+ * @returns result of evaluating the function.
+ */
+export function doOrContinueTransaction<T>(
+  client: pg.PoolClient | undefined,
+  func: (client: pg.PoolClient) => Promise<T>
+): Promise<T> {
+  if (client) return func(client);
+  else return doTransaction(func);
+}
+
 export function getPoolClient(): Promise<pg.PoolClient> {
   return pool.connect();
 }

--- a/app/services/validations.ts
+++ b/app/services/validations.ts
@@ -232,6 +232,24 @@ export async function getValidationRecords(
 }
 
 /**
+ * Get basic validation records for the given entities.
+ * @param entityIds - Entities to get validations for.
+ * @param client - Postgres client to use.
+ * @returns validation records.
+ */
+export async function getValidationRecordsWithoutAtlasPropertiesForEntities(
+  entityIds: string[],
+  client: pg.PoolClient
+): Promise<HCAAtlasTrackerDBValidation[]> {
+  return (
+    await client.query<HCAAtlasTrackerDBValidation>(
+      "SELECT * FROM hat.validations WHERE entity_id=ANY($1)",
+      [entityIds]
+    )
+  ).rows;
+}
+
+/**
  * Apply a given validation to a given entity.
  * @param entityType - Type of the entity.
  * @param validation - Validation to apply.

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -28,6 +28,7 @@ import {
   Network,
   NetworkKey,
   TASK_STATUS,
+  VALIDATION_ID,
 } from "../../../../apis/catalog/hca-atlas-tracker/common/entities";
 import {
   getSourceStudyCitation,
@@ -1214,9 +1215,10 @@ function getSourceStudyInHCADataRepositoryColumnDef(): ColumnDef<HCAAtlasTracker
 function getSourceStudyInCap(
   sourceStudy: HCAAtlasTrackerSourceStudy
 ): SOURCE_STUDY_STATUS {
-  return sourceStudy.capId
-    ? SOURCE_STUDY_STATUS.DONE
-    : SOURCE_STUDY_STATUS.REQUIRED;
+  return getSourceStudyStatusFromValidation(
+    sourceStudy,
+    VALIDATION_ID.SOURCE_STUDY_IN_CAP
+  );
 }
 
 /**
@@ -1227,9 +1229,10 @@ function getSourceStudyInCap(
 function getSourceStudyInCellxGene(
   sourceStudy: HCAAtlasTrackerSourceStudy
 ): SOURCE_STUDY_STATUS {
-  return sourceStudy.cellxgeneCollectionId
-    ? SOURCE_STUDY_STATUS.DONE
-    : SOURCE_STUDY_STATUS.REQUIRED;
+  return getSourceStudyStatusFromValidation(
+    sourceStudy,
+    VALIDATION_ID.SOURCE_STUDY_IN_CELLXGENE
+  );
 }
 
 /**
@@ -1240,8 +1243,29 @@ function getSourceStudyInCellxGene(
 function getSourceStudyInHcaDataRepository(
   sourceStudy: HCAAtlasTrackerSourceStudy
 ): SOURCE_STUDY_STATUS {
-  return sourceStudy.hcaProjectId
+  return getSourceStudyStatusFromValidation(
+    sourceStudy,
+    VALIDATION_ID.SOURCE_STUDY_IN_HCA_DATA_REPOSITORY
+  );
+}
+
+/**
+ * Get source study status reflecting the status of a given task for the specified source study.
+ * @param sourceStudy - Source study.
+ * @param validationId - Validation ID to get task status for.
+ * @returns source study status.
+ */
+function getSourceStudyStatusFromValidation(
+  sourceStudy: HCAAtlasTrackerSourceStudy,
+  validationId: VALIDATION_ID
+): SOURCE_STUDY_STATUS {
+  const taskStatus = sourceStudy.validations.find(
+    (v) => v.validationId === validationId
+  )?.taskStatus;
+  return taskStatus === TASK_STATUS.DONE
     ? SOURCE_STUDY_STATUS.DONE
+    : taskStatus === TASK_STATUS.IN_PROGRESS
+    ? SOURCE_STUDY_STATUS.IN_PROGRESS
     : SOURCE_STUDY_STATUS.REQUIRED;
 }
 

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -1259,7 +1259,7 @@ function getSourceStudyStatusFromValidation(
   sourceStudy: HCAAtlasTrackerSourceStudy,
   validationId: VALIDATION_ID
 ): SOURCE_STUDY_STATUS {
-  const taskStatus = sourceStudy.validations.find(
+  const taskStatus = sourceStudy.tasks.find(
     (v) => v.validationId === validationId
   )?.taskStatus;
   return taskStatus === TASK_STATUS.DONE

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -9,6 +9,7 @@ import {
   HCAAtlasTrackerDBSourceStudy,
   HCAAtlasTrackerDBUser,
   HCAAtlasTrackerDBValidation,
+  HCAAtlasTrackerSourceStudy,
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { updateTaskCounts } from "../app/services/atlases";
 import { query } from "../app/services/database";
@@ -24,6 +25,7 @@ import {
 } from "./constants";
 import {
   aggregateSourceDatasetArrayField,
+  expectApiValidationsToMatchDb,
   makeTestAtlasOverview,
   makeTestSourceDatasetInfo,
   makeTestSourceStudyOverview,
@@ -286,4 +288,11 @@ export async function getValidationsByEntityId(
       [id]
     )
   ).rows;
+}
+
+export async function expectApiSourceStudyToHaveMatchingDbValidations(
+  sourceStudy: HCAAtlasTrackerSourceStudy
+): Promise<void> {
+  const validations = await getValidationsByEntityId(sourceStudy.id);
+  expectApiValidationsToMatchDb(sourceStudy.validations, validations);
 }

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -294,5 +294,5 @@ export async function expectApiSourceStudyToHaveMatchingDbValidations(
   sourceStudy: HCAAtlasTrackerSourceStudy
 ): Promise<void> {
   const validations = await getValidationsByEntityId(sourceStudy.id);
-  expectApiValidationsToMatchDb(sourceStudy.validations, validations);
+  expectApiValidationsToMatchDb(sourceStudy.tasks, validations);
 }

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -10,7 +10,9 @@ import {
   HCAAtlasTrackerDBSourceDatasetInfo,
   HCAAtlasTrackerDBSourceStudy,
   HCAAtlasTrackerDBUnpublishedSourceStudyInfo,
+  HCAAtlasTrackerDBValidation,
   HCAAtlasTrackerSourceStudy,
+  HCAAtlasTrackerValidationRecordWithoutAtlases,
   ROLE,
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD } from "../app/common/entities";
@@ -332,6 +334,63 @@ export function expectComponentAtlasDatasetsToHaveDifference(
       sourceDataset.suspensionType ?? []
     );
     expectArrayToContainItems(infoWith.tissue, sourceDataset.tissue ?? []);
+  }
+}
+
+export function expectApiValidationsToMatchDb(
+  apiValidations: HCAAtlasTrackerValidationRecordWithoutAtlases[],
+  dbValidations: HCAAtlasTrackerDBValidation[]
+): void {
+  expect(apiValidations).toHaveLength(dbValidations.length);
+  for (const apiValidation of apiValidations) {
+    const dbValidation = dbValidations.find((v) => v.id === apiValidation.id);
+    if (!expectIsDefined(dbValidation)) continue;
+    expect(apiValidation.commentThreadId).toEqual(
+      dbValidation.comment_thread_id
+    );
+    expect(apiValidation.createdAt).toEqual(
+      dbValidation.created_at.toISOString()
+    );
+    expect(apiValidation.description).toEqual(
+      dbValidation.validation_info.description
+    );
+    expect(apiValidation.differences).toEqual(
+      dbValidation.validation_info.differences
+    );
+    expect(apiValidation.doi).toEqual(dbValidation.validation_info.doi);
+    expect(apiValidation.entityId).toEqual(dbValidation.entity_id);
+    expect(apiValidation.entityTitle).toEqual(
+      dbValidation.validation_info.entityTitle
+    );
+    expect(apiValidation.entityType).toEqual(
+      dbValidation.validation_info.entityType
+    );
+    expect(apiValidation.publicationString).toEqual(
+      dbValidation.validation_info.publicationString
+    );
+    expect(apiValidation.relatedEntityUrl).toEqual(
+      dbValidation.validation_info.relatedEntityUrl
+    );
+    expect(apiValidation.resolvedAt).toEqual(
+      dbValidation.resolved_at?.toISOString() ?? null
+    );
+    expect(apiValidation.system).toEqual(dbValidation.validation_info.system);
+    expect(apiValidation.targetCompletion).toEqual(
+      dbValidation.target_completion?.toISOString() ?? null
+    );
+    expect(apiValidation.taskStatus).toEqual(
+      dbValidation.validation_info.taskStatus
+    );
+    expect(apiValidation.updatedAt).toEqual(
+      dbValidation.updated_at.toISOString()
+    );
+    expect(apiValidation.validationId).toEqual(dbValidation.validation_id);
+    expect(apiValidation.validationStatus).toEqual(
+      dbValidation.validation_info.validationStatus
+    );
+    expect(apiValidation.validationType).toEqual(
+      dbValidation.validation_info.validationType
+    );
   }
 }
 


### PR DESCRIPTION
The validations returned with source studies don't have atlas-related information included, which is in line with the example response given in the ticket but does mean there's some non-duplicate information that is not included (namely, what other atlases the source study is in)