### PR TITLE
feat: add resource column to reports table (#571)

### DIFF
--- a/site-config/hca-atlas-tracker/local/index/tasks/columns.ts
+++ b/site-config/hca-atlas-tracker/local/index/tasks/columns.ts
@@ -6,6 +6,7 @@ export const COLUMNS: ColumnConfig<HCAAtlasTrackerListValidationRecord>[] = [
   COLUMN.DESCRIPTION, // Task.
   COLUMN.PUBLICATION_STRING, // Source study.
   COLUMN.SYSTEM,
+  COLUMN.RELATED_ENTITY_URL, // Resource.
   COLUMN.ATLAS_NAMES,
   COLUMN.ATLAS_VERSIONS,
   COLUMN.NETWORKS,

--- a/site-config/hca-atlas-tracker/local/index/tasks/tableOptions.ts
+++ b/site-config/hca-atlas-tracker/local/index/tasks/tableOptions.ts
@@ -15,6 +15,7 @@ export const TABLE_OPTIONS: ListConfig<HCAAtlasTrackerListValidationRecord>["tab
     enableRowSelection: (row) => !row.getIsGrouped(),
     initialState: {
       columnVisibility: {
+        [HCA_ATLAS_TRACKER_CATEGORY_KEY.RELATED_ENTITY_URL]: false,
         [HCA_ATLAS_TRACKER_CATEGORY_KEY.ATLAS_VERSIONS]: false,
         [HCA_ATLAS_TRACKER_CATEGORY_KEY.CREATED_AT]: false,
         [HCA_ATLAS_TRACKER_CATEGORY_KEY.ENTITY_TITLE]: false,


### PR DESCRIPTION
I've left the column hidden by default because it seems tricky to have it visible with the current column layout while keeping target completion in view