### PR TITLE
feat: add title to atlas cellxgene collection input (#505)

### DIFF
--- a/__tests__/api-atlases-id-component-atlases-create.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-create.test.ts
@@ -1,11 +1,11 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
+import { dbComponentAtlasToApiComponentAtlas } from "../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import {
   HCAAtlasTrackerComponentAtlas,
   HCAAtlasTrackerDBComponentAtlas,
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { NewComponentAtlasData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { dbComponentAtlasToApiComponentAtlas } from "../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../app/common/entities";
 import { endPgPool, query } from "../app/services/database";
 import createHandler from "../pages/api/atlases/[atlasId]/component-atlases/create";

--- a/__tests__/api-atlases-id-component-atlases-id.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id.test.ts
@@ -1,11 +1,11 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
+import { dbComponentAtlasToApiComponentAtlas } from "../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import {
   HCAAtlasTrackerComponentAtlas,
   HCAAtlasTrackerDBComponentAtlas,
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { ComponentAtlasEditData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { dbComponentAtlasToApiComponentAtlas } from "../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../app/common/entities";
 import { endPgPool, query } from "../app/services/database";
 import componentAtlasHandler from "../pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId]";

--- a/__tests__/api-atlases-id-source-studies-id-source-datasets-create.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id-source-datasets-create.test.ts
@@ -1,12 +1,12 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
+import { dbSourceDatasetToApiSourceDataset } from "../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import {
   HCAAtlasTrackerDBSourceDataset,
   HCAAtlasTrackerDBSourceDatasetWithStudyProperties,
   HCAAtlasTrackerSourceDataset,
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { NewSourceDatasetData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { dbSourceDatasetToApiSourceDataset } from "../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../app/common/entities";
 import { endPgPool } from "../app/services/database";
 import { getSourceDataset } from "../app/services/source-datasets";

--- a/__tests__/api-atlases-id-source-studies-id-source-datasets-id.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id-source-datasets-id.test.ts
@@ -1,11 +1,11 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
+import { dbSourceDatasetToApiSourceDataset } from "../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import {
   HCAAtlasTrackerDBSourceDataset,
   HCAAtlasTrackerSourceDataset,
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { SourceDatasetEditData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { dbSourceDatasetToApiSourceDataset } from "../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../app/common/entities";
 import { endPgPool, query } from "../app/services/database";
 import { getSourceDataset } from "../app/services/source-datasets";

--- a/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
@@ -1,4 +1,4 @@
-import { getCellxGeneCollectionById } from "../../../../services/cellxgene";
+import { getCellxGeneCollectionInfoById } from "../../../../services/cellxgene";
 import {
   HCAAtlasTrackerAtlas,
   HCAAtlasTrackerComment,
@@ -28,7 +28,7 @@ export function dbAtlasToApiAtlas(
     cellxgeneAtlasCollection: dbAtlas.overview.cellxgeneAtlasCollection,
     cellxgeneAtlasCollectionTitle:
       dbAtlas.overview.cellxgeneAtlasCollection &&
-      (getCellxGeneCollectionById(dbAtlas.overview.cellxgeneAtlasCollection)
+      (getCellxGeneCollectionInfoById(dbAtlas.overview.cellxgeneAtlasCollection)
         ?.title ??
         null),
     codeLinks: dbAtlas.overview.codeLinks,

--- a/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
@@ -1,8 +1,24 @@
 import { getCellxGeneCollectionById } from "../../../../services/cellxgene";
 import {
   HCAAtlasTrackerAtlas,
+  HCAAtlasTrackerComment,
+  HCAAtlasTrackerComponentAtlas,
   HCAAtlasTrackerDBAtlasWithComponentAtlases,
+  HCAAtlasTrackerDBComment,
+  HCAAtlasTrackerDBComponentAtlas,
+  HCAAtlasTrackerDBSourceDatasetWithStudyProperties,
+  HCAAtlasTrackerDBSourceStudy,
+  HCAAtlasTrackerDBSourceStudyWithRelatedEntities,
+  HCAAtlasTrackerDBUserWithAssociatedResources,
+  HCAAtlasTrackerDBValidation,
+  HCAAtlasTrackerDBValidationWithAtlasProperties,
+  HCAAtlasTrackerSourceDataset,
+  HCAAtlasTrackerSourceStudy,
+  HCAAtlasTrackerUser,
+  HCAAtlasTrackerValidationRecord,
+  HCAAtlasTrackerValidationRecordWithoutAtlases,
 } from "./entities";
+import { getPublishedCitation, getUnpublishedCitation } from "./utils";
 
 export function dbAtlasToApiAtlas(
   dbAtlas: HCAAtlasTrackerDBAtlasWithComponentAtlases
@@ -34,4 +50,190 @@ export function dbAtlasToApiAtlas(
     version: dbAtlas.overview.version,
     wave: dbAtlas.overview.wave,
   };
+}
+
+export function dbComponentAtlasToApiComponentAtlas(
+  dbComponentAtlas: HCAAtlasTrackerDBComponentAtlas
+): HCAAtlasTrackerComponentAtlas {
+  return {
+    assay: dbComponentAtlas.component_info.assay,
+    atlasId: dbComponentAtlas.atlas_id,
+    cellCount: dbComponentAtlas.component_info.cellCount,
+    cellxgeneDatasetId: dbComponentAtlas.component_info.cellxgeneDatasetId,
+    cellxgeneDatasetVersion:
+      dbComponentAtlas.component_info.cellxgeneDatasetVersion,
+    description: dbComponentAtlas.component_info.description,
+    disease: dbComponentAtlas.component_info.disease,
+    id: dbComponentAtlas.id,
+    sourceDatasetCount: dbComponentAtlas.source_datasets.length,
+    suspensionType: dbComponentAtlas.component_info.suspensionType,
+    tissue: dbComponentAtlas.component_info.tissue,
+    title: dbComponentAtlas.title,
+  };
+}
+
+export function dbSourceStudyToApiSourceStudy(
+  dbSourceStudy: HCAAtlasTrackerDBSourceStudyWithRelatedEntities
+): HCAAtlasTrackerSourceStudy {
+  const {
+    study_info: { capId, cellxgeneCollectionId, hcaProjectId, publication },
+  } = dbSourceStudy;
+  const tasks = dbSourceStudy.validations.map(
+    dbValidationToApiValidationWithoutAtlasProperties
+  );
+  if (dbSourceStudy.doi === null) {
+    const unpublishedInfo = dbSourceStudy.study_info.unpublishedInfo;
+    return {
+      capId,
+      cellxgeneCollectionId,
+      contactEmail: unpublishedInfo.contactEmail,
+      doi: null,
+      doiStatus: dbSourceStudy.study_info.doiStatus,
+      hcaProjectId,
+      id: dbSourceStudy.id,
+      journal: null,
+      publicationDate: null,
+      referenceAuthor: unpublishedInfo.referenceAuthor,
+      sourceDatasetCount: dbSourceStudy.source_dataset_count,
+      tasks,
+      title: unpublishedInfo.title,
+    };
+  } else {
+    return {
+      capId,
+      cellxgeneCollectionId,
+      contactEmail: null,
+      doi: dbSourceStudy.doi,
+      doiStatus: dbSourceStudy.study_info.doiStatus,
+      hcaProjectId,
+      id: dbSourceStudy.id,
+      journal: publication?.journal ?? null,
+      publicationDate: publication?.publicationDate ?? null,
+      referenceAuthor: publication?.authors[0]?.name ?? null,
+      sourceDatasetCount: dbSourceStudy.source_dataset_count,
+      tasks,
+      title: publication?.title ?? null,
+    };
+  }
+}
+
+export function dbSourceDatasetToApiSourceDataset(
+  dbSourceDataset: HCAAtlasTrackerDBSourceDatasetWithStudyProperties
+): HCAAtlasTrackerSourceDataset {
+  const studyInfo = dbSourceDataset.study_info;
+  return {
+    assay: dbSourceDataset.sd_info.assay,
+    cellCount: dbSourceDataset.sd_info.cellCount,
+    cellxgeneDatasetId: dbSourceDataset.sd_info.cellxgeneDatasetId,
+    cellxgeneDatasetVersion: dbSourceDataset.sd_info.cellxgeneDatasetVersion,
+    cellxgeneExplorerUrl: dbSourceDataset.sd_info.cellxgeneExplorerUrl,
+    createdAt: dbSourceDataset.created_at.toISOString(),
+    disease: dbSourceDataset.sd_info.disease,
+    doi: dbSourceDataset.doi,
+    id: dbSourceDataset.id,
+    metadataSpreadsheetUrl: dbSourceDataset.sd_info.metadataSpreadsheetUrl,
+    publicationString: getDbEntityCitation(dbSourceDataset),
+    sourceStudyId: dbSourceDataset.source_study_id,
+    sourceStudyTitle:
+      studyInfo.publication?.title ?? studyInfo.unpublishedInfo?.title ?? null,
+    suspensionType: dbSourceDataset.sd_info.suspensionType,
+    tissue: dbSourceDataset.sd_info.tissue,
+    title: dbSourceDataset.sd_info.title,
+    updatedAt: dbSourceDataset.updated_at.toISOString(),
+  };
+}
+
+export function dbValidationToApiValidation(
+  validation: HCAAtlasTrackerDBValidationWithAtlasProperties
+): HCAAtlasTrackerValidationRecord {
+  return {
+    ...dbValidationToApiValidationWithoutAtlasProperties(validation),
+    atlasIds: validation.atlas_ids,
+    atlasNames: validation.atlas_names,
+    atlasShortNames: validation.atlas_short_names,
+    atlasVersions: validation.atlas_versions,
+    networks: validation.networks,
+    waves: validation.waves,
+  };
+}
+
+function dbValidationToApiValidationWithoutAtlasProperties(
+  validation: HCAAtlasTrackerDBValidation
+): HCAAtlasTrackerValidationRecordWithoutAtlases {
+  const validationInfo = validation.validation_info;
+  return {
+    commentThreadId: validation.comment_thread_id,
+    createdAt: validation.created_at.toISOString(),
+    description: validationInfo.description,
+    differences: validationInfo.differences,
+    doi: validationInfo.doi,
+    entityId: validation.entity_id,
+    entityTitle: validationInfo.entityTitle,
+    entityType: validationInfo.entityType,
+    id: validation.id,
+    publicationString: validationInfo.publicationString,
+    relatedEntityUrl: validationInfo.relatedEntityUrl,
+    resolvedAt: validation.resolved_at?.toISOString() ?? null,
+    system: validationInfo.system,
+    targetCompletion: validation.target_completion?.toISOString() ?? null,
+    taskStatus: validationInfo.taskStatus,
+    updatedAt: validation.updated_at.toISOString(),
+    validationId: validation.validation_id,
+    validationStatus: validationInfo.validationStatus,
+    validationType: validationInfo.validationType,
+  };
+}
+
+export function dbCommentToApiComment(
+  dbComment: HCAAtlasTrackerDBComment
+): HCAAtlasTrackerComment {
+  return {
+    createdAt: dbComment.created_at.toISOString(),
+    createdBy: dbComment.created_by,
+    id: dbComment.id,
+    text: dbComment.text,
+    threadId: dbComment.thread_id,
+    updatedAt: dbComment.updated_at.toISOString(),
+    updatedBy: dbComment.updated_by,
+  };
+}
+
+export function dbUserToApiUser(
+  dbUser: HCAAtlasTrackerDBUserWithAssociatedResources
+): HCAAtlasTrackerUser {
+  return {
+    disabled: dbUser.disabled,
+    email: dbUser.email,
+    fullName: dbUser.full_name,
+    id: dbUser.id,
+    lastLogin: dbUser.last_login.toISOString(),
+    role: dbUser.role,
+    roleAssociatedResourceIds: dbUser.role_associated_resource_ids,
+    roleAssociatedResourceNames: dbUser.role_associated_resource_names,
+  };
+}
+
+/**
+ * Returns the entity's citation.
+ * @param entity - Database model of entity with source study properties.
+ * @returns citation for the associated source study.
+ */
+export function getDbEntityCitation(
+  entity:
+    | HCAAtlasTrackerDBSourceStudy
+    | HCAAtlasTrackerDBSourceDatasetWithStudyProperties
+): string {
+  if (entity.doi === null) {
+    const { contactEmail, referenceAuthor } = entity.study_info.unpublishedInfo;
+    return getUnpublishedCitation(referenceAuthor, contactEmail);
+  } else {
+    const studyInfo = entity.study_info;
+    const publication = studyInfo.publication;
+    return getPublishedCitation(
+      studyInfo.doiStatus,
+      publication?.authors[0].name ?? null,
+      publication?.publicationDate ?? null,
+      publication?.journal ?? null
+    );
+  }
 }

--- a/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
@@ -1,0 +1,37 @@
+import { getCellxGeneCollectionById } from "../../../../services/cellxgene";
+import {
+  HCAAtlasTrackerAtlas,
+  HCAAtlasTrackerDBAtlasWithComponentAtlases,
+} from "./entities";
+
+export function dbAtlasToApiAtlas(
+  dbAtlas: HCAAtlasTrackerDBAtlasWithComponentAtlases
+): HCAAtlasTrackerAtlas {
+  return {
+    bioNetwork: dbAtlas.overview.network,
+    cellxgeneAtlasCollection: dbAtlas.overview.cellxgeneAtlasCollection,
+    cellxgeneAtlasCollectionTitle:
+      dbAtlas.overview.cellxgeneAtlasCollection &&
+      (getCellxGeneCollectionById(dbAtlas.overview.cellxgeneAtlasCollection)
+        ?.title ??
+        null),
+    codeLinks: dbAtlas.overview.codeLinks,
+    completedTaskCount: dbAtlas.overview.completedTaskCount,
+    componentAtlasCount: dbAtlas.component_atlas_count,
+    description: dbAtlas.overview.description,
+    highlights: dbAtlas.overview.highlights,
+    id: dbAtlas.id,
+    integrationLead: dbAtlas.overview.integrationLead,
+    metadataSpecificationUrl: dbAtlas.overview.metadataSpecificationUrl,
+    publications: dbAtlas.overview.publications,
+    shortName: dbAtlas.overview.shortName,
+    sourceDatasetCount: dbAtlas.source_datasets.length,
+    sourceStudyCount: dbAtlas.source_studies.length,
+    status: dbAtlas.status,
+    targetCompletion: dbAtlas.target_completion?.toISOString() ?? null,
+    taskCount: dbAtlas.overview.taskCount,
+    title: "",
+    version: dbAtlas.overview.version,
+    wave: dbAtlas.overview.wave,
+  };
+}

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -16,6 +16,7 @@ export type HCAAtlasTrackerListAtlas = Omit<
 export interface HCAAtlasTrackerAtlas {
   bioNetwork: NetworkKey;
   cellxgeneAtlasCollection: string | null;
+  cellxgeneAtlasCollectionTitle: string | null;
   codeLinks: LinkInfo[];
   completedTaskCount: number;
   componentAtlasCount: number;

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -4,23 +4,11 @@ import {
   DOI_STATUS,
   DoiPublicationInfo,
   HCAAtlasTrackerAtlas,
-  HCAAtlasTrackerComment,
-  HCAAtlasTrackerComponentAtlas,
-  HCAAtlasTrackerDBComment,
-  HCAAtlasTrackerDBComponentAtlas,
-  HCAAtlasTrackerDBSourceDatasetWithStudyProperties,
-  HCAAtlasTrackerDBSourceStudy,
-  HCAAtlasTrackerDBSourceStudyWithRelatedEntities,
-  HCAAtlasTrackerDBUserWithAssociatedResources,
-  HCAAtlasTrackerDBValidation,
-  HCAAtlasTrackerDBValidationWithAtlasProperties,
   HCAAtlasTrackerListAtlas,
   HCAAtlasTrackerListValidationRecord,
-  HCAAtlasTrackerSourceDataset,
   HCAAtlasTrackerSourceStudy,
   HCAAtlasTrackerUser,
   HCAAtlasTrackerValidationRecord,
-  HCAAtlasTrackerValidationRecordWithoutAtlases,
   NetworkKey,
   PublicationInfo,
   Wave,
@@ -68,194 +56,8 @@ export function atlasInputMapper(
   };
 }
 
-export function dbComponentAtlasToApiComponentAtlas(
-  dbComponentAtlas: HCAAtlasTrackerDBComponentAtlas
-): HCAAtlasTrackerComponentAtlas {
-  return {
-    assay: dbComponentAtlas.component_info.assay,
-    atlasId: dbComponentAtlas.atlas_id,
-    cellCount: dbComponentAtlas.component_info.cellCount,
-    cellxgeneDatasetId: dbComponentAtlas.component_info.cellxgeneDatasetId,
-    cellxgeneDatasetVersion:
-      dbComponentAtlas.component_info.cellxgeneDatasetVersion,
-    description: dbComponentAtlas.component_info.description,
-    disease: dbComponentAtlas.component_info.disease,
-    id: dbComponentAtlas.id,
-    sourceDatasetCount: dbComponentAtlas.source_datasets.length,
-    suspensionType: dbComponentAtlas.component_info.suspensionType,
-    tissue: dbComponentAtlas.component_info.tissue,
-    title: dbComponentAtlas.title,
-  };
-}
-
-export function dbSourceStudyToApiSourceStudy(
-  dbSourceStudy: HCAAtlasTrackerDBSourceStudyWithRelatedEntities
-): HCAAtlasTrackerSourceStudy {
-  const {
-    study_info: { capId, cellxgeneCollectionId, hcaProjectId, publication },
-  } = dbSourceStudy;
-  const tasks = dbSourceStudy.validations.map(
-    dbValidationToApiValidationWithoutAtlasProperties
-  );
-  if (dbSourceStudy.doi === null) {
-    const unpublishedInfo = dbSourceStudy.study_info.unpublishedInfo;
-    return {
-      capId,
-      cellxgeneCollectionId,
-      contactEmail: unpublishedInfo.contactEmail,
-      doi: null,
-      doiStatus: dbSourceStudy.study_info.doiStatus,
-      hcaProjectId,
-      id: dbSourceStudy.id,
-      journal: null,
-      publicationDate: null,
-      referenceAuthor: unpublishedInfo.referenceAuthor,
-      sourceDatasetCount: dbSourceStudy.source_dataset_count,
-      tasks,
-      title: unpublishedInfo.title,
-    };
-  } else {
-    return {
-      capId,
-      cellxgeneCollectionId,
-      contactEmail: null,
-      doi: dbSourceStudy.doi,
-      doiStatus: dbSourceStudy.study_info.doiStatus,
-      hcaProjectId,
-      id: dbSourceStudy.id,
-      journal: publication?.journal ?? null,
-      publicationDate: publication?.publicationDate ?? null,
-      referenceAuthor: publication?.authors[0]?.name ?? null,
-      sourceDatasetCount: dbSourceStudy.source_dataset_count,
-      tasks,
-      title: publication?.title ?? null,
-    };
-  }
-}
-
-export function dbSourceDatasetToApiSourceDataset(
-  dbSourceDataset: HCAAtlasTrackerDBSourceDatasetWithStudyProperties
-): HCAAtlasTrackerSourceDataset {
-  const studyInfo = dbSourceDataset.study_info;
-  return {
-    assay: dbSourceDataset.sd_info.assay,
-    cellCount: dbSourceDataset.sd_info.cellCount,
-    cellxgeneDatasetId: dbSourceDataset.sd_info.cellxgeneDatasetId,
-    cellxgeneDatasetVersion: dbSourceDataset.sd_info.cellxgeneDatasetVersion,
-    cellxgeneExplorerUrl: dbSourceDataset.sd_info.cellxgeneExplorerUrl,
-    createdAt: dbSourceDataset.created_at.toISOString(),
-    disease: dbSourceDataset.sd_info.disease,
-    doi: dbSourceDataset.doi,
-    id: dbSourceDataset.id,
-    metadataSpreadsheetUrl: dbSourceDataset.sd_info.metadataSpreadsheetUrl,
-    publicationString: getDbEntityCitation(dbSourceDataset),
-    sourceStudyId: dbSourceDataset.source_study_id,
-    sourceStudyTitle:
-      studyInfo.publication?.title ?? studyInfo.unpublishedInfo?.title ?? null,
-    suspensionType: dbSourceDataset.sd_info.suspensionType,
-    tissue: dbSourceDataset.sd_info.tissue,
-    title: dbSourceDataset.sd_info.title,
-    updatedAt: dbSourceDataset.updated_at.toISOString(),
-  };
-}
-
-export function dbValidationToApiValidation(
-  validation: HCAAtlasTrackerDBValidationWithAtlasProperties
-): HCAAtlasTrackerValidationRecord {
-  return {
-    ...dbValidationToApiValidationWithoutAtlasProperties(validation),
-    atlasIds: validation.atlas_ids,
-    atlasNames: validation.atlas_names,
-    atlasShortNames: validation.atlas_short_names,
-    atlasVersions: validation.atlas_versions,
-    networks: validation.networks,
-    waves: validation.waves,
-  };
-}
-
-function dbValidationToApiValidationWithoutAtlasProperties(
-  validation: HCAAtlasTrackerDBValidation
-): HCAAtlasTrackerValidationRecordWithoutAtlases {
-  const validationInfo = validation.validation_info;
-  return {
-    commentThreadId: validation.comment_thread_id,
-    createdAt: validation.created_at.toISOString(),
-    description: validationInfo.description,
-    differences: validationInfo.differences,
-    doi: validationInfo.doi,
-    entityId: validation.entity_id,
-    entityTitle: validationInfo.entityTitle,
-    entityType: validationInfo.entityType,
-    id: validation.id,
-    publicationString: validationInfo.publicationString,
-    relatedEntityUrl: validationInfo.relatedEntityUrl,
-    resolvedAt: validation.resolved_at?.toISOString() ?? null,
-    system: validationInfo.system,
-    targetCompletion: validation.target_completion?.toISOString() ?? null,
-    taskStatus: validationInfo.taskStatus,
-    updatedAt: validation.updated_at.toISOString(),
-    validationId: validation.validation_id,
-    validationStatus: validationInfo.validationStatus,
-    validationType: validationInfo.validationType,
-  };
-}
-
-export function dbCommentToApiComment(
-  dbComment: HCAAtlasTrackerDBComment
-): HCAAtlasTrackerComment {
-  return {
-    createdAt: dbComment.created_at.toISOString(),
-    createdBy: dbComment.created_by,
-    id: dbComment.id,
-    text: dbComment.text,
-    threadId: dbComment.thread_id,
-    updatedAt: dbComment.updated_at.toISOString(),
-    updatedBy: dbComment.updated_by,
-  };
-}
-
-export function dbUserToApiUser(
-  dbUser: HCAAtlasTrackerDBUserWithAssociatedResources
-): HCAAtlasTrackerUser {
-  return {
-    disabled: dbUser.disabled,
-    email: dbUser.email,
-    fullName: dbUser.full_name,
-    id: dbUser.id,
-    lastLogin: dbUser.last_login.toISOString(),
-    role: dbUser.role,
-    roleAssociatedResourceIds: dbUser.role_associated_resource_ids,
-    roleAssociatedResourceNames: dbUser.role_associated_resource_names,
-  };
-}
-
 export function getAtlasName(atlas: HCAAtlasTrackerAtlas): string {
   return `${atlas.shortName} v${atlas.version}`;
-}
-
-/**
- * Returns the entity's citation.
- * @param entity - Database model of entity with source study properties.
- * @returns citation for the associated source study.
- */
-export function getDbEntityCitation(
-  entity:
-    | HCAAtlasTrackerDBSourceStudy
-    | HCAAtlasTrackerDBSourceDatasetWithStudyProperties
-): string {
-  if (entity.doi === null) {
-    const { contactEmail, referenceAuthor } = entity.study_info.unpublishedInfo;
-    return getUnpublishedCitation(referenceAuthor, contactEmail);
-  } else {
-    const studyInfo = entity.study_info;
-    const publication = studyInfo.publication;
-    return getPublishedCitation(
-      studyInfo.doiStatus,
-      publication?.authors[0].name ?? null,
-      publication?.publicationDate ?? null,
-      publication?.journal ?? null
-    );
-  }
 }
 
 /**
@@ -299,7 +101,7 @@ export function getPublicationCitation({
   );
 }
 
-function getPublishedCitation(
+export function getPublishedCitation(
   doiStatus: DOI_STATUS,
   author: string | null,
   date: string | null,
@@ -320,7 +122,10 @@ function getPublishedCitation(
   return citation.join(" ");
 }
 
-function getUnpublishedCitation(author: string, email: string | null): string {
+export function getUnpublishedCitation(
+  author: string,
+  email: string | null
+): string {
   return email
     ? `${author}, ${email} - Unpublished`
     : `${author} - Unpublished`;

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -6,7 +6,6 @@ import {
   HCAAtlasTrackerAtlas,
   HCAAtlasTrackerComment,
   HCAAtlasTrackerComponentAtlas,
-  HCAAtlasTrackerDBAtlasWithComponentAtlases,
   HCAAtlasTrackerDBComment,
   HCAAtlasTrackerDBComponentAtlas,
   HCAAtlasTrackerDBSourceDatasetWithStudyProperties,
@@ -45,6 +44,7 @@ export function atlasInputMapper(
   return {
     bioNetwork: apiAtlas.bioNetwork,
     cellxgeneAtlasCollection: apiAtlas.cellxgeneAtlasCollection,
+    cellxgeneAtlasCollectionTitle: apiAtlas.cellxgeneAtlasCollectionTitle,
     codeLinks: apiAtlas.codeLinks,
     completedTaskCount: apiAtlas.completedTaskCount,
     componentAtlasCount: apiAtlas.componentAtlasCount,
@@ -65,33 +65,6 @@ export function atlasInputMapper(
     title: apiAtlas.title,
     version: apiAtlas.version,
     wave: apiAtlas.wave,
-  };
-}
-
-export function dbAtlasToApiAtlas(
-  dbAtlas: HCAAtlasTrackerDBAtlasWithComponentAtlases
-): HCAAtlasTrackerAtlas {
-  return {
-    bioNetwork: dbAtlas.overview.network,
-    cellxgeneAtlasCollection: dbAtlas.overview.cellxgeneAtlasCollection,
-    codeLinks: dbAtlas.overview.codeLinks,
-    completedTaskCount: dbAtlas.overview.completedTaskCount,
-    componentAtlasCount: dbAtlas.component_atlas_count,
-    description: dbAtlas.overview.description,
-    highlights: dbAtlas.overview.highlights,
-    id: dbAtlas.id,
-    integrationLead: dbAtlas.overview.integrationLead,
-    metadataSpecificationUrl: dbAtlas.overview.metadataSpecificationUrl,
-    publications: dbAtlas.overview.publications,
-    shortName: dbAtlas.overview.shortName,
-    sourceDatasetCount: dbAtlas.source_datasets.length,
-    sourceStudyCount: dbAtlas.source_studies.length,
-    status: dbAtlas.status,
-    targetCompletion: dbAtlas.target_completion?.toISOString() ?? null,
-    taskCount: dbAtlas.overview.taskCount,
-    title: "",
-    version: dbAtlas.overview.version,
-    wave: dbAtlas.overview.wave,
   };
 }
 

--- a/app/components/Forms/components/Atlas/common/constants.ts
+++ b/app/components/Forms/components/Atlas/common/constants.ts
@@ -79,6 +79,9 @@ const CELLXGENE_COLLECTION_ID: CommonControllerConfig = {
   },
   labelLink: true,
   name: FIELD_NAME.CELLXGENE_ATLAS_COLLECTION,
+  renderHelperText(atlas) {
+    return atlas?.cellxgeneAtlasCollectionTitle;
+  },
 };
 
 const METADATA_SPECIFICATION_URL: ControllerConfig<

--- a/app/components/Forms/components/Atlas/common/constants.ts
+++ b/app/components/Forms/components/Atlas/common/constants.ts
@@ -74,6 +74,9 @@ const DOI: CommonControllerConfig = {
 
 const CELLXGENE_COLLECTION_ID: CommonControllerConfig = {
   inputProps: {
+    helperTextProps: {
+      noWrap: false,
+    },
     isFullWidth: true,
     label: "CELLxGENE collection ID",
   },

--- a/app/components/common/Form/components/Controllers/common/entities.ts
+++ b/app/components/common/Form/components/Controllers/common/entities.ts
@@ -13,7 +13,11 @@ export type ControllerSelectConfig<T extends FieldValues> = Pick<
   PickedSelectProps
 > & { SelectComponent: SelectControllerProps<T>["SelectComponent"] };
 
-type PickedInputProps = "label" | "isFullWidth" | "placeholder";
+type PickedInputProps =
+  | "label"
+  | "helperTextProps"
+  | "isFullWidth"
+  | "placeholder";
 type PickedSelectProps = "displayEmpty" | "label";
 
 export interface ControllerConfig<T extends FieldValues, R = undefined> {

--- a/app/components/common/Form/components/FormHelperText/formHelperText.tsx
+++ b/app/components/common/Form/components/FormHelperText/formHelperText.tsx
@@ -5,15 +5,20 @@ import {
 } from "@mui/material";
 import { FormHelperText as HelperText } from "./formHelperText.styles";
 
+export interface FormHelperTextProps extends MFormHelperTextProps {
+  noWrap?: boolean;
+}
+
 export const FormHelperText = ({
   children,
+  noWrap = true,
   ...props /* Spread props to allow for Mui FormHelperText specific prop overrides e.g. "filled". */
-}: MFormHelperTextProps): JSX.Element => {
+}: FormHelperTextProps): JSX.Element => {
   const { error } = props;
   return (
     <HelperText component="div" {...props}>
       {error && <ErrorIcon color="inherit" fontSize="xxsmall" />}
-      <Typography component="span" noWrap>
+      <Typography component="span" noWrap={noWrap}>
         {children}
       </Typography>
     </HelperText>

--- a/app/components/common/Form/components/Input/input.tsx
+++ b/app/components/common/Form/components/Input/input.tsx
@@ -3,13 +3,17 @@ import {
   OutlinedInputProps as MOutlinedInputProps,
 } from "@mui/material";
 import { forwardRef, ReactNode } from "react";
-import { FormHelperText } from "../FormHelperText/formHelperText";
+import {
+  FormHelperText,
+  FormHelperTextProps,
+} from "../FormHelperText/formHelperText";
 import { FormLabel } from "../FormLabel/formLabel";
 import { InputFormControl as FormControl } from "./input.styles";
 
 export interface InputProps extends MOutlinedInputProps {
   className?: string;
   helperText?: ReactNode;
+  helperTextProps?: Partial<FormHelperTextProps>;
   isFilled?: boolean;
   isFullWidth?: boolean;
 }
@@ -20,6 +24,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
     disabled,
     error,
     helperText,
+    helperTextProps,
     isFilled = false,
     isFullWidth = false,
     label,
@@ -47,7 +52,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
         {...props}
       />
       {helperText && (
-        <FormHelperText disabled={disabled} error={error}>
+        <FormHelperText disabled={disabled} error={error} {...helperTextProps}>
           {helperText}
         </FormHelperText>
       )}

--- a/app/services/__mocks__/cellxgene.ts
+++ b/app/services/__mocks__/cellxgene.ts
@@ -1,6 +1,7 @@
 import { CellxGeneDataset } from "../../../app/utils/cellxgene-api";
 import {
   TEST_CELLXGENE_COLLECTIONS_BY_DOI,
+  TEST_CELLXGENE_COLLECTIONS_BY_ID,
   TEST_CELLXGENE_DATASETS_BY_COLLECTION_ID,
 } from "../../../testing/constants";
 import { CollectionInfo } from "../cellxgene";
@@ -23,6 +24,12 @@ export function getCellxGeneInfoByDoi(dois: string[]): CollectionInfo | null {
       };
   }
   return null;
+}
+
+export function getCellxGeneCollectionInfoById(
+  collectionId: string
+): CollectionInfo | undefined {
+  return TEST_CELLXGENE_COLLECTIONS_BY_ID.get(collectionId);
 }
 
 export function getCellxGeneDatasetsByCollectionId(

--- a/app/services/cellxgene.ts
+++ b/app/services/cellxgene.ts
@@ -15,6 +15,7 @@ export interface CollectionInfo {
 
 interface CellxGeneData {
   collectionInfoByDoi: Map<string, CollectionInfo>;
+  collectionInfoById: Map<string, CollectionInfo>;
   datasetsByCollectionId: Map<string, CellxGeneDataset[]>;
   lastRefreshTime: number;
 }
@@ -35,12 +36,12 @@ const refreshService = makeRefreshService({
   getRefreshParams: () => undefined,
   async getRefreshedData() {
     const time = Date.now();
-    const [collectionInfoByDoi, datasetsByCollectionId] = await Promise.all([
-      getRefreshedCollectionIdsByDoi(),
+    const [collectionMaps, datasetsByCollectionId] = await Promise.all([
+      getRefreshedCollectionMaps(),
       getRefreshedDatasetsByCollectionId(),
     ]);
     return {
-      collectionInfoByDoi,
+      ...collectionMaps,
       datasetsByCollectionId,
       lastRefreshTime: time,
     };
@@ -96,14 +97,21 @@ export function getCellxGeneInfoByDoi(dois: string[]): CollectionInfo | null {
   return null;
 }
 
+export function getCellxGeneCollectionById(
+  collectionId: string
+): CollectionInfo | undefined {
+  return refreshService.getData().collectionInfoById.get(collectionId);
+}
+
 /**
  * Fetch CELLxGENE collections and build DOI-to-ID mapping.
  * @returns collection IDs by DOI.
  */
-async function getRefreshedCollectionIdsByDoi(): Promise<
-  Map<string, CollectionInfo>
+async function getRefreshedCollectionMaps(): Promise<
+  Pick<CellxGeneData, "collectionInfoByDoi" | "collectionInfoById">
 > {
-  const idsByDoi = new Map<string, CollectionInfo>();
+  const byDoi = new Map<string, CollectionInfo>();
+  const byId = new Map<string, CollectionInfo>();
   console.log("Requesting CELLxGENE collections");
   const collections = await getCellxGeneCollections({
     hooks: {
@@ -117,13 +125,17 @@ async function getRefreshedCollectionIdsByDoi(): Promise<
   });
   console.log("Loaded CELLxGENE collections");
   for (const { collection_id, doi, name } of collections) {
-    if (doi)
-      idsByDoi.set(normalizeDoi(doi), {
-        id: collection_id,
-        title: name,
-      });
+    const info: CollectionInfo = {
+      id: collection_id,
+      title: name,
+    };
+    byId.set(collection_id, info);
+    if (doi) byDoi.set(normalizeDoi(doi), info);
   }
-  return idsByDoi;
+  return {
+    collectionInfoByDoi: byDoi,
+    collectionInfoById: byId,
+  };
 }
 
 async function getRefreshedDatasetsByCollectionId(): Promise<

--- a/app/services/cellxgene.ts
+++ b/app/services/cellxgene.ts
@@ -49,7 +49,8 @@ const refreshService = makeRefreshService({
   getStoredInfo() {
     return globalThis.hcaAtlasTrackerCellxGeneInfoCache;
   },
-  notReadyMessage: "DOI to CELLxGENE collection ID mapping not initialized",
+  notReadyMessage:
+    "Cache of CELLxGENE collections and datasets not initialized",
   onRefreshSuccess() {
     doUpdatesIfRefreshesComplete();
   },

--- a/app/services/cellxgene.ts
+++ b/app/services/cellxgene.ts
@@ -97,7 +97,7 @@ export function getCellxGeneInfoByDoi(dois: string[]): CollectionInfo | null {
   return null;
 }
 
-export function getCellxGeneCollectionById(
+export function getCellxGeneCollectionInfoById(
   collectionId: string
 ): CollectionInfo | undefined {
   return refreshService.getData().collectionInfoById.get(collectionId);

--- a/app/services/validations.ts
+++ b/app/services/validations.ts
@@ -2,6 +2,7 @@ import { NewCommentThreadData } from "app/apis/catalog/hca-atlas-tracker/common/
 import { dequal } from "dequal";
 import DOMPurify from "isomorphic-dompurify";
 import pg from "pg";
+import { getDbEntityCitation } from "../apis/catalog/hca-atlas-tracker/common/backend-utils";
 import {
   ALLOWED_TASK_STATUSES_BY_VALIDATION_STATUS,
   DEFAULT_TASK_STATUS_BY_VALIDATION_STATUS,
@@ -30,7 +31,6 @@ import {
   ValidationDBEntityOfType,
   ValidationDifference,
 } from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { getDbEntityCitation } from "../apis/catalog/hca-atlas-tracker/common/utils";
 import { ForbiddenError, NotFoundError } from "../utils/api-handler";
 import { ProjectInfo } from "../utils/hca-projects";
 import { updateTaskCounts } from "./atlases";

--- a/pages/api/atlases.ts
+++ b/pages/api/atlases.ts
@@ -1,6 +1,6 @@
 import { ROLE_GROUP } from "app/apis/catalog/hca-atlas-tracker/common/constants";
 import { getAllAtlases } from "app/services/atlases";
-import { dbAtlasToApiAtlas } from "../../app/apis/catalog/hca-atlas-tracker/common/utils";
+import { dbAtlasToApiAtlas } from "../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { METHOD } from "../../app/common/entities";
 import { handler, method, role } from "../../app/utils/api-handler";
 

--- a/pages/api/atlases/[atlasId].ts
+++ b/pages/api/atlases/[atlasId].ts
@@ -1,5 +1,5 @@
+import { dbAtlasToApiAtlas } from "app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { atlasEditSchema } from "app/apis/catalog/hca-atlas-tracker/common/schema";
-import { dbAtlasToApiAtlas } from "app/apis/catalog/hca-atlas-tracker/common/utils";
 import { NextApiRequest, NextApiResponse } from "next";
 import { ROLE_GROUP } from "../../../app/apis/catalog/hca-atlas-tracker/common/constants";
 import { ROLE } from "../../../app/apis/catalog/hca-atlas-tracker/common/entities";

--- a/pages/api/atlases/[atlasId]/component-atlases.ts
+++ b/pages/api/atlases/[atlasId]/component-atlases.ts
@@ -1,5 +1,5 @@
+import { dbComponentAtlasToApiComponentAtlas } from "../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE_GROUP } from "../../../../app/apis/catalog/hca-atlas-tracker/common/constants";
-import { dbComponentAtlasToApiComponentAtlas } from "../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../../app/common/entities";
 import { getAtlasComponentAtlases } from "../../../../app/services/component-atlases";
 import { handler, method, role } from "../../../../app/utils/api-handler";

--- a/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId].ts
+++ b/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId].ts
@@ -1,4 +1,4 @@
-import { dbComponentAtlasToApiComponentAtlas } from "app/apis/catalog/hca-atlas-tracker/common/utils";
+import { dbComponentAtlasToApiComponentAtlas } from "app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE_GROUP } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/constants";
 import { ROLE } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { componentAtlasEditSchema } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/schema";

--- a/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId]/source-datasets.ts
+++ b/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId]/source-datasets.ts
@@ -1,7 +1,7 @@
 import { ROLE_GROUP } from "app/apis/catalog/hca-atlas-tracker/common/constants";
+import { dbSourceDatasetToApiSourceDataset } from "../../../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE } from "../../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { componentAtlasAddSourceDatasetsSchema } from "../../../../../../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { dbSourceDatasetToApiSourceDataset } from "../../../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../../../../app/common/entities";
 import {
   addSourceDatasetsToComponentAtlas,

--- a/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId]/source-datasets/[sourceDatasetId].ts
+++ b/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId]/source-datasets/[sourceDatasetId].ts
@@ -1,4 +1,4 @@
-import { dbSourceDatasetToApiSourceDataset } from "app/apis/catalog/hca-atlas-tracker/common/utils";
+import { dbSourceDatasetToApiSourceDataset } from "app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE_GROUP } from "../../../../../../../app/apis/catalog/hca-atlas-tracker/common/constants";
 import { ROLE } from "../../../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD } from "../../../../../../../app/common/entities";

--- a/pages/api/atlases/[atlasId]/component-atlases/create.ts
+++ b/pages/api/atlases/[atlasId]/component-atlases/create.ts
@@ -1,6 +1,6 @@
+import { dbComponentAtlasToApiComponentAtlas } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { newComponentAtlasSchema } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { dbComponentAtlasToApiComponentAtlas } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../../../app/common/entities";
 import { createComponentAtlas } from "../../../../../app/services/component-atlases";
 import {

--- a/pages/api/atlases/[atlasId]/source-datasets.ts
+++ b/pages/api/atlases/[atlasId]/source-datasets.ts
@@ -1,5 +1,5 @@
+import { dbSourceDatasetToApiSourceDataset } from "../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE_GROUP } from "../../../../app/apis/catalog/hca-atlas-tracker/common/constants";
-import { dbSourceDatasetToApiSourceDataset } from "../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../../app/common/entities";
 import { getAtlasDatasets } from "../../../../app/services/source-datasets";
 import { handler, method, role } from "../../../../app/utils/api-handler";

--- a/pages/api/atlases/[atlasId]/source-datasets/[sourceDatasetId].ts
+++ b/pages/api/atlases/[atlasId]/source-datasets/[sourceDatasetId].ts
@@ -2,10 +2,10 @@ import {
   addSourceDatasetToAtlas,
   removeSourceDatasetFromAtlas,
 } from "app/services/atlases";
+import { dbSourceDatasetToApiSourceDataset } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE_GROUP } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/constants";
 import { ROLE } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { atlasSourceDatasetEditSchema } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { dbSourceDatasetToApiSourceDataset } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../../../app/common/entities";
 import {
   getAtlasSourceDataset,

--- a/pages/api/atlases/[atlasId]/source-studies.ts
+++ b/pages/api/atlases/[atlasId]/source-studies.ts
@@ -1,5 +1,5 @@
+import { dbSourceStudyToApiSourceStudy } from "../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE_GROUP } from "../../../../app/apis/catalog/hca-atlas-tracker/common/constants";
-import { dbSourceStudyToApiSourceStudy } from "../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../../app/common/entities";
 import { getAtlasSourceStudies } from "../../../../app/services/source-studies";
 import { handler, method, role } from "../../../../app/utils/api-handler";

--- a/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId].ts
+++ b/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId].ts
@@ -1,8 +1,8 @@
 import { NextApiRequest, NextApiResponse } from "next";
+import { dbSourceStudyToApiSourceStudy } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE_GROUP } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/constants";
 import { ROLE } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { sourceStudyEditSchema } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { dbSourceStudyToApiSourceStudy } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../../../app/common/entities";
 import {
   deleteAtlasSourceStudy,

--- a/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets.ts
+++ b/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets.ts
@@ -1,5 +1,5 @@
+import { dbSourceDatasetToApiSourceDataset } from "../../../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE_GROUP } from "../../../../../../app/apis/catalog/hca-atlas-tracker/common/constants";
-import { dbSourceDatasetToApiSourceDataset } from "../../../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../../../../app/common/entities";
 import { getSourceStudyDatasets } from "../../../../../../app/services/source-datasets";
 import { handler, method, role } from "../../../../../../app/utils/api-handler";

--- a/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/[sourceDatasetId].ts
+++ b/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/[sourceDatasetId].ts
@@ -1,7 +1,7 @@
 import { ROLE } from "app/apis/catalog/hca-atlas-tracker/common/entities";
 import { sourceDatasetEditSchema } from "app/apis/catalog/hca-atlas-tracker/common/schema";
+import { dbSourceDatasetToApiSourceDataset } from "../../../../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE_GROUP } from "../../../../../../../app/apis/catalog/hca-atlas-tracker/common/constants";
-import { dbSourceDatasetToApiSourceDataset } from "../../../../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../../../../../app/common/entities";
 import {
   deleteSourceDataset,

--- a/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/create.ts
+++ b/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets/create.ts
@@ -1,6 +1,6 @@
+import { dbSourceDatasetToApiSourceDataset } from "../../../../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE } from "../../../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { newSourceDatasetSchema } from "../../../../../../../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { dbSourceDatasetToApiSourceDataset } from "../../../../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../../../../../app/common/entities";
 import { createSourceDataset } from "../../../../../../../app/services/source-datasets";
 import {

--- a/pages/api/atlases/[atlasId]/source-studies/create.ts
+++ b/pages/api/atlases/[atlasId]/source-studies/create.ts
@@ -1,7 +1,7 @@
 import { createSourceStudy } from "app/services/source-studies";
+import { dbSourceStudyToApiSourceStudy } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { newSourceStudySchema } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { dbSourceStudyToApiSourceStudy } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../../../app/common/entities";
 import {
   handler,

--- a/pages/api/atlases/create.ts
+++ b/pages/api/atlases/create.ts
@@ -1,6 +1,6 @@
+import { dbAtlasToApiAtlas } from "../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE } from "../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { newAtlasSchema } from "../../../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { dbAtlasToApiAtlas } from "../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../app/common/entities";
 import { createAtlas } from "../../../app/services/atlases";
 import { handler, method, role } from "../../../app/utils/api-handler";

--- a/pages/api/comments.ts
+++ b/pages/api/comments.ts
@@ -1,5 +1,5 @@
+import { dbCommentToApiComment } from "../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { newCommentThreadSchema } from "../../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { dbCommentToApiComment } from "../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../app/common/entities";
 import { createCommentThread } from "../../app/services/comments";
 import {

--- a/pages/api/comments/[threadId]/comments.ts
+++ b/pages/api/comments/[threadId]/comments.ts
@@ -1,5 +1,5 @@
+import { dbCommentToApiComment } from "../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { newCommentSchema } from "../../../../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { dbCommentToApiComment } from "../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../../app/common/entities";
 import {
   createComment,

--- a/pages/api/comments/[threadId]/comments/[commentId].ts
+++ b/pages/api/comments/[threadId]/comments/[commentId].ts
@@ -1,6 +1,6 @@
+import { dbCommentToApiComment } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { commentEditSchema } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { dbCommentToApiComment } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../../../app/common/entities";
 import {
   deleteComment,

--- a/pages/api/tasks.ts
+++ b/pages/api/tasks.ts
@@ -1,5 +1,5 @@
+import { dbValidationToApiValidation } from "../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE_GROUP } from "../../app/apis/catalog/hca-atlas-tracker/common/constants";
-import { dbValidationToApiValidation } from "../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../app/common/entities";
 import { getValidationRecords } from "../../app/services/validations";
 import { handler, method, role } from "../../app/utils/api-handler";

--- a/pages/api/tasks/[validationId]/comment.ts
+++ b/pages/api/tasks/[validationId]/comment.ts
@@ -1,6 +1,6 @@
+import { dbCommentToApiComment } from "../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE } from "../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { newCommentThreadSchema } from "../../../../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { dbCommentToApiComment } from "../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../../app/common/entities";
 import {
   createValidationComment,

--- a/pages/api/tasks/completion-dates.ts
+++ b/pages/api/tasks/completion-dates.ts
@@ -1,6 +1,6 @@
+import { dbValidationToApiValidation } from "app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE } from "app/apis/catalog/hca-atlas-tracker/common/entities";
 import { taskCompletionDatesSchema } from "app/apis/catalog/hca-atlas-tracker/common/schema";
-import { dbValidationToApiValidation } from "app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "app/common/entities";
 import { updateTargetCompletions } from "app/services/validations";
 import { handler, method, role } from "app/utils/api-handler";

--- a/pages/api/users.ts
+++ b/pages/api/users.ts
@@ -1,6 +1,6 @@
+import { dbUserToApiUser } from "../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE_GROUP } from "../../app/apis/catalog/hca-atlas-tracker/common/constants";
 import { HCAAtlasTrackerDBUserWithAssociatedResources } from "../../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { dbUserToApiUser } from "../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../app/common/entities";
 import { getAllUsers, getUserByEmail } from "../../app/services/users";
 import {

--- a/pages/api/users/[id].tsx
+++ b/pages/api/users/[id].tsx
@@ -1,6 +1,6 @@
+import { dbUserToApiUser } from "../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE } from "../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { userEditSchema } from "../../../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { dbUserToApiUser } from "../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../app/common/entities";
 import { getUserById, updateUser } from "../../../app/services/users";
 import {

--- a/pages/api/users/create.ts
+++ b/pages/api/users/create.ts
@@ -1,6 +1,6 @@
+import { dbUserToApiUser } from "../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE } from "../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { newUserSchema } from "../../../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { dbUserToApiUser } from "../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD } from "../../../app/common/entities";
 import { createUser } from "../../../app/services/users";
 import { handler, method, role } from "../../../app/utils/api-handler";

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -643,6 +643,13 @@ export const TEST_CELLXGENE_COLLECTIONS_BY_DOI = new Map([
   ],
 ]);
 
+export const TEST_CELLXGENE_COLLECTIONS_BY_ID = new Map(
+  Array.from(TEST_CELLXGENE_COLLECTIONS_BY_DOI.values(), (c) => [
+    c.collection_id,
+    { id: c.collection_id, title: c.name },
+  ])
+);
+
 export const TEST_CELLXGENE_COLLECTIONS_A = [TEST_CELLXGENE_COLLECTION_NORMAL];
 
 export const TEST_CELLXGENE_COLLECTIONS_B = [


### PR DESCRIPTION
I've set it up so the collection title is retrieved dynamically from the CELLxGENE data cache on the backend, rather than being stored in the database; because of this, converting a database atlas to an API atlas requires imports that only work on the backend, so I've created a new `backend-utils` file