### PR TITLE
feat: added roadmap grouping by default (#546)

### DIFF
--- a/site-config/hca-atlas-tracker/local/index/atlas/atlasEntityConfig.ts
+++ b/site-config/hca-atlas-tracker/local/index/atlas/atlasEntityConfig.ts
@@ -2,7 +2,6 @@ import {
   ComponentConfig,
   EntityConfig,
   ListConfig,
-  SORT_DIRECTION,
 } from "@databiosphere/findable-ui/lib/config/entities";
 import { EXPLORE_MODE } from "@databiosphere/findable-ui/lib/hooks/useExploreMode";
 import { HCAAtlasTrackerListAtlas } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
@@ -64,26 +63,6 @@ export const atlasEntityConfig: EntityConfig = {
       },
     ],
     key: "atlas",
-    savedFilters: [
-      {
-        filters: [],
-        sorting: [
-          {
-            desc: SORT_DIRECTION.ASCENDING,
-            id: HCA_ATLAS_TRACKER_CATEGORY_KEY.TARGET_COMPLETION_DATE,
-          },
-          {
-            desc: SORT_DIRECTION.ASCENDING,
-            id: HCA_ATLAS_TRACKER_CATEGORY_KEY.PUBLICATION_STATUS,
-          },
-          {
-            desc: SORT_DIRECTION.ASCENDING,
-            id: HCA_ATLAS_TRACKER_CATEGORY_KEY.NAME,
-          },
-        ],
-        title: "Atlas Roadmap",
-      },
-    ],
   },
   detail: {
     detailOverviews: [],

--- a/site-config/hca-atlas-tracker/local/index/atlas/atlasEntityConfig.ts
+++ b/site-config/hca-atlas-tracker/local/index/atlas/atlasEntityConfig.ts
@@ -67,7 +67,6 @@ export const atlasEntityConfig: EntityConfig = {
     savedFilters: [
       {
         filters: [],
-        grouping: [HCA_ATLAS_TRACKER_CATEGORY_KEY.TARGET_COMPLETION_DATE],
         sorting: [
           {
             desc: SORT_DIRECTION.ASCENDING,

--- a/site-config/hca-atlas-tracker/local/index/atlas/tableOptions.ts
+++ b/site-config/hca-atlas-tracker/local/index/atlas/tableOptions.ts
@@ -23,6 +23,10 @@ export const TABLE_OPTIONS: ListConfig<HCAAtlasTrackerListAtlas>["tableOptions"]
       sorting: [
         {
           desc: SORT_DIRECTION.ASCENDING,
+          id: HCA_ATLAS_TRACKER_CATEGORY_KEY.TARGET_COMPLETION_DATE,
+        },
+        {
+          desc: SORT_DIRECTION.ASCENDING,
           id: HCA_ATLAS_TRACKER_CATEGORY_KEY.PUBLICATION_STATUS,
         },
         {

--- a/site-config/hca-atlas-tracker/local/index/atlas/tableOptions.ts
+++ b/site-config/hca-atlas-tracker/local/index/atlas/tableOptions.ts
@@ -19,7 +19,12 @@ export const TABLE_OPTIONS: ListConfig<HCAAtlasTrackerListAtlas>["tableOptions"]
         [HCA_ATLAS_TRACKER_CATEGORY_KEY.COMPONENT_ATLAS_COUNT]: false,
       },
       expanded: true,
+      grouping: [HCA_ATLAS_TRACKER_CATEGORY_KEY.TARGET_COMPLETION_DATE],
       sorting: [
+        {
+          desc: SORT_DIRECTION.ASCENDING,
+          id: HCA_ATLAS_TRACKER_CATEGORY_KEY.PUBLICATION_STATUS,
+        },
         {
           desc: SORT_DIRECTION.ASCENDING,
           id: HCA_ATLAS_TRACKER_CATEGORY_KEY.NAME,


### PR DESCRIPTION
- Set the default table settings to group by roadmap and sort first by status then by name