### PR TITLE
feat: add metadata correctness report to atlas detail (#578)

### DIFF
--- a/__tests__/api-atlases-create.test.ts
+++ b/__tests__/api-atlases-create.test.ts
@@ -40,6 +40,8 @@ const NEW_ATLAS_DATA: NewAtlasData = {
   dois: [DOI_PREPRINT_NO_JOURNAL],
   highlights: "bar foo baz baz baz foo",
   integrationLead: [],
+  metadataCorrectnessUrl:
+    "https://example.com/new-atlas-foo-metadata-correctness",
   metadataSpecificationUrl: "https://docs.google.com/spreadsheets/foo",
   network: "eye",
   shortName: "test",
@@ -369,6 +371,21 @@ describe("/api/atlases/create", () => {
           {
             ...NEW_ATLAS_DATA,
             metadataSpecificationUrl: "https://example.com",
+          },
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+  });
+
+  it("returns error 400 when metadata correctness report is not a url", async () => {
+    expect(
+      (
+        await doCreateTest(
+          USER_CONTENT_ADMIN,
+          {
+            ...NEW_ATLAS_DATA,
+            metadataCorrectnessUrl: "not-a-url",
           },
           true
         )

--- a/__tests__/api-atlases-id.test.ts
+++ b/__tests__/api-atlases-id.test.ts
@@ -15,6 +15,7 @@ import {
   ATLAS_PUBLIC,
   ATLAS_PUBLIC_BAR,
   ATLAS_WITH_IL,
+  ATLAS_WITH_METADATA_CORRECTNESS,
   ATLAS_WITH_MISC_SOURCE_STUDIES,
   DOI_JOURNAL_WITH_PREPRINT_COUNTERPART,
   DOI_PREPRINT_WITH_JOURNAL_COUNTERPART,
@@ -124,6 +125,16 @@ const ATLAS_PUBLIC_BAR_EDIT: AtlasEditData = {
   shortName: ATLAS_PUBLIC_BAR.shortName,
   version: ATLAS_PUBLIC_BAR.version,
   wave: ATLAS_PUBLIC_BAR.wave,
+};
+
+const ATLAS_WITH_METADATA_CORRECTNESS_EDIT: AtlasEditData = {
+  cellxgeneAtlasCollection:
+    ATLAS_WITH_METADATA_CORRECTNESS.cellxgeneAtlasCollection,
+  integrationLead: ATLAS_WITH_METADATA_CORRECTNESS.integrationLead,
+  network: ATLAS_WITH_METADATA_CORRECTNESS.network,
+  shortName: ATLAS_WITH_METADATA_CORRECTNESS.shortName,
+  version: ATLAS_WITH_METADATA_CORRECTNESS.version,
+  wave: ATLAS_WITH_METADATA_CORRECTNESS.wave,
 };
 
 beforeAll(async () => {
@@ -450,6 +461,23 @@ describe(TEST_ROUTE, () => {
     ).toEqual(400);
   });
 
+  it("PUT returns error 400 when metadata correctness report is not a url", async () => {
+    expect(
+      (
+        await doAtlasRequest(
+          ATLAS_PUBLIC.id,
+          USER_CONTENT_ADMIN,
+          true,
+          METHOD.PUT,
+          {
+            ...ATLAS_PUBLIC_EDIT,
+            metadataCorrectnessUrl: "not-a-url",
+          }
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+  });
+
   it("PUT returns error 400 when status is not a valid atlas status", async () => {
     expect(
       (
@@ -510,6 +538,16 @@ describe(TEST_ROUTE, () => {
       []
     );
     expect(updatedAtlas.status).toEqual(ATLAS_STATUS.IN_PROGRESS);
+  });
+
+  it("PUT removes metadata correctness url when specified as empty string", async () => {
+    const updatedAtlas = await testSuccessfulEdit(
+      ATLAS_WITH_METADATA_CORRECTNESS,
+      ATLAS_WITH_METADATA_CORRECTNESS_EDIT,
+      0,
+      []
+    );
+    expect(updatedAtlas.overview.metadataCorrectnessUrl).toBeNull();
   });
 });
 

--- a/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
@@ -39,6 +39,7 @@ export function dbAtlasToApiAtlas(
     id: dbAtlas.id,
     ingestionTaskCounts: dbAtlas.overview.ingestionTaskCounts,
     integrationLead: dbAtlas.overview.integrationLead,
+    metadataCorrectnessUrl: dbAtlas.overview.metadataCorrectnessUrl,
     metadataSpecificationUrl: dbAtlas.overview.metadataSpecificationUrl,
     publications: dbAtlas.overview.publications,
     shortName: dbAtlas.overview.shortName,

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -25,6 +25,7 @@ export interface HCAAtlasTrackerAtlas {
   id: string;
   ingestionTaskCounts: IngestionTaskCounts;
   integrationLead: IntegrationLead[];
+  metadataCorrectnessUrl: string | null;
   metadataSpecificationUrl: string | null;
   publications: DoiPublicationInfo[];
   shortName: string;
@@ -220,6 +221,7 @@ export interface HCAAtlasTrackerDBAtlasOverview {
   highlights: string;
   ingestionTaskCounts: IngestionTaskCounts;
   integrationLead: IntegrationLead[];
+  metadataCorrectnessUrl: string | null;
   metadataSpecificationUrl: string | null;
   network: NetworkKey;
   publications: DoiPublicationInfo[];

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -49,6 +49,7 @@ export const newAtlasSchema = object({
       }).required()
     )
     .required(),
+  metadataCorrectnessUrl: string().nullable(),
   metadataSpecificationUrl: string()
     .matches(
       GOOGLE_SHEETS_URL_OR_EMPTY_STRING_REGEX,

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -49,7 +49,9 @@ export const newAtlasSchema = object({
       }).required()
     )
     .required(),
-  metadataCorrectnessUrl: string().nullable(),
+  metadataCorrectnessUrl: string()
+    .url("Metadata correctness report must be a URL")
+    .nullable(),
   metadataSpecificationUrl: string()
     .matches(
       GOOGLE_SHEETS_URL_OR_EMPTY_STRING_REGEX,

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -42,6 +42,7 @@ export function atlasInputMapper(
     ingestionTaskCounts: apiAtlas.ingestionTaskCounts,
     integrationLeadEmail: apiAtlas.integrationLead.map(({ email }) => email),
     integrationLeadName: apiAtlas.integrationLead.map(({ name }) => name),
+    metadataCorrectnessUrl: apiAtlas.metadataCorrectnessUrl,
     metadataSpecificationUrl: apiAtlas.metadataSpecificationUrl,
     name: getAtlasName(apiAtlas),
     publications: apiAtlas.publications,

--- a/app/components/Detail/components/TrackerForm/components/Breadcrumbs/common/constants.ts
+++ b/app/components/Detail/components/TrackerForm/components/Breadcrumbs/common/constants.ts
@@ -37,6 +37,12 @@ export const BREADCRUMB_COMPONENT_ATLAS: Breadcrumb = {
   text: "Integration Object",
 };
 
+export const BREADCRUMB_METADATA_CORRECTNESS: Breadcrumb = {
+  path: ROUTE.METADATA_CORRECTNESS,
+  route: ROUTE.METADATA_CORRECTNESS,
+  text: "Metadata Correctness",
+};
+
 export const BREADCRUMB_SOURCE_STUDIES: Breadcrumb = {
   path: ROUTE.SOURCE_STUDIES,
   route: ROUTE.SOURCE_STUDIES,

--- a/app/components/Detail/components/TrackerForm/components/Breadcrumbs/common/utils.ts
+++ b/app/components/Detail/components/TrackerForm/components/Breadcrumbs/common/utils.ts
@@ -16,6 +16,7 @@ import {
   BREADCRUMB_ATLASES,
   BREADCRUMB_COMPONENT_ATLAS,
   BREADCRUMB_COMPONENT_ATLASES,
+  BREADCRUMB_METADATA_CORRECTNESS,
   BREADCRUMB_SOURCE_DATASETS,
   BREADCRUMB_SOURCE_STUDIES,
   BREADCRUMB_SOURCE_STUDY,
@@ -95,6 +96,17 @@ export function getComponentAtlasBreadcrumb(
   );
   if (!componentAtlas) return breadcrumb;
   return { ...breadcrumb, text: componentAtlas.title };
+}
+
+/**
+ * Returns the breadcrumb for the metadata correctness view.
+ * @param pathParameter - Path parameter.
+ * @returns metadata correctness view breadcrumb.
+ */
+export function getMetadataCorrectnessBreadcrumb(
+  pathParameter?: PathParameter
+): Breadcrumb {
+  return resolveBreadcrumbPath(BREADCRUMB_METADATA_CORRECTNESS, pathParameter);
 }
 
 /**

--- a/app/components/Detail/components/ViewAtlas/components/Tabs/tabs.tsx
+++ b/app/components/Detail/components/ViewAtlas/components/Tabs/tabs.tsx
@@ -54,6 +54,10 @@ export const Tabs = ({
           ),
           value: ROUTE.COMPONENT_ATLASES,
         },
+        {
+          label: "Metadata Correctness",
+          value: ROUTE.METADATA_CORRECTNESS,
+        },
       ]}
       value={route}
     />

--- a/app/components/Detail/components/ViewAtlasMetadataCorrectness/components/RequestAccess/requestAccess.tsx
+++ b/app/components/Detail/components/ViewAtlasMetadataCorrectness/components/RequestAccess/requestAccess.tsx
@@ -1,0 +1,12 @@
+import { Link } from "@databiosphere/findable-ui/lib/components/Links/components/Link/link";
+import { ROUTE } from "../../../../../../routes/constants";
+import { RequestAccess as Section } from "../../../TrackerForm/components/Section/components/RequestAccess/requestAccess";
+
+export const RequestAccess = (): JSX.Element => {
+  return (
+    <Section>
+      <Link label="Sign in" url={ROUTE.LOGIN} /> to view the metadata
+      correctness report.
+    </Section>
+  );
+};

--- a/app/components/Detail/components/ViewAtlasMetadataCorrectness/vewAtlasMetadataCorrectness.styles.ts
+++ b/app/components/Detail/components/ViewAtlasMetadataCorrectness/vewAtlasMetadataCorrectness.styles.ts
@@ -1,0 +1,9 @@
+import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
+import styled from "@emotion/styled";
+
+export const Paper = styled(FluidPaper)`
+  &.MuiPaper-root {
+    grid-column: 1 / -1;
+    padding: 16px;
+  }
+`;

--- a/app/components/Detail/components/ViewAtlasMetadataCorrectness/vewAtlasMetadataCorrectness.styles.ts
+++ b/app/components/Detail/components/ViewAtlasMetadataCorrectness/vewAtlasMetadataCorrectness.styles.ts
@@ -1,7 +1,11 @@
 import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
 import styled from "@emotion/styled";
 
-export const Paper = styled(FluidPaper)`
+export const SectionPaper = styled(FluidPaper)`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
   &.MuiPaper-root {
     grid-column: 1 / -1;
     padding: 16px;

--- a/app/components/Detail/components/ViewAtlasMetadataCorrectness/viewAtlasMetadataCorrectness.tsx
+++ b/app/components/Detail/components/ViewAtlasMetadataCorrectness/viewAtlasMetadataCorrectness.tsx
@@ -1,0 +1,33 @@
+import { Link } from "@databiosphere/findable-ui/lib/components/Links/components/Link/link";
+import { TEXT_BODY_400 } from "@databiosphere/findable-ui/lib/theme/common/typography";
+import { Typography } from "@mui/material";
+import { HCAAtlasTrackerAtlas } from "app/apis/catalog/hca-atlas-tracker/common/entities";
+import { FormManager } from "../../../../hooks/useFormManager/common/entities";
+import { RequestAccess } from "./components/RequestAccess/requestAccess";
+import { Paper } from "./vewAtlasMetadataCorrectness.styles";
+
+interface ViewAtlasMetadataCorrectness {
+  atlas?: HCAAtlasTrackerAtlas;
+  formManager: FormManager;
+}
+
+export const ViewAtlasMetadataCorrectness = ({
+  atlas,
+  formManager,
+}: ViewAtlasMetadataCorrectness): JSX.Element => {
+  const {
+    access: { canView },
+  } = formManager;
+  if (!canView) return <RequestAccess />;
+  return (
+    <Paper>
+      <Typography variant={TEXT_BODY_400}>
+        {atlas?.metadataCorrectnessUrl ? (
+          <Link url={atlas.metadataCorrectnessUrl} label="View Report" />
+        ) : (
+          "The metadata correctness report is unavailable for this atlas."
+        )}
+      </Typography>
+    </Paper>
+  );
+};

--- a/app/components/Detail/components/ViewAtlasMetadataCorrectness/viewAtlasMetadataCorrectness.tsx
+++ b/app/components/Detail/components/ViewAtlasMetadataCorrectness/viewAtlasMetadataCorrectness.tsx
@@ -1,10 +1,11 @@
+import { SectionTitle } from "@databiosphere/findable-ui/lib/components/common/Section/components/SectionTitle/sectionTitle";
 import { Link } from "@databiosphere/findable-ui/lib/components/Links/components/Link/link";
 import { TEXT_BODY_400 } from "@databiosphere/findable-ui/lib/theme/common/typography";
 import { Typography } from "@mui/material";
 import { HCAAtlasTrackerAtlas } from "app/apis/catalog/hca-atlas-tracker/common/entities";
 import { FormManager } from "../../../../hooks/useFormManager/common/entities";
 import { RequestAccess } from "./components/RequestAccess/requestAccess";
-import { Paper } from "./vewAtlasMetadataCorrectness.styles";
+import { SectionPaper } from "./vewAtlasMetadataCorrectness.styles";
 
 interface ViewAtlasMetadataCorrectness {
   atlas?: HCAAtlasTrackerAtlas;
@@ -20,7 +21,8 @@ export const ViewAtlasMetadataCorrectness = ({
   } = formManager;
   if (!canView) return <RequestAccess />;
   return (
-    <Paper>
+    <SectionPaper>
+      <SectionTitle title="Metadata Correctness Report" />
       <Typography variant={TEXT_BODY_400}>
         {atlas?.metadataCorrectnessUrl ? (
           <Link url={atlas.metadataCorrectnessUrl} label="View Report" />
@@ -28,6 +30,6 @@ export const ViewAtlasMetadataCorrectness = ({
           "The metadata correctness report is unavailable for this atlas."
         )}
       </Typography>
-    </Paper>
+    </SectionPaper>
   );
 };

--- a/app/components/Forms/components/Atlas/common/constants.ts
+++ b/app/components/Forms/components/Atlas/common/constants.ts
@@ -109,6 +109,18 @@ const METADATA_SPECIFICATION_URL: ControllerConfig<
   name: FIELD_NAME.METADATA_SPECIFICATION_URL,
 };
 
+const METADATA_CORRECTNESS_URL: ControllerConfig<
+  AtlasEditData,
+  HCAAtlasTrackerAtlas
+> = {
+  inputProps: {
+    isFullWidth: true,
+    label: "Metadata Correctness Report",
+  },
+  labelLink: true,
+  name: FIELD_NAME.METADATA_CORRECTNESS_URL,
+};
+
 export const GENERAL_INFO_NEW_ATLAS_CONTROLLERS: ControllerConfig<
   NewAtlasData,
   HCAAtlasTrackerAtlas
@@ -132,4 +144,4 @@ export const IDENTIFIERS_VIEW_ATLAS_CONTROLLERS: ControllerConfig<
 export const METADATA_VIEW_ATLAS_CONTROLLERS: ControllerConfig<
   AtlasEditData,
   HCAAtlasTrackerAtlas
->[] = [METADATA_SPECIFICATION_URL];
+>[] = [METADATA_SPECIFICATION_URL, METADATA_CORRECTNESS_URL];

--- a/app/routes/constants.ts
+++ b/app/routes/constants.ts
@@ -11,6 +11,7 @@ export const ROUTE = {
   CREATE_SOURCE_STUDY: "/atlases/[atlasId]/source-studies/create",
   CREATE_USER: "/team/create",
   LOGIN: "/login",
+  METADATA_CORRECTNESS: "/atlases/[atlasId]/metadata-correctness",
   REPORTS: "/reports",
   REQUESTING_ELEVATED_PERMISSIONS: "/requesting-elevated-permissions",
   SOURCE_DATASETS:

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -94,10 +94,36 @@ export async function updateAtlas(
 export async function atlasInputDataToDbData(
   inputData: NewAtlasData | AtlasEditData
 ): Promise<AtlasInputDbData> {
+  const publications = await getPublicationsFromInputDois(inputData.dois);
+  return {
+    overviewData: {
+      cellxgeneAtlasCollection: inputData.cellxgeneAtlasCollection ?? null,
+      codeLinks: inputData.codeLinks ?? [],
+      description: inputData.description ?? "",
+      highlights: inputData.highlights ?? "",
+      integrationLead: inputData.integrationLead,
+      metadataCorrectnessUrl: inputData.metadataCorrectnessUrl || null,
+      metadataSpecificationUrl: inputData.metadataSpecificationUrl || null,
+      network: inputData.network,
+      publications,
+      shortName: inputData.shortName,
+      version: inputData.version,
+      wave: inputData.wave,
+    },
+    status: inputData.status ?? ATLAS_STATUS.IN_PROGRESS,
+    targetCompletion: inputData.targetCompletion
+      ? new Date(inputData.targetCompletion)
+      : null,
+  };
+}
+
+async function getPublicationsFromInputDois(
+  dois: string[] | undefined
+): Promise<DoiPublicationInfo[]> {
   const publications: DoiPublicationInfo[] = [];
-  if (inputData.dois)
+  if (dois) {
     try {
-      for (const sourceDoi of inputData.dois) {
+      for (const sourceDoi of dois) {
         const doi = normalizeDoi(sourceDoi);
         publications.push({
           doi,
@@ -114,25 +140,8 @@ export async function atlasInputDataToDbData(
       }
       throw e;
     }
-  return {
-    overviewData: {
-      cellxgeneAtlasCollection: inputData.cellxgeneAtlasCollection ?? null,
-      codeLinks: inputData.codeLinks ?? [],
-      description: inputData.description ?? "",
-      highlights: inputData.highlights ?? "",
-      integrationLead: inputData.integrationLead,
-      metadataSpecificationUrl: inputData.metadataSpecificationUrl || null,
-      network: inputData.network,
-      publications,
-      shortName: inputData.shortName,
-      version: inputData.version,
-      wave: inputData.wave,
-    },
-    status: inputData.status ?? ATLAS_STATUS.IN_PROGRESS,
-    targetCompletion: inputData.targetCompletion
-      ? new Date(inputData.targetCompletion)
-      : null,
-  };
+  }
+  return publications;
 }
 
 export async function updateTaskCounts(): Promise<void> {

--- a/app/views/AtlasMetadataCorrectnessView/atlasMetadataCorrectnessView.tsx
+++ b/app/views/AtlasMetadataCorrectnessView/atlasMetadataCorrectnessView.tsx
@@ -1,0 +1,44 @@
+import { Breadcrumbs } from "@databiosphere/findable-ui/lib/components/common/Breadcrumbs/breadcrumbs";
+import { ConditionalComponent } from "@databiosphere/findable-ui/lib/components/ComponentCreator/components/ConditionalComponent/conditionalComponent";
+import { getAtlasName } from "../../apis/catalog/hca-atlas-tracker/common/utils";
+import { PathParameter } from "../../common/entities";
+import { shouldRenderView } from "../../components/Detail/common/utils";
+import { Tabs } from "../../components/Detail/components/ViewAtlas/components/Tabs/tabs";
+import { ViewAtlasMetadataCorrectness } from "../../components/Detail/components/ViewAtlasMetadataCorrectness/viewAtlasMetadataCorrectness";
+import { AtlasStatus } from "../../components/Layout/components/Detail/components/DetailViewHero/components/AtlasStatus/atlasStatus";
+import { DetailView } from "../../components/Layout/components/Detail/detailView";
+import { useFetchAtlas } from "../../hooks/useFetchAtlas";
+import { useFormManager } from "../../hooks/useFormManager/useFormManager";
+import { getBreadcrumbs } from "./common/utils";
+
+interface AtlasMetadataCorrectnessView {
+  pathParameter: PathParameter;
+}
+
+export const AtlasMetadataCorrectnessView = ({
+  pathParameter,
+}: AtlasMetadataCorrectnessView): JSX.Element => {
+  const { atlas } = useFetchAtlas(pathParameter);
+  const formManager = useFormManager();
+  const {
+    access: { canView },
+  } = formManager;
+  return (
+    <ConditionalComponent isIn={shouldRenderView(canView, Boolean(atlas))}>
+      <DetailView
+        breadcrumbs={
+          <Breadcrumbs breadcrumbs={getBreadcrumbs(pathParameter, atlas)} />
+        }
+        mainColumn={
+          <ViewAtlasMetadataCorrectness
+            atlas={atlas}
+            formManager={formManager}
+          />
+        }
+        status={atlas && <AtlasStatus atlasStatus={atlas.status} />}
+        tabs={<Tabs atlas={atlas} pathParameter={pathParameter} />}
+        title={atlas ? getAtlasName(atlas) : "View Integration Objects"}
+      />
+    </ConditionalComponent>
+  );
+};

--- a/app/views/AtlasMetadataCorrectnessView/common/utils.ts
+++ b/app/views/AtlasMetadataCorrectnessView/common/utils.ts
@@ -1,0 +1,25 @@
+import { HCAAtlasTrackerAtlas } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { PathParameter } from "../../../common/entities";
+import { Breadcrumb } from "../../../components/Detail/components/TrackerForm/components/Breadcrumbs/breadcrumbs";
+import {
+  getAtlasBreadcrumb,
+  getAtlasesBreadcrumb,
+  getComponentAtlasesBreadcrumb,
+} from "../../../components/Detail/components/TrackerForm/components/Breadcrumbs/common/utils";
+
+/**
+ * Returns the breadcrumbs for the metadata correctness view.
+ * @param pathParameter - Path parameter.
+ * @param atlas - Atlas.
+ * @returns breadcrumbs.
+ */
+export function getBreadcrumbs(
+  pathParameter: PathParameter,
+  atlas?: HCAAtlasTrackerAtlas
+): Breadcrumb[] {
+  return [
+    getAtlasesBreadcrumb(),
+    getAtlasBreadcrumb(pathParameter, atlas),
+    getComponentAtlasesBreadcrumb(),
+  ];
+}

--- a/app/views/AtlasMetadataCorrectnessView/common/utils.ts
+++ b/app/views/AtlasMetadataCorrectnessView/common/utils.ts
@@ -4,7 +4,7 @@ import { Breadcrumb } from "../../../components/Detail/components/TrackerForm/co
 import {
   getAtlasBreadcrumb,
   getAtlasesBreadcrumb,
-  getComponentAtlasesBreadcrumb,
+  getMetadataCorrectnessBreadcrumb,
 } from "../../../components/Detail/components/TrackerForm/components/Breadcrumbs/common/utils";
 
 /**
@@ -20,6 +20,6 @@ export function getBreadcrumbs(
   return [
     getAtlasesBreadcrumb(),
     getAtlasBreadcrumb(pathParameter, atlas),
-    getComponentAtlasesBreadcrumb(),
+    getMetadataCorrectnessBreadcrumb(),
   ];
 }

--- a/app/views/AtlasView/common/constants.ts
+++ b/app/views/AtlasView/common/constants.ts
@@ -2,6 +2,7 @@ import { FIELD_NAME as NEW_ATLAS_FIELD_NAME } from "../../AddNewAtlasView/common
 
 export const FIELD_NAME = {
   ...NEW_ATLAS_FIELD_NAME,
+  METADATA_CORRECTNESS_URL: "metadataCorrectnessUrl",
   METADATA_SPECIFICATION_URL: "metadataSpecificationUrl",
   TARGET_COMPLETION: "targetCompletion",
 } as const;

--- a/app/views/AtlasView/common/schema.ts
+++ b/app/views/AtlasView/common/schema.ts
@@ -10,7 +10,10 @@ import { FIELD_NAME } from "./constants";
 
 export const atlasEditSchema = newAtlasSchema.concat(
   object({
-    [FIELD_NAME.METADATA_CORRECTNESS_URL]: string().default("").notRequired(),
+    [FIELD_NAME.METADATA_CORRECTNESS_URL]: string()
+      .default("")
+      .notRequired()
+      .url("Metadata correctness report must be a URL"),
     [FIELD_NAME.METADATA_SPECIFICATION_URL]: string()
       .default("")
       .notRequired()

--- a/app/views/AtlasView/common/schema.ts
+++ b/app/views/AtlasView/common/schema.ts
@@ -10,6 +10,7 @@ import { FIELD_NAME } from "./constants";
 
 export const atlasEditSchema = newAtlasSchema.concat(
   object({
+    [FIELD_NAME.METADATA_CORRECTNESS_URL]: string().default("").notRequired(),
     [FIELD_NAME.METADATA_SPECIFICATION_URL]: string()
       .default("")
       .notRequired()

--- a/app/views/AtlasView/hooks/useEditAtlasForm.ts
+++ b/app/views/AtlasView/hooks/useEditAtlasForm.ts
@@ -53,6 +53,7 @@ function mapSchemaValues(atlas?: HCAAtlasTrackerAtlas): Partial<AtlasEditData> {
       atlas.cellxgeneAtlasCollection
     ),
     [FIELD_NAME.DOI]: atlas.publications[0]?.doi,
+    [FIELD_NAME.METADATA_CORRECTNESS_URL]: atlas.metadataCorrectnessUrl ?? "",
     [FIELD_NAME.METADATA_SPECIFICATION_URL]:
       atlas.metadataSpecificationUrl ?? "",
     [FIELD_NAME.SHORT_NAME]: atlas.shortName,

--- a/migrations/1738635767121_atlas-metadata-correctness.ts
+++ b/migrations/1738635767121_atlas-metadata-correctness.ts
@@ -1,0 +1,11 @@
+import { MigrationBuilder } from "node-pg-migrate";
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.sql(
+    `UPDATE hat.atlases SET overview=overview||'{"metadataCorrectnessUrl": null}'`
+  );
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.sql(`UPDATE hat.atlases SET overview=overview-'metadataCorrectnessUrl'`);
+}

--- a/pages/atlases/[atlasId]/metadata-correctness/index.tsx
+++ b/pages/atlases/[atlasId]/metadata-correctness/index.tsx
@@ -1,0 +1,32 @@
+import { GetServerSideProps, GetServerSidePropsContext } from "next";
+import { ParsedUrlQuery } from "querystring";
+import { PathParameter } from "../../../../app/common/entities";
+import { AtlasMetadataCorrectnessView } from "../../../../app/views/AtlasMetadataCorrectnessView/atlasMetadataCorrectnessView";
+
+interface MetadataCorrectnessPageUrlParams extends ParsedUrlQuery {
+  atlasId: string;
+}
+
+interface MetadataCorrectnessPageProps {
+  pathParameter: PathParameter;
+}
+
+export const getServerSideProps: GetServerSideProps = async (
+  context: GetServerSidePropsContext
+) => {
+  const { atlasId } = context.params as MetadataCorrectnessPageUrlParams;
+  return {
+    props: {
+      pageTitle: "Metadata Correctness",
+      pathParameter: { atlasId },
+    },
+  };
+};
+
+const ViewMetadataCorrectnessPage = ({
+  pathParameter,
+}: MetadataCorrectnessPageProps): JSX.Element => {
+  return <AtlasMetadataCorrectnessView pathParameter={pathParameter} />;
+};
+
+export default ViewMetadataCorrectnessPage;

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -1844,6 +1844,24 @@ export const ATLAS_PUBLIC_BAR: TestAtlas = {
   wave: "3",
 };
 
+export const ATLAS_WITH_METADATA_CORRECTNESS: TestAtlas = {
+  cellxgeneAtlasCollection: null,
+  codeLinks: [],
+  description: "foo barbaz bazbar foo foo foobaz",
+  highlights: "",
+  id: "22d1ece3-9e62-42f5-a737-a9c84042a1a0",
+  integrationLead: [],
+  metadataCorrectnessUrl: "https://example.com/atlas-with-metadata-correctness",
+  network: "reproduction",
+  publications: [],
+  shortName: "test-with-metadata-correctness",
+  sourceDatasets: [],
+  sourceStudies: [],
+  status: ATLAS_STATUS.IN_PROGRESS,
+  version: "2.6",
+  wave: "3",
+};
+
 export const ATLAS_NONEXISTENT = {
   id: "aa992f01-39ea-4906-ac12-053552561187",
 };
@@ -1858,6 +1876,7 @@ export const INITIAL_TEST_ATLASES = [
   ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_A,
   ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_B,
   ATLAS_PUBLIC_BAR,
+  ATLAS_WITH_METADATA_CORRECTNESS,
 ];
 
 export const INITIAL_TEST_ATLASES_BY_SOURCE_STUDY = INITIAL_TEST_ATLASES.reduce(

--- a/testing/entities.ts
+++ b/testing/entities.ts
@@ -28,6 +28,7 @@ export interface TestAtlas {
   highlights: string;
   id: string;
   integrationLead: IntegrationLead[];
+  metadataCorrectnessUrl?: string;
   metadataSpecificationUrl?: string;
   network: NetworkKey;
   publications: DoiPublicationInfo[];

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -75,6 +75,7 @@ export function makeTestAtlasOverview(
       [SYSTEM.HCA_DATA_REPOSITORY]: { completedCount: 0, count: 0 },
     },
     integrationLead: atlas.integrationLead,
+    metadataCorrectnessUrl: atlas.metadataCorrectnessUrl ?? null,
     metadataSpecificationUrl: atlas.metadataSpecificationUrl ?? null,
     network: atlas.network,
     publications: atlas.publications,


### PR DESCRIPTION
Wasn't sure exactly what the page should look like -- ~~here's what I have (EDIT: aside from the breadcrumbs which I have fixed):~~

<img width="1280" alt="Screenshot 2025-02-04 at 2 24 58 AM" src="https://github.com/user-attachments/assets/7aa6142f-e582-44ab-b949-18bbbec19164" />
