### PR TITLE
feat: add download buttons to atlas source datasets (#526)

### DIFF
--- a/app/components/Detail/components/ViewAtlasSourceDatasets/viewAtlasSourceDatasets.tsx
+++ b/app/components/Detail/components/ViewAtlasSourceDatasets/viewAtlasSourceDatasets.tsx
@@ -33,7 +33,7 @@ export const ViewAtlasSourceDatasets = ({
         {atlas && atlasSourceDatasets.length > 0 && (
           <Table
             columns={getAtlasSourceDatasetsTableColumns(atlas)}
-            gridTemplateColumns="minmax(76px, auto) max-content repeat(2, minmax(180px, 0.4fr)) minmax(200px, 1fr) minmax(180px, auto) repeat(4, minmax(88px, 0.4fr)) auto"
+            gridTemplateColumns="max-content minmax(100px, auto) repeat(2, minmax(180px, 0.4fr)) minmax(200px, 1fr) minmax(180px, auto) repeat(4, minmax(88px, 0.4fr)) auto"
             items={atlasSourceDatasets.sort(sortLinkedSourceDataset)}
             tableOptions={TABLE_OPTIONS}
           />

--- a/app/components/Detail/components/ViewAtlasSourceDatasets/viewAtlasSourceDatasets.tsx
+++ b/app/components/Detail/components/ViewAtlasSourceDatasets/viewAtlasSourceDatasets.tsx
@@ -33,7 +33,7 @@ export const ViewAtlasSourceDatasets = ({
         {atlas && atlasSourceDatasets.length > 0 && (
           <Table
             columns={getAtlasSourceDatasetsTableColumns(atlas)}
-            gridTemplateColumns="max-content repeat(2, minmax(180px, 0.4fr)) minmax(200px, 1fr) minmax(180px, auto) repeat(4, minmax(88px, 0.4fr)) auto"
+            gridTemplateColumns="minmax(76px, auto) max-content repeat(2, minmax(180px, 0.4fr)) minmax(200px, 1fr) minmax(180px, auto) repeat(4, minmax(88px, 0.4fr)) auto"
             items={atlasSourceDatasets.sort(sortLinkedSourceDataset)}
             tableOptions={TABLE_OPTIONS}
           />

--- a/app/components/Index/components/FileDownload/fileDownload.tsx
+++ b/app/components/Index/components/FileDownload/fileDownload.tsx
@@ -1,0 +1,29 @@
+import { DownloadIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/DownloadIcon/downloadIcon";
+import { IconButton } from "@databiosphere/findable-ui/lib/components/common/IconButton/iconButton";
+import { useRef } from "react";
+
+export interface FileDownloadProps {
+  fileName: string;
+  fileUrl?: string;
+}
+
+export const FileDownload = ({
+  fileName,
+  fileUrl,
+}: FileDownloadProps): JSX.Element => {
+  const downloadRef = useRef<HTMLAnchorElement>(null);
+
+  return (
+    <a download={fileName} href={fileUrl}>
+      <IconButton
+        color="primary"
+        disabled={!fileUrl}
+        Icon={DownloadIcon}
+        onClick={(): void => {
+          downloadRef.current?.click();
+        }}
+        size="medium"
+      />
+    </a>
+  );
+};

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -21,6 +21,7 @@ export { AlertTitle } from "@mui/material";
 export { IconButton } from "./common/IconButton/iconButton";
 export { LinkDatasetDropdown } from "./Detail/components/ViewAtlasSourceDatasets/components/LinkDatasetDropdown/linkDatasetDropdown";
 export { ViewSourceDataset } from "./Detail/components/ViewSourceDataset/viewSourceDataset";
+export { FileDownload } from "./Index/components/FileDownload/fileDownload";
 export { EditTasks } from "./Index/components/ViewTasks/components/EditTasks/editTasks";
 export { PreviewTask } from "./Index/components/ViewTasks/components/PreviewTask/previewTask";
 export { AlertText } from "./Layout/components/Content/components/AlertText/alertText.styles";

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -882,9 +882,9 @@ export function getAtlasSourceDatasetsTableColumns(
 ): ColumnDef<HCAAtlasTrackerSourceDataset>[] {
   return [
     getSourceDatasetDownloadColumnDef(),
+    getAtlasSourceDatasetTitleColumnDef(atlas),
     getSourceDatasetPublicationColumnDef(),
     getSourceDatasetSourceStudyColumnDef(atlas),
-    getAtlasSourceDatasetTitleColumnDef(atlas),
     getSourceDatasetExploreColumnDef(),
     getAssayColumnDef(),
     getSuspensionTypeColumnDef(),

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -324,6 +324,23 @@ export const buildSourceDatasetCount = (
 };
 
 /**
+ * Build props for the source dataset download component.
+ * @param sourceDataset - Source dataset entity.
+ * @returns Props to be used for the cell.
+ */
+export const buildSourceDatasetDownload = (
+  sourceDataset: HCAAtlasTrackerSourceDataset
+): ComponentProps<typeof C.FileDownload> => {
+  const versionId = sourceDataset.cellxgeneDatasetVersion;
+  return {
+    fileName: `${versionId}.h5ad`,
+    fileUrl: versionId
+      ? `https://datasets.cellxgene.cziscience.com/${versionId}.h5ad`
+      : undefined,
+  };
+};
+
+/**
  * Build props for the source study publication Link component.
  * @param sourceStudy - Source study entity.
  * @returns Props to be used for the Link component.
@@ -864,6 +881,7 @@ export function getAtlasSourceDatasetsTableColumns(
   atlas: HCAAtlasTrackerAtlas
 ): ColumnDef<HCAAtlasTrackerSourceDataset>[] {
   return [
+    getSourceDatasetDownloadColumnDef(),
     getSourceDatasetPublicationColumnDef(),
     getSourceDatasetSourceStudyColumnDef(atlas),
     getAtlasSourceDatasetTitleColumnDef(atlas),
@@ -1174,6 +1192,21 @@ function getEntityFromRowData<T extends RowData>(
 function getProgressValue(numerator: number, denominator: number): number {
   if (denominator === 0) return 0;
   return (numerator / denominator) * 100;
+}
+
+/**
+ * Returns source dataset download column def.
+ * @returns Column def.
+ */
+function getSourceDatasetDownloadColumnDef(): ColumnDef<HCAAtlasTrackerSourceDataset> {
+  return {
+    accessorKey: "cellxgeneDatasetVersion",
+    cell: ({ row }): JSX.Element => {
+      return C.FileDownload(buildSourceDatasetDownload(row.original));
+    },
+    enableSorting: false,
+    header: "Download",
+  };
 }
 
 /**


### PR DESCRIPTION
Closes #526

- URL are constructed under the assumption that for any dataset version ID there will be a file with a URL of the form `https://datasets.cellxgene.cziscience.com/${versionId}.h5ad` (this appears to be the case for all current datasets on CELLxGENE)
- Only the atlas source datasets list has the download button