### PR TITLE
feat: add form to create a user (#423)

### DIFF
--- a/__tests__/api-users-create.test.ts
+++ b/__tests__/api-users-create.test.ts
@@ -1,6 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
-import { testApiRole } from "testing/utils";
 import {
   HCAAtlasTrackerDBUser,
   HCAAtlasTrackerUser,
@@ -18,6 +17,7 @@ import {
 } from "../testing/constants";
 import { resetDatabase } from "../testing/db-utils";
 import { TestUser } from "../testing/entities";
+import { expectDbUserToMatchInputData, testApiRole } from "../testing/utils";
 
 jest.mock("../app/services/user-profile");
 jest.mock("../app/utils/crossref/crossref-api");
@@ -122,19 +122,15 @@ describe(TEST_ROUTE, () => {
     expect(newUser.roleAssociatedResourceIds).toEqual(
       NEW_USER_DATA.roleAssociatedResourceIds
     );
+
     const newUserFromDb = (
       await query<HCAAtlasTrackerDBUser>(
         "SELECT * FROM hat.users WHERE email=$1",
         [USER_NEW.email]
       )
     ).rows[0];
-    expect(newUserFromDb.disabled).toEqual(NEW_USER_DATA.disabled);
-    expect(newUserFromDb.email).toEqual(NEW_USER_DATA.email);
-    expect(newUserFromDb.full_name).toEqual(NEW_USER_DATA.fullName);
-    expect(newUserFromDb.role).toEqual(NEW_USER_DATA.role);
-    expect(newUserFromDb.role_associated_resource_ids).toEqual(
-      NEW_USER_DATA.roleAssociatedResourceIds
-    );
+
+    await expectDbUserToMatchInputData(newUserFromDb, NEW_USER_DATA);
   });
 });
 

--- a/__tests__/api-users-id.test.ts
+++ b/__tests__/api-users-id.test.ts
@@ -1,0 +1,284 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
+import {
+  HCAAtlasTrackerDBUser,
+  HCAAtlasTrackerUser,
+  ROLE,
+} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { UserEditData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
+import { METHOD } from "../app/common/entities";
+import { endPgPool, query } from "../app/services/database";
+import userHandler from "../pages/api/users/[id]";
+import {
+  INITIAL_TEST_USERS,
+  STAKEHOLDER_ANALOGOUS_ROLES,
+  USER_CONTENT_ADMIN,
+  USER_NONEXISTENT,
+  USER_STAKEHOLDER,
+  USER_UNREGISTERED,
+} from "../testing/constants";
+import { resetDatabase } from "../testing/db-utils";
+import { TestUser } from "../testing/entities";
+import {
+  expectApiUserToMatchTest,
+  expectDbUserToMatchInputData,
+  testApiRole,
+  withConsoleErrorHiding,
+} from "../testing/utils";
+
+jest.mock("../app/services/user-profile");
+jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/cellxgene");
+jest.mock("../app/utils/pg-app-connect-config");
+
+const TEST_ROUTE = "/api/users/[id]";
+
+const USER_STAKEHOLDER_EDIT: UserEditData = {
+  disabled: false,
+  email: "test-stakeholder-edited@example.com",
+  fullName: "test-stakeholder-edited",
+  role: ROLE.STAKEHOLDER,
+  roleAssociatedResourceIds: [],
+};
+
+let userIdsByEmail: Map<string, number>;
+
+beforeAll(async () => {
+  await resetDatabase();
+
+  const usersResult = await query<Pick<HCAAtlasTrackerDBUser, "id" | "email">>(
+    "SELECT id, email FROM hat.users"
+  );
+  userIdsByEmail = new Map(
+    usersResult.rows.map(({ email, id }) => [email, id])
+  );
+  userIdsByEmail.set(USER_NONEXISTENT.email, INITIAL_TEST_USERS.length + 100);
+});
+
+afterAll(async () => {
+  endPgPool();
+});
+
+describe(TEST_ROUTE, () => {
+  it("returns error 405 for non-GET, non-PATCH request", async () => {
+    expect(
+      (
+        await doUserRequest(USER_STAKEHOLDER, undefined, false, METHOD.POST)
+      )._getStatusCode()
+    ).toEqual(405);
+  });
+
+  it("returns error 401 when user is GET requested by logged out user", async () => {
+    expect((await doUserRequest(USER_STAKEHOLDER))._getStatusCode()).toEqual(
+      401
+    );
+  });
+
+  it("returns error 403 when user is GET requested by unregistered user", async () => {
+    expect(
+      (
+        await doUserRequest(USER_STAKEHOLDER, USER_UNREGISTERED)
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("GET returns error 404 when nonexistent user is requested", async () => {
+    expect(
+      (
+        await doUserRequest(USER_NONEXISTENT, USER_CONTENT_ADMIN, true)
+      )._getStatusCode()
+    ).toEqual(404);
+  });
+
+  for (const role of STAKEHOLDER_ANALOGOUS_ROLES) {
+    testApiRole(
+      "returns error 503",
+      TEST_ROUTE,
+      userHandler,
+      METHOD.GET,
+      role,
+      () => getQueryValues(USER_STAKEHOLDER),
+      undefined,
+      false,
+      (res) => {
+        expect(res._getStatusCode()).toEqual(403);
+      }
+    );
+  }
+
+  it("returns user when GET requested by logged in user with CONTENT_ADMIN role", async () => {
+    const res = await doUserRequest(USER_STAKEHOLDER, USER_CONTENT_ADMIN);
+    expect(res._getStatusCode()).toEqual(200);
+    const user = res._getJSONData() as HCAAtlasTrackerUser;
+    expectApiUserToMatchTest(user, USER_STAKEHOLDER);
+  });
+
+  it("returns error 401 when user is PATCH requested by logged out user", async () => {
+    expect(
+      (
+        await doUserRequest(
+          USER_STAKEHOLDER,
+          undefined,
+          false,
+          METHOD.PATCH,
+          USER_STAKEHOLDER_EDIT
+        )
+      )._getStatusCode()
+    ).toEqual(401);
+  });
+
+  it("returns error 403 when user is PATCH requested by unregistered user", async () => {
+    expect(
+      (
+        await doUserRequest(
+          USER_STAKEHOLDER,
+          USER_UNREGISTERED,
+          false,
+          METHOD.PATCH,
+          USER_STAKEHOLDER_EDIT
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("PATCH returns error 404 when nonexistent user is requested", async () => {
+    expect(
+      (
+        await doUserRequest(
+          USER_NONEXISTENT,
+          USER_CONTENT_ADMIN,
+          true,
+          METHOD.PATCH,
+          USER_STAKEHOLDER_EDIT
+        )
+      )._getStatusCode()
+    ).toEqual(404);
+  });
+
+  for (const role of STAKEHOLDER_ANALOGOUS_ROLES) {
+    testApiRole(
+      "returns error 503",
+      TEST_ROUTE,
+      userHandler,
+      METHOD.PATCH,
+      role,
+      () => getQueryValues(USER_STAKEHOLDER),
+      USER_STAKEHOLDER_EDIT,
+      false,
+      (res) => {
+        expect(res._getStatusCode()).toEqual(403);
+      }
+    );
+  }
+
+  it("returns error 400 when email value is not an email", async () => {
+    expect(
+      (
+        await doUserRequest(
+          USER_STAKEHOLDER,
+          USER_CONTENT_ADMIN,
+          true,
+          METHOD.PATCH,
+          {
+            ...USER_STAKEHOLDER_EDIT,
+            email: "notanemail",
+          }
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+  });
+
+  it("returns error 400 when role is undefined", async () => {
+    expect(
+      (
+        await doUserRequest(
+          USER_STAKEHOLDER,
+          USER_CONTENT_ADMIN,
+          true,
+          METHOD.PATCH,
+          {
+            ...USER_STAKEHOLDER_EDIT,
+            role: undefined,
+          }
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+  });
+
+  it("returns error 400 when role is not an actual role", async () => {
+    expect(
+      (
+        await doUserRequest(
+          USER_STAKEHOLDER,
+          USER_CONTENT_ADMIN,
+          true,
+          METHOD.PATCH,
+          {
+            ...USER_STAKEHOLDER_EDIT,
+            role: "notarole",
+          }
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+  });
+
+  it("updates and returns user when PATCH requested by logged in user with CONTENT_ADMIN role", async () => {
+    const res = await doUserRequest(
+      USER_STAKEHOLDER,
+      USER_CONTENT_ADMIN,
+      false,
+      METHOD.PATCH,
+      USER_STAKEHOLDER_EDIT
+    );
+    expect(res._getStatusCode()).toEqual(201);
+    const user = res._getJSONData() as HCAAtlasTrackerUser;
+    expectApiUserToMatchEdit(user, USER_STAKEHOLDER_EDIT);
+    const updatedUserFromDb = (
+      await query<HCAAtlasTrackerDBUser>(
+        "SELECT * FROM hat.users WHERE email=$1",
+        [USER_STAKEHOLDER_EDIT.email]
+      )
+    ).rows[0];
+    await expectDbUserToMatchInputData(
+      updatedUserFromDb,
+      USER_STAKEHOLDER_EDIT
+    );
+  });
+});
+
+async function doUserRequest(
+  targetUser: TestUser,
+  user?: TestUser,
+  hideConsoleError = false,
+  method = METHOD.GET,
+  updatedData?: Record<string, unknown>
+): Promise<httpMocks.MockResponse<NextApiResponse>> {
+  const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>({
+    body: updatedData,
+    headers: { authorization: user?.authorization },
+    method,
+    query: getQueryValues(targetUser),
+  });
+  await withConsoleErrorHiding(() => userHandler(req, res), hideConsoleError);
+  return res;
+}
+
+function getQueryValues(user: TestUser): Record<string, string> {
+  const userId = userIdsByEmail.get(user.email);
+  if (!userId)
+    throw new Error(`ID not found for test user email ${user.email}`);
+  return { id: String(userId) };
+}
+
+function expectApiUserToMatchEdit(
+  apiUser: HCAAtlasTrackerUser,
+  editData: UserEditData
+): void {
+  expect(apiUser.disabled).toEqual(editData.disabled);
+  expect(apiUser.email).toEqual(editData.email);
+  expect(apiUser.fullName).toEqual(editData.fullName);
+  expect(apiUser.role).toEqual(editData.role);
+  expect(apiUser.roleAssociatedResourceIds).toEqual(
+    editData.roleAssociatedResourceIds
+  );
+}

--- a/app/apis/catalog/hca-atlas-tracker/common/api.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/api.ts
@@ -7,10 +7,12 @@ export enum API {
   ATLAS_SOURCE_DATASETS = "/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets",
   ATLAS_SOURCE_STUDIES = "/api/atlases/[atlasId]/source-studies",
   ATLAS_SOURCE_STUDY = "/api/atlases/[atlasId]/source-studies/[sourceStudyId]",
+  ATLASES = "/api/atlases",
   CREATE_ATLAS = "/api/atlases/create",
   CREATE_ATLAS_COMPONENT_ATLAS = "/api/atlases/[atlasId]/component-atlases/create",
   CREATE_ATLAS_SOURCE_STUDY = "/api/atlases/[atlasId]/source-studies/create",
   CREATE_SOURCE_DATASET = "/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/create",
+  CREATE_USER = "/api/users/create",
   TASKS_COMPLETION_DATES = "/api/tasks/completion-dates",
   USER = "/api/me",
 }

--- a/app/apis/catalog/hca-atlas-tracker/common/api.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/api.ts
@@ -1,4 +1,5 @@
 export enum API {
+  ACTIVE_USER = "/api/me",
   ATLAS = "/api/atlases/[atlasId]",
   ATLAS_COMPONENT_ATLAS = "/api/atlases/[atlasId]/component-atlases/[componentAtlasId]",
   ATLAS_COMPONENT_ATLAS_SOURCE_DATASETS = "/api/atlases/[atlasId]/component-atlases/[componentAtlasId]/source-datasets",
@@ -14,5 +15,5 @@ export enum API {
   CREATE_SOURCE_DATASET = "/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/create",
   CREATE_USER = "/api/users/create",
   TASKS_COMPLETION_DATES = "/api/tasks/completion-dates",
-  USER = "/api/me",
+  USER = "/api/users/[userId]",
 }

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -484,6 +484,8 @@ export type SourceDatasetId = string;
 
 export type SourceStudyId = string;
 
+export type UserId = number;
+
 export interface ValidationDifference {
   actual: string | string[] | null;
   expected: string | string[];

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -339,6 +339,13 @@ export const newUserSchema = object({
 
 export type NewUserData = InferType<typeof newUserSchema>;
 
+/**
+ * Schema for data used to edit a user.
+ */
+export const userEditSchema = newUserSchema;
+
+export type UserEditData = InferType<typeof userEditSchema>;
+
 export const taskCompletionDatesSchema = object({
   targetCompletion: string().datetime().required().nullable(),
   taskIds: array(string().uuid().required()).required().min(1),

--- a/app/common/entities.ts
+++ b/app/common/entities.ts
@@ -3,6 +3,7 @@ import {
   ComponentAtlasId,
   SourceDatasetId,
   SourceStudyId,
+  UserId,
 } from "../apis/catalog/hca-atlas-tracker/common/entities";
 
 export enum FETCH_STATUS {
@@ -25,4 +26,5 @@ export interface PathParameter {
   componentAtlasId?: ComponentAtlasId;
   sourceDatasetId?: SourceDatasetId;
   sourceStudyId?: SourceStudyId;
+  userId?: UserId;
 }

--- a/app/components/Detail/components/TrackerForm/components/Breadcrumbs/common/constants.ts
+++ b/app/components/Detail/components/TrackerForm/components/Breadcrumbs/common/constants.ts
@@ -24,3 +24,9 @@ export const BREADCRUMB_SOURCE_STUDY: Breadcrumb = {
   route: ROUTE.SOURCE_STUDY,
   text: "Source Study",
 };
+
+export const BREADCRUMB_USERS: Breadcrumb = {
+  path: ROUTE.USERS,
+  route: ROUTE.USERS,
+  text: "Team",
+};

--- a/app/components/Detail/components/TrackerForm/components/Breadcrumbs/common/constants.ts
+++ b/app/components/Detail/components/TrackerForm/components/Breadcrumbs/common/constants.ts
@@ -25,6 +25,12 @@ export const BREADCRUMB_SOURCE_STUDY: Breadcrumb = {
   text: "Source Study",
 };
 
+export const BREADCRUMB_USER: Breadcrumb = {
+  path: ROUTE.USER,
+  route: ROUTE.USER,
+  text: "User",
+};
+
 export const BREADCRUMB_USERS: Breadcrumb = {
   path: ROUTE.USERS,
   route: ROUTE.USERS,

--- a/app/components/Detail/components/TrackerForm/components/Breadcrumbs/common/utils.ts
+++ b/app/components/Detail/components/TrackerForm/components/Breadcrumbs/common/utils.ts
@@ -13,6 +13,7 @@ import {
   BREADCRUMB_ATLASES,
   BREADCRUMB_COMPONENT_ATLAS,
   BREADCRUMB_SOURCE_STUDY,
+  BREADCRUMB_USERS,
 } from "./constants";
 
 /**
@@ -72,6 +73,14 @@ export function getSourceStudyBreadcrumb(
   );
   if (!sourceStudy) return breadcrumb;
   return { ...breadcrumb, text: sourceStudy.title };
+}
+
+/**
+ * Returns the breadcrumb for the users view.
+ * @returns users view breadcrumb.
+ */
+export function getUsersBreadcrumb(): Breadcrumb {
+  return BREADCRUMB_USERS;
 }
 
 /**

--- a/app/components/Detail/components/TrackerForm/components/Breadcrumbs/common/utils.ts
+++ b/app/components/Detail/components/TrackerForm/components/Breadcrumbs/common/utils.ts
@@ -2,6 +2,7 @@ import {
   HCAAtlasTrackerAtlas,
   HCAAtlasTrackerComponentAtlas,
   HCAAtlasTrackerSourceStudy,
+  HCAAtlasTrackerUser,
 } from "../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { getAtlasName } from "../../../../../../../apis/catalog/hca-atlas-tracker/common/utils";
 import { PathParameter } from "../../../../../../../common/entities";
@@ -13,6 +14,7 @@ import {
   BREADCRUMB_ATLASES,
   BREADCRUMB_COMPONENT_ATLAS,
   BREADCRUMB_SOURCE_STUDY,
+  BREADCRUMB_USER,
   BREADCRUMB_USERS,
 } from "./constants";
 
@@ -73,6 +75,21 @@ export function getSourceStudyBreadcrumb(
   );
   if (!sourceStudy) return breadcrumb;
   return { ...breadcrumb, text: sourceStudy.title };
+}
+
+/**
+ * Returns the breadcrumb for the user view.
+ * @param pathParameter - Path parameter.
+ * @param user - User.
+ * @returns user view breadcrumb.
+ */
+export function getUserBreadcrumb(
+  pathParameter?: PathParameter,
+  user?: HCAAtlasTrackerUser
+): Breadcrumb {
+  const breadcrumb = resolveBreadcrumbPath(BREADCRUMB_USER, pathParameter);
+  if (!user) return breadcrumb;
+  return { ...breadcrumb, text: user.fullName };
 }
 
 /**

--- a/app/components/Forms/components/User/user.tsx
+++ b/app/components/Forms/components/User/user.tsx
@@ -94,11 +94,13 @@ export const UserForm = ({
                 label="Role"
                 readOnly={isReadOnly}
               >
-                {Object.keys(ROLE).map((role) => (
-                  <MMenuItem key={role} value={role}>
-                    {role}
-                  </MMenuItem>
-                ))}
+                {Object.keys(ROLE).map((role) =>
+                  role === ROLE.UNREGISTERED ? null : (
+                    <MMenuItem key={role} value={role}>
+                      {role}
+                    </MMenuItem>
+                  )
+                )}
               </Select>
             )}
           />

--- a/app/components/Forms/components/User/user.tsx
+++ b/app/components/Forms/components/User/user.tsx
@@ -77,7 +77,7 @@ export const UserForm = ({
                 error={Boolean(errors[FIELD_NAME.EMAIL])}
                 helperText={errors[FIELD_NAME.EMAIL]?.message}
                 isFilled={Boolean(field.value)}
-                label="Email"
+                label="Gmail/Google Workspace email"
                 readOnly={isReadOnly}
               />
             )}

--- a/app/components/Forms/components/User/user.tsx
+++ b/app/components/Forms/components/User/user.tsx
@@ -34,6 +34,7 @@ export const UserForm = ({
   formMethod,
 }: UserFormProps): JSX.Element => {
   const { atlases } = useFetchAtlases();
+  const selectedRole = formMethod.watch(FIELD_NAME.ROLE);
   if (accessFallback) return <Fragment>{accessFallback}</Fragment>;
   const {
     formStatus: { isReadOnly },
@@ -101,29 +102,33 @@ export const UserForm = ({
               </Select>
             )}
           />
-          <Controller
-            control={control}
-            name={FIELD_NAME.ROLE_ASSOCIATED_RESOURCE_IDS}
-            render={({ field }): JSX.Element => (
-              <Select
-                {...field}
-                error={Boolean(errors[FIELD_NAME.ROLE_ASSOCIATED_RESOURCE_IDS])}
-                helperText={
-                  errors[FIELD_NAME.ROLE_ASSOCIATED_RESOURCE_IDS]?.message
-                }
-                isFilled={Boolean(field.value)}
-                label="Associated atlases"
-                multiple
-                readOnly={isReadOnly}
-              >
-                {(atlases ?? []).map((atlas) => (
-                  <MMenuItem key={atlas.id} value={atlas.id}>
-                    {atlas.shortName} v{atlas.version}
-                  </MMenuItem>
-                ))}
-              </Select>
-            )}
-          />
+          {selectedRole === ROLE.INTEGRATION_LEAD ? (
+            <Controller
+              control={control}
+              name={FIELD_NAME.ROLE_ASSOCIATED_RESOURCE_IDS}
+              render={({ field }): JSX.Element => (
+                <Select
+                  {...field}
+                  error={Boolean(
+                    errors[FIELD_NAME.ROLE_ASSOCIATED_RESOURCE_IDS]
+                  )}
+                  helperText={
+                    errors[FIELD_NAME.ROLE_ASSOCIATED_RESOURCE_IDS]?.message
+                  }
+                  isFilled={Boolean(field.value)}
+                  label="Associated atlases"
+                  multiple
+                  readOnly={isReadOnly}
+                >
+                  {(atlases ?? []).map((atlas) => (
+                    <MMenuItem key={atlas.id} value={atlas.id}>
+                      {atlas.shortName} v{atlas.version}
+                    </MMenuItem>
+                  ))}
+                </Select>
+              )}
+            />
+          ) : null}
         </SectionCard>
       </Section>
     </TrackerForm>

--- a/app/components/Forms/components/User/user.tsx
+++ b/app/components/Forms/components/User/user.tsx
@@ -1,0 +1,131 @@
+import { MenuItem as MMenuItem } from "@mui/material";
+import { Fragment, ReactNode } from "react";
+import { Controller } from "react-hook-form";
+import { useFetchAtlases } from "../../../..//hooks/useFetchAtlases";
+import {
+  HCAAtlasTrackerUser,
+  ROLE,
+} from "../../../../apis/catalog/hca-atlas-tracker/common/entities";
+import {
+  SectionCard,
+  SectionHero,
+  SectionTitle,
+} from "../../../../components/Detail/components/TrackerForm/components/Section/section.styles";
+import { FormMethod } from "../../../../hooks/useForm/common/entities";
+import { FormManager as FormManagerProps } from "../../../../hooks/useFormManager/common/entities";
+import { FIELD_NAME } from "../../../../views/AddNewUserView/common/constants";
+import { NewUserData } from "../../../../views/AddNewUserView/common/entities";
+import { FormManager } from "../../../common/Form/components/FormManager/formManager";
+import { Input } from "../../../common/Form/components/Input/input";
+import { Select } from "../../../common/Form/components/Select/select";
+import { Divider } from "../../../Detail/components/TrackerForm/components/Divider/divider.styles";
+import { Section } from "../../../Detail/components/TrackerForm/components/Section/section.styles";
+import { TrackerForm } from "../../../Detail/components/TrackerForm/trackerForm";
+
+interface UserFormProps {
+  accessFallback: ReactNode;
+  formManager: FormManagerProps;
+  formMethod: FormMethod<NewUserData, HCAAtlasTrackerUser>;
+}
+
+export const UserForm = ({
+  accessFallback,
+  formManager,
+  formMethod,
+}: UserFormProps): JSX.Element => {
+  const { atlases } = useFetchAtlases();
+  if (accessFallback) return <Fragment>{accessFallback}</Fragment>;
+  const {
+    formStatus: { isReadOnly },
+  } = formManager;
+  const {
+    control,
+    formState: { errors },
+  } = formMethod;
+  return (
+    <TrackerForm>
+      <FormManager {...formManager} />
+      <Divider />
+      <Section>
+        <SectionHero>
+          <SectionTitle>General info</SectionTitle>
+        </SectionHero>
+        <SectionCard>
+          <Controller
+            control={control}
+            key={FIELD_NAME.FULL_NAME}
+            name={FIELD_NAME.FULL_NAME}
+            render={({ field }): JSX.Element => (
+              <Input
+                {...field}
+                error={Boolean(errors[FIELD_NAME.FULL_NAME])}
+                helperText={errors[FIELD_NAME.FULL_NAME]?.message}
+                isFilled={Boolean(field.value)}
+                label="Name"
+                readOnly={isReadOnly}
+              />
+            )}
+          />
+          <Controller
+            control={control}
+            key={FIELD_NAME.EMAIL}
+            name={FIELD_NAME.EMAIL}
+            render={({ field }): JSX.Element => (
+              <Input
+                {...field}
+                error={Boolean(errors[FIELD_NAME.EMAIL])}
+                helperText={errors[FIELD_NAME.EMAIL]?.message}
+                isFilled={Boolean(field.value)}
+                label="Email"
+                readOnly={isReadOnly}
+              />
+            )}
+          />
+          <Controller
+            control={control}
+            name={FIELD_NAME.ROLE}
+            render={({ field }): JSX.Element => (
+              <Select
+                {...field}
+                error={Boolean(errors[FIELD_NAME.ROLE])}
+                helperText={errors[FIELD_NAME.ROLE]?.message}
+                isFilled={Boolean(field.value)}
+                label="Role"
+                readOnly={isReadOnly}
+              >
+                {Object.keys(ROLE).map((role) => (
+                  <MMenuItem key={role} value={role}>
+                    {role}
+                  </MMenuItem>
+                ))}
+              </Select>
+            )}
+          />
+          <Controller
+            control={control}
+            name={FIELD_NAME.ROLE_ASSOCIATED_RESOURCE_IDS}
+            render={({ field }): JSX.Element => (
+              <Select
+                {...field}
+                error={Boolean(errors[FIELD_NAME.ROLE_ASSOCIATED_RESOURCE_IDS])}
+                helperText={
+                  errors[FIELD_NAME.ROLE_ASSOCIATED_RESOURCE_IDS]?.message
+                }
+                isFilled={Boolean(field.value)}
+                label="Associated atlases"
+                multiple
+                readOnly={isReadOnly}
+              >
+                {(atlases ?? []).map((atlas) => (
+                  <MMenuItem key={atlas.id} value={atlas.id}>
+                    {atlas.shortName} v{atlas.version}
+                  </MMenuItem>
+                ))}
+              </Select>
+            )}
+          />
+        </SectionCard>
+      </Section>
+    </TrackerForm>
+  );
+};

--- a/app/components/Forms/components/User/user.tsx
+++ b/app/components/Forms/components/User/user.tsx
@@ -102,6 +102,23 @@ export const UserForm = ({
               </Select>
             )}
           />
+          <Controller
+            control={control}
+            name={FIELD_NAME.DISABLED}
+            render={({ field }): JSX.Element => (
+              <Select
+                {...field}
+                error={Boolean(errors[FIELD_NAME.DISABLED])}
+                helperText={errors[FIELD_NAME.DISABLED]?.message}
+                isFilled={Boolean(field.value)}
+                label={<br />}
+                readOnly={isReadOnly}
+              >
+                <MMenuItem value={"enabled"}>Enabled</MMenuItem>
+                <MMenuItem value={"disabled"}>Disabled</MMenuItem>
+              </Select>
+            )}
+          />
           {selectedRole === ROLE.INTEGRATION_LEAD ? (
             <Controller
               control={control}

--- a/app/components/Layout/components/IndexPage/components/Hero/components/HeroActions/heroActions.tsx
+++ b/app/components/Layout/components/IndexPage/components/Hero/components/HeroActions/heroActions.tsx
@@ -1,8 +1,7 @@
 import { useRouter } from "next/router";
 import { useFormManager } from "../../../../../../../../hooks/useFormManager/useFormManager";
 import { ROUTE } from "../../../../../../../../routes/constants";
-import { BUTTON_COLOR } from "../../../../../../../common/Button/components/ButtonLink/buttonLink";
-import { Button } from "./heroActions.styles";
+import { HeroButton } from "../../../HeroButton/heroButton";
 
 export const HeroActions = (): JSX.Element | null => {
   const { asPath } = useRouter();
@@ -10,8 +9,6 @@ export const HeroActions = (): JSX.Element | null => {
     access: { canEdit },
   } = useFormManager();
   return canEdit && asPath.startsWith(ROUTE.ATLASES) ? (
-    <Button color={BUTTON_COLOR.PRIMARY} href={ROUTE.CREATE_ATLAS}>
-      Add Atlas
-    </Button>
+    <HeroButton href={ROUTE.CREATE_ATLAS}>Add Atlas</HeroButton>
   ) : null;
 };

--- a/app/components/Layout/components/IndexPage/components/HeroButton/heroButton.styles.ts
+++ b/app/components/Layout/components/IndexPage/components/HeroButton/heroButton.styles.ts
@@ -3,7 +3,7 @@ import {
   mediaTabletUp,
 } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
 import styled from "@emotion/styled";
-import { ButtonLink } from "../../../../../../../common/Button/components/ButtonLink/buttonLink";
+import { ButtonLink } from "../../../../../common/Button/components/ButtonLink/buttonLink";
 
 export const Button = styled(ButtonLink)`
   ${mediaTabletUp} {

--- a/app/components/Layout/components/IndexPage/components/HeroButton/heroButton.tsx
+++ b/app/components/Layout/components/IndexPage/components/HeroButton/heroButton.tsx
@@ -1,0 +1,9 @@
+import {
+  ButtonLinkProps,
+  BUTTON_COLOR,
+} from "../../../../../common/Button/components/ButtonLink/buttonLink";
+import { Button } from "./heroButton.styles";
+
+export const HeroButton = (props: ButtonLinkProps): JSX.Element | null => {
+  return <Button {...props} color={BUTTON_COLOR.PRIMARY} />;
+};

--- a/app/components/Layout/components/IndexPage/components/UsersHero/components/UsersHeroActions/usersHeroActions.tsx
+++ b/app/components/Layout/components/IndexPage/components/UsersHero/components/UsersHeroActions/usersHeroActions.tsx
@@ -1,0 +1,15 @@
+import { useFormManager } from "../../../../../../../../hooks/useFormManager/useFormManager";
+import { ROUTE } from "../../../../../../../../routes/constants";
+import { BUTTON_COLOR } from "../../../../../../../common/Button/components/ButtonLink/buttonLink";
+import { Button } from "../../../Hero/components/HeroActions/heroActions.styles";
+
+export const UsersHeroActions = (): JSX.Element | null => {
+  const {
+    access: { canEdit },
+  } = useFormManager();
+  return canEdit ? (
+    <Button color={BUTTON_COLOR.PRIMARY} href={ROUTE.CREATE_USER}>
+      Add User
+    </Button>
+  ) : null;
+};

--- a/app/components/Layout/components/IndexPage/components/UsersHero/components/UsersHeroActions/usersHeroActions.tsx
+++ b/app/components/Layout/components/IndexPage/components/UsersHero/components/UsersHeroActions/usersHeroActions.tsx
@@ -1,15 +1,12 @@
 import { useFormManager } from "../../../../../../../../hooks/useFormManager/useFormManager";
 import { ROUTE } from "../../../../../../../../routes/constants";
-import { BUTTON_COLOR } from "../../../../../../../common/Button/components/ButtonLink/buttonLink";
-import { Button } from "../../../Hero/components/HeroActions/heroActions.styles";
+import { HeroButton } from "../../../HeroButton/heroButton";
 
 export const UsersHeroActions = (): JSX.Element | null => {
   const {
     access: { canEdit },
   } = useFormManager();
   return canEdit ? (
-    <Button color={BUTTON_COLOR.PRIMARY} href={ROUTE.CREATE_USER}>
-      Add User
-    </Button>
+    <HeroButton href={ROUTE.CREATE_USER}>Add User</HeroButton>
   ) : null;
 };

--- a/app/components/Layout/components/IndexPage/components/UsersHero/usersHero.tsx
+++ b/app/components/Layout/components/IndexPage/components/UsersHero/usersHero.tsx
@@ -1,0 +1,12 @@
+import { Title } from "@databiosphere/findable-ui/lib/components/common/Title/title";
+import { Fragment } from "react";
+import { UsersHeroActions } from "./components/UsersHeroActions/usersHeroActions";
+
+export const UsersHero = (): JSX.Element => {
+  return (
+    <Fragment>
+      <Title title="Team" />
+      <UsersHeroActions />
+    </Fragment>
+  );
+};

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -25,6 +25,7 @@ export { PreviewTask } from "./Index/components/ViewTasks/components/PreviewTask
 export { HCABranding } from "./Layout/components/Footer/components/Branding/components/HCABranding/hcaBranding";
 export { LabelIconMenuItem } from "./Layout/components/Header/components/Content/components/Navigation/components/NavigationMenuItems/components/LabelIconMenuItem/labelIconMenuItem";
 export { Hero } from "./Layout/components/IndexPage/components/Hero/hero";
+export { UsersHero } from "./Layout/components/IndexPage/components/UsersHero/usersHero";
 export { AnalysisPortalCell } from "./Table/components/TableCell/components/AnalysisPortalCell/analysisPortalCell";
 export { BioNetworkCell } from "./Table/components/TableCell/components/BioNetworkCell/bioNetworkCell";
 export { ButtonTextPrimaryCell } from "./Table/components/TableCell/components/ButtonTextPrimaryCell/buttonTextPrimaryCell.styles";

--- a/app/hooks/useFetchActiveUser.ts
+++ b/app/hooks/useFetchActiveUser.ts
@@ -1,0 +1,13 @@
+import { API } from "../apis/catalog/hca-atlas-tracker/common/api";
+import { HCAAtlasTrackerActiveUser } from "../apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "../common/entities";
+import { useFetchData } from "./useFetchData";
+
+export const useFetchActiveUser = (): HCAAtlasTrackerActiveUser | undefined => {
+  const { data: user } = useFetchData<HCAAtlasTrackerActiveUser | undefined>(
+    API.ACTIVE_USER,
+    METHOD.GET
+  );
+
+  return user;
+};

--- a/app/hooks/useFetchAtlases.ts
+++ b/app/hooks/useFetchAtlases.ts
@@ -1,0 +1,17 @@
+import { API } from "../apis/catalog/hca-atlas-tracker/common/api";
+import { HCAAtlasTrackerAtlas } from "../apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "../common/entities";
+import { getRequestURL } from "../common/utils";
+import { useFetchData } from "./useFetchData";
+
+interface UseFetchAtlas {
+  atlases?: HCAAtlasTrackerAtlas[];
+}
+
+export const useFetchAtlases = (): UseFetchAtlas => {
+  const { data: atlases } = useFetchData<HCAAtlasTrackerAtlas[] | undefined>(
+    getRequestURL(API.ATLASES),
+    METHOD.GET
+  );
+  return { atlases };
+};

--- a/app/hooks/useFetchUser.ts
+++ b/app/hooks/useFetchUser.ts
@@ -1,13 +1,17 @@
 import { API } from "../apis/catalog/hca-atlas-tracker/common/api";
-import { HCAAtlasTrackerActiveUser } from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../common/entities";
+import { HCAAtlasTrackerUser } from "../apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD, PathParameter } from "../common/entities";
+import { getRequestURL } from "../common/utils";
 import { useFetchData } from "./useFetchData";
 
-export const useFetchUser = (): HCAAtlasTrackerActiveUser | undefined => {
-  const { data: user } = useFetchData<HCAAtlasTrackerActiveUser | undefined>(
-    API.USER,
+interface UseFetchUser {
+  user?: HCAAtlasTrackerUser;
+}
+
+export const useFetchUser = (pathParameter: PathParameter): UseFetchUser => {
+  const { data: user } = useFetchData<HCAAtlasTrackerUser | undefined>(
+    getRequestURL(API.USER, pathParameter),
     METHOD.GET
   );
-
-  return user;
+  return { user };
 };

--- a/app/providers/authorization.tsx
+++ b/app/providers/authorization.tsx
@@ -5,7 +5,7 @@ import {
   HCAAtlasTrackerActiveUser,
   ROLE,
 } from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { useFetchUser } from "../hooks/useFetchUser";
+import { useFetchActiveUser } from "../hooks/useFetchActiveUser";
 import { ROUTE } from "../routes/constants";
 
 export interface AuthorizationContextProps {
@@ -22,7 +22,7 @@ interface Props {
 
 export function AuthorizationProvider({ children }: Props): JSX.Element {
   const { isAuthenticated } = useAuthentication();
-  const user = useFetchUser();
+  const user = useFetchActiveUser();
   const { role } = user || {};
   const isAuthorized = isUserAuthorized(role);
 

--- a/app/routes/constants.ts
+++ b/app/routes/constants.ts
@@ -6,6 +6,7 @@ export const ROUTE = {
   CREATE_ATLAS: "/atlases/create",
   CREATE_COMPONENT_ATLAS: "/atlases/[atlasId]/component-atlases/create",
   CREATE_SOURCE_STUDY: "/atlases/[atlasId]/source-studies/create",
+  CREATE_USER: "/team/create",
   LOGIN: "/login",
   OVERVIEW: "/overview",
   REGISTRATION_REQUIRED: "/registration-required",

--- a/app/routes/constants.ts
+++ b/app/routes/constants.ts
@@ -17,6 +17,7 @@ export const ROUTE = {
     "/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets",
   SOURCE_STUDIES: "/atlases/[atlasId]/source-studies",
   SOURCE_STUDY: "/atlases/[atlasId]/source-studies/[sourceStudyId]",
+  USER: "/team/[userId]",
   USERS: "/team",
   VALIDATIONS_AND_TASKS: "/validations-and-tasks",
 } as const;

--- a/app/services/users.ts
+++ b/app/services/users.ts
@@ -135,6 +135,8 @@ export async function updateUser(
       id,
     ]
   );
+  if (queryResult.rows.length === 0)
+    throw new NotFoundError(`User with ID ${id} doesn't exist`);
   return await getUserById(queryResult.rows[0].id);
 }
 

--- a/app/services/users.ts
+++ b/app/services/users.ts
@@ -65,6 +65,35 @@ export async function getUserByEmail(
 }
 
 /**
+ * Get a user by ID.
+ * @param id - ID of user to get.
+ * @returns user.
+ */
+export async function getUserById(
+  id: number
+): Promise<HCAAtlasTrackerDBUserWithAssociatedResources> {
+  const queryResult = await query<HCAAtlasTrackerDBUserWithAssociatedResources>(
+    `
+      SELECT
+        u.*,
+        (
+          CASE WHEN cardinality(u.role_associated_resource_ids) = 0 THEN '{}'::text[]
+          ELSE ARRAY_AGG(DISTINCT concat(a.overview->>'shortName', ' v', a.overview->>'version'))
+          END
+        ) AS role_associated_resource_names
+      FROM hat.users u
+      LEFT JOIN hat.atlases a ON a.id=ANY(u.role_associated_resource_ids)
+      WHERE u.id=$1
+      GROUP BY u.id
+    `,
+    [id]
+  );
+  if (queryResult.rows.length === 0)
+    throw new NotFoundError(`User with ID ${id} doesn't exist`);
+  return queryResult.rows[0];
+}
+
+/**
  * Create a user.
  * @param inputData - Values used to create the new user.
  * @returns new user.
@@ -72,8 +101,8 @@ export async function getUserByEmail(
 export async function createUser(
   inputData: NewUserData
 ): Promise<HCAAtlasTrackerDBUserWithAssociatedResources> {
-  await query<HCAAtlasTrackerDBUser>(
-    "INSERT INTO hat.users (disabled, email, full_name, role, role_associated_resource_ids) VALUES ($1, $2, $3, $4, $5)",
+  const queryResult = await query<Pick<HCAAtlasTrackerDBUser, "id">>(
+    "INSERT INTO hat.users (disabled, email, full_name, role, role_associated_resource_ids) VALUES ($1, $2, $3, $4, $5) RETURNING id",
     [
       inputData.disabled.toString(),
       inputData.email,
@@ -82,7 +111,7 @@ export async function createUser(
       inputData.roleAssociatedResourceIds,
     ]
   );
-  return await getUserByEmail(inputData.email);
+  return await getUserById(queryResult.rows[0].id);
 }
 
 /**
@@ -95,8 +124,8 @@ export async function updateUser(
   id: number,
   inputData: UserEditData
 ): Promise<HCAAtlasTrackerDBUserWithAssociatedResources> {
-  await query<HCAAtlasTrackerDBUser>(
-    "UPDATE hat.users SET disabled=$1, email=$2, full_name=$3, role=$4, role_associated_resource_ids=$5 WHERE id=$6",
+  const queryResult = await query<Pick<HCAAtlasTrackerDBUser, "id">>(
+    "UPDATE hat.users SET disabled=$1, email=$2, full_name=$3, role=$4, role_associated_resource_ids=$5 WHERE id=$6 RETURNING id",
     [
       inputData.disabled.toString(),
       inputData.email,
@@ -106,7 +135,7 @@ export async function updateUser(
       id,
     ]
   );
-  return await getUserByEmail(inputData.email);
+  return await getUserById(queryResult.rows[0].id);
 }
 
 /**

--- a/app/services/users.ts
+++ b/app/services/users.ts
@@ -1,4 +1,7 @@
-import { NewUserData } from "app/apis/catalog/hca-atlas-tracker/common/schema";
+import {
+  NewUserData,
+  UserEditData,
+} from "app/apis/catalog/hca-atlas-tracker/common/schema";
 import {
   HCAAtlasTrackerDBUser,
   HCAAtlasTrackerDBUserWithAssociatedResources,
@@ -77,6 +80,30 @@ export async function createUser(
       inputData.fullName,
       inputData.role,
       inputData.roleAssociatedResourceIds,
+    ]
+  );
+  return await getUserByEmail(inputData.email);
+}
+
+/**
+ * Update a user.
+ * @param id - ID of the user to update.
+ * @param inputData - Values used to update a user.
+ * @returns updated user.
+ */
+export async function updateUser(
+  id: number,
+  inputData: UserEditData
+): Promise<HCAAtlasTrackerDBUserWithAssociatedResources> {
+  await query<HCAAtlasTrackerDBUser>(
+    "UPDATE hat.users SET disabled=$1, email=$2, full_name=$3, role=$4, role_associated_resource_ids=$5 WHERE id=$6",
+    [
+      inputData.disabled.toString(),
+      inputData.email,
+      inputData.fullName,
+      inputData.role,
+      inputData.roleAssociatedResourceIds,
+      id,
     ]
   );
   return await getUserByEmail(inputData.email);

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -705,9 +705,10 @@ export const buildUserEmail = (
  */
 export const buildUserFullName = (
   user: HCAAtlasTrackerUser
-): ComponentProps<typeof C.BasicCell> => {
+): ComponentProps<typeof C.Link> => {
   return {
-    value: user.fullName,
+    label: user.fullName,
+    url: getRouteURL(ROUTE.USER, { userId: user.id }),
   };
 };
 

--- a/app/views/AddNewUserView/addNewUserView.tsx
+++ b/app/views/AddNewUserView/addNewUserView.tsx
@@ -1,0 +1,51 @@
+import { Fragment } from "react";
+import { AccessDeniedPrompt } from "../../components/common/Form/components/FormManager/components/AccessDeniedPrompt/accessDeniedPrompt";
+import { AccessPrompt } from "../../components/common/Form/components/FormManager/components/AccessPrompt/accessPrompt";
+import { Breadcrumbs } from "../../components/Detail/components/TrackerForm/components/Breadcrumbs/breadcrumbs";
+import { Divider } from "../../components/Detail/components/TrackerForm/components/Divider/divider.styles";
+import { UserForm } from "../../components/Forms/components/User/user";
+import { DetailView } from "../../components/Layout/components/Detail/detailView";
+import { FormManager } from "../../hooks/useFormManager/common/entities";
+import { getBreadcrumbs } from "./common/utils";
+import { useAddUserForm } from "./hooks/useAddUserForm";
+import { useAddUserFormManager } from "./hooks/useAddUserFormManager";
+
+export const AddNewUserView = (): JSX.Element => {
+  const formMethod = useAddUserForm();
+  const formManager = useAddUserFormManager(formMethod);
+  const { formAction, isLoading } = formManager;
+  if (isLoading) return <Fragment />;
+  return (
+    <DetailView
+      breadcrumbs={
+        <Breadcrumbs
+          breadcrumbs={getBreadcrumbs()}
+          onNavigate={formAction?.onNavigate}
+        />
+      }
+      mainColumn={
+        <UserForm
+          accessFallback={renderAccessFallback(formManager)}
+          formManager={formManager}
+          formMethod={formMethod}
+        />
+      }
+      title="Add New User"
+    />
+  );
+};
+
+/**
+ * Returns the access fallback component from the form manager access state.
+ * @param formManager - Form manager.
+ * @returns access fallback component.
+ */
+function renderAccessFallback(formManager: FormManager): JSX.Element | null {
+  const {
+    access: { canEdit, canView },
+  } = formManager;
+  if (!canView)
+    return <AccessPrompt divider={<Divider />} text="to add a new user" />;
+  if (!canEdit) return <AccessDeniedPrompt divider={<Divider />} />;
+  return null;
+}

--- a/app/views/AddNewUserView/common/constants.ts
+++ b/app/views/AddNewUserView/common/constants.ts
@@ -1,0 +1,7 @@
+export const FIELD_NAME = {
+  DISABLED: "disabled",
+  EMAIL: "email",
+  FULL_NAME: "fullName",
+  ROLE: "role",
+  ROLE_ASSOCIATED_RESOURCE_IDS: "roleAssociatedResourceIds",
+} as const;

--- a/app/views/AddNewUserView/common/entities.ts
+++ b/app/views/AddNewUserView/common/entities.ts
@@ -1,0 +1,4 @@
+import { InferType } from "yup";
+import { newUserSchema } from "./schema";
+
+export type NewUserData = InferType<typeof newUserSchema>;

--- a/app/views/AddNewUserView/common/schema.ts
+++ b/app/views/AddNewUserView/common/schema.ts
@@ -1,0 +1,13 @@
+import { array, boolean, object, string } from "yup";
+import { ROLE } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { FIELD_NAME } from "./constants";
+
+export const newUserSchema = object({
+  [FIELD_NAME.DISABLED]: boolean().required(),
+  [FIELD_NAME.EMAIL]: string().required().email(),
+  [FIELD_NAME.FULL_NAME]: string().required(),
+  [FIELD_NAME.ROLE]: string().defined().oneOf(Object.values(ROLE)),
+  [FIELD_NAME.ROLE_ASSOCIATED_RESOURCE_IDS]: array()
+    .of(string().uuid().required())
+    .required(),
+}).strict(true);

--- a/app/views/AddNewUserView/common/schema.ts
+++ b/app/views/AddNewUserView/common/schema.ts
@@ -1,9 +1,9 @@
-import { array, boolean, object, string } from "yup";
+import { array, object, string } from "yup";
 import { ROLE } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { FIELD_NAME } from "./constants";
 
 export const newUserSchema = object({
-  [FIELD_NAME.DISABLED]: boolean().required(),
+  [FIELD_NAME.DISABLED]: string().oneOf(["enabled", "disabled"]).required(),
   [FIELD_NAME.EMAIL]: string().required().email(),
   [FIELD_NAME.FULL_NAME]: string().required(),
   [FIELD_NAME.ROLE]: string().defined().oneOf(Object.values(ROLE)),

--- a/app/views/AddNewUserView/common/utils.ts
+++ b/app/views/AddNewUserView/common/utils.ts
@@ -1,0 +1,10 @@
+import { Breadcrumb } from "../../../components/Detail/components/TrackerForm/components/Breadcrumbs/breadcrumbs";
+import { getUsersBreadcrumb } from "../../../components/Detail/components/TrackerForm/components/Breadcrumbs/common/utils";
+
+/**
+ * Returns the breadcrumbs for the create atlas view.
+ * @returns breadcrumbs.
+ */
+export function getBreadcrumbs(): Breadcrumb[] {
+  return [getUsersBreadcrumb()];
+}

--- a/app/views/AddNewUserView/hooks/useAddUserForm.ts
+++ b/app/views/AddNewUserView/hooks/useAddUserForm.ts
@@ -1,0 +1,31 @@
+import {
+  HCAAtlasTrackerUser,
+  ROLE,
+} from "../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { FormMethod } from "../../../hooks/useForm/common/entities";
+import { useForm } from "../../../hooks/useForm/useForm";
+import { NewUserData } from "../common/entities";
+import { newUserSchema } from "../common/schema";
+
+const SCHEMA = newUserSchema;
+
+export const useAddUserForm = (): FormMethod<
+  NewUserData,
+  HCAAtlasTrackerUser
+> => {
+  return useForm<NewUserData, HCAAtlasTrackerUser>(
+    SCHEMA,
+    undefined,
+    mapSchemaValues
+  );
+};
+
+function mapSchemaValues(data?: NewUserData): NewUserData {
+  return {
+    disabled: data?.disabled ?? false,
+    email: data?.email ?? "",
+    fullName: data?.fullName ?? "",
+    role: data?.role ?? ROLE.STAKEHOLDER,
+    roleAssociatedResourceIds: data?.roleAssociatedResourceIds ?? [],
+  };
+}

--- a/app/views/AddNewUserView/hooks/useAddUserForm.ts
+++ b/app/views/AddNewUserView/hooks/useAddUserForm.ts
@@ -36,5 +36,7 @@ function mapApiValues(user: NewUserData): ApiNewUserData {
   return {
     ...user,
     disabled: user.disabled === "disabled",
+    roleAssociatedResourceIds:
+      user.role === ROLE.INTEGRATION_LEAD ? user.roleAssociatedResourceIds : [],
   };
 }

--- a/app/views/AddNewUserView/hooks/useAddUserForm.ts
+++ b/app/views/AddNewUserView/hooks/useAddUserForm.ts
@@ -2,6 +2,7 @@ import {
   HCAAtlasTrackerUser,
   ROLE,
 } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { NewUserData as ApiNewUserData } from "../../../apis/catalog/hca-atlas-tracker/common/schema";
 import { FormMethod } from "../../../hooks/useForm/common/entities";
 import { useForm } from "../../../hooks/useForm/useForm";
 import { NewUserData } from "../common/entities";
@@ -16,16 +17,24 @@ export const useAddUserForm = (): FormMethod<
   return useForm<NewUserData, HCAAtlasTrackerUser>(
     SCHEMA,
     undefined,
-    mapSchemaValues
+    mapSchemaValues,
+    mapApiValues
   );
 };
 
-function mapSchemaValues(data?: NewUserData): NewUserData {
+function mapSchemaValues(data?: ApiNewUserData): NewUserData {
   return {
-    disabled: data?.disabled ?? false,
+    disabled: data?.disabled ? "disabled" : "enabled",
     email: data?.email ?? "",
     fullName: data?.fullName ?? "",
     role: data?.role ?? ROLE.STAKEHOLDER,
     roleAssociatedResourceIds: data?.roleAssociatedResourceIds ?? [],
+  };
+}
+
+function mapApiValues(user: NewUserData): ApiNewUserData {
+  return {
+    ...user,
+    disabled: user.disabled === "disabled",
   };
 }

--- a/app/views/AddNewUserView/hooks/useAddUserFormManager.ts
+++ b/app/views/AddNewUserView/hooks/useAddUserFormManager.ts
@@ -1,0 +1,41 @@
+import Router from "next/router";
+import { useCallback } from "react";
+import { API } from "../../../apis/catalog/hca-atlas-tracker/common/api";
+import { HCAAtlasTrackerUser } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "../../../common/entities";
+import { getRouteURL } from "../../../common/utils";
+import { FormMethod } from "../../../hooks/useForm/common/entities";
+import { FormManager } from "../../../hooks/useFormManager/common/entities";
+import { useFormManager } from "../../../hooks/useFormManager/useFormManager";
+import { ROUTE } from "../../../routes/constants";
+import { NewUserData } from "../common/entities";
+
+export const useAddUserFormManager = (
+  formMethod: FormMethod<NewUserData, HCAAtlasTrackerUser>
+): FormManager => {
+  const { onSubmit } = formMethod;
+
+  const onDiscard = useCallback((url?: string) => {
+    Router.push(url ?? ROUTE.USERS);
+  }, []);
+
+  const onSave = useCallback(
+    (payload: NewUserData, url?: string) => {
+      onSubmit(API.CREATE_USER, METHOD.POST, payload, {
+        onSuccess: (data) => onSuccess(data.id, url),
+      });
+    },
+    [onSubmit]
+  );
+
+  return useFormManager(formMethod, { onDiscard, onSave });
+};
+
+/**
+ * Side effect "onSuccess"; redirects to the users page, or to the specified URL.
+ * @param userId - User ID.
+ * @param url - URL to redirect to.
+ */
+export function onSuccess(userId: number, url?: string): void {
+  Router.push(url ?? getRouteURL(ROUTE.USERS));
+}

--- a/app/views/UserView/common/constants.ts
+++ b/app/views/UserView/common/constants.ts
@@ -1,0 +1,7 @@
+export const FIELD_NAME = {
+  DISABLED: "disabled",
+  EMAIL: "email",
+  FULL_NAME: "fullName",
+  ROLE: "role",
+  ROLE_ASSOCIATED_RESOURCE_IDS: "roleAssociatedResourceIds",
+} as const;

--- a/app/views/UserView/common/entities.ts
+++ b/app/views/UserView/common/entities.ts
@@ -1,0 +1,4 @@
+import { InferType } from "yup";
+import { userEditSchema } from "./schema";
+
+export type UserEditData = InferType<typeof userEditSchema>;

--- a/app/views/UserView/common/schema.ts
+++ b/app/views/UserView/common/schema.ts
@@ -1,0 +1,13 @@
+import { array, boolean, object, string } from "yup";
+import { ROLE } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { FIELD_NAME } from "./constants";
+
+export const userEditSchema = object({
+  [FIELD_NAME.DISABLED]: boolean().required(),
+  [FIELD_NAME.EMAIL]: string().required().email(),
+  [FIELD_NAME.FULL_NAME]: string().required(),
+  [FIELD_NAME.ROLE]: string().defined().oneOf(Object.values(ROLE)),
+  [FIELD_NAME.ROLE_ASSOCIATED_RESOURCE_IDS]: array()
+    .of(string().uuid().required())
+    .required(),
+}).strict(true);

--- a/app/views/UserView/common/schema.ts
+++ b/app/views/UserView/common/schema.ts
@@ -1,9 +1,9 @@
-import { array, boolean, object, string } from "yup";
+import { array, object, string } from "yup";
 import { ROLE } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { FIELD_NAME } from "./constants";
 
 export const userEditSchema = object({
-  [FIELD_NAME.DISABLED]: boolean().required(),
+  [FIELD_NAME.DISABLED]: string().oneOf(["enabled", "disabled"]).required(),
   [FIELD_NAME.EMAIL]: string().required().email(),
   [FIELD_NAME.FULL_NAME]: string().required(),
   [FIELD_NAME.ROLE]: string().defined().oneOf(Object.values(ROLE)),

--- a/app/views/UserView/common/utils.ts
+++ b/app/views/UserView/common/utils.ts
@@ -1,0 +1,15 @@
+import { HCAAtlasTrackerUser } from "app/apis/catalog/hca-atlas-tracker/common/entities";
+import { Breadcrumb } from "../../../components/Detail/components/TrackerForm/components/Breadcrumbs/breadcrumbs";
+import {
+  getUserBreadcrumb,
+  getUsersBreadcrumb,
+} from "../../../components/Detail/components/TrackerForm/components/Breadcrumbs/common/utils";
+
+/**
+ * Returns the breadcrumbs for the edit user view.
+ * @param user - User.
+ * @returns breadcrumbs.
+ */
+export function getBreadcrumbs(user?: HCAAtlasTrackerUser): Breadcrumb[] {
+  return [getUsersBreadcrumb(), getUserBreadcrumb(undefined, user)];
+}

--- a/app/views/UserView/hooks/useEditUserForm.ts
+++ b/app/views/UserView/hooks/useEditUserForm.ts
@@ -2,6 +2,7 @@ import {
   HCAAtlasTrackerUser,
   ROLE,
 } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { UserEditData as ApiUserEditData } from "../../../apis/catalog/hca-atlas-tracker/common/schema";
 import { PathParameter } from "../../../common/entities";
 import { useFetchUser } from "../../../hooks/useFetchUser";
 import { FormMethod } from "../../../hooks/useForm/common/entities";
@@ -19,7 +20,8 @@ export const useEditUserForm = (
   return useForm<UserEditData, HCAAtlasTrackerUser>(
     SCHEMA,
     user,
-    mapSchemaValues
+    mapSchemaValues,
+    mapApiValues
   );
 };
 
@@ -30,11 +32,18 @@ export const useEditUserForm = (
  */
 function mapSchemaValues(user?: HCAAtlasTrackerUser): UserEditData {
   return {
-    [FIELD_NAME.DISABLED]: user?.disabled ?? false,
+    [FIELD_NAME.DISABLED]: user?.disabled ? "disabled" : "enabled",
     [FIELD_NAME.EMAIL]: user?.email ?? "",
     [FIELD_NAME.FULL_NAME]: user?.fullName ?? "",
     [FIELD_NAME.ROLE]: user?.role ?? ROLE.STAKEHOLDER,
     [FIELD_NAME.ROLE_ASSOCIATED_RESOURCE_IDS]:
       user?.roleAssociatedResourceIds ?? [],
+  };
+}
+
+function mapApiValues(user: UserEditData): ApiUserEditData {
+  return {
+    ...user,
+    disabled: user.disabled === "disabled",
   };
 }

--- a/app/views/UserView/hooks/useEditUserForm.ts
+++ b/app/views/UserView/hooks/useEditUserForm.ts
@@ -1,0 +1,40 @@
+import {
+  HCAAtlasTrackerUser,
+  ROLE,
+} from "../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { PathParameter } from "../../../common/entities";
+import { useFetchUser } from "../../../hooks/useFetchUser";
+import { FormMethod } from "../../../hooks/useForm/common/entities";
+import { useForm } from "../../../hooks/useForm/useForm";
+import { FIELD_NAME } from "../common/constants";
+import { UserEditData } from "../common/entities";
+import { userEditSchema } from "../common/schema";
+
+const SCHEMA = userEditSchema;
+
+export const useEditUserForm = (
+  pathParameter: PathParameter
+): FormMethod<UserEditData, HCAAtlasTrackerUser> => {
+  const { user } = useFetchUser(pathParameter);
+  return useForm<UserEditData, HCAAtlasTrackerUser>(
+    SCHEMA,
+    user,
+    mapSchemaValues
+  );
+};
+
+/**
+ * Returns schema default values mapped from user.
+ * @param user - User.
+ * @returns schema default values.
+ */
+function mapSchemaValues(user?: HCAAtlasTrackerUser): UserEditData {
+  return {
+    [FIELD_NAME.DISABLED]: user?.disabled ?? false,
+    [FIELD_NAME.EMAIL]: user?.email ?? "",
+    [FIELD_NAME.FULL_NAME]: user?.fullName ?? "",
+    [FIELD_NAME.ROLE]: user?.role ?? ROLE.STAKEHOLDER,
+    [FIELD_NAME.ROLE_ASSOCIATED_RESOURCE_IDS]:
+      user?.roleAssociatedResourceIds ?? [],
+  };
+}

--- a/app/views/UserView/hooks/useEditUserForm.ts
+++ b/app/views/UserView/hooks/useEditUserForm.ts
@@ -45,5 +45,7 @@ function mapApiValues(user: UserEditData): ApiUserEditData {
   return {
     ...user,
     disabled: user.disabled === "disabled",
+    roleAssociatedResourceIds:
+      user.role === ROLE.INTEGRATION_LEAD ? user.roleAssociatedResourceIds : [],
   };
 }

--- a/app/views/UserView/hooks/useEditUserFormManager.ts
+++ b/app/views/UserView/hooks/useEditUserFormManager.ts
@@ -2,40 +2,42 @@ import Router from "next/router";
 import { useCallback } from "react";
 import { API } from "../../../apis/catalog/hca-atlas-tracker/common/api";
 import { HCAAtlasTrackerUser } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../../../common/entities";
-import { getRouteURL } from "../../../common/utils";
+import { METHOD, PathParameter } from "../../../common/entities";
+import { getRequestURL, getRouteURL } from "../../../common/utils";
 import { FormMethod } from "../../../hooks/useForm/common/entities";
 import { FormManager } from "../../../hooks/useFormManager/common/entities";
 import { useFormManager } from "../../../hooks/useFormManager/useFormManager";
 import { ROUTE } from "../../../routes/constants";
-import { NewUserData } from "../common/entities";
+import { UserEditData } from "../common/entities";
 
-export const useAddUserFormManager = (
-  formMethod: FormMethod<NewUserData, HCAAtlasTrackerUser>
+export const useEditUserFormManager = (
+  pathParameter: PathParameter,
+  formMethod: FormMethod<UserEditData, HCAAtlasTrackerUser>
 ): FormManager => {
-  const { onSubmit } = formMethod;
+  const { onSubmit, reset } = formMethod;
 
   const onDiscard = useCallback((url?: string) => {
     Router.push(url ?? ROUTE.USERS);
   }, []);
 
   const onSave = useCallback(
-    (payload: NewUserData, url?: string) => {
-      onSubmit(API.CREATE_USER, METHOD.POST, payload, {
+    (payload: UserEditData, url?: string) => {
+      onSubmit(getRequestURL(API.USER, pathParameter), METHOD.PATCH, payload, {
+        onReset: reset,
         onSuccess: (data) => onSuccess(data.id, url),
       });
     },
-    [onSubmit]
+    [onSubmit, pathParameter, reset]
   );
 
   return useFormManager(formMethod, { onDiscard, onSave });
 };
 
 /**
- * Side effect "onSuccess"; redirects to the users page, or to the specified URL.
+ * Side effect "onSuccess"; redirects to the user page, or to the specified URL.
  * @param userId - User ID.
  * @param url - URL to redirect to.
  */
 export function onSuccess(userId: number, url?: string): void {
-  Router.push(url ?? getRouteURL(ROUTE.USER, { userId: userId }));
+  Router.push(url ?? getRouteURL(ROUTE.USER, { userId }));
 }

--- a/app/views/UserView/userView.tsx
+++ b/app/views/UserView/userView.tsx
@@ -56,6 +56,6 @@ function renderAccessFallback(formManager: FormManager): JSX.Element | null {
   const {
     access: { canView },
   } = formManager;
-  if (!canView) return <AccessPrompt text="to view the atlas" />;
+  if (!canView) return <AccessPrompt text="to view the user" />;
   return null;
 }

--- a/app/views/UserView/userView.tsx
+++ b/app/views/UserView/userView.tsx
@@ -1,0 +1,61 @@
+import { ConditionalComponent } from "@databiosphere/findable-ui/lib/components/ComponentCreator/components/ConditionalComponent/conditionalComponent";
+import { Fragment } from "react";
+import { PathParameter } from "../../common/entities";
+import { AccessPrompt } from "../../components/common/Form/components/FormManager/components/AccessPrompt/accessPrompt";
+import { shouldRenderView } from "../../components/Detail/common/utils";
+import { Breadcrumbs } from "../../components/Detail/components/TrackerForm/components/Breadcrumbs/breadcrumbs";
+import { UserForm } from "../../components/Forms/components/User/user";
+import { DetailView } from "../../components/Layout/components/Detail/detailView";
+import { FormManager } from "../../hooks/useFormManager/common/entities";
+import { getBreadcrumbs } from "./common/utils";
+import { useEditUserForm } from "./hooks/useEditUserForm";
+import { useEditUserFormManager } from "./hooks/useEditUserFormManager";
+
+interface UserViewProps {
+  pathParameter: PathParameter;
+}
+
+export const UserView = ({ pathParameter }: UserViewProps): JSX.Element => {
+  const formMethod = useEditUserForm(pathParameter);
+  const formManager = useEditUserFormManager(pathParameter, formMethod);
+  const {
+    access: { canView },
+    formAction,
+    isLoading,
+  } = formManager;
+  const { data: user } = formMethod;
+  if (isLoading) return <Fragment />;
+  return (
+    <ConditionalComponent isIn={shouldRenderView(canView, Boolean(user))}>
+      <DetailView
+        breadcrumbs={
+          <Breadcrumbs
+            breadcrumbs={getBreadcrumbs(user)}
+            onNavigate={formAction?.onNavigate}
+          />
+        }
+        mainColumn={
+          <UserForm
+            accessFallback={renderAccessFallback(formManager)}
+            formManager={formManager}
+            formMethod={formMethod}
+          />
+        }
+        title={user ? user.fullName : "View User"}
+      />
+    </ConditionalComponent>
+  );
+};
+
+/**
+ * Returns the access fallback component from the form manager access state.
+ * @param formManager - Form manager.
+ * @returns access fallback component.
+ */
+function renderAccessFallback(formManager: FormManager): JSX.Element | null {
+  const {
+    access: { canView },
+  } = formManager;
+  if (!canView) return <AccessPrompt text="to view the atlas" />;
+  return null;
+}

--- a/pages/api/users/[id].tsx
+++ b/pages/api/users/[id].tsx
@@ -2,26 +2,28 @@ import { ROLE } from "../../../app/apis/catalog/hca-atlas-tracker/common/entitie
 import { userEditSchema } from "../../../app/apis/catalog/hca-atlas-tracker/common/schema";
 import { dbUserToApiUser } from "../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../app/common/entities";
-import { updateUser } from "../../../app/services/users";
+import { getUserById, updateUser } from "../../../app/services/users";
 import {
+  handleByMethod,
   handler,
   handleRequiredParam,
-  method,
   role,
 } from "../../../app/utils/api-handler";
 
-/**
- * API route for updating a user. Updated user information is provided as a JSON body.
- */
-export default handler(
-  method(METHOD.PATCH),
-  role(ROLE.CONTENT_ADMIN),
-  async (req, res) => {
-    const id = handleRequiredParam(req, res, "id", /^\d+$/);
-    if (id === null) return;
-    const editInfo = await userEditSchema.validate(req.body);
-    res
-      .status(201)
-      .json(dbUserToApiUser(await updateUser(Number(id), editInfo)));
-  }
-);
+const getHandler = handler(role(ROLE.CONTENT_ADMIN), async (req, res) => {
+  const id = handleRequiredParam(req, res, "id", /^\d+$/);
+  if (id === null) return;
+  res.status(200).json(dbUserToApiUser(await getUserById(Number(id))));
+});
+
+const patchHandler = handler(role(ROLE.CONTENT_ADMIN), async (req, res) => {
+  const id = handleRequiredParam(req, res, "id", /^\d+$/);
+  if (id === null) return;
+  const editInfo = await userEditSchema.validate(req.body);
+  res.status(201).json(dbUserToApiUser(await updateUser(Number(id), editInfo)));
+});
+
+export default handleByMethod({
+  [METHOD.GET]: getHandler,
+  [METHOD.PATCH]: patchHandler,
+});

--- a/pages/api/users/[id].tsx
+++ b/pages/api/users/[id].tsx
@@ -1,0 +1,27 @@
+import { ROLE } from "../../../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { userEditSchema } from "../../../app/apis/catalog/hca-atlas-tracker/common/schema";
+import { dbUserToApiUser } from "../../../app/apis/catalog/hca-atlas-tracker/common/utils";
+import { METHOD } from "../../../app/common/entities";
+import { updateUser } from "../../../app/services/users";
+import {
+  handler,
+  handleRequiredParam,
+  method,
+  role,
+} from "../../../app/utils/api-handler";
+
+/**
+ * API route for updating a user. Updated user information is provided as a JSON body.
+ */
+export default handler(
+  method(METHOD.PATCH),
+  role(ROLE.CONTENT_ADMIN),
+  async (req, res) => {
+    const id = handleRequiredParam(req, res, "id", /^\d+$/);
+    if (id === null) return;
+    const editInfo = await userEditSchema.validate(req.body);
+    res
+      .status(201)
+      .json(dbUserToApiUser(await updateUser(Number(id), editInfo)));
+  }
+);

--- a/pages/team/[userId]/index.tsx
+++ b/pages/team/[userId]/index.tsx
@@ -1,0 +1,30 @@
+import { GetServerSideProps, GetServerSidePropsContext } from "next";
+import { ParsedUrlQuery } from "querystring";
+import { PathParameter } from "../../../app/common/entities";
+import { UserView } from "../../../app/views/UserView/userView";
+
+interface UserPageProps {
+  pathParameter: PathParameter;
+}
+
+interface UserPageUrlParams extends ParsedUrlQuery {
+  userId: string;
+}
+
+export const getServerSideProps: GetServerSideProps = async (
+  context: GetServerSidePropsContext
+) => {
+  const { userId } = context.params as UserPageUrlParams;
+  return {
+    props: {
+      pageTitle: "User",
+      pathParameter: { userId: Number(userId) },
+    },
+  };
+};
+
+const AtlasPage = ({ pathParameter }: UserPageProps): JSX.Element => {
+  return <UserView pathParameter={pathParameter} />;
+};
+
+export default AtlasPage;

--- a/pages/team/create.tsx
+++ b/pages/team/create.tsx
@@ -1,0 +1,16 @@
+import { GetServerSideProps } from "next";
+import { AddNewUserView } from "../../app/views/AddNewUserView/addNewUserView";
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return {
+    props: {
+      pageTitle: "Add New User",
+    },
+  };
+};
+
+const CreateUserPage = (): JSX.Element => {
+  return <AddNewUserView />;
+};
+
+export default CreateUserPage;

--- a/site-config/hca-atlas-tracker/local/index/userEntityConfig.ts
+++ b/site-config/hca-atlas-tracker/local/index/userEntityConfig.ts
@@ -60,7 +60,7 @@ export const userEntityConfig: EntityConfig = {
     top: [],
   },
   exploreMode: EXPLORE_MODE.SS_FETCH_CS_FILTERING,
-  explorerTitle: "Team",
+  explorerTitle: C.UsersHero(),
   getId: getUserId,
   label: "Team",
   list: {

--- a/site-config/hca-atlas-tracker/local/index/userEntityConfig.ts
+++ b/site-config/hca-atlas-tracker/local/index/userEntityConfig.ts
@@ -67,9 +67,9 @@ export const userEntityConfig: EntityConfig = {
     columns: [
       {
         componentConfig: {
-          component: C.BasicCell,
+          component: C.Link,
           viewBuilder: V.buildUserFullName,
-        } as ComponentConfig<typeof C.BasicCell, HCAAtlasTrackerUser>,
+        } as ComponentConfig<typeof C.Link, HCAAtlasTrackerUser>,
         header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.FULL_NAME,
         id: HCA_ATLAS_TRACKER_CATEGORY_KEY.FULL_NAME,
         width: { max: "1fr", min: "160px" },


### PR DESCRIPTION
- New API route `/api/users/[id]`: GET to get user, PATCH to update user (using same payload as existing create API)
  - In the `API` enum, `/api/me` is renamed from `USER` to `ACTIVE_USER` so that `USER` can be used for the new API
  - Similarly, `useFetchUser` is renamed to `useFetchActiveUser`
- New forms (using the same underlying component) for creating and editing users
- The "Add Atlas" button is generalized to a `HeroButton` component, which is used by both the atlases hero and the users hero
- The forms have API mappers to:
  - Convert the enabled/disabled select value to a boolean
  - Remove associated atlases for roles other than integration lead