### PR TITLE
feat: prevent users with disabled accounts from accessing the app (#426)

### DIFF
--- a/__tests__/api-atlases-create.test.ts
+++ b/__tests__/api-atlases-create.test.ts
@@ -16,6 +16,7 @@ import {
   PUBLICATION_PREPRINT_NO_JOURNAL,
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
 } from "../testing/constants";
 import { resetDatabase } from "../testing/db-utils";
@@ -134,6 +135,14 @@ describe("/api/atlases/create", () => {
   it("returns error 403 for unregistered user", async () => {
     expect(
       (await doCreateTest(USER_UNREGISTERED, NEW_ATLAS_DATA))._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 for disabled user", async () => {
+    expect(
+      (
+        await doCreateTest(USER_DISABLED_CONTENT_ADMIN, NEW_ATLAS_DATA)
+      )._getStatusCode()
     ).toEqual(403);
   });
 

--- a/__tests__/api-atlases-id-component-atlases-create.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-create.test.ts
@@ -14,6 +14,7 @@ import {
   ATLAS_NONEXISTENT,
   STAKEHOLDER_ANALOGOUS_ROLES_WITHOUT_INTEGRATION_LEAD,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_INTEGRATION_LEAD_PUBLIC,
   USER_UNREGISTERED,
 } from "../testing/constants";
@@ -76,6 +77,18 @@ describe("/api/atlases/[atlasId]/component-atlases/create", () => {
       (
         await doCreateTest(
           USER_UNREGISTERED,
+          ATLAS_DRAFT,
+          NEW_COMPONENT_ATLAS_DATA
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 for disabled user", async () => {
+    expect(
+      (
+        await doCreateTest(
+          USER_DISABLED_CONTENT_ADMIN,
           ATLAS_DRAFT,
           NEW_COMPONENT_ATLAS_DATA
         )

--- a/__tests__/api-atlases-id-component-atlases-id-source-datasets-id.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id-source-datasets-id.test.ts
@@ -23,6 +23,7 @@ import {
   STAKEHOLDER_ANALOGOUS_ROLES_WITHOUT_INTEGRATION_LEAD,
   TEST_SOURCE_STUDIES,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_INTEGRATION_LEAD_DRAFT,
   USER_INTEGRATION_LEAD_PUBLIC,
   USER_UNREGISTERED,
@@ -101,6 +102,19 @@ describe(TEST_ROUTE, () => {
     ).toEqual(403);
   });
 
+  it("returns error 403 when source dataset is requested by disabled user", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_DRAFT.id,
+          COMPONENT_ATLAS_DRAFT_FOO.id,
+          SOURCE_DATASET_FOOBAZ.id,
+          USER_DISABLED_CONTENT_ADMIN
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
   for (const role of STAKEHOLDER_ANALOGOUS_ROLES) {
     testApiRole(
       "returns source dataset",
@@ -159,6 +173,21 @@ describe(TEST_ROUTE, () => {
           COMPONENT_ATLAS_DRAFT_FOO.id,
           SOURCE_DATASET_FOO.id,
           USER_UNREGISTERED,
+          METHOD.POST
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectComponentAtlasToBeUnchanged(COMPONENT_ATLAS_DRAFT_FOO);
+  });
+
+  it("returns error 403 when POST requested from draft atlas by disabled user", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_DRAFT.id,
+          COMPONENT_ATLAS_DRAFT_FOO.id,
+          SOURCE_DATASET_FOO.id,
+          USER_DISABLED_CONTENT_ADMIN,
           METHOD.POST
         )
       )._getStatusCode()
@@ -376,6 +405,21 @@ describe(TEST_ROUTE, () => {
           COMPONENT_ATLAS_DRAFT_FOO.id,
           SOURCE_DATASET_FOOFOO.id,
           USER_UNREGISTERED,
+          METHOD.DELETE
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectComponentAtlasToBeUnchanged(COMPONENT_ATLAS_DRAFT_FOO);
+  });
+
+  it("returns error 403 when DELETE requested from draft atlas by disabled user", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_DRAFT.id,
+          COMPONENT_ATLAS_DRAFT_FOO.id,
+          SOURCE_DATASET_FOOFOO.id,
+          USER_DISABLED_CONTENT_ADMIN,
           METHOD.DELETE
         )
       )._getStatusCode()

--- a/__tests__/api-atlases-id-component-atlases-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id-source-datasets.test.ts
@@ -28,6 +28,7 @@ import {
   STAKEHOLDER_ANALOGOUS_ROLES_WITHOUT_INTEGRATION_LEAD,
   TEST_SOURCE_STUDIES,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_INTEGRATION_LEAD_DRAFT,
   USER_INTEGRATION_LEAD_PUBLIC,
   USER_UNREGISTERED,
@@ -126,6 +127,18 @@ describe(TEST_ROUTE, () => {
     ).toEqual(403);
   });
 
+  it("returns error 403 when source datasets are requested by disabled user", async () => {
+    expect(
+      (
+        await doSourceDatasetsRequest(
+          ATLAS_DRAFT.id,
+          COMPONENT_ATLAS_DRAFT_FOO.id,
+          USER_DISABLED_CONTENT_ADMIN
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
   for (const role of STAKEHOLDER_ANALOGOUS_ROLES) {
     testApiRole(
       "returns source datasets",
@@ -188,6 +201,21 @@ describe(TEST_ROUTE, () => {
           ATLAS_DRAFT.id,
           COMPONENT_ATLAS_DRAFT_FOO.id,
           USER_UNREGISTERED,
+          METHOD.POST,
+          NEW_DATASETS_DATA
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectComponentAtlasToBeUnchanged(COMPONENT_ATLAS_DRAFT_FOO);
+  });
+
+  it("returns error 403 when POST requested from draft atlas by disabled user", async () => {
+    expect(
+      (
+        await doSourceDatasetsRequest(
+          ATLAS_DRAFT.id,
+          COMPONENT_ATLAS_DRAFT_FOO.id,
+          USER_DISABLED_CONTENT_ADMIN,
           METHOD.POST,
           NEW_DATASETS_DATA
         )
@@ -353,6 +381,21 @@ describe(TEST_ROUTE, () => {
           ATLAS_DRAFT.id,
           COMPONENT_ATLAS_DRAFT_FOO.id,
           USER_UNREGISTERED,
+          METHOD.DELETE,
+          DELETE_DATASETS_DATA
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectComponentAtlasToBeUnchanged(COMPONENT_ATLAS_DRAFT_FOO);
+  });
+
+  it("returns error 403 when DELETE requested from draft atlas by disabled user", async () => {
+    expect(
+      (
+        await doSourceDatasetsRequest(
+          ATLAS_DRAFT.id,
+          COMPONENT_ATLAS_DRAFT_FOO.id,
+          USER_DISABLED_CONTENT_ADMIN,
           METHOD.DELETE,
           DELETE_DATASETS_DATA
         )

--- a/__tests__/api-atlases-id-component-atlases-id.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id.test.ts
@@ -19,6 +19,7 @@ import {
   STAKEHOLDER_ANALOGOUS_ROLES,
   STAKEHOLDER_ANALOGOUS_ROLES_WITHOUT_INTEGRATION_LEAD,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_INTEGRATION_LEAD_PUBLIC,
   USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
   USER_UNREGISTERED,
@@ -89,6 +90,18 @@ describe(TEST_ROUTE, () => {
           ATLAS_DRAFT.id,
           COMPONENT_ATLAS_DRAFT_FOO.id,
           USER_UNREGISTERED
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 when component atlas is GET requested from draft atlas by disabled user", async () => {
+    expect(
+      (
+        await doComponentAtlasRequest(
+          ATLAS_DRAFT.id,
+          COMPONENT_ATLAS_DRAFT_FOO.id,
+          USER_DISABLED_CONTENT_ADMIN
         )
       )._getStatusCode()
     ).toEqual(403);
@@ -167,6 +180,21 @@ describe(TEST_ROUTE, () => {
           ATLAS_DRAFT.id,
           COMPONENT_ATLAS_DRAFT_FOO.id,
           USER_UNREGISTERED,
+          METHOD.PATCH,
+          COMPONENT_ATLAS_DRAFT_FOO_EDIT
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectComponentAtlasToBeUnchanged(COMPONENT_ATLAS_DRAFT_FOO);
+  });
+
+  it("returns error 403 when component atlas is PATCH requested from draft atlas by disabled user", async () => {
+    expect(
+      (
+        await doComponentAtlasRequest(
+          ATLAS_DRAFT.id,
+          COMPONENT_ATLAS_DRAFT_FOO.id,
+          USER_DISABLED_CONTENT_ADMIN,
           METHOD.PATCH,
           COMPONENT_ATLAS_DRAFT_FOO_EDIT
         )
@@ -364,6 +392,20 @@ describe(TEST_ROUTE, () => {
           ATLAS_DRAFT.id,
           COMPONENT_ATLAS_DRAFT_FOO.id,
           USER_UNREGISTERED,
+          METHOD.DELETE
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectComponentAtlasToBeUnchanged(COMPONENT_ATLAS_DRAFT_FOO);
+  });
+
+  it("returns error 403 when component atlas is DELETE requested from draft atlas by disabled user", async () => {
+    expect(
+      (
+        await doComponentAtlasRequest(
+          ATLAS_DRAFT.id,
+          COMPONENT_ATLAS_DRAFT_FOO.id,
+          USER_DISABLED_CONTENT_ADMIN,
           METHOD.DELETE
         )
       )._getStatusCode()

--- a/__tests__/api-atlases-id-component-atlases.test.ts
+++ b/__tests__/api-atlases-id-component-atlases.test.ts
@@ -10,6 +10,7 @@ import {
   COMPONENT_ATLAS_DRAFT_FOO,
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
 } from "../testing/constants";
 import { resetDatabase } from "../testing/db-utils";
@@ -45,10 +46,22 @@ describe(TEST_ROUTE, () => {
       (await doComponentAtlasesRequest(ATLAS_DRAFT.id))._getStatusCode()
     ).toEqual(401);
   });
+
   it("returns error 403 when draft atlas component atlases are requested by unregistered user", async () => {
     expect(
       (
         await doComponentAtlasesRequest(ATLAS_DRAFT.id, USER_UNREGISTERED)
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 when draft atlas component atlases are requested by disabled user", async () => {
+    expect(
+      (
+        await doComponentAtlasesRequest(
+          ATLAS_DRAFT.id,
+          USER_DISABLED_CONTENT_ADMIN
+        )
       )._getStatusCode()
     ).toEqual(403);
   });

--- a/__tests__/api-atlases-id-source-studies-create.test.ts
+++ b/__tests__/api-atlases-id-source-studies-create.test.ts
@@ -43,6 +43,7 @@ import {
   SOURCE_STUDY_PUBLIC_WITH_PREPRINT,
   STAKEHOLDER_ANALOGOUS_ROLES_WITHOUT_INTEGRATION_LEAD,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_INTEGRATION_LEAD_DRAFT,
   USER_UNREGISTERED,
 } from "../testing/constants";
@@ -151,6 +152,18 @@ describe(TEST_ROUTE, () => {
     expect(
       (
         await doCreateTest(USER_UNREGISTERED, ATLAS_DRAFT, NEW_STUDY_DATA)
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 for disabled user", async () => {
+    expect(
+      (
+        await doCreateTest(
+          USER_DISABLED_CONTENT_ADMIN,
+          ATLAS_DRAFT,
+          NEW_STUDY_DATA
+        )
       )._getStatusCode()
     ).toEqual(403);
   });

--- a/__tests__/api-atlases-id-source-studies-id-source-datasets-create.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id-source-datasets-create.test.ts
@@ -19,6 +19,7 @@ import {
   SOURCE_STUDY_WITH_SOURCE_DATASETS,
   STAKEHOLDER_ANALOGOUS_ROLES_WITHOUT_INTEGRATION_LEAD,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
   USER_UNREGISTERED,
 } from "../testing/constants";
@@ -84,6 +85,19 @@ describe(TEST_ROUTE, () => {
       (
         await doCreateTest(
           USER_UNREGISTERED,
+          ATLAS_WITH_MISC_SOURCE_STUDIES,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS,
+          NEW_SOURCE_DATASET_DATA
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 for disabled user", async () => {
+    expect(
+      (
+        await doCreateTest(
+          USER_DISABLED_CONTENT_ADMIN,
           ATLAS_WITH_MISC_SOURCE_STUDIES,
           SOURCE_STUDY_WITH_SOURCE_DATASETS,
           NEW_SOURCE_DATASET_DATA

--- a/__tests__/api-atlases-id-source-studies-id-source-datasets-id.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id-source-datasets-id.test.ts
@@ -24,6 +24,7 @@ import {
   STAKEHOLDER_ANALOGOUS_ROLES,
   STAKEHOLDER_ANALOGOUS_ROLES_WITHOUT_INTEGRATION_LEAD,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_INTEGRATION_LEAD_DRAFT,
   USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
   USER_STAKEHOLDER,
@@ -99,6 +100,19 @@ describe(TEST_ROUTE, () => {
           SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
           SOURCE_DATASET_FOO.id,
           USER_UNREGISTERED
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 when source dataset is GET requested from draft atlas by disabled user", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+          SOURCE_DATASET_FOO.id,
+          USER_DISABLED_CONTENT_ADMIN
         )
       )._getStatusCode()
     ).toEqual(403);
@@ -209,6 +223,22 @@ describe(TEST_ROUTE, () => {
           SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
           SOURCE_DATASET_FOO.id,
           USER_STAKEHOLDER,
+          METHOD.PATCH,
+          SOURCE_DATASET_FOO_EDIT
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_FOO);
+  });
+
+  it("returns error 403 when source dataset is PATCH requested from draft atlas by disabled user", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+          SOURCE_DATASET_FOO.id,
+          USER_DISABLED_CONTENT_ADMIN,
           METHOD.PATCH,
           SOURCE_DATASET_FOO_EDIT
         )
@@ -408,6 +438,21 @@ describe(TEST_ROUTE, () => {
           SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
           SOURCE_DATASET_FOO.id,
           USER_STAKEHOLDER,
+          METHOD.DELETE
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_FOO);
+  });
+
+  it("returns error 403 when source dataset is DELETE requested from draft atlas by disabled user", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+          SOURCE_DATASET_FOO.id,
+          USER_DISABLED_CONTENT_ADMIN,
           METHOD.DELETE
         )
       )._getStatusCode()

--- a/__tests__/api-atlases-id-source-studies-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id-source-datasets.test.ts
@@ -13,6 +13,7 @@ import {
   SOURCE_STUDY_WITH_SOURCE_DATASETS,
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
 } from "../testing/constants";
 import { resetDatabase } from "../testing/db-utils";
@@ -59,6 +60,7 @@ describe(TEST_ROUTE, () => {
       )._getStatusCode()
     ).toEqual(401);
   });
+
   it("returns error 403 when source datasets are requested by unregistered user", async () => {
     expect(
       (
@@ -66,6 +68,18 @@ describe(TEST_ROUTE, () => {
           ATLAS_WITH_MISC_SOURCE_STUDIES.id,
           SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
           USER_UNREGISTERED
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 when source datasets are requested by disabled user", async () => {
+    expect(
+      (
+        await doSourceDatasetsRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+          USER_DISABLED_CONTENT_ADMIN
         )
       )._getStatusCode()
     ).toEqual(403);

--- a/__tests__/api-atlases-id-source-studies-id.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id.test.ts
@@ -46,6 +46,7 @@ import {
   STAKEHOLDER_ANALOGOUS_ROLES,
   STAKEHOLDER_ANALOGOUS_ROLES_WITHOUT_INTEGRATION_LEAD,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_INTEGRATION_LEAD_DRAFT,
   USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
   USER_STAKEHOLDER,
@@ -170,6 +171,18 @@ describe(TEST_ROUTE, () => {
     ).toEqual(403);
   });
 
+  it("returns error 403 when study is requested from public atlas by disabled user", async () => {
+    expect(
+      (
+        await doStudyRequest(
+          ATLAS_PUBLIC.id,
+          SOURCE_STUDY_PUBLIC_NO_CROSSREF.id,
+          USER_DISABLED_CONTENT_ADMIN
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
   it("returns error 401 when study is GET requested from draft atlas by logged out user", async () => {
     expect(
       (
@@ -185,6 +198,18 @@ describe(TEST_ROUTE, () => {
           ATLAS_DRAFT.id,
           SOURCE_STUDY_DRAFT_OK.id,
           USER_UNREGISTERED
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 when study is GET requested from draft atlas by disabled user", async () => {
+    expect(
+      (
+        await doStudyRequest(
+          ATLAS_DRAFT.id,
+          SOURCE_STUDY_DRAFT_OK.id,
+          USER_DISABLED_CONTENT_ADMIN
         )
       )._getStatusCode()
     ).toEqual(403);
@@ -268,6 +293,21 @@ describe(TEST_ROUTE, () => {
           ATLAS_PUBLIC.id,
           SOURCE_STUDY_PUBLIC_NO_CROSSREF.id,
           USER_STAKEHOLDER,
+          METHOD.PUT,
+          SOURCE_STUDY_PUBLIC_NO_CROSSREF_EDIT
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectStudyToBeUnchanged(SOURCE_STUDY_PUBLIC_NO_CROSSREF);
+  });
+
+  it("returns error 403 when study is PUT requested from public atlas by disabled user", async () => {
+    expect(
+      (
+        await doStudyRequest(
+          ATLAS_PUBLIC.id,
+          SOURCE_STUDY_PUBLIC_NO_CROSSREF.id,
+          USER_DISABLED_CONTENT_ADMIN,
           METHOD.PUT,
           SOURCE_STUDY_PUBLIC_NO_CROSSREF_EDIT
         )
@@ -646,6 +686,20 @@ describe(TEST_ROUTE, () => {
           ATLAS_PUBLIC.id,
           SOURCE_STUDY_PUBLIC_NO_CROSSREF.id,
           USER_STAKEHOLDER,
+          METHOD.DELETE
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectStudyToBeUnchanged(SOURCE_STUDY_PUBLIC_NO_CROSSREF);
+  });
+
+  it("returns error 403 when study is DELETE requested from public atlas by disabled user", async () => {
+    expect(
+      (
+        await doStudyRequest(
+          ATLAS_PUBLIC.id,
+          SOURCE_STUDY_PUBLIC_NO_CROSSREF.id,
+          USER_DISABLED_CONTENT_ADMIN,
           METHOD.DELETE
         )
       )._getStatusCode()

--- a/__tests__/api-atlases-id-source-studies.test.ts
+++ b/__tests__/api-atlases-id-source-studies.test.ts
@@ -13,6 +13,7 @@ import {
   SOURCE_STUDY_SHARED,
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
 } from "../testing/constants";
 import {
@@ -51,10 +52,19 @@ describe(TEST_ROUTE, () => {
       401
     );
   });
+
   it("returns error 403 when public atlas studies are requested by unregistered user", async () => {
     expect(
       (
         await doStudiesRequest(ATLAS_PUBLIC.id, USER_UNREGISTERED)
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 when public atlas studies are requested by disabled user", async () => {
+    expect(
+      (
+        await doStudiesRequest(ATLAS_PUBLIC.id, USER_DISABLED_CONTENT_ADMIN)
       )._getStatusCode()
     ).toEqual(403);
   });
@@ -69,6 +79,14 @@ describe(TEST_ROUTE, () => {
     expect(
       (
         await doStudiesRequest(ATLAS_DRAFT.id, USER_UNREGISTERED)
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 when draft atlas studies are requested by disabled user", async () => {
+    expect(
+      (
+        await doStudiesRequest(ATLAS_DRAFT.id, USER_DISABLED_CONTENT_ADMIN)
       )._getStatusCode()
     ).toEqual(403);
   });

--- a/__tests__/api-atlases-id.test.ts
+++ b/__tests__/api-atlases-id.test.ts
@@ -20,6 +20,7 @@ import {
   PUBLICATION_PREPRINT_WITH_JOURNAL_COUNTERPART,
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
 } from "../testing/constants";
 import { resetDatabase } from "../testing/db-utils";
@@ -144,6 +145,14 @@ describe(TEST_ROUTE, () => {
     ).toEqual(403);
   });
 
+  it("returns error 403 when public atlas is GET requested by disabled user", async () => {
+    expect(
+      (
+        await doAtlasRequest(ATLAS_PUBLIC.id, USER_DISABLED_CONTENT_ADMIN)
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
   it("returns error 401 when draft atlas is GET requested by logged out user", async () => {
     expect((await doAtlasRequest(ATLAS_DRAFT.id))._getStatusCode()).toEqual(
       401
@@ -153,6 +162,14 @@ describe(TEST_ROUTE, () => {
   it("returns error 403 when draft atlas is GET requested by unregistered user", async () => {
     expect(
       (await doAtlasRequest(ATLAS_DRAFT.id, USER_UNREGISTERED))._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 when draft atlas is GET requested by disabled user", async () => {
+    expect(
+      (
+        await doAtlasRequest(ATLAS_DRAFT.id, USER_DISABLED_CONTENT_ADMIN)
+      )._getStatusCode()
     ).toEqual(403);
   });
 
@@ -228,6 +245,20 @@ describe(TEST_ROUTE, () => {
         await doAtlasRequest(
           ATLAS_PUBLIC.id,
           USER_UNREGISTERED,
+          false,
+          METHOD.PUT,
+          ATLAS_PUBLIC_EDIT
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 when public atlas is PUT requested by disabled user", async () => {
+    expect(
+      (
+        await doAtlasRequest(
+          ATLAS_PUBLIC.id,
+          USER_DISABLED_CONTENT_ADMIN,
           false,
           METHOD.PUT,
           ATLAS_PUBLIC_EDIT

--- a/__tests__/api-atlases.test.ts
+++ b/__tests__/api-atlases.test.ts
@@ -8,6 +8,7 @@ import {
   INITIAL_TEST_ATLASES,
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
 } from "../testing/constants";
 import { resetDatabase } from "../testing/db-utils";
@@ -44,6 +45,12 @@ describe(TEST_ROUTE, () => {
   it("returns error 403 for unregistered user", async () => {
     expect(
       (await doAtlasesRequest(USER_UNREGISTERED))._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 for disabled user", async () => {
+    expect(
+      (await doAtlasesRequest(USER_DISABLED_CONTENT_ADMIN))._getStatusCode()
     ).toEqual(403);
   });
 

--- a/__tests__/api-comments-thread-id-comments-comment-id.test.ts
+++ b/__tests__/api-comments-thread-id-comments-comment-id.test.ts
@@ -36,6 +36,7 @@ import {
   THREAD_ID_BY_STAKEHOLDER_FOO,
   USER_CELLXGENE_ADMIN,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_INTEGRATION_LEAD_DRAFT,
   USER_STAKEHOLDER,
   USER_STAKEHOLDER2,
@@ -113,6 +114,20 @@ describe("/api/comments/[threadId]/comments/[commentId]", () => {
       (
         await doCommentTest(
           USER_UNREGISTERED,
+          THREAD_ID_BY_STAKEHOLDER,
+          COMMENT_BY_STAKEHOLDER_REPLY1_STAKEHOLDER.id,
+          METHOD.GET,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("GET returns error 403 for disabled user", async () => {
+    expect(
+      (
+        await doCommentTest(
+          USER_DISABLED_CONTENT_ADMIN,
           THREAD_ID_BY_STAKEHOLDER,
           COMMENT_BY_STAKEHOLDER_REPLY1_STAKEHOLDER.id,
           METHOD.GET,
@@ -213,6 +228,22 @@ describe("/api/comments/[threadId]/comments/[commentId]", () => {
       (
         await doCommentTest(
           USER_UNREGISTERED,
+          THREAD_ID_BY_STAKEHOLDER,
+          COMMENT_BY_STAKEHOLDER_ROOT.id,
+          METHOD.PATCH,
+          true,
+          COMMENT_BY_STAKEHOLDER_ROOT_EDIT
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectCommentToBeUnchanged(COMMENT_BY_STAKEHOLDER_ROOT);
+  });
+
+  it("PATCH returns error 403 for disabled user", async () => {
+    expect(
+      (
+        await doCommentTest(
+          USER_DISABLED_CONTENT_ADMIN,
           THREAD_ID_BY_STAKEHOLDER,
           COMMENT_BY_STAKEHOLDER_ROOT.id,
           METHOD.PATCH,
@@ -402,6 +433,23 @@ describe("/api/comments/[threadId]/comments/[commentId]", () => {
       (
         await doCommentTest(
           USER_UNREGISTERED,
+          THREAD_ID_BY_STAKEHOLDER2,
+          COMMENT_BY_STAKEHOLDER2_REPLY2_STAKEHOLDER.id,
+          METHOD.DELETE,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectCommentToBeUnchanged(
+      COMMENT_BY_STAKEHOLDER2_REPLY2_STAKEHOLDER
+    );
+  });
+
+  it("DELETE returns error 403 for disabled user", async () => {
+    expect(
+      (
+        await doCommentTest(
+          USER_DISABLED_CONTENT_ADMIN,
           THREAD_ID_BY_STAKEHOLDER2,
           COMMENT_BY_STAKEHOLDER2_REPLY2_STAKEHOLDER.id,
           METHOD.DELETE,

--- a/__tests__/api-comments-thread-id-comments.test.ts
+++ b/__tests__/api-comments-thread-id-comments.test.ts
@@ -17,6 +17,7 @@ import {
   THREAD_ID_BY_STAKEHOLDER_FOO,
   USER_CELLXGENE_ADMIN,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_INTEGRATION_LEAD_DRAFT,
   USER_STAKEHOLDER,
   USER_UNREGISTERED,
@@ -92,6 +93,19 @@ describe("/api/comments/[threadId]/comments", () => {
       (
         await doCommentsTest(
           USER_UNREGISTERED,
+          THREAD_ID_BY_STAKEHOLDER,
+          undefined,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("GET returns error 403 for disabled user", async () => {
+    expect(
+      (
+        await doCommentsTest(
+          USER_DISABLED_CONTENT_ADMIN,
           THREAD_ID_BY_STAKEHOLDER,
           undefined,
           true
@@ -184,6 +198,20 @@ describe("/api/comments/[threadId]/comments", () => {
       (
         await doCommentsTest(
           USER_UNREGISTERED,
+          THREAD_ID_BY_STAKEHOLDER,
+          NEW_COMMENT_FOO_DATA,
+          true,
+          METHOD.POST
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("POST returns error 403 for disabled user", async () => {
+    expect(
+      (
+        await doCommentsTest(
+          USER_DISABLED_CONTENT_ADMIN,
           THREAD_ID_BY_STAKEHOLDER,
           NEW_COMMENT_FOO_DATA,
           true,

--- a/__tests__/api-comments.test.ts
+++ b/__tests__/api-comments.test.ts
@@ -11,6 +11,7 @@ import commentsHandler from "../pages/api/comments";
 import {
   USER_CELLXGENE_ADMIN,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_INTEGRATION_LEAD_DRAFT,
   USER_STAKEHOLDER,
   USER_UNREGISTERED,
@@ -68,6 +69,18 @@ describe("/api/comments", () => {
     expect(
       (
         await doCommentsTest(USER_UNREGISTERED, NEW_COMMENT_FOO_DATA, true)
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 for disabled user", async () => {
+    expect(
+      (
+        await doCommentsTest(
+          USER_DISABLED_CONTENT_ADMIN,
+          NEW_COMMENT_FOO_DATA,
+          true
+        )
       )._getStatusCode()
     ).toEqual(403);
   });

--- a/__tests__/api-me.test.ts
+++ b/__tests__/api-me.test.ts
@@ -55,6 +55,7 @@ describe(TEST_ROUTE, () => {
     const res = await doMeRequest(USER_UNREGISTERED);
     expect(res.statusCode).toEqual(200);
     const user: HCAAtlasTrackerActiveUser = res._getJSONData();
+    expect(user.disabled).toEqual(false);
     expect(user.email).toEqual(USER_UNREGISTERED.email);
     expect(user.fullName).toEqual(USER_UNREGISTERED.name);
     expect(user.role).toEqual(ROLE.UNREGISTERED);
@@ -116,6 +117,7 @@ function expectActiveUserToMatchTest(
   activeUser: HCAAtlasTrackerActiveUser,
   testUser: TestUser
 ): void {
+  expect(activeUser.disabled).toEqual(testUser.disabled);
   expect(activeUser.email).toEqual(testUser.email);
   expect(activeUser.fullName).toEqual(testUser.name);
   expect(activeUser.role).toEqual(testUser.role);

--- a/__tests__/api-refresh.test.ts
+++ b/__tests__/api-refresh.test.ts
@@ -15,6 +15,7 @@ import {
   TEST_CELLXGENE_COLLECTIONS_A,
   TEST_HCA_CATALOGS,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
 } from "../testing/constants";
 import { TestUser } from "../testing/entities";
@@ -98,6 +99,14 @@ describe(TEST_ROUTE, () => {
     ).toEqual(403);
   });
 
+  it("returns error 403 when GET requested by disabled user", async () => {
+    expect(
+      (
+        await doRefreshTest(USER_DISABLED_CONTENT_ADMIN, METHOD.GET)
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
   for (const role of STAKEHOLDER_ANALOGOUS_ROLES) {
     testApiRole(
       "returns error 403",
@@ -141,6 +150,14 @@ describe(TEST_ROUTE, () => {
   it("returns error 403 when POST requested by unregistered user", async () => {
     expect(
       (await doRefreshTest(USER_UNREGISTERED, METHOD.POST))._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 when POST requested by disabled user", async () => {
+    expect(
+      (
+        await doRefreshTest(USER_DISABLED_CONTENT_ADMIN, METHOD.POST)
+      )._getStatusCode()
     ).toEqual(403);
   });
 

--- a/__tests__/api-tasks-cellxgene-in-progress.test.ts
+++ b/__tests__/api-tasks-cellxgene-in-progress.test.ts
@@ -25,6 +25,7 @@ import {
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CELLXGENE_ADMIN,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
 } from "../testing/constants";
 import { resetDatabase } from "../testing/db-utils";
@@ -134,6 +135,14 @@ describe(TEST_ROUTE, () => {
     expect(
       (
         await doCellxGeneInProgressRequest(DOIS, USER_UNREGISTERED)
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 for disabled user", async () => {
+    expect(
+      (
+        await doCellxGeneInProgressRequest(DOIS, USER_DISABLED_CONTENT_ADMIN)
       )._getStatusCode()
     ).toEqual(403);
   });

--- a/__tests__/api-tasks-completion-dates.test.ts
+++ b/__tests__/api-tasks-completion-dates.test.ts
@@ -13,6 +13,7 @@ import {
   SOURCE_STUDY_PUBLISHED_WITH_HCA,
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
 } from "../testing/constants";
 import { resetDatabase } from "../testing/db-utils";
@@ -89,6 +90,19 @@ describe(TEST_ROUTE, () => {
       (
         await doCompletionDatesRequest(
           USER_UNREGISTERED,
+          DATE_VALID,
+          validationIds
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectValidationsToBeUnchanged();
+  });
+
+  it("returns error 403 for disabled user", async () => {
+    expect(
+      (
+        await doCompletionDatesRequest(
+          USER_DISABLED_CONTENT_ADMIN,
           DATE_VALID,
           validationIds
         )

--- a/__tests__/api-tasks-validation-id-comment.test.ts
+++ b/__tests__/api-tasks-validation-id-comment.test.ts
@@ -16,6 +16,7 @@ import {
   THREAD_ID_BY_STAKEHOLDER,
   USER_CELLXGENE_ADMIN,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_INTEGRATION_LEAD_DRAFT,
   USER_STAKEHOLDER,
   USER_UNREGISTERED,
@@ -117,6 +118,21 @@ describe("/api/tasks/[validationId]/comment", () => {
         await doCommentRequest(
           validationWithoutCommentA.id,
           USER_UNREGISTERED,
+          METHOD.POST,
+          NEW_COMMENT_FOO_DATA,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    await expectCommentTextToNotExist(NEW_COMMENT_FOO_DATA.text);
+  });
+
+  it("POST returns error 403 for disabled user", async () => {
+    expect(
+      (
+        await doCommentRequest(
+          validationWithoutCommentA.id,
+          USER_DISABLED_CONTENT_ADMIN,
           METHOD.POST,
           NEW_COMMENT_FOO_DATA,
           true
@@ -241,6 +257,19 @@ describe("/api/tasks/[validationId]/comment", () => {
         await doCommentRequest(
           validationWithComment.id,
           USER_UNREGISTERED,
+          METHOD.DELETE
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+    expectThreadToBeUnchanged(THREAD_ID_BY_STAKEHOLDER);
+  });
+
+  it("DELETE returns error 403 for disabled user", async () => {
+    expect(
+      (
+        await doCommentRequest(
+          validationWithComment.id,
+          USER_DISABLED_CONTENT_ADMIN,
           METHOD.DELETE
         )
       )._getStatusCode()

--- a/__tests__/api-tasks.test.ts
+++ b/__tests__/api-tasks.test.ts
@@ -10,6 +10,7 @@ import {
   STAKEHOLDER_ANALOGOUS_ROLES,
   TEST_HCA_PROJECTS_BY_DOI,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_STAKEHOLDER,
   USER_UNREGISTERED,
 } from "../testing/constants";
@@ -47,6 +48,12 @@ describe(TEST_ROUTE, () => {
     expect((await doTasksRequest(USER_UNREGISTERED))._getStatusCode()).toEqual(
       403
     );
+  });
+
+  it("returns error 403 for disabled user", async () => {
+    expect(
+      (await doTasksRequest(USER_DISABLED_CONTENT_ADMIN))._getStatusCode()
+    ).toEqual(403);
   });
 
   for (const role of STAKEHOLDER_ANALOGOUS_ROLES) {

--- a/__tests__/api-users-create.test.ts
+++ b/__tests__/api-users-create.test.ts
@@ -12,6 +12,7 @@ import createHandler from "../pages/api/users/create";
 import {
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_NEW,
   USER_UNREGISTERED,
 } from "../testing/constants";
@@ -59,6 +60,14 @@ describe(TEST_ROUTE, () => {
   it("returns error 403 for unregistered user", async () => {
     expect(
       (await doCreateTest(USER_UNREGISTERED, NEW_USER_DATA))._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 for disabled user", async () => {
+    expect(
+      (
+        await doCreateTest(USER_DISABLED_CONTENT_ADMIN, NEW_USER_DATA)
+      )._getStatusCode()
     ).toEqual(403);
   });
 

--- a/__tests__/api-users-id-disable.test.ts
+++ b/__tests__/api-users-id-disable.test.ts
@@ -7,6 +7,7 @@ import disableHandler from "../pages/api/users/[id]/disable";
 import {
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_STAKEHOLDER,
   USER_UNREGISTERED,
 } from "../testing/constants";
@@ -59,6 +60,14 @@ describe(TEST_ROUTE, () => {
     expect(
       (
         await doDisableRequest(USER_UNREGISTERED, userStakeholderId)
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 for disabled user", async () => {
+    expect(
+      (
+        await doDisableRequest(USER_DISABLED_CONTENT_ADMIN, userStakeholderId)
       )._getStatusCode()
     ).toEqual(403);
   });

--- a/__tests__/api-users-id-enable.test.ts
+++ b/__tests__/api-users-id-enable.test.ts
@@ -8,6 +8,7 @@ import {
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
   USER_DISABLED,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
 } from "../testing/constants";
 import { resetDatabase } from "../testing/db-utils";
@@ -57,6 +58,14 @@ describe(TEST_ROUTE, () => {
     expect(
       (
         await doEnableRequest(USER_UNREGISTERED, userDisabledId)
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 for disabled user", async () => {
+    expect(
+      (
+        await doEnableRequest(USER_DISABLED_CONTENT_ADMIN, userDisabledId)
       )._getStatusCode()
     ).toEqual(403);
   });

--- a/__tests__/api-users-id.test.ts
+++ b/__tests__/api-users-id.test.ts
@@ -13,6 +13,7 @@ import {
   INITIAL_TEST_USERS,
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_NONEXISTENT,
   USER_STAKEHOLDER,
   USER_UNREGISTERED,
@@ -82,6 +83,14 @@ describe(TEST_ROUTE, () => {
     ).toEqual(403);
   });
 
+  it("returns error 403 when user is GET requested by disabled user", async () => {
+    expect(
+      (
+        await doUserRequest(USER_STAKEHOLDER, USER_DISABLED_CONTENT_ADMIN)
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
   it("GET returns error 404 when nonexistent user is requested", async () => {
     expect(
       (
@@ -133,6 +142,20 @@ describe(TEST_ROUTE, () => {
         await doUserRequest(
           USER_STAKEHOLDER,
           USER_UNREGISTERED,
+          false,
+          METHOD.PATCH,
+          USER_STAKEHOLDER_EDIT
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 when user is PATCH requested by disabled user", async () => {
+    expect(
+      (
+        await doUserRequest(
+          USER_STAKEHOLDER,
+          USER_DISABLED_CONTENT_ADMIN,
           false,
           METHOD.PATCH,
           USER_STAKEHOLDER_EDIT

--- a/__tests__/api-users-integration-leads-from-atlases.test.ts
+++ b/__tests__/api-users-integration-leads-from-atlases.test.ts
@@ -13,6 +13,7 @@ import {
   INTEGRATION_LEAD_BAZ_BAZ,
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_INTEGRATION_LEAD_DRAFT,
   USER_INTEGRATION_LEAD_PUBLIC,
   USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
@@ -58,6 +59,14 @@ describe(TEST_ROUTE, () => {
   it("returns error 403 for unregistered user", async () => {
     expect(
       (await doIntegrationLeadsRequest(USER_UNREGISTERED))._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 for disabled user", async () => {
+    expect(
+      (
+        await doIntegrationLeadsRequest(USER_DISABLED_CONTENT_ADMIN)
+      )._getStatusCode()
     ).toEqual(403);
   });
 

--- a/__tests__/api-users.test.ts
+++ b/__tests__/api-users.test.ts
@@ -13,6 +13,7 @@ import {
   INITIAL_TEST_USERS,
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
   USER_NONEXISTENT,
   USER_STAKEHOLDER,
   USER_UNREGISTERED,
@@ -51,6 +52,12 @@ describe(TEST_ROUTE, () => {
     expect((await doUsersRequest(USER_UNREGISTERED))._getStatusCode()).toEqual(
       403
     );
+  });
+
+  it("returns error 403 for disabled user", async () => {
+    expect(
+      (await doUsersRequest(USER_DISABLED_CONTENT_ADMIN))._getStatusCode()
+    ).toEqual(403);
   });
 
   for (const role of STAKEHOLDER_ANALOGOUS_ROLES) {

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -174,6 +174,7 @@ export interface HCAAtlasTrackerComment {
 }
 
 export interface HCAAtlasTrackerActiveUser {
+  disabled: boolean;
   email: string;
   fullName: string;
   role: ROLE;

--- a/app/content/hca-atlas-tracker/account-disabled.mdx
+++ b/app/content/hca-atlas-tracker/account-disabled.mdx
@@ -1,0 +1,3 @@
+# Account Disabled
+
+Your account is currently disabled. If you believe this is an error, please email [Ellen Todres](mailto:etodres@humancellatlas.org).

--- a/app/providers/authorization.tsx
+++ b/app/providers/authorization.tsx
@@ -23,14 +23,16 @@ interface Props {
 export function AuthorizationProvider({ children }: Props): JSX.Element {
   const { isAuthenticated } = useAuthentication();
   const user = useFetchActiveUser();
-  const { role } = user || {};
-  const isAuthorized = isUserAuthorized(role);
+  const { disabled, role } = user || {};
+  const isAuthorized = isUserAuthorized(role, disabled);
 
   useEffect(() => {
     if (role === ROLE.UNREGISTERED) {
       location.href = ROUTE.REGISTRATION_REQUIRED;
+    } else if (disabled) {
+      location.href = ROUTE.ACCOUNT_DISABLED;
     }
-  }, [role]);
+  }, [role, disabled]);
 
   return (
     <AuthorizationContext.Provider value={{ user }}>
@@ -46,10 +48,11 @@ export function AuthorizationProvider({ children }: Props): JSX.Element {
 /**
  * Returns true if the user is authorized.
  * @param role - User's role.
+ * @param disabled - Whether the user's account is disabled.
  * @returns true if the user is authorized.
  */
-function isUserAuthorized(role?: ROLE): boolean {
-  if (!role) return false;
+function isUserAuthorized(role?: ROLE, disabled?: boolean): boolean {
+  if (!role || disabled) return false;
   return role !== ROLE.UNREGISTERED;
 }
 

--- a/app/routes/constants.ts
+++ b/app/routes/constants.ts
@@ -1,4 +1,5 @@
 export const ROUTE = {
+  ACCOUNT_DISABLED: "/account-disabled",
   ATLAS: "/atlases/[atlasId]",
   ATLASES: "/atlases",
   COMPONENT_ATLAS: "/atlases/[atlasId]/component-atlases/[componentAtlasId]",

--- a/pages/account-disabled/index.tsx
+++ b/pages/account-disabled/index.tsx
@@ -1,0 +1,33 @@
+import { Main } from "@databiosphere/findable-ui/lib/components/Layout/components/ContentLayout/components/Main/main";
+import { ContentView } from "@databiosphere/findable-ui/lib/views/ContentView/contentView";
+import { GetStaticProps, InferGetStaticPropsType } from "next";
+import { MDXRemote } from "next-mdx-remote";
+import { Content } from "../../app/components/Layout/components/Content/content";
+import { MDX_COMPONENTS } from "../../app/content/common/constants";
+import { getContentStaticProps } from "../../app/content/common/contentPages";
+
+const slug = ["account-disabled"];
+
+export const getStaticProps: GetStaticProps = async () => {
+  return getContentStaticProps({ params: { slug } }, "Account Disabled");
+};
+
+const RegistrationRequiredPage = ({
+  layoutStyle,
+  mdxSource,
+}: InferGetStaticPropsType<typeof getStaticProps>): JSX.Element => {
+  return (
+    <ContentView
+      content={
+        <Content>
+          <MDXRemote {...mdxSource} components={MDX_COMPONENTS} />
+        </Content>
+      }
+      layoutStyle={layoutStyle ?? undefined}
+    />
+  );
+};
+
+RegistrationRequiredPage.Main = Main;
+
+export default RegistrationRequiredPage;

--- a/pages/api/me.ts
+++ b/pages/api/me.ts
@@ -18,6 +18,7 @@ export default handler(method(METHOD.GET), async (req, res) => {
   if (user) {
     await updateLastLogin(user.id);
     activeUserInfo = {
+      disabled: user.disabled,
       email: user.email,
       fullName: user.full_name,
       role: user.role,
@@ -25,6 +26,7 @@ export default handler(method(METHOD.GET), async (req, res) => {
     };
   } else if (userProfile) {
     activeUserInfo = {
+      disabled: false,
       email: userProfile.email,
       fullName: userProfile.name,
       role: ROLE.UNREGISTERED,

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -1515,6 +1515,11 @@ export const USER_CELLXGENE_ADMIN = makeTestUser(
   "test-cellxgene-admin",
   ROLE.CELLXGENE_ADMIN
 );
+export const USER_DISABLED_CONTENT_ADMIN = makeTestUser(
+  "test-disabled-content-admin",
+  ROLE.CONTENT_ADMIN,
+  true
+);
 
 // Users initialized in the database before tests
 export const INITIAL_TEST_USERS = [
@@ -1527,6 +1532,7 @@ export const INITIAL_TEST_USERS = [
   USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
   USER_INTEGRATION_LEAD_WITH_NEW_ATLAS,
   USER_CELLXGENE_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
 ];
 
 export const TEST_USERS = [


### PR DESCRIPTION
- APIs that require a registered account now also require an enabled account
  - Many of the changed files are tests updated to check this
- A message is shown when a user tries to log in with a disabled account