### PR TITLE
feat: add doi input to atlas forms (#485)

### DIFF
--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -307,8 +307,8 @@ export function getSourceStudyCitation(
 
 /**
  * Returns the publication citation.
- * @param param0 - DOI and publication info.
- * @param param0.publication - Publication.
+ * @param doiPuplicationInfo - DOI and publication info.
+ * @param doiPuplicationInfo.publication - Publication.
  * @returns publication citation.
  */
 export function getPublicationCitation({

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -315,7 +315,7 @@ export function getPublicationCitation({
   publication,
 }: DoiPublicationInfo): string {
   return getPublishedCitation(
-    DOI_STATUS.NA, // TODO should be actually based on something?
+    DOI_STATUS.OK, // TODO should be actually based on something?
     publication?.authors[0].name ?? null,
     publication?.publicationDate ?? null,
     publication?.journal ?? null

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -2,6 +2,7 @@ import { GREATEST_UNIX_TIME } from "../../../../utils/date-fns";
 import { NETWORK_KEYS, UNPUBLISHED, WAVES } from "./constants";
 import {
   DOI_STATUS,
+  DoiPublicationInfo,
   HCAAtlasTrackerAtlas,
   HCAAtlasTrackerComment,
   HCAAtlasTrackerComponentAtlas,
@@ -302,6 +303,23 @@ export function getSourceStudyCitation(
       journal
     );
   }
+}
+
+/**
+ * Returns the publication citation.
+ * @param param0 - DOI and publication info.
+ * @param param0.publication - Publication.
+ * @returns publication citation.
+ */
+export function getPublicationCitation({
+  publication,
+}: DoiPublicationInfo): string {
+  return getPublishedCitation(
+    DOI_STATUS.NA, // TODO should be actually based on something?
+    publication?.authors[0].name ?? null,
+    publication?.publicationDate ?? null,
+    publication?.journal ?? null
+  );
 }
 
 function getPublishedCitation(

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -315,7 +315,7 @@ export function getPublicationCitation({
   publication,
 }: DoiPublicationInfo): string {
   return getPublishedCitation(
-    DOI_STATUS.OK, // TODO should be actually based on something?
+    publication ? DOI_STATUS.OK : DOI_STATUS.DOI_NOT_ON_CROSSREF,
     publication?.authors[0].name ?? null,
     publication?.publicationDate ?? null,
     publication?.journal ?? null

--- a/app/components/Detail/components/TrackerForm/components/Section/components/ComponentAtlas/common/constants.ts
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/ComponentAtlas/common/constants.ts
@@ -1,10 +1,12 @@
+import { HCAAtlasTrackerComponentAtlas } from "../../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { NewComponentAtlasData } from "../../../../../../../../../views/AddNewComponentAtlasView/common/entities";
 import { FIELD_NAME } from "../../../../../../../../../views/ComponentAtlasView/common/constants";
 import { ComponentAtlasEditData } from "../../../../../../../../../views/ComponentAtlasView/common/entities";
 import { ControllerConfig } from "../../../../../../../../common/Form/components/Controllers/common/entities";
 
 type CommonControllerConfig = ControllerConfig<
-  ComponentAtlasEditData | NewComponentAtlasData
+  ComponentAtlasEditData | NewComponentAtlasData,
+  HCAAtlasTrackerComponentAtlas
 >;
 
 const TITLE: CommonControllerConfig = {
@@ -15,8 +17,12 @@ const TITLE: CommonControllerConfig = {
   name: FIELD_NAME.TITLE,
 };
 
-export const GENERAL_INFO_NEW_COMPONENT_ATLAS_CONTROLLERS: ControllerConfig<NewComponentAtlasData>[] =
-  [TITLE];
+export const GENERAL_INFO_NEW_COMPONENT_ATLAS_CONTROLLERS: ControllerConfig<
+  NewComponentAtlasData,
+  HCAAtlasTrackerComponentAtlas
+>[] = [TITLE];
 
-export const GENERAL_INFO_VIEW_COMPONENT_ATLAS_CONTROLLERS: ControllerConfig<ComponentAtlasEditData>[] =
-  GENERAL_INFO_NEW_COMPONENT_ATLAS_CONTROLLERS;
+export const GENERAL_INFO_VIEW_COMPONENT_ATLAS_CONTROLLERS: ControllerConfig<
+  ComponentAtlasEditData,
+  HCAAtlasTrackerComponentAtlas
+>[] = GENERAL_INFO_NEW_COMPONENT_ATLAS_CONTROLLERS;

--- a/app/components/Detail/components/TrackerForm/components/Section/components/ComponentAtlas/components/GeneralInfo/generalInfo.tsx
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/ComponentAtlas/components/GeneralInfo/generalInfo.tsx
@@ -12,7 +12,7 @@ import {
 } from "../../../../section.styles";
 
 export interface GeneralInfoProps<T extends FieldValues> {
-  controllerConfigs: ControllerConfig<T>[];
+  controllerConfigs: ControllerConfig<T, HCAAtlasTrackerComponentAtlas>[];
   formManager: FormManager;
   formMethod: FormMethod<T, HCAAtlasTrackerComponentAtlas>;
 }

--- a/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/common/constants.ts
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/common/constants.ts
@@ -1,10 +1,12 @@
+import { HCAAtlasTrackerSourceDataset } from "../../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { ControllerConfig } from "../../../../../../../../common/Form/components/Controllers/common/entities";
 import { NewSourceDatasetData } from "../../../../../../AddSourceDataset/common/entities";
 import { FIELD_NAME } from "../../../../../../ViewSourceDataset/common/constants";
 import { SourceDatasetEditData } from "../../../../../../ViewSourceDataset/common/entities";
 
 type CommonControllerConfig = ControllerConfig<
-  NewSourceDatasetData | SourceDatasetEditData
+  NewSourceDatasetData | SourceDatasetEditData,
+  HCAAtlasTrackerSourceDataset
 >;
 
 const TITLE: CommonControllerConfig = {
@@ -14,8 +16,12 @@ const TITLE: CommonControllerConfig = {
   name: FIELD_NAME.TITLE,
 };
 
-export const GENERAL_INFO_NEW_SOURCE_DATASET_CONTROLLERS: ControllerConfig<NewSourceDatasetData>[] =
-  [TITLE];
+export const GENERAL_INFO_NEW_SOURCE_DATASET_CONTROLLERS: ControllerConfig<
+  NewSourceDatasetData,
+  HCAAtlasTrackerSourceDataset
+>[] = [TITLE];
 
-export const GENERAL_INFO_VIEW_SOURCE_DATASET_CONTROLLERS: ControllerConfig<SourceDatasetEditData>[] =
-  GENERAL_INFO_NEW_SOURCE_DATASET_CONTROLLERS;
+export const GENERAL_INFO_VIEW_SOURCE_DATASET_CONTROLLERS: ControllerConfig<
+  SourceDatasetEditData,
+  HCAAtlasTrackerSourceDataset
+>[] = GENERAL_INFO_NEW_SOURCE_DATASET_CONTROLLERS;

--- a/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/GeneralInfo/generalInfo.tsx
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/SourceDataset/components/GeneralInfo/generalInfo.tsx
@@ -19,7 +19,7 @@ export interface GeneralInfoProps<T extends FieldValues> {
   actions?: DialogBodyProps<T, HCAAtlasTrackerSourceDataset>["actions"];
   apiData?: HCAAtlasTrackerSourceDataset;
   canDelete?: boolean;
-  controllerConfigs: ControllerConfig<T>[];
+  controllerConfigs: ControllerConfig<T, HCAAtlasTrackerSourceDataset>[];
   mapSchemaValues?: MapSchemaValuesFn<T, HCAAtlasTrackerSourceDataset>;
   method: METHOD;
   onClose: () => void;

--- a/app/components/Detail/components/TrackerForm/components/Section/components/TrackerFormSection/trackerFormSection.tsx
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/TrackerFormSection/trackerFormSection.tsx
@@ -15,7 +15,7 @@ import {
 import { SlotProps } from "./common/utils";
 
 export interface TrackerFormSectionProps<T extends FieldValues, R = undefined> {
-  controllerConfigs?: ControllerConfig<T>[];
+  controllerConfigs?: ControllerConfig<T, R>[];
   formManager: FormManager;
   formMethod: FormMethod<T, R>;
   SectionCard?: SectionContent<T, R>;

--- a/app/components/Forms/components/Atlas/common/constants.ts
+++ b/app/components/Forms/components/Atlas/common/constants.ts
@@ -1,3 +1,6 @@
+import { HCAAtlasTrackerAtlas } from "app/apis/catalog/hca-atlas-tracker/common/entities";
+import { getPublicationCitation } from "../../../../../apis/catalog/hca-atlas-tracker/common/utils";
+import { getDOILink } from "../../../../../viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders";
 import { NewAtlasData } from "../../../../../views/AddNewAtlasView/common/entities";
 import { FIELD_NAME } from "../../../../../views/AtlasView/common/constants";
 import { AtlasEditData } from "../../../../../views/AtlasView/common/entities";
@@ -6,7 +9,10 @@ import { BioNetwork } from "../../../../Form/components/Select/components/BioNet
 import { TargetCompletion } from "../../../../Form/components/Select/components/TargetCompletion/targetCompletion";
 import { Wave } from "../../../../Form/components/Select/components/Wave/wave";
 
-type CommonControllerConfig = ControllerConfig<NewAtlasData | AtlasEditData>;
+type CommonControllerConfig = ControllerConfig<
+  NewAtlasData | AtlasEditData,
+  HCAAtlasTrackerAtlas
+>;
 
 const BIO_NETWORK: CommonControllerConfig = {
   name: FIELD_NAME.BIO_NETWORK,
@@ -25,14 +31,15 @@ const SHORT_NAME: CommonControllerConfig = {
   name: FIELD_NAME.SHORT_NAME,
 };
 
-const TARGET_COMPLETION: ControllerConfig<AtlasEditData> = {
-  name: FIELD_NAME.TARGET_COMPLETION,
-  selectProps: {
-    SelectComponent: TargetCompletion,
-    displayEmpty: true,
-    label: "Target completion",
-  },
-};
+const TARGET_COMPLETION: ControllerConfig<AtlasEditData, HCAAtlasTrackerAtlas> =
+  {
+    name: FIELD_NAME.TARGET_COMPLETION,
+    selectProps: {
+      SelectComponent: TargetCompletion,
+      displayEmpty: true,
+      label: "Target completion",
+    },
+  };
 
 const VERSION: CommonControllerConfig = {
   inputProps: {
@@ -51,6 +58,20 @@ const WAVE: CommonControllerConfig = {
   },
 };
 
+const DOI: CommonControllerConfig = {
+  inputProps: {
+    label: "Publication DOI",
+  },
+  labelLink: {
+    getUrl: (v) => getDOILink(v) || null,
+  },
+  name: FIELD_NAME.DOI,
+  renderHelperText(atlas) {
+    const publication = atlas?.publications[0];
+    return publication ? getPublicationCitation(publication) : "";
+  },
+};
+
 const CELLXGENE_COLLECTION_ID: CommonControllerConfig = {
   inputProps: {
     isFullWidth: true,
@@ -60,14 +81,22 @@ const CELLXGENE_COLLECTION_ID: CommonControllerConfig = {
   name: FIELD_NAME.CELLXGENE_ATLAS_COLLECTION,
 };
 
-export const GENERAL_INFO_NEW_ATLAS_CONTROLLERS: ControllerConfig<NewAtlasData>[] =
-  [SHORT_NAME, VERSION, BIO_NETWORK, WAVE];
+export const GENERAL_INFO_NEW_ATLAS_CONTROLLERS: ControllerConfig<
+  NewAtlasData,
+  HCAAtlasTrackerAtlas
+>[] = [SHORT_NAME, VERSION, BIO_NETWORK, WAVE, DOI];
 
-export const IDENTIFIERS_NEW_ATLAS_CONTROLLERS: ControllerConfig<NewAtlasData>[] =
-  [CELLXGENE_COLLECTION_ID];
+export const IDENTIFIERS_NEW_ATLAS_CONTROLLERS: ControllerConfig<
+  NewAtlasData,
+  HCAAtlasTrackerAtlas
+>[] = [CELLXGENE_COLLECTION_ID];
 
-export const GENERAL_INFO_VIEW_ATLAS_CONTROLLERS: ControllerConfig<AtlasEditData>[] =
-  [...GENERAL_INFO_NEW_ATLAS_CONTROLLERS, TARGET_COMPLETION];
+export const GENERAL_INFO_VIEW_ATLAS_CONTROLLERS: ControllerConfig<
+  AtlasEditData,
+  HCAAtlasTrackerAtlas
+>[] = [...GENERAL_INFO_NEW_ATLAS_CONTROLLERS, TARGET_COMPLETION];
 
-export const IDENTIFIERS_VIEW_ATLAS_CONTROLLERS: ControllerConfig<AtlasEditData>[] =
-  [...IDENTIFIERS_NEW_ATLAS_CONTROLLERS];
+export const IDENTIFIERS_VIEW_ATLAS_CONTROLLERS: ControllerConfig<
+  AtlasEditData,
+  HCAAtlasTrackerAtlas
+>[] = [...IDENTIFIERS_NEW_ATLAS_CONTROLLERS];

--- a/app/components/common/Form/components/Controllers/common/entities.ts
+++ b/app/components/common/Form/components/Controllers/common/entities.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from "react";
 import { FieldValues, Path } from "react-hook-form";
 import { YupValidatedFormValues } from "../../../../../../hooks/useForm/common/entities";
 import { InputProps } from "../../Input/input";
@@ -15,9 +16,10 @@ export type ControllerSelectConfig<T extends FieldValues> = Pick<
 type PickedInputProps = "label" | "isFullWidth" | "placeholder";
 type PickedSelectProps = "displayEmpty" | "label";
 
-export interface ControllerConfig<T extends FieldValues> {
+export interface ControllerConfig<T extends FieldValues, R = undefined> {
   inputProps?: ControllerInputConfig;
   labelLink?: LabelLinkConfig | true;
   name: Path<YupValidatedFormValues<T>>;
+  renderHelperText?: (data?: R) => ReactNode;
   selectProps?: ControllerSelectConfig<T>;
 }

--- a/app/components/common/Form/components/Controllers/components/InputController/inputController.tsx
+++ b/app/components/common/Form/components/Controllers/components/InputController/inputController.tsx
@@ -21,6 +21,7 @@ export interface InputControllerProps<T extends FieldValues, R = undefined>
   formMethod: FormMethod<T, R>;
   inputProps?: Partial<Omit<InputProps, "ref">>;
   labelLink?: LabelLinkConfig | true;
+  renderHelperText?: (data?: R) => ReactNode;
 }
 
 export const InputController = <T extends FieldValues, R = undefined>({
@@ -30,6 +31,7 @@ export const InputController = <T extends FieldValues, R = undefined>({
   inputProps: { label, ...inputProps } = {},
   labelLink,
   name,
+  renderHelperText,
   ...props
 }: InputControllerProps<T, R>): JSX.Element => {
   const {
@@ -45,7 +47,7 @@ export const InputController = <T extends FieldValues, R = undefined>({
           {...field}
           className={className}
           error={invalid}
-          helperText={error?.message}
+          helperText={error?.message || renderHelperText?.(formMethod.data)}
           isFilled={Boolean(field.value)}
           label={
             labelLink

--- a/app/components/common/Form/components/Controllers/controllers.tsx
+++ b/app/components/common/Form/components/Controllers/controllers.tsx
@@ -7,7 +7,7 @@ import { InputController } from "./components/InputController/inputController";
 import { SelectController } from "./components/SelectController/selectController";
 
 export interface ControllersProps<T extends FieldValues, R = undefined> {
-  controllerConfigs: ControllerConfig<T>[];
+  controllerConfigs: ControllerConfig<T, R>[];
   formManager: FormManager;
   formMethod: FormMethod<T, R>;
 }
@@ -20,7 +20,7 @@ export const Controllers = <T extends FieldValues, R = undefined>({
   return (
     <Fragment>
       {controllerConfigs.map(
-        ({ inputProps, labelLink, name, selectProps }, i) => {
+        ({ inputProps, labelLink, name, renderHelperText, selectProps }, i) => {
           const { SelectComponent } = selectProps || {};
           return SelectComponent ? (
             <SelectController
@@ -39,6 +39,7 @@ export const Controllers = <T extends FieldValues, R = undefined>({
               formManager={formManager}
               formMethod={formMethod}
               labelLink={labelLink}
+              renderHelperText={renderHelperText}
             />
           );
         }

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -16,6 +16,7 @@ import {
   AtlasEditData,
   NewAtlasData,
 } from "../apis/catalog/hca-atlas-tracker/common/schema";
+import { normalizeDoi } from "../utils/doi";
 import { query } from "./database";
 import { confirmSourceDatasetStudyIsOnAtlas } from "./source-datasets";
 
@@ -91,7 +92,8 @@ export async function atlasInputDataToDbData(
   const publications: DoiPublicationInfo[] = [];
   if (inputData.dois)
     try {
-      for (const doi of inputData.dois) {
+      for (const sourceDoi of inputData.dois) {
+        const doi = normalizeDoi(sourceDoi);
         publications.push({
           doi,
           publication: await getCrossrefPublicationInfo(doi),

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -1109,11 +1109,12 @@ function getComponentAtlasTitleColumnDef(
 
 /**
  * Returns the DOI link.
- * @param doi - DOI.
+ * @param doi - DOI or DOI URL.
  * @returns DOI link.
  */
 export function getDOILink(doi: string | null): string {
   if (!doi || doi === UNPUBLISHED) return "";
+  if (doi.startsWith("https://doi.org/")) return doi;
   return `https://doi.org/${encodeURIComponent(doi)}`;
 }
 

--- a/app/views/AddNewAtlasView/common/constants.ts
+++ b/app/views/AddNewAtlasView/common/constants.ts
@@ -1,6 +1,7 @@
 export const FIELD_NAME = {
   BIO_NETWORK: "network",
   CELLXGENE_ATLAS_COLLECTION: "cellxgeneAtlasCollection",
+  DOI: "doi",
   INTEGRATION_LEAD: "integrationLead",
   SHORT_NAME: "shortName",
   VERSION: "version",

--- a/app/views/AddNewAtlasView/common/schema.ts
+++ b/app/views/AddNewAtlasView/common/schema.ts
@@ -4,6 +4,7 @@ import {
   WAVES,
 } from "../../../apis/catalog/hca-atlas-tracker/common/constants";
 import { CELLXGENE_COLLECTION_ID_REGEX } from "../../../common/constants";
+import { isDoi } from "../../../utils/doi";
 import { FIELD_NAME } from "./constants";
 
 export const newAtlasSchema = object({
@@ -31,6 +32,14 @@ export const newAtlasSchema = object({
     .matches(
       CELLXGENE_COLLECTION_ID_REGEX,
       "CELLxGENE collection ID must be a UUID or CELLxGENE collection URL"
+    ),
+  [FIELD_NAME.DOI]: string()
+    .default("")
+    .notRequired()
+    .test(
+      "is-doi",
+      "DOI must be a syntactically-valid DOI",
+      (value) => !value || isDoi(value)
     ),
   [FIELD_NAME.SHORT_NAME]: string()
     .default("")

--- a/app/views/AddNewAtlasView/hooks/useAddAtlasForm.ts
+++ b/app/views/AddNewAtlasView/hooks/useAddAtlasForm.ts
@@ -1,4 +1,5 @@
 import { HCAAtlasTrackerAtlas } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { NewAtlasData as APINewAtlasData } from "../../../apis/catalog/hca-atlas-tracker/common/schema";
 import { FormMethod } from "../../../hooks/useForm/common/entities";
 import { useForm } from "../../../hooks/useForm/useForm";
 import { NewAtlasData } from "../common/entities";
@@ -13,7 +14,8 @@ export const useAddAtlasForm = (): FormMethod<
   return useForm<NewAtlasData, HCAAtlasTrackerAtlas>(
     SCHEMA,
     undefined,
-    mapSchemaValues
+    mapSchemaValues,
+    mapApiValues
   );
 };
 
@@ -29,5 +31,18 @@ function mapSchemaValues(): Partial<NewAtlasData> {
         name: "",
       },
     ],
+  };
+}
+
+/**
+ * Returns API payload mapped from data.
+ * @param data - Form data.
+ * @param data.doi - DOI.
+ * @returns API payload.
+ */
+function mapApiValues({ doi, ...data }: NewAtlasData): APINewAtlasData {
+  return {
+    ...data,
+    dois: doi ? [doi] : undefined,
   };
 }

--- a/app/views/AtlasView/hooks/useEditAtlasForm.ts
+++ b/app/views/AtlasView/hooks/useEditAtlasForm.ts
@@ -52,6 +52,7 @@ function mapSchemaValues(atlas?: HCAAtlasTrackerAtlas): Partial<AtlasEditData> {
     [FIELD_NAME.CELLXGENE_ATLAS_COLLECTION]: mapCELLxGENECollectionId(
       atlas.cellxgeneAtlasCollection
     ),
+    [FIELD_NAME.DOI]: atlas.publications[0]?.doi,
     [FIELD_NAME.SHORT_NAME]: atlas.shortName,
     [FIELD_NAME.TARGET_COMPLETION]:
       atlas.targetCompletion ?? TARGET_COMPLETION_NULL,
@@ -75,11 +76,13 @@ function mapCELLxGENECollectionId(
 /**
  * Returns API payload mapped from data.
  * @param data - Form data.
+ * @param data.doi - DOI.
  * @returns API payload.
  */
-function mapApiValues(data: AtlasEditData): APIAtlasEditData {
+function mapApiValues({ doi, ...data }: AtlasEditData): APIAtlasEditData {
   return {
     ...data,
+    dois: doi ? [doi] : undefined,
     targetCompletion: mapTargetCompletion(data.targetCompletion),
   };
 }


### PR DESCRIPTION
The backend already supports atlas DOIs/publications; each atlas technically can have multiple publications, which I've kept as-is while making the forms only support setting 1 or 0 DOIs