### PR TITLE
feat: trim whitespace from email in user forms (#429)

### DIFF
--- a/__tests__/api-users-id.test.ts
+++ b/__tests__/api-users-id.test.ts
@@ -211,6 +211,23 @@ describe(TEST_ROUTE, () => {
     ).toEqual(400);
   });
 
+  it("returns error 400 when email value has trailing whitespace", async () => {
+    expect(
+      (
+        await doUserRequest(
+          USER_STAKEHOLDER,
+          USER_CONTENT_ADMIN,
+          true,
+          METHOD.PATCH,
+          {
+            ...USER_STAKEHOLDER_EDIT,
+            email: USER_STAKEHOLDER_EDIT.email + " ",
+          }
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+  });
+
   it("returns error 400 when role is undefined", async () => {
     expect(
       (

--- a/app/views/AddNewUserView/common/schema.ts
+++ b/app/views/AddNewUserView/common/schema.ts
@@ -4,10 +4,10 @@ import { FIELD_NAME } from "./constants";
 
 export const newUserSchema = object({
   [FIELD_NAME.DISABLED]: string().oneOf(["enabled", "disabled"]).required(),
-  [FIELD_NAME.EMAIL]: string().required().email(),
+  [FIELD_NAME.EMAIL]: string().required().trim().email(),
   [FIELD_NAME.FULL_NAME]: string().required(),
   [FIELD_NAME.ROLE]: string().defined().oneOf(Object.values(ROLE)),
   [FIELD_NAME.ROLE_ASSOCIATED_RESOURCE_IDS]: array()
     .of(string().uuid().required())
     .required(),
-}).strict(true);
+});

--- a/app/views/UserView/common/schema.ts
+++ b/app/views/UserView/common/schema.ts
@@ -4,10 +4,10 @@ import { FIELD_NAME } from "./constants";
 
 export const userEditSchema = object({
   [FIELD_NAME.DISABLED]: string().oneOf(["enabled", "disabled"]).required(),
-  [FIELD_NAME.EMAIL]: string().required().email(),
+  [FIELD_NAME.EMAIL]: string().required().trim().email(),
   [FIELD_NAME.FULL_NAME]: string().required(),
   [FIELD_NAME.ROLE]: string().defined().oneOf(Object.values(ROLE)),
   [FIELD_NAME.ROLE_ASSOCIATED_RESOURCE_IDS]: array()
     .of(string().uuid().required())
     .required(),
-}).strict(true);
+});

--- a/pages/api/users/create.ts
+++ b/pages/api/users/create.ts
@@ -1,9 +1,5 @@
-import { ValidationError } from "yup";
 import { ROLE } from "../../../app/apis/catalog/hca-atlas-tracker/common/entities";
-import {
-  NewUserData,
-  newUserSchema,
-} from "../../../app/apis/catalog/hca-atlas-tracker/common/schema";
+import { newUserSchema } from "../../../app/apis/catalog/hca-atlas-tracker/common/schema";
 import { dbUserToApiUser } from "../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../app/common/entities";
 import { createUser } from "../../../app/services/users";
@@ -16,17 +12,7 @@ export default handler(
   method(METHOD.POST),
   role(ROLE.CONTENT_ADMIN),
   async (req, res) => {
-    let newInfo: NewUserData;
-    try {
-      newInfo = await newUserSchema.validate(req.body);
-    } catch (e) {
-      if (e instanceof ValidationError) {
-        res.status(400).end();
-        return;
-      } else {
-        throw e;
-      }
-    }
+    const newInfo = await newUserSchema.validate(req.body);
     res.status(201).json(dbUserToApiUser(await createUser(newInfo)));
   }
 );


### PR DESCRIPTION
I've removed the "strict" setting from the forms' schemas, which allows the email to be automatically trimmed before being sent to the API; as far as I know removing that setting won't have any other effects -- I believe it's a carryover from the API schemas, where we wanted to prevent values of the wrong type from being cast to the correct type and thus accepted

(Note: I've also tacked on a change to the user create handler, because I came across an issue where a validation error that happened server-side didn't get returned to the client)