### PR TITLE
fix: avoid error when saving published source study (#496)

### DIFF
--- a/app/views/SourceStudyView/hooks/useEditSourceStudyFormManager.ts
+++ b/app/views/SourceStudyView/hooks/useEditSourceStudyFormManager.ts
@@ -116,11 +116,14 @@ function isFormDirty(
  * @returns payload.
  */
 function mapPayload(payload: SourceStudyEditData): SourceStudyEditData {
-  return {
-    ...payload,
-    cellxgeneCollectionId: getIdentifierId(payload.cellxgeneCollectionId),
-    hcaProjectId: getIdentifierId(payload.hcaProjectId),
-  };
+  const mappedPayload = { ...payload };
+  if (payload.cellxgeneCollectionId)
+    mappedPayload.cellxgeneCollectionId = getIdentifierId(
+      payload.cellxgeneCollectionId
+    );
+  if (payload.hcaProjectId)
+    mappedPayload.hcaProjectId = getIdentifierId(payload.hcaProjectId);
+  return mappedPayload;
 }
 
 /**


### PR DESCRIPTION
Closes #496

Turns out the fields *were* getting unregistered, but were being added back by `mapPayload`