### PR TITLE
feat: add description fields to atlases and integration objects (#406)

### DIFF
--- a/__tests__/api-atlases-create.test.ts
+++ b/__tests__/api-atlases-create.test.ts
@@ -245,6 +245,21 @@ describe("/api/atlases/create", () => {
     ).toEqual(400);
   });
 
+  it("returns error 400 when description is too long", async () => {
+    expect(
+      (
+        await doCreateTest(
+          USER_CONTENT_ADMIN,
+          {
+            ...NEW_ATLAS_WITH_TARGET_COMPLETION,
+            description: "x".repeat(10001),
+          },
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+  });
+
   it("creates and returns atlas entry with no integration leads", async () => {
     await testSuccessfulCreate(NEW_ATLAS_DATA);
   });

--- a/__tests__/api-atlases-create.test.ts
+++ b/__tests__/api-atlases-create.test.ts
@@ -79,6 +79,14 @@ const NEW_ATLAS_WITH_TARGET_COMPLETION: NewAtlasData = {
   wave: "2",
 };
 
+const NEW_ATLAS_WITHOUT_DESCRIPTION: NewAtlasData = {
+  integrationLead: [],
+  network: "nervous-system",
+  shortName: "test5",
+  version: "5.3",
+  wave: "2",
+};
+
 beforeAll(async () => {
   await resetDatabase();
 });
@@ -252,6 +260,10 @@ describe("/api/atlases/create", () => {
   it("creates and returns atlas entry with target completion", async () => {
     await testSuccessfulCreate(NEW_ATLAS_WITH_TARGET_COMPLETION);
   });
+
+  it("creates and returns atlas entry without description", async () => {
+    await testSuccessfulCreate(NEW_ATLAS_WITHOUT_DESCRIPTION);
+  });
 });
 
 async function testSuccessfulCreate(atlasData: NewAtlasData): Promise<void> {
@@ -264,7 +276,9 @@ async function testSuccessfulCreate(atlasData: NewAtlasData): Promise<void> {
   expect(newAtlasFromDb.target_completion).toEqual(
     atlasData.targetCompletion ? new Date(atlasData.targetCompletion) : null
   );
-  expect(newAtlasFromDb.overview.description).toEqual(atlasData.description);
+  expect(newAtlasFromDb.overview.description).toEqual(
+    atlasData.description ?? ""
+  );
   expect(newAtlasFromDb.overview.integrationLead).toEqual(
     atlasData.integrationLead
   );

--- a/__tests__/api-atlases-create.test.ts
+++ b/__tests__/api-atlases-create.test.ts
@@ -25,6 +25,7 @@ jest.mock("../app/services/cellxgene");
 jest.mock("../app/utils/pg-app-connect-config");
 
 const NEW_ATLAS_DATA: NewAtlasData = {
+  description: "foo bar baz baz foo bar",
   integrationLead: [],
   network: "eye",
   shortName: "test",
@@ -33,6 +34,7 @@ const NEW_ATLAS_DATA: NewAtlasData = {
 };
 
 const NEW_ATLAS_WITH_IL_DATA: NewAtlasData = {
+  description: "bar foo baz foo bar baz bar",
   integrationLead: [
     {
       email: "foo@example.com",
@@ -46,6 +48,7 @@ const NEW_ATLAS_WITH_IL_DATA: NewAtlasData = {
 };
 
 const NEW_ATLAS_WITH_MULTIPLE_ILS: NewAtlasData = {
+  description: "foo baz foo foo",
   integrationLead: [
     {
       email: "foofoo@example.com",
@@ -67,6 +70,7 @@ const NEW_ATLAS_WITH_MULTIPLE_ILS: NewAtlasData = {
 };
 
 const NEW_ATLAS_WITH_TARGET_COMPLETION: NewAtlasData = {
+  description: "bar bar foo foo foo bar",
   integrationLead: [],
   network: "musculoskeletal",
   shortName: "test4",
@@ -260,6 +264,7 @@ async function testSuccessfulCreate(atlasData: NewAtlasData): Promise<void> {
   expect(newAtlasFromDb.target_completion).toEqual(
     atlasData.targetCompletion ? new Date(atlasData.targetCompletion) : null
   );
+  expect(newAtlasFromDb.overview.description).toEqual(atlasData.description);
   expect(newAtlasFromDb.overview.integrationLead).toEqual(
     atlasData.integrationLead
   );

--- a/__tests__/api-atlases-id-component-atlases-create.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-create.test.ts
@@ -27,10 +27,12 @@ jest.mock("../app/services/cellxgene");
 jest.mock("../app/utils/pg-app-connect-config");
 
 const NEW_COMPONENT_ATLAS_DATA: NewComponentAtlasData = {
+  description: "New component atlas description",
   title: "New Component Atlas",
 };
 
 const NEW_COMPONENT_ATLAS_FOO_DATA: NewComponentAtlasData = {
+  description: "New component atlas foo description",
   title: "New Component Atlas Foo",
 };
 
@@ -149,26 +151,17 @@ describe("/api/atlases/[atlasId]/component-atlases/create", () => {
   });
 
   it("creates and returns component atlas entry when requested by user with INTEGRATION_LEAD role for the atlas", async () => {
-    await testSuccessfulCreate(
-      ATLAS_DRAFT,
-      NEW_COMPONENT_ATLAS_FOO_DATA,
-      NEW_COMPONENT_ATLAS_FOO_DATA.title
-    );
+    await testSuccessfulCreate(ATLAS_DRAFT, NEW_COMPONENT_ATLAS_FOO_DATA);
   });
 
   it("creates and returns component atlas entry when requested by user with CONTENT_ADMIN role", async () => {
-    await testSuccessfulCreate(
-      ATLAS_DRAFT,
-      NEW_COMPONENT_ATLAS_DATA,
-      NEW_COMPONENT_ATLAS_DATA.title
-    );
+    await testSuccessfulCreate(ATLAS_DRAFT, NEW_COMPONENT_ATLAS_DATA);
   });
 });
 
 async function testSuccessfulCreate(
   atlas: TestAtlas,
-  newData: Record<string, unknown>,
-  expectedTitle: string
+  newData: NewComponentAtlasData
 ): Promise<HCAAtlasTrackerDBComponentAtlas> {
   const res = await doCreateTest(USER_CONTENT_ADMIN, atlas, newData);
   expect(res._getStatusCode()).toEqual(201);
@@ -183,7 +176,7 @@ async function testSuccessfulCreate(
     newComponentAtlasFromDb,
     newComponentAtlas,
     atlas.id,
-    expectedTitle
+    newData
   );
   return newComponentAtlasFromDb;
 }
@@ -213,11 +206,12 @@ function expectDbComponentAtlasToMatch(
   dbComponentAtlas: HCAAtlasTrackerDBComponentAtlas,
   apiComponentAtlas: HCAAtlasTrackerComponentAtlas,
   atlasId: string,
-  title: string
+  data: NewComponentAtlasData
 ): void {
   expect(dbComponentAtlas).toBeDefined();
   expect(dbComponentAtlas.atlas_id).toEqual(atlasId);
-  expect(dbComponentAtlas.title).toEqual(title);
+  expect(dbComponentAtlas.component_info.description).toEqual(data.description);
+  expect(dbComponentAtlas.title).toEqual(data.title);
   expect(dbComponentAtlasToApiComponentAtlas(dbComponentAtlas)).toEqual(
     apiComponentAtlas
   );

--- a/__tests__/api-atlases-id-component-atlases-create.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-create.test.ts
@@ -154,6 +154,22 @@ describe("/api/atlases/[atlasId]/component-atlases/create", () => {
     ).toEqual(400);
   });
 
+  it("returns error 400 when description is too long", async () => {
+    expect(
+      (
+        await doCreateTest(
+          USER_CONTENT_ADMIN,
+          ATLAS_DRAFT,
+          {
+            ...NEW_COMPONENT_ATLAS_DATA,
+            description: "x".repeat(10001),
+          },
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+  });
+
   it("creates and returns component atlas entry when requested by user with INTEGRATION_LEAD role for the atlas", async () => {
     await testSuccessfulCreate(ATLAS_DRAFT, NEW_COMPONENT_ATLAS_FOO_DATA);
   });

--- a/__tests__/api-atlases-id-component-atlases-create.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-create.test.ts
@@ -36,6 +36,10 @@ const NEW_COMPONENT_ATLAS_FOO_DATA: NewComponentAtlasData = {
   title: "New Component Atlas Foo",
 };
 
+const NEW_COMPONENT_ATLAS_WITHOUT_DESCRIPTION_DATA: NewComponentAtlasData = {
+  title: "New Component Atlas Without Description",
+};
+
 beforeAll(async () => {
   await resetDatabase();
 });
@@ -157,6 +161,13 @@ describe("/api/atlases/[atlasId]/component-atlases/create", () => {
   it("creates and returns component atlas entry when requested by user with CONTENT_ADMIN role", async () => {
     await testSuccessfulCreate(ATLAS_DRAFT, NEW_COMPONENT_ATLAS_DATA);
   });
+
+  it("creates and returns component atlas entry without description specified", async () => {
+    await testSuccessfulCreate(
+      ATLAS_DRAFT,
+      NEW_COMPONENT_ATLAS_WITHOUT_DESCRIPTION_DATA
+    );
+  });
 });
 
 async function testSuccessfulCreate(
@@ -210,7 +221,9 @@ function expectDbComponentAtlasToMatch(
 ): void {
   expect(dbComponentAtlas).toBeDefined();
   expect(dbComponentAtlas.atlas_id).toEqual(atlasId);
-  expect(dbComponentAtlas.component_info.description).toEqual(data.description);
+  expect(dbComponentAtlas.component_info.description).toEqual(
+    data.description ?? ""
+  );
   expect(dbComponentAtlas.title).toEqual(data.title);
   expect(dbComponentAtlasToApiComponentAtlas(dbComponentAtlas)).toEqual(
     apiComponentAtlas

--- a/__tests__/api-atlases-id-component-atlases-id.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id.test.ts
@@ -35,10 +35,12 @@ const TEST_ROUTE =
   "/api/atlases/[atlasId]/component-atlases/[componentAtlasId]";
 
 const COMPONENT_ATLAS_DRAFT_FOO_EDIT: ComponentAtlasEditData = {
+  description: "Component atlas draft foo description edited",
   title: "Component Atlas Draft Foo Edited",
 };
 
 const COMPONENT_ATLAS_MISC_FOO_EDIT: ComponentAtlasEditData = {
+  description: "Component atlas misc foo description edited",
   title: "Component Atlas Misc Foo Edited",
 };
 
@@ -117,6 +119,9 @@ describe(TEST_ROUTE, () => {
         const componentAtlas =
           res._getJSONData() as HCAAtlasTrackerComponentAtlas;
         expect(componentAtlas.title).toEqual(COMPONENT_ATLAS_DRAFT_FOO.title);
+        expect(componentAtlas.description).toEqual(
+          COMPONENT_ATLAS_DRAFT_FOO.description
+        );
       }
     );
   }
@@ -130,6 +135,9 @@ describe(TEST_ROUTE, () => {
     expect(res._getStatusCode()).toEqual(200);
     const componentAtlas = res._getJSONData() as HCAAtlasTrackerComponentAtlas;
     expect(componentAtlas.title).toEqual(COMPONENT_ATLAS_DRAFT_FOO.title);
+    expect(componentAtlas.description).toEqual(
+      COMPONENT_ATLAS_DRAFT_FOO.description
+    );
   });
 
   it("returns error 401 when component atlas is PATCH requested from draft atlas by logged out user", async () => {

--- a/__tests__/api-atlases-id-component-atlases-id.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id.test.ts
@@ -242,6 +242,25 @@ describe(TEST_ROUTE, () => {
     await expectComponentAtlasToBeUnchanged(COMPONENT_ATLAS_DRAFT_FOO);
   });
 
+  it("returns error 400 for component atlas PATCH requested with excessively long description", async () => {
+    expect(
+      (
+        await doComponentAtlasRequest(
+          ATLAS_DRAFT.id,
+          COMPONENT_ATLAS_DRAFT_FOO.id,
+          USER_CONTENT_ADMIN,
+          METHOD.PATCH,
+          {
+            ...COMPONENT_ATLAS_DRAFT_FOO_EDIT,
+            description: "x".repeat(10001),
+          },
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+    await expectComponentAtlasToBeUnchanged(COMPONENT_ATLAS_DRAFT_FOO);
+  });
+
   it("updates and returns component atlas when PATCH requested by user with INTEGRATION_LEAD role for the atlas", async () => {
     const res = await doComponentAtlasRequest(
       ATLAS_WITH_MISC_SOURCE_STUDIES.id,

--- a/__tests__/api-atlases-id-component-atlases-id.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id.test.ts
@@ -13,6 +13,7 @@ import {
   ATLAS_DRAFT,
   ATLAS_PUBLIC,
   ATLAS_WITH_MISC_SOURCE_STUDIES,
+  COMPONENT_ATLAS_DRAFT_BAR,
   COMPONENT_ATLAS_DRAFT_FOO,
   COMPONENT_ATLAS_MISC_FOO,
   STAKEHOLDER_ANALOGOUS_ROLES,
@@ -42,6 +43,10 @@ const COMPONENT_ATLAS_DRAFT_FOO_EDIT: ComponentAtlasEditData = {
 const COMPONENT_ATLAS_MISC_FOO_EDIT: ComponentAtlasEditData = {
   description: "Component atlas misc foo description edited",
   title: "Component Atlas Misc Foo Edited",
+};
+
+const COMPONENT_ATLAS_DRAFT_BAR_EDIT: ComponentAtlasEditData = {
+  title: COMPONENT_ATLAS_DRAFT_BAR.title,
 };
 
 beforeAll(async () => {
@@ -285,6 +290,38 @@ describe(TEST_ROUTE, () => {
     );
 
     await restoreDbComponentAtlas(COMPONENT_ATLAS_DRAFT_FOO);
+  });
+
+  it("removes description when description is unspecified", async () => {
+    const componentAtlasFromDbBefore = await getComponentAtlasFromDatabase(
+      COMPONENT_ATLAS_DRAFT_BAR.id
+    );
+    expect(componentAtlasFromDbBefore?.component_info.description).toBeTruthy();
+
+    const res = await doComponentAtlasRequest(
+      ATLAS_DRAFT.id,
+      COMPONENT_ATLAS_DRAFT_BAR.id,
+      USER_CONTENT_ADMIN,
+      METHOD.PATCH,
+      COMPONENT_ATLAS_DRAFT_BAR_EDIT
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const updatedComponentAtlas = res._getJSONData();
+    const componentAtlasFromDb = await getComponentAtlasFromDatabase(
+      COMPONENT_ATLAS_DRAFT_BAR.id
+    );
+    expect(componentAtlasFromDb).toBeDefined();
+    if (!componentAtlasFromDb) return;
+    expect(componentAtlasFromDb.title).toEqual(
+      COMPONENT_ATLAS_DRAFT_BAR_EDIT.title
+    );
+    expect(dbComponentAtlasToApiComponentAtlas(componentAtlasFromDb)).toEqual(
+      updatedComponentAtlas
+    );
+
+    expect(componentAtlasFromDb.component_info.description).toEqual("");
+
+    await restoreDbComponentAtlas(COMPONENT_ATLAS_DRAFT_BAR);
   });
 
   it("returns error 401 when component atlas is DELETE requested from draft atlas by logged out user", async () => {

--- a/__tests__/api-atlases-id-component-atlases.test.ts
+++ b/__tests__/api-atlases-id-component-atlases.test.ts
@@ -122,5 +122,6 @@ function expectComponentAtlasesToMatch(
     if (!componentAtlas) continue;
     expect(componentAtlas.atlasId).toEqual(testComponentAtlas.atlasId);
     expect(componentAtlas.title).toEqual(testComponentAtlas.title);
+    expect(componentAtlas.description).toEqual(testComponentAtlas.description);
   }
 }

--- a/__tests__/api-atlases-id.test.ts
+++ b/__tests__/api-atlases-id.test.ts
@@ -12,6 +12,7 @@ import {
   ATLAS_DRAFT,
   ATLAS_PUBLIC,
   ATLAS_WITH_IL,
+  ATLAS_WITH_MISC_SOURCE_STUDIES,
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
   USER_UNREGISTERED,
@@ -88,6 +89,14 @@ const ATLAS_PUBLIC_EDIT_NO_TARGET_COMPLETION: AtlasEditData = {
   shortName: ATLAS_DRAFT.shortName,
   version: ATLAS_DRAFT.version,
   wave: ATLAS_DRAFT.wave,
+};
+
+const ATLAS_WITH_MISC_SOURCE_STUDIES_EDIT: AtlasEditData = {
+  integrationLead: ATLAS_WITH_MISC_SOURCE_STUDIES.integrationLead,
+  network: ATLAS_WITH_MISC_SOURCE_STUDIES.network,
+  shortName: ATLAS_WITH_MISC_SOURCE_STUDIES.shortName,
+  version: ATLAS_WITH_MISC_SOURCE_STUDIES.version,
+  wave: ATLAS_WITH_MISC_SOURCE_STUDIES.wave,
 };
 
 beforeAll(async () => {
@@ -370,6 +379,15 @@ describe(TEST_ROUTE, () => {
     );
     expect(updatedAtlas.target_completion).toBeNull();
   });
+
+  it("PUT updates and returns atlas entry with description removed", async () => {
+    const updatedAtlas = await testSuccessfulEdit(
+      ATLAS_WITH_MISC_SOURCE_STUDIES,
+      ATLAS_WITH_MISC_SOURCE_STUDIES_EDIT,
+      1
+    );
+    expect(updatedAtlas.overview.description).toEqual("");
+  });
 });
 
 async function testSuccessfulEdit(
@@ -395,7 +413,7 @@ async function testSuccessfulEdit(
 
   const updatedOverview = updatedAtlasFromDb.overview;
 
-  expect(updatedOverview.description).toEqual(editData.description);
+  expect(updatedOverview.description).toEqual(editData.description ?? "");
   expect(updatedOverview.integrationLead).toEqual(editData.integrationLead);
   expect(updatedOverview.network).toEqual(editData.network);
   expect(updatedOverview.shortName).toEqual(editData.shortName);

--- a/__tests__/api-atlases-id.test.ts
+++ b/__tests__/api-atlases-id.test.ts
@@ -36,6 +36,7 @@ const TEST_ROUTE = "/api/atlases/[id]";
 const ATLAS_ID_NONEXISTENT = "f643a5ff-0803-4bf1-b650-184161220bc2";
 
 const ATLAS_PUBLIC_EDIT: AtlasEditData = {
+  description: "test-public-description-edited",
   integrationLead: [
     {
       email: "bar@example.com",
@@ -50,6 +51,7 @@ const ATLAS_PUBLIC_EDIT: AtlasEditData = {
 };
 
 const ATLAS_WITH_IL_EDIT: AtlasEditData = {
+  description: ATLAS_WITH_IL.description,
   integrationLead: [],
   network: "development",
   shortName: ATLAS_WITH_IL.shortName,
@@ -58,6 +60,7 @@ const ATLAS_WITH_IL_EDIT: AtlasEditData = {
 };
 
 const ATLAS_DRAFT_EDIT: AtlasEditData = {
+  description: "foo bar baz",
   integrationLead: [
     {
       email: "foofoo@example.com",
@@ -79,6 +82,7 @@ const ATLAS_DRAFT_EDIT: AtlasEditData = {
 };
 
 const ATLAS_PUBLIC_EDIT_NO_TARGET_COMPLETION: AtlasEditData = {
+  description: ATLAS_DRAFT.description,
   integrationLead: ATLAS_DRAFT.integrationLead,
   network: ATLAS_DRAFT.network,
   shortName: ATLAS_DRAFT.shortName,
@@ -391,6 +395,7 @@ async function testSuccessfulEdit(
 
   const updatedOverview = updatedAtlasFromDb.overview;
 
+  expect(updatedOverview.description).toEqual(editData.description);
   expect(updatedOverview.integrationLead).toEqual(editData.integrationLead);
   expect(updatedOverview.network).toEqual(editData.network);
   expect(updatedOverview.shortName).toEqual(editData.shortName);

--- a/__tests__/api-atlases-id.test.ts
+++ b/__tests__/api-atlases-id.test.ts
@@ -359,6 +359,23 @@ describe(TEST_ROUTE, () => {
     ).toEqual(400);
   });
 
+  it("PUT returns error 400 when description is too long", async () => {
+    expect(
+      (
+        await doAtlasRequest(
+          ATLAS_PUBLIC.id,
+          USER_CONTENT_ADMIN,
+          true,
+          METHOD.PUT,
+          {
+            ...ATLAS_PUBLIC_EDIT,
+            description: "x".repeat(10001),
+          }
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+  });
+
   it("PUT updates and returns atlas entry", async () => {
     await testSuccessfulEdit(ATLAS_PUBLIC, ATLAS_PUBLIC_EDIT, 0);
   });

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -8,6 +8,7 @@ export interface HCAAtlasTrackerListAtlas {
   bioNetwork: NetworkKey;
   completedTaskCount: number;
   componentAtlasCount: number;
+  description: string;
   id: string;
   integrationLeadEmail: IntegrationLead["email"][];
   integrationLeadName: IntegrationLead["name"][];
@@ -28,6 +29,7 @@ export interface HCAAtlasTrackerAtlas {
   bioNetwork: NetworkKey;
   completedTaskCount: number;
   componentAtlasCount: number;
+  description: string;
   id: string;
   integrationLead: IntegrationLead[];
   publication: {
@@ -50,6 +52,7 @@ export interface HCAAtlasTrackerComponentAtlas {
   cellCount: number;
   cellxgeneDatasetId: string | null;
   cellxgeneDatasetVersion: string | null;
+  description: string;
   disease: string[];
   id: string;
   sourceDatasetCount: number;
@@ -215,6 +218,7 @@ export interface HCAAtlasTrackerDBAtlasWithComponentAtlases
 
 export interface HCAAtlasTrackerDBAtlasOverview {
   completedTaskCount: number;
+  description: string;
   integrationLead: IntegrationLead[];
   network: NetworkKey;
   shortName: string;
@@ -238,6 +242,7 @@ export interface HCAAtlasTrackerDBComponentAtlasInfo {
   cellCount: number;
   cellxgeneDatasetId: string | null;
   cellxgeneDatasetVersion: string | null;
+  description: string;
   disease: string[];
   suspensionType: string[];
   tissue: string[];

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -16,6 +16,7 @@ import { ROLE } from "./entities";
  * Schema for data used to create a new atlas.
  */
 export const newAtlasSchema = object({
+  description: string().required().max(10000),
   integrationLead: array()
     .of(
       object({
@@ -57,6 +58,7 @@ export type AtlasEditData = InferType<typeof atlasEditSchema>;
  * Schema for data used to create a new component atlas.
  */
 export const newComponentAtlasSchema = object({
+  description: string().required().max(10000),
   title: string().required(),
 }).strict(true);
 

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -16,7 +16,7 @@ import { ROLE } from "./entities";
  * Schema for data used to create a new atlas.
  */
 export const newAtlasSchema = object({
-  description: string().required().max(10000),
+  description: string().max(10000),
   integrationLead: array()
     .of(
       object({
@@ -58,7 +58,7 @@ export type AtlasEditData = InferType<typeof atlasEditSchema>;
  * Schema for data used to create a new component atlas.
  */
 export const newComponentAtlasSchema = object({
-  description: string().required().max(10000),
+  description: string().max(10000),
   title: string().required(),
 }).strict(true);
 

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -45,6 +45,7 @@ export function atlasInputMapper(
     bioNetwork: apiAtlas.bioNetwork,
     completedTaskCount: apiAtlas.completedTaskCount,
     componentAtlasCount: apiAtlas.componentAtlasCount,
+    description: apiAtlas.description,
     id: apiAtlas.id,
     integrationLeadEmail: apiAtlas.integrationLead.map(({ email }) => email),
     integrationLeadName: apiAtlas.integrationLead.map(({ name }) => name),
@@ -69,6 +70,7 @@ export function dbAtlasToApiAtlas(
     bioNetwork: dbAtlas.overview.network,
     completedTaskCount: dbAtlas.overview.completedTaskCount,
     componentAtlasCount: dbAtlas.component_atlas_count,
+    description: dbAtlas.overview.description,
     id: dbAtlas.id,
     integrationLead: dbAtlas.overview.integrationLead,
     publication: {
@@ -96,6 +98,7 @@ export function dbComponentAtlasToApiComponentAtlas(
     cellxgeneDatasetId: dbComponentAtlas.component_info.cellxgeneDatasetId,
     cellxgeneDatasetVersion:
       dbComponentAtlas.component_info.cellxgeneDatasetVersion,
+    description: dbComponentAtlas.component_info.description,
     disease: dbComponentAtlas.component_info.disease,
     id: dbComponentAtlas.id,
     sourceDatasetCount: dbComponentAtlas.source_datasets.length,

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -83,6 +83,7 @@ export async function atlasInputDataToDbData(
 ): Promise<AtlasInputDbData> {
   return {
     overviewData: {
+      description: inputData.description,
       integrationLead: inputData.integrationLead,
       network: inputData.network,
       shortName: inputData.shortName,

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -83,7 +83,7 @@ export async function atlasInputDataToDbData(
 ): Promise<AtlasInputDbData> {
   return {
     overviewData: {
-      description: inputData.description,
+      description: inputData.description ?? "",
       integrationLead: inputData.integrationLead,
       network: inputData.network,
       shortName: inputData.shortName,

--- a/app/services/component-atlases.ts
+++ b/app/services/component-atlases.ts
@@ -19,7 +19,7 @@ import {
 interface ComponentAtlasDbEditData {
   componentInfoEdit: Pick<
     HCAAtlasTrackerDBComponentAtlasInfo,
-    "cellxgeneDatasetId" | "cellxgeneDatasetVersion"
+    "description" | "cellxgeneDatasetId" | "cellxgeneDatasetVersion"
   >;
   title: HCAAtlasTrackerDBComponentAtlas["title"];
 }
@@ -130,6 +130,7 @@ async function newComponentAtlasDataToDbData(
       cellCount: 0,
       cellxgeneDatasetId: null,
       cellxgeneDatasetVersion: null,
+      description: inputData.description,
       disease: [],
       suspensionType: [],
       tissue: [],
@@ -150,6 +151,7 @@ async function componentAtlasEditDataToDbData(
     componentInfoEdit: {
       cellxgeneDatasetId: null,
       cellxgeneDatasetVersion: null,
+      description: inputData.description,
     },
     title: inputData.title,
   };

--- a/app/services/component-atlases.ts
+++ b/app/services/component-atlases.ts
@@ -130,7 +130,7 @@ async function newComponentAtlasDataToDbData(
       cellCount: 0,
       cellxgeneDatasetId: null,
       cellxgeneDatasetVersion: null,
-      description: inputData.description,
+      description: inputData.description ?? "",
       disease: [],
       suspensionType: [],
       tissue: [],
@@ -151,7 +151,7 @@ async function componentAtlasEditDataToDbData(
     componentInfoEdit: {
       cellxgeneDatasetId: null,
       cellxgeneDatasetVersion: null,
-      description: inputData.description,
+      description: inputData.description ?? "",
     },
     title: inputData.title,
   };

--- a/migrations/1722625517148_description-fields.ts
+++ b/migrations/1722625517148_description-fields.ts
@@ -1,0 +1,15 @@
+import { MigrationBuilder } from "node-pg-migrate";
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.sql(`UPDATE hat.atlases SET overview=overview||'{"description":""}'`);
+  pgm.sql(
+    `UPDATE hat.component_atlases SET component_info=component_info||'{"description":""}'`
+  );
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.sql(`UPDATE hat.atlases SET overview=overview-'description'`);
+  pgm.sql(
+    `UPDATE hat.component_atlases SET component_info=component_info-'description'`
+  );
+}

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -1537,6 +1537,7 @@ export const INTEGRATION_LEAD_BAZ_BAZ = {
 };
 
 export const ATLAS_DRAFT: TestAtlas = {
+  description: "bar baz baz foo baz",
   id: ATLAS_ID_DRAFT,
   integrationLead: [
     {
@@ -1561,6 +1562,7 @@ export const ATLAS_DRAFT: TestAtlas = {
 };
 
 export const ATLAS_PUBLIC: TestAtlas = {
+  description: "foo foo bar bar foo",
   id: ATLAS_ID_PUBLIC,
   integrationLead: [
     {
@@ -1582,6 +1584,7 @@ export const ATLAS_PUBLIC: TestAtlas = {
 };
 
 export const ATLAS_WITH_IL: TestAtlas = {
+  description: "foo baz bar baz foo baz",
   id: "798b563d-16ff-438a-8e15-77be05b1f8ec",
   integrationLead: [INTEGRATION_LEAD_BAZ],
   network: "heart",
@@ -1593,6 +1596,7 @@ export const ATLAS_WITH_IL: TestAtlas = {
 };
 
 export const ATLAS_WITH_MISC_SOURCE_STUDIES: TestAtlas = {
+  description: "bar foo bar bar foo baz",
   id: ATLAS_ID_WITH_MISC_SOURCE_STUDIES,
   integrationLead: [INTEGRATION_LEAD_BAZ_BAZ],
   network: "adipose",
@@ -1619,6 +1623,7 @@ export const ATLAS_WITH_MISC_SOURCE_STUDIES: TestAtlas = {
 };
 
 export const ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_A: TestAtlas = {
+  description: "foo baz baz bar foo bar",
   id: "7ce0814d-606c-475b-942a-0f72ff8c5c0b",
   integrationLead: [],
   network: "organoid",
@@ -1636,6 +1641,7 @@ export const ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_A: TestAtlas = {
 };
 
 export const ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_B: TestAtlas = {
+  description: "baz foo baz foo bar bar foo",
   id: "9766683a-3c8d-4ec8-b8b5-3fceb8fe0d31",
   integrationLead: [],
   network: "gut",
@@ -1679,6 +1685,7 @@ export const INITIAL_TEST_ATLASES_BY_SOURCE_STUDY = INITIAL_TEST_ATLASES.reduce(
 
 export const COMPONENT_ATLAS_DRAFT_FOO: TestComponentAtlas = {
   atlasId: ATLAS_DRAFT.id,
+  description: "bar baz baz foo baz foo bar",
   id: "b1820416-5886-4585-b0fe-7f70487331d8",
   sourceDatasets: [
     SOURCE_DATASET_FOOFOO,
@@ -1690,6 +1697,7 @@ export const COMPONENT_ATLAS_DRAFT_FOO: TestComponentAtlas = {
 
 export const COMPONENT_ATLAS_DRAFT_BAR: TestComponentAtlas = {
   atlasId: ATLAS_DRAFT.id,
+  description: "baz baz bar foo baz",
   id: "484bc93b-836d-4efe-880a-de90eb1c4dfb",
   sourceDatasets: [
     SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE,
@@ -1700,6 +1708,7 @@ export const COMPONENT_ATLAS_DRAFT_BAR: TestComponentAtlas = {
 
 export const COMPONENT_ATLAS_MISC_FOO: TestComponentAtlas = {
   atlasId: ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+  description: "foo foo bar baz bar bar",
   id: "b95614cc-5356-4f47-b3a2-da05d23e86ce",
   sourceDatasets: [
     SOURCE_DATASET_FOO,

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -136,6 +136,7 @@ async function initComponentAtlases(client: pg.PoolClient): Promise<void> {
         ) ?? 0,
       cellxgeneDatasetId: null,
       cellxgeneDatasetVersion: null,
+      description: componentAtlas.description,
       disease: aggregateSourceDatasetArrayField(
         componentAtlas.sourceDatasets,
         "disease"

--- a/testing/entities.ts
+++ b/testing/entities.ts
@@ -20,6 +20,7 @@ export interface TestUser {
 }
 
 export interface TestAtlas {
+  description: string;
   id: string;
   integrationLead: IntegrationLead[];
   network: NetworkKey;
@@ -33,6 +34,7 @@ export interface TestAtlas {
 
 export interface TestComponentAtlas {
   atlasId: string;
+  description: string;
   id: string;
   sourceDatasets?: TestSourceDataset[];
   title: string;

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -56,6 +56,7 @@ export function makeTestAtlasOverview(
 ): HCAAtlasTrackerDBAtlasOverview {
   return {
     completedTaskCount: 0,
+    description: atlas.description,
     integrationLead: atlas.integrationLead,
     network: atlas.network,
     shortName: atlas.shortName,
@@ -257,6 +258,7 @@ export function expectApiAtlasToMatchTest(
   apiAtlas: HCAAtlasTrackerAtlas,
   testAtlas: TestAtlas
 ): void {
+  expect(apiAtlas.description).toEqual(testAtlas.description);
   expect(apiAtlas.id).toEqual(testAtlas.id);
   expect(apiAtlas.integrationLead).toEqual(testAtlas.integrationLead);
   expect(apiAtlas.bioNetwork).toEqual(testAtlas.network);


### PR DESCRIPTION
Create and edit APIs for atlases and integration objects accept an optional `description` field, which is limited to 10000 characters by the validator