### PR TITLE
feat: add validation for hca project networks and atlases (#419)

### DIFF
--- a/__tests__/api-tasks-completion-dates.test.ts
+++ b/__tests__/api-tasks-completion-dates.test.ts
@@ -8,6 +8,7 @@ import { METHOD } from "../app/common/entities";
 import { endPgPool, query } from "../app/services/database";
 import completionDatesHandler from "../pages/api/tasks/completion-dates";
 import {
+  ATLAS_WITH_IL,
   ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_A,
   SOURCE_STUDY_PUBLISHED_WITH_HCA,
   STAKEHOLDER_ANALOGOUS_ROLES,
@@ -32,6 +33,7 @@ const DATE_NON_UTC = "2024-05-19T18:16:42.761-0700";
 const VALIDATION_ID_NONEXISTENT = "8fb38ac8-78fe-4d47-a858-145175819dfe";
 
 const ATLAS_NAMES_PUBLISHED_WITH_HCA = [
+  `${ATLAS_WITH_IL.shortName} v${ATLAS_WITH_IL.version}`,
   `${ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_A.shortName} v${ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_A.version}`,
 ];
 

--- a/__tests__/api-tasks.test.ts
+++ b/__tests__/api-tasks.test.ts
@@ -98,7 +98,7 @@ function expectInitialValidationsToExist(
         ? testStudy.doi !== null && TEST_HCA_PROJECTS_BY_DOI.has(testStudy.doi)
         : testStudy.hcaProjectId !== null
     ) {
-      expectedValidationCount++;
+      expectedValidationCount += 2;
       if ("doi" in testStudy && testStudy.doi !== null)
         expectedValidationCount++;
     }

--- a/__tests__/refresh-validations.test.ts
+++ b/__tests__/refresh-validations.test.ts
@@ -33,7 +33,7 @@ afterAll(async () => {
 
 describe("refreshValidations", () => {
   it("updates source study validations and atlas task counts", async () => {
-    const aExpectedSubjectTasksBefore = 5;
+    const aExpectedSubjectTasksBefore = 6;
     const aExpectedSubjectCompletedTasksBefore = 4;
     const aExpectedSubjectTasksAfter = 3;
     const aExpectedSubjectCompletedTasksAfter = 1;

--- a/__tests__/source-study-validation-results.test.ts
+++ b/__tests__/source-study-validation-results.test.ts
@@ -1,11 +1,11 @@
 import {
-  HCAAtlasTrackerDBSourceStudy,
   HCAAtlasTrackerValidationResult,
   SYSTEM,
   VALIDATION_ID,
   VALIDATION_STATUS,
   VALIDATION_TYPE,
 } from "app/apis/catalog/hca-atlas-tracker/common/entities";
+import { getSourceStudyWithAtlasProperties } from "app/services/source-studies";
 import pg from "pg";
 import { endPgPool, getPoolClient } from "../app/services/database";
 import { getSourceStudyValidationResults } from "../app/services/validations";
@@ -345,12 +345,10 @@ async function testValidations(
   testAtlases: TestAtlas[],
   expectedValidationProperties: ExpectedValidationProperties[]
 ): Promise<void> {
-  const sourceStudy = (
-    await client.query<HCAAtlasTrackerDBSourceStudy>(
-      "SELECT * FROM hat.source_studies WHERE id=$1",
-      [testStudy.id]
-    )
-  ).rows[0];
+  const sourceStudy = await getSourceStudyWithAtlasProperties(
+    testStudy.id,
+    client
+  );
   const validationResults = await getSourceStudyValidationResults(
     sourceStudy,
     client

--- a/__tests__/source-study-validation-results.test.ts
+++ b/__tests__/source-study-validation-results.test.ts
@@ -4,12 +4,14 @@ import {
   VALIDATION_ID,
   VALIDATION_STATUS,
   VALIDATION_TYPE,
+  VALIDATION_VARIABLE,
 } from "app/apis/catalog/hca-atlas-tracker/common/entities";
 import { getSourceStudyWithAtlasProperties } from "app/services/source-studies";
 import pg from "pg";
 import { endPgPool, getPoolClient } from "../app/services/database";
 import { getSourceStudyValidationResults } from "../app/services/validations";
 import {
+  ATLAS_WITH_IL,
   ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_A,
   ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_B,
   SOURCE_STUDY_PUBLISHED_WITH_CAP_AND_CELLXGENE,
@@ -27,7 +29,8 @@ import { TestAtlas, TestSourceStudy } from "../testing/entities";
 type ExpectedValidationProperties = Pick<
   HCAAtlasTrackerValidationResult,
   "system" | "validationId" | "validationStatus" | "validationType"
->;
+> &
+  Partial<Pick<HCAAtlasTrackerValidationResult, "differences">>;
 
 jest.mock("../app/utils/pg-app-connect-config");
 jest.mock("../app/services/hca-projects");
@@ -86,6 +89,20 @@ const VALIDATIONS_PUBLISHED_WITH_HCA: ExpectedValidationProperties[] = [
     validationStatus: VALIDATION_STATUS.PASSED,
     validationType: VALIDATION_TYPE.INGEST,
   },
+  {
+    differences: [
+      {
+        actual: ["organoid"],
+        expected: ["heart", "organoid"],
+        variable: VALIDATION_VARIABLE.NETWORKS,
+      },
+    ],
+    system: SYSTEM.HCA_DATA_REPOSITORY,
+    validationId:
+      VALIDATION_ID.SOURCE_STUDY_HCA_PROJECT_HAS_LINKED_BIONETWORKS_AND_ATLASES,
+    validationStatus: VALIDATION_STATUS.FAILED,
+    validationType: VALIDATION_TYPE.INGEST,
+  },
 ];
 
 const VALIDATIONS_PUBLISHED_WITH_HCA_TITLE_MISMATCH: ExpectedValidationProperties[] =
@@ -109,6 +126,13 @@ const VALIDATIONS_PUBLISHED_WITH_HCA_TITLE_MISMATCH: ExpectedValidationPropertie
       validationType: VALIDATION_TYPE.INGEST,
     },
     {
+      differences: [
+        {
+          actual: "Published With HCA Title Mismatch MISMATCHED",
+          expected: "Published With HCA Title Mismatch",
+          variable: VALIDATION_VARIABLE.TITLE,
+        },
+      ],
       system: SYSTEM.HCA_DATA_REPOSITORY,
       validationId:
         VALIDATION_ID.SOURCE_STUDY_TITLE_MATCHES_HCA_DATA_REPOSITORY,
@@ -119,6 +143,25 @@ const VALIDATIONS_PUBLISHED_WITH_HCA_TITLE_MISMATCH: ExpectedValidationPropertie
       system: SYSTEM.HCA_DATA_REPOSITORY,
       validationId: VALIDATION_ID.SOURCE_STUDY_HCA_PROJECT_HAS_PRIMARY_DATA,
       validationStatus: VALIDATION_STATUS.PASSED,
+      validationType: VALIDATION_TYPE.INGEST,
+    },
+    {
+      differences: [
+        {
+          actual: [],
+          expected: ["organoid"],
+          variable: VALIDATION_VARIABLE.NETWORKS,
+        },
+        {
+          actual: [],
+          expected: ["test-with-source-study-validations-a v5.4"],
+          variable: VALIDATION_VARIABLE.ATLASES,
+        },
+      ],
+      system: SYSTEM.HCA_DATA_REPOSITORY,
+      validationId:
+        VALIDATION_ID.SOURCE_STUDY_HCA_PROJECT_HAS_LINKED_BIONETWORKS_AND_ATLASES,
+      validationStatus: VALIDATION_STATUS.FAILED,
       validationType: VALIDATION_TYPE.INGEST,
     },
   ];
@@ -156,6 +199,13 @@ const VALIDATIONS_PUBLISHED_WITH_HCA_TITLE_NEAR_MATCH: ExpectedValidationPropert
       validationStatus: VALIDATION_STATUS.PASSED,
       validationType: VALIDATION_TYPE.INGEST,
     },
+    {
+      system: SYSTEM.HCA_DATA_REPOSITORY,
+      validationId:
+        VALIDATION_ID.SOURCE_STUDY_HCA_PROJECT_HAS_LINKED_BIONETWORKS_AND_ATLASES,
+      validationStatus: VALIDATION_STATUS.PASSED,
+      validationType: VALIDATION_TYPE.INGEST,
+    },
   ];
 
 const VALIDATIONS_PUBLISHED_WITH_NO_HCA_PRIMARY_DATA: ExpectedValidationProperties[] =
@@ -189,6 +239,13 @@ const VALIDATIONS_PUBLISHED_WITH_NO_HCA_PRIMARY_DATA: ExpectedValidationProperti
       system: SYSTEM.HCA_DATA_REPOSITORY,
       validationId: VALIDATION_ID.SOURCE_STUDY_HCA_PROJECT_HAS_PRIMARY_DATA,
       validationStatus: VALIDATION_STATUS.FAILED,
+      validationType: VALIDATION_TYPE.INGEST,
+    },
+    {
+      system: SYSTEM.HCA_DATA_REPOSITORY,
+      validationId:
+        VALIDATION_ID.SOURCE_STUDY_HCA_PROJECT_HAS_LINKED_BIONETWORKS_AND_ATLASES,
+      validationStatus: VALIDATION_STATUS.PASSED,
       validationType: VALIDATION_TYPE.INGEST,
     },
   ];
@@ -286,7 +343,7 @@ describe("getSourceStudyValidationResults", () => {
   it("returns validations for source study with HCA project with matching title", async () => {
     await testValidations(
       SOURCE_STUDY_PUBLISHED_WITH_HCA,
-      [ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_A],
+      [ATLAS_WITH_IL, ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_A],
       VALIDATIONS_PUBLISHED_WITH_HCA
     );
   });
@@ -356,6 +413,10 @@ async function testValidations(
   expect(validationResults).toHaveLength(expectedValidationProperties.length);
   const atlasIds = testAtlases.map((atlas) => atlas.id);
   for (const [i, validationResult] of validationResults.entries()) {
+    if (validationResult.differences.length)
+      expect(validationResult.differences).toEqual(
+        expectedValidationProperties[i].differences
+      );
     expect(validationResult).toMatchObject(expectedValidationProperties[i]);
     expect(validationResult.atlasIds).toEqual(atlasIds);
     expect(validationResult.entityId).toEqual(testStudy.id);

--- a/app/apis/azul/hca-dcp/common/entities.ts
+++ b/app/apis/azul/hca-dcp/common/entities.ts
@@ -43,7 +43,7 @@ export interface FileTypeSummary {
 export interface ProjectResponse {
   accessible: boolean;
   accessions: AccessionResponse[];
-  bionetworkName: string[];
+  bionetworkName: (string | null)[];
   contributedAnalyses: ProjectResponseContributedAnalyses;
   contributors: ContributorResponse[];
   estimatedCellCount: number | null;
@@ -55,7 +55,7 @@ export interface ProjectResponse {
   projectTitle: string;
   publications: PublicationResponse[];
   supplementaryLinks: (string | null)[];
-  tissueAtlas: { atlas: string; version: string }[];
+  tissueAtlas: { atlas: string; version: string | null }[];
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO - revisit nested Azul structure.

--- a/app/apis/azul/hca-dcp/common/entities.ts
+++ b/app/apis/azul/hca-dcp/common/entities.ts
@@ -43,6 +43,7 @@ export interface FileTypeSummary {
 export interface ProjectResponse {
   accessible: boolean;
   accessions: AccessionResponse[];
+  bionetworkName: string[];
   contributedAnalyses: ProjectResponseContributedAnalyses;
   contributors: ContributorResponse[];
   estimatedCellCount: number | null;
@@ -54,6 +55,7 @@ export interface ProjectResponse {
   projectTitle: string;
   publications: PublicationResponse[];
   supplementaryLinks: (string | null)[];
+  tissueAtlas: { atlas: string; version: string }[];
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO - revisit nested Azul structure.

--- a/app/apis/catalog/hca-atlas-tracker/common/constants.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/constants.ts
@@ -175,6 +175,8 @@ export const UNPUBLISHED = "Unpublished";
 export const VALIDATION_DESCRIPTION = {
   ADD_PRIMARY_DATA: "Add primary data.",
   INGEST_SOURCE_STUDY: "Ingest source study.",
+  LINK_PROJECT_BIONETWORKS_AND_ATLASES:
+    "Link project to HCA BioNeworks and Atlases.",
   UPDATE_TITLE_TO_MATCH_PUBLICATION:
     "Update project title to match publication title.",
 };

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -197,11 +197,12 @@ export interface TaskStatusesUpdatedByDOIResult {
   updated: string[];
 }
 
-export type DBEntityOfType<T extends ENTITY_TYPE> = T extends ENTITY_TYPE.ATLAS
-  ? HCAAtlasTrackerDBAtlas
-  : T extends ENTITY_TYPE.SOURCE_STUDY
-  ? HCAAtlasTrackerDBSourceStudy
-  : never;
+export type ValidationDBEntityOfType<T extends ENTITY_TYPE> =
+  T extends ENTITY_TYPE.ATLAS
+    ? HCAAtlasTrackerDBAtlas
+    : T extends ENTITY_TYPE.SOURCE_STUDY
+    ? HCAAtlasTrackerDBSourceStudyWithAtlasProperties
+    : never;
 
 export interface HCAAtlasTrackerDBAtlas {
   created_at: Date;
@@ -304,6 +305,13 @@ export type HCAAtlasTrackerDBSourceStudyWithSourceDatasets =
 export type HCAAtlasTrackerDBSourceStudyWithRelatedEntities =
   HCAAtlasTrackerDBSourceStudyWithSourceDatasets & {
     validations: HCAAtlasTrackerDBValidation[];
+  };
+
+export type HCAAtlasTrackerDBSourceStudyWithAtlasProperties =
+  HCAAtlasTrackerDBSourceStudy & {
+    atlas_short_names: string[];
+    atlas_versions: string[];
+    networks: NetworkKey[];
   };
 
 export interface HCAAtlasTrackerDBSourceDataset {
@@ -507,6 +515,7 @@ export enum VALIDATION_TYPE {
 }
 
 export enum VALIDATION_ID {
+  SOURCE_STUDY_HCA_PROJECT_HAS_LINKED_BIONETWORKS_AND_ATLASES = "SOURCE_STUDY_HCA_PROJECT_HAS_LINKED_BIONETWORKS_AND_ATLASES",
   SOURCE_STUDY_HCA_PROJECT_HAS_PRIMARY_DATA = "SOURCE_STUDY_HCA_PROJECT_HAS_PRIMARY_DATA",
   SOURCE_STUDY_IN_CAP = "SOURCE_STUDY_IN_CAP",
   SOURCE_STUDY_IN_CELLXGENE = "SOURCE_STUDY_IN_CELLXGENE",

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -309,6 +309,7 @@ export type HCAAtlasTrackerDBSourceStudyWithRelatedEntities =
 
 export type HCAAtlasTrackerDBSourceStudyWithAtlasProperties =
   HCAAtlasTrackerDBSourceStudy & {
+    atlas_names: string[];
     atlas_short_names: string[];
     atlas_versions: string[];
     networks: NetworkKey[];
@@ -484,8 +485,8 @@ export type SourceDatasetId = string;
 export type SourceStudyId = string;
 
 export interface ValidationDifference {
-  actual: string | null;
-  expected: string;
+  actual: string | string[] | null;
+  expected: string | string[];
   variable: VALIDATION_VARIABLE;
 }
 
@@ -530,6 +531,8 @@ export enum VALIDATION_STATUS {
 }
 
 export enum VALIDATION_VARIABLE {
+  ATLASES = "Atlases",
+  NETWORKS = "Networks",
   TITLE = "Title",
 }
 

--- a/app/components/Index/components/ViewTasks/components/PreviewTask/components/Section/components/Description/description.tsx
+++ b/app/components/Index/components/ViewTasks/components/PreviewTask/components/Section/components/Description/description.tsx
@@ -15,12 +15,19 @@ export const Description = ({ task }: DescriptionProps): JSX.Element | null => {
     <Section title="Description">
       <Typography variant={TEXT_BODY_400_2_LINES}>
         <p>{getTaskDescription(task)}</p>
-        {differences.map(({ actual, expected, variable }, i) => (
-          <Fragment key={`${variable}${i}`}>
-            <p>Expected: {expected}</p>
-            <p>Actual: {actual}</p>
-          </Fragment>
-        ))}
+        {differences.map(({ actual, expected, variable }, i) =>
+          Array.isArray(expected) && typeof actual !== "string" ? (
+            <p key={`${variable}${i}`}>
+              Missing {variable}:{" "}
+              {expected.filter((value) => !actual?.includes(value)).join(", ")}
+            </p>
+          ) : (
+            <Fragment key={`${variable}${i}`}>
+              <p>Expected: {expected}</p>
+              <p>Actual: {actual}</p>
+            </Fragment>
+          )
+        )}
       </Typography>
     </Section>
   );

--- a/app/services/source-studies.ts
+++ b/app/services/source-studies.ts
@@ -501,9 +501,10 @@ export async function getSourceStudiesWithAtlasProperties(
     await client.query<HCAAtlasTrackerDBSourceStudyWithAtlasProperties>(`
       SELECT
         s.*,
-        ARRAY_AGG(DISTINCT a.overview->>'network') AS networks,
+        ARRAY_AGG(DISTINCT concat(a.overview->>'shortName', ' v', a.overview->>'version')) AS atlas_names,
         ARRAY_AGG(DISTINCT a.overview->>'shortName') AS atlas_short_names,
-        ARRAY_AGG(DISTINCT a.overview->>'version') AS atlas_versions
+        ARRAY_AGG(DISTINCT a.overview->>'version') AS atlas_versions,
+        ARRAY_AGG(DISTINCT a.overview->>'network') AS networks
       FROM hat.source_studies s
       LEFT JOIN hat.atlases a ON a.source_studies @> to_jsonb(s.id)
       GROUP BY s.id
@@ -526,9 +527,10 @@ export async function getSourceStudyWithAtlasProperties(
       `
         SELECT
           s.*,
-          ARRAY_AGG(DISTINCT a.overview->>'network') AS networks,
+          ARRAY_AGG(DISTINCT concat(a.overview->>'shortName', ' v', a.overview->>'version')) AS atlas_names,
           ARRAY_AGG(DISTINCT a.overview->>'shortName') AS atlas_short_names,
-          ARRAY_AGG(DISTINCT a.overview->>'version') AS atlas_versions
+          ARRAY_AGG(DISTINCT a.overview->>'version') AS atlas_versions,
+          ARRAY_AGG(DISTINCT a.overview->>'network') AS networks
         FROM hat.source_studies s
         LEFT JOIN hat.atlases a ON a.source_studies @> to_jsonb(s.id)
         WHERE s.id=$1

--- a/app/services/source-studies.ts
+++ b/app/services/source-studies.ts
@@ -8,6 +8,7 @@ import {
   HCAAtlasTrackerDBPublishedSourceStudyInfo,
   HCAAtlasTrackerDBSourceStudy,
   HCAAtlasTrackerDBSourceStudyMinimumColumns,
+  HCAAtlasTrackerDBSourceStudyWithAtlasProperties,
   HCAAtlasTrackerDBSourceStudyWithRelatedEntities,
   HCAAtlasTrackerDBSourceStudyWithSourceDatasets,
   HCAAtlasTrackerDBValidation,
@@ -170,12 +171,12 @@ export async function createSourceStudy(
           undefined,
           "doi"
         );
+      await updateSourceStudyValidationsByEntityId(existingStudyId, client);
       const existingStudy = await getSourceStudy(
         atlasId,
         existingStudyId,
         client
       );
-      await updateSourceStudyValidations(existingStudy, client);
       await client.query("COMMIT");
       return existingStudy;
     }
@@ -193,7 +194,7 @@ export async function createSourceStudy(
     );
     // Add source datasets and validations
     await updateSourceStudyCellxGeneDatasets(newStudyRow, client);
-    await updateSourceStudyValidations(newStudyRow, client);
+    await updateSourceStudyValidationsByEntityId(newStudyRow.id, client);
     const newStudy = await getSourceStudy(atlasId, newStudyRow.id, client);
     await client.query("COMMIT");
     return newStudy;
@@ -278,7 +279,7 @@ export async function updateSourceStudy(
     const updatedStudyRow = queryResult.rows[0];
 
     await updateSourceStudyCellxGeneDatasets(updatedStudyRow, client);
-    await updateSourceStudyValidations(updatedStudyRow, client);
+    await updateSourceStudyValidationsByEntityId(sourceStudyId, client);
 
     const updatedStudy = await getSourceStudy(atlasId, sourceStudyId, client);
 
@@ -482,15 +483,64 @@ export async function updateSourceStudyValidationsByEntityId(
   entityId: string,
   client: pg.PoolClient
 ): Promise<void> {
-  const sourceStudy = (
-    await client.query<HCAAtlasTrackerDBSourceStudy>(
-      "SELECT * FROM hat.source_studies WHERE id=$1",
-      [entityId]
-    )
-  ).rows[0];
-  if (!sourceStudy)
-    throw new NotFoundError(`Source study with ID ${entityId} doesn't exist`);
-  await updateSourceStudyValidations(sourceStudy, client);
+  await updateSourceStudyValidations(
+    await getSourceStudyWithAtlasProperties(entityId, client),
+    client
+  );
+}
+
+/**
+ * Get all source studies, with properties of their atlases added.
+ * @param client - Postgres client to use.
+ * @returns source studies with atlas properties.
+ */
+export async function getSourceStudiesWithAtlasProperties(
+  client: pg.PoolClient
+): Promise<HCAAtlasTrackerDBSourceStudyWithAtlasProperties[]> {
+  const queryResult =
+    await client.query<HCAAtlasTrackerDBSourceStudyWithAtlasProperties>(`
+      SELECT
+        s.*,
+        ARRAY_AGG(DISTINCT a.overview->>'network') AS networks,
+        ARRAY_AGG(DISTINCT a.overview->>'shortName') AS atlas_short_names,
+        ARRAY_AGG(DISTINCT a.overview->>'version') AS atlas_versions
+      FROM hat.source_studies s
+      LEFT JOIN hat.atlases a ON a.source_studies @> to_jsonb(s.id)
+      GROUP BY s.id
+    `);
+  return queryResult.rows;
+}
+
+/**
+ * Get a specified source study, with properties of its atlases added.
+ * @param sourceStudyId - ID of the soruce study to get.
+ * @param client - Postgres client to use.
+ * @returns source studies with atlas properties.
+ */
+export async function getSourceStudyWithAtlasProperties(
+  sourceStudyId: string,
+  client: pg.PoolClient
+): Promise<HCAAtlasTrackerDBSourceStudyWithAtlasProperties> {
+  const queryResult =
+    await client.query<HCAAtlasTrackerDBSourceStudyWithAtlasProperties>(
+      `
+        SELECT
+          s.*,
+          ARRAY_AGG(DISTINCT a.overview->>'network') AS networks,
+          ARRAY_AGG(DISTINCT a.overview->>'shortName') AS atlas_short_names,
+          ARRAY_AGG(DISTINCT a.overview->>'version') AS atlas_versions
+        FROM hat.source_studies s
+        LEFT JOIN hat.atlases a ON a.source_studies @> to_jsonb(s.id)
+        WHERE s.id=$1
+        GROUP BY s.id
+      `,
+      [sourceStudyId]
+    );
+  if (queryResult.rows.length === 0)
+    throw new NotFoundError(
+      `Source study with ID ${sourceStudyId} doesn't exist`
+    );
+  return queryResult.rows[0];
 }
 
 /**

--- a/app/services/validations.ts
+++ b/app/services/validations.ts
@@ -187,7 +187,7 @@ export const SOURCE_STUDY_VALIDATIONS: ValidationDefinition<HCAAtlasTrackerDBSou
             const missingAtlases = sourceStudy.atlas_names.filter(
               (name) => !projectAtlasNames.includes(name)
             );
-            const missingNetworks = sourceStudy.atlas_names.filter(
+            const missingNetworks = sourceStudy.networks.filter(
               (name) => !projectInfo.networks.includes(name)
             );
             const info: ValidationStatusInfo = {

--- a/app/services/validations.ts
+++ b/app/services/validations.ts
@@ -184,11 +184,14 @@ export const SOURCE_STUDY_VALIDATIONS: ValidationDefinition<HCAAtlasTrackerDBSou
             const projectAtlasNames = projectInfo.atlases.map(
               ({ shortName, version }) => shortName + " " + version
             );
+            const projectNetworksLower = projectInfo.networks.map((name) =>
+              name.toLowerCase()
+            );
             const missingAtlases = sourceStudy.atlas_names.filter(
               (name) => !projectAtlasNames.includes(name)
             );
             const missingNetworks = sourceStudy.networks.filter(
-              (name) => !projectInfo.networks.includes(name)
+              (name) => !projectNetworksLower.includes(name.toLocaleLowerCase())
             );
             const info: ValidationStatusInfo = {
               ...infoProperties,

--- a/app/services/validations.ts
+++ b/app/services/validations.ts
@@ -9,11 +9,11 @@ import {
   VALIDATION_STATUS_BY_TASK_STATUS,
 } from "../apis/catalog/hca-atlas-tracker/common/constants";
 import {
-  DBEntityOfType,
   ENTITY_TYPE,
   HCAAtlasTrackerDBAtlas,
   HCAAtlasTrackerDBComment,
   HCAAtlasTrackerDBSourceStudy,
+  HCAAtlasTrackerDBSourceStudyWithAtlasProperties,
   HCAAtlasTrackerDBUser,
   HCAAtlasTrackerDBValidation,
   HCAAtlasTrackerDBValidationUpdateColumns,
@@ -23,6 +23,7 @@ import {
   SYSTEM,
   TaskStatusesUpdatedByDOIResult,
   TASK_STATUS,
+  ValidationDBEntityOfType,
   ValidationDifference,
   VALIDATION_ID,
   VALIDATION_STATUS,
@@ -36,7 +37,10 @@ import { updateTaskCounts } from "./atlases";
 import { createCommentThread, deleteCommentThread } from "./comments";
 import { doTransaction, getPoolClient, query } from "./database";
 import { getProjectInfoById } from "./hca-projects";
-import { getSourceStudiesByDois } from "./source-studies";
+import {
+  getSourceStudiesByDois,
+  getSourceStudiesWithAtlasProperties,
+} from "./source-studies";
 
 interface ValidationStatusInfo {
   differences?: ValidationDifference[];
@@ -68,7 +72,7 @@ const CHANGE_INDICATING_VALIDATION_KEYS = [
   "validationStatus",
 ] as const;
 
-export const SOURCE_STUDY_VALIDATIONS: ValidationDefinition<HCAAtlasTrackerDBSourceStudy>[] =
+export const SOURCE_STUDY_VALIDATIONS: ValidationDefinition<HCAAtlasTrackerDBSourceStudyWithAtlasProperties>[] =
   [
     {
       description: VALIDATION_DESCRIPTION.INGEST_SOURCE_STUDY,
@@ -259,8 +263,8 @@ export async function getValidationRecordsWithoutAtlasPropertiesForEntities(
  */
 function getValidationResult<T extends ENTITY_TYPE>(
   entityType: T,
-  validation: ValidationDefinition<DBEntityOfType<T>>,
-  entity: DBEntityOfType<T>,
+  validation: ValidationDefinition<ValidationDBEntityOfType<T>>,
+  entity: ValidationDBEntityOfType<T>,
   typeSpecificProperties: TypeSpecificValidationProperties
 ): HCAAtlasTrackerValidationResult | null {
   const validationStatusInfo = validation.validate(entity);
@@ -293,12 +297,7 @@ export async function refreshValidations(): Promise<void> {
  */
 async function revalidateAllSourceStudies(): Promise<void> {
   const client = await getPoolClient();
-  const sourceStudies = (
-    await client.query<HCAAtlasTrackerDBSourceStudy>(
-      "SELECT * FROM hat.source_studies"
-    )
-  ).rows;
-  for (const study of sourceStudies) {
+  for (const study of await getSourceStudiesWithAtlasProperties(client)) {
     try {
       await client.query("BEGIN");
       await updateSourceStudyValidations(study, client);
@@ -318,7 +317,7 @@ async function revalidateAllSourceStudies(): Promise<void> {
  * @param client - Postgres client to use.
  */
 export async function updateSourceStudyValidations(
-  sourceStudy: HCAAtlasTrackerDBSourceStudy,
+  sourceStudy: HCAAtlasTrackerDBSourceStudyWithAtlasProperties,
   client: pg.PoolClient
 ): Promise<void> {
   const validationResults = await getSourceStudyValidationResults(
@@ -472,7 +471,7 @@ function shouldUpdateValidation(
  * @returns validation results.
  */
 export async function getSourceStudyValidationResults(
-  sourceStudy: HCAAtlasTrackerDBSourceStudy,
+  sourceStudy: HCAAtlasTrackerDBSourceStudyWithAtlasProperties,
   client: pg.PoolClient
 ): Promise<HCAAtlasTrackerValidationResult[]> {
   const validationResults: HCAAtlasTrackerValidationResult[] = [];

--- a/app/utils/hca-projects.ts
+++ b/app/utils/hca-projects.ts
@@ -2,9 +2,11 @@ import { ProjectsResponse } from "../apis/azul/hca-dcp/common/responses";
 import { normalizeDoi } from "../utils/doi";
 
 export interface ProjectInfo {
+  atlases: { shortName: string; version: string }[];
   doi: string | null;
   hasPrimaryData: boolean;
   id: string;
+  networks: string[];
   title: string;
 }
 
@@ -16,11 +18,18 @@ export function getProjectsInfo(
     /^fastq(?:\.gz)?$/i.test(fileType.format)
   );
   for (const project of projectsResponse.projects) {
+    const networks = project.bionetworkName;
+    const atlases = project.tissueAtlas.map(({ atlas, version }) => ({
+      shortName: atlas,
+      version,
+    }));
     for (const publication of project.publications) {
       projectsInfo.push({
+        atlases,
         doi: publication.doi && normalizeDoi(publication.doi),
         hasPrimaryData,
         id: project.projectId,
+        networks,
         title: project.projectTitle,
       });
     }

--- a/app/utils/hca-projects.ts
+++ b/app/utils/hca-projects.ts
@@ -2,7 +2,7 @@ import { ProjectsResponse } from "../apis/azul/hca-dcp/common/responses";
 import { normalizeDoi } from "../utils/doi";
 
 export interface ProjectInfo {
-  atlases: { shortName: string; version: string }[];
+  atlases: { shortName: string; version: string | null }[];
   doi: string | null;
   hasPrimaryData: boolean;
   id: string;
@@ -29,10 +29,18 @@ export function getProjectsInfo(
         doi: publication.doi && normalizeDoi(publication.doi),
         hasPrimaryData,
         id: project.projectId,
-        networks,
+        networks: removeArrayNulls(networks),
         title: project.projectTitle,
       });
     }
   }
   return projectsInfo;
+}
+
+function removeArrayNulls<T>(array: (T | null)[]): T[] {
+  const result: T[] = [];
+  for (const item of array) {
+    if (item !== null) result.push(item);
+  }
+  return result;
 }

--- a/site-config/hca-atlas-tracker/local/index/tasks/tasksEntityConfig.ts
+++ b/site-config/hca-atlas-tracker/local/index/tasks/tasksEntityConfig.ts
@@ -204,6 +204,26 @@ export const tasksEntityConfig: EntityConfig = {
         title:
           "HCA Data Repository -  project title does not match publication title",
       },
+      {
+        filters: [
+          {
+            categoryKey: HCA_ATLAS_TRACKER_CATEGORY_KEY.DESCRIPTION,
+            value: [
+              VALIDATION_DESCRIPTION.LINK_PROJECT_BIONETWORKS_AND_ATLASES,
+            ],
+          },
+          {
+            categoryKey: HCA_ATLAS_TRACKER_CATEGORY_KEY.TASK_STATUS,
+            value: [TASK_STATUS.TODO],
+          },
+          {
+            categoryKey: HCA_ATLAS_TRACKER_CATEGORY_KEY.SYSTEM,
+            value: [SYSTEM.HCA_DATA_REPOSITORY],
+          },
+        ],
+        sorting: SAVED_FILTERS_SORTING_TARGET_COMPLETION_DATE,
+        title: "HCA Data Repository - Missing Network or Atlas",
+      },
     ],
   },
   detail: {

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -30,6 +30,9 @@ export const STAKEHOLDER_ANALOGOUS_ROLES = [
 export const STAKEHOLDER_ANALOGOUS_ROLES_WITHOUT_INTEGRATION_LEAD =
   STAKEHOLDER_ANALOGOUS_ROLES.filter((r) => r !== ROLE.INTEGRATION_LEAD);
 
+const ATLAS_SHORT_NAME_WITH_SOURCE_STUDY_VALIDATIONS_A =
+  "test-with-source-study-validations-a";
+
 // DOIS
 
 export const DOI_NORMAL = "10.123/test";
@@ -367,7 +370,16 @@ export const HCA_PROJECTS_RESPONSE_PUBLISHED_WITH_HCA =
   makeTestProjectsResponse(
     HCA_ID_PUBLISHED_WITH_HCA,
     DOI_PUBLISHED_WITH_HCA,
-    "Published With HCA"
+    "Published With HCA",
+    undefined,
+    [
+      {
+        shortName: ATLAS_SHORT_NAME_WITH_SOURCE_STUDY_VALIDATIONS_A,
+        version: "v5.4",
+      },
+      { shortName: "test-with-il", version: "v2.0" },
+    ],
+    ["organoid"]
   );
 
 export const HCA_PROJECTS_RESPONSE_PUBLISHED_WITH_HCA_TITLE_MISMATCH =
@@ -381,7 +393,15 @@ export const HCA_PROJECTS_RESPONSE_PUBLISHED_WITH_HCA_TITLE_NEAR_MATCH =
   makeTestProjectsResponse(
     HCA_ID_PUBLISHED_WITH_HCA_TITLE_NEAR_MATCH,
     DOI_PUBLISHED_WITH_HCA_TITLE_NEAR_MATCH,
-    "Published – With     Hca Title <i>Near</i> Match. "
+    "Published – With     Hca Title <i>Near</i> Match. ",
+    undefined,
+    [
+      {
+        shortName: ATLAS_SHORT_NAME_WITH_SOURCE_STUDY_VALIDATIONS_A,
+        version: "v5.4",
+      },
+    ],
+    ["organoid"]
   );
 
 export const HCA_PROJECTS_RESPONSE_PUBLISHED_WITH_NO_HCA_PRIMARY_DATA =
@@ -389,7 +409,14 @@ export const HCA_PROJECTS_RESPONSE_PUBLISHED_WITH_NO_HCA_PRIMARY_DATA =
     HCA_ID_PUBLISHED_WITH_NO_HCA_PRIMARY_DATA,
     DOI_PUBLISHED_WITH_NO_HCA_PRIMARY_DATA,
     "Published With No HCA Primary Data",
-    []
+    [],
+    [
+      {
+        shortName: ATLAS_SHORT_NAME_WITH_SOURCE_STUDY_VALIDATIONS_A,
+        version: "v5.4",
+      },
+    ],
+    ["organoid"]
   );
 
 export const HCA_PROJECTS_RESPONSE_PUBLISHED_WITH_UNCHANGING_IDS =
@@ -1601,7 +1628,7 @@ export const ATLAS_WITH_IL: TestAtlas = {
   network: "heart",
   publications: [],
   shortName: "test-with-il",
-  sourceStudies: [],
+  sourceStudies: [SOURCE_STUDY_PUBLISHED_WITH_HCA.id],
   status: ATLAS_STATUS.DRAFT,
   version: "2.0",
   wave: "3",
@@ -1649,7 +1676,7 @@ export const ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_A: TestAtlas = {
   integrationLead: [],
   network: "organoid",
   publications: [],
-  shortName: "test-with-source-study-validations-a",
+  shortName: ATLAS_SHORT_NAME_WITH_SOURCE_STUDY_VALIDATIONS_A,
   sourceStudies: [
     SOURCE_STUDY_PUBLISHED_WITH_HCA.id,
     SOURCE_STUDY_UNPUBLISHED_WITH_CELLXGENE.id,

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -1,3 +1,4 @@
+import { updateSourceStudyValidationsByEntityId } from "app/services/source-studies";
 import migrate from "node-pg-migrate";
 import { MigrationDirection } from "node-pg-migrate/dist/types";
 import pg from "pg";
@@ -13,7 +14,6 @@ import {
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { updateTaskCounts } from "../app/services/atlases";
 import { query } from "../app/services/database";
-import { updateSourceStudyValidations } from "../app/services/validations";
 import { getPoolConfig } from "../app/utils/__mocks__/pg-app-connect-config";
 import {
   INITIAL_TEST_ATLASES,
@@ -76,7 +76,7 @@ async function initDatabaseEntries(client: pg.PoolClient): Promise<void> {
     )
   ).rows;
   for (const study of dbSourceStudies) {
-    await updateSourceStudyValidations(study, client);
+    await updateSourceStudyValidationsByEntityId(study.id, client);
   }
 
   await updateTaskCounts();

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -129,7 +129,9 @@ export function makeTestProjectsResponse(
   id: string,
   doi: string,
   title: string,
-  fileFormats = ["fastq"]
+  fileFormats = ["fastq"],
+  atlases?: { shortName: string; version: string }[],
+  networks?: string[]
 ): ProjectsResponse {
   return {
     cellSuspensions: [],
@@ -147,6 +149,7 @@ export function makeTestProjectsResponse(
       {
         accessible: true,
         accessions: [],
+        bionetworkName: networks ?? [],
         contributedAnalyses: {},
         contributors: [],
         estimatedCellCount: 0,
@@ -165,6 +168,11 @@ export function makeTestProjectsResponse(
           },
         ],
         supplementaryLinks: [],
+        tissueAtlas:
+          atlases?.map(({ shortName, version }) => ({
+            atlas: shortName,
+            version,
+          })) ?? [],
       },
     ],
     protocols: [],


### PR DESCRIPTION
- Source studies provided to validations now have some atlas properties attached
- Differences listed in validation results can now be arrays, in which case, in the app, the values from `expected` that are missing from `actual` are displayed
- Networks are compared case-insensitively, since they're stored in lowercase in the tracker but appear to be capitalized in the data browser