### PR TITLE
feat: incorporate primary data status into source study hca status (#589)

### DIFF
--- a/@types/theme.d.ts
+++ b/@types/theme.d.ts
@@ -1,0 +1,23 @@
+import { PaletteColorOptions } from "@mui/material/styles";
+
+/**
+ * Palette definitions.
+ */
+declare module "@mui/material/styles/createPalette" {
+  interface Palette {
+    caution: PaletteColor;
+  }
+
+  interface PaletteOptions {
+    caution?: PaletteColorOptions;
+  }
+}
+
+/**
+ * Chip prop options.
+ */
+declare module "@mui/material/Chip" {
+  interface ChipPropsColorOverrides {
+    caution: true;
+  }
+}

--- a/app/apis/catalog/hca-atlas-tracker/common/constants.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/constants.ts
@@ -136,6 +136,14 @@ export const ROLE_GROUP = {
   ],
 };
 
+export const SOURCE_STUDY_STATUS_LABEL = {
+  COMPLETE: "Complete",
+  IN_PROGRESS: "In progress",
+  NO_PRIMARY_DATA: "No primary data",
+  PRIMARY_DATA_BLOCKED: "Primary data blocked",
+  TODO: "To do",
+};
+
 export const SYSTEM_DISPLAY_NAMES: { [key in SYSTEM]: string } = {
   CAP: "CAP",
   CELLXGENE: "CELLxGENE",

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -11,6 +11,8 @@ import {
   HCAAtlasTrackerValidationRecord,
   NetworkKey,
   PublicationInfo,
+  TASK_STATUS,
+  VALIDATION_ID,
   Wave,
 } from "./entities";
 
@@ -84,6 +86,20 @@ export function getSourceStudyCitation(
       journal
     );
   }
+}
+
+/**
+ * Get the status of a task of a source study.
+ * @param sourceStudy - Source study.
+ * @param validationId - Validation ID of task to get status of.
+ * @returns task status, or undefined if the task doesn't exist on the given source study.
+ */
+export function getSourceStudyTaskStatus(
+  sourceStudy: HCAAtlasTrackerSourceStudy,
+  validationId: VALIDATION_ID
+): TASK_STATUS | undefined {
+  return sourceStudy.tasks.find((v) => v.validationId === validationId)
+    ?.taskStatus;
 }
 
 /**

--- a/app/components/Detail/components/ViewSourceStudies/viewSourceStudies.tsx
+++ b/app/components/Detail/components/ViewSourceStudies/viewSourceStudies.tsx
@@ -86,7 +86,7 @@ export const ViewSourceStudies = ({
                 pathParameter,
                 atlasLinkedDatasetCountsByStudyId
               )}
-              gridTemplateColumns="max-content minmax(260px, 1fr) minmax(100px, 118px) minmax(80px, 130px) repeat(3, minmax(100px, 118px))"
+              gridTemplateColumns="max-content minmax(260px, 1fr) minmax(100px, 118px) minmax(80px, 130px) repeat(2, minmax(130px, 150px)) minmax(195px, 210px)"
               items={sortedSourceStudies}
               tableOptions={TABLE_OPTIONS}
             />

--- a/app/components/Table/components/TableCell/components/SourceStudyStatusCell/sourceStudyStatusCell.styles.ts
+++ b/app/components/Table/components/TableCell/components/SourceStudyStatusCell/sourceStudyStatusCell.styles.ts
@@ -1,0 +1,8 @@
+import styled from "@emotion/styled";
+import { Chip } from "@mui/material";
+
+export const SourceStudyStatusBadge = styled(Chip)`
+  .MuiSvgIcon-root {
+    font-size: 12px;
+  }
+`;

--- a/app/components/Table/components/TableCell/components/SourceStudyStatusCell/sourceStudyStatusCell.tsx
+++ b/app/components/Table/components/TableCell/components/SourceStudyStatusCell/sourceStudyStatusCell.tsx
@@ -36,7 +36,7 @@ export const SourceStudyStatusCell = ({
 /**
  * Switch status badge color for the given value.
  * @param value - Status value.
- * @returns icon element for the status value.
+ * @returns status badge color for the status value.
  */
 function switchStatusBadgeColor(
   value: SOURCE_STUDY_STATUS

--- a/app/components/Table/components/TableCell/components/SourceStudyStatusCell/sourceStudyStatusCell.tsx
+++ b/app/components/Table/components/TableCell/components/SourceStudyStatusCell/sourceStudyStatusCell.tsx
@@ -1,38 +1,76 @@
+import { ErrorIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/ErrorIcon/errorIcon";
 import { InProgressIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/InProgressIcon/inProgressIcon";
 import { SuccessIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/SuccessIcon/successIcon";
-import { Fragment } from "react";
+import { ChipProps } from "@mui/material";
+import { PartiallyCompleteIcon } from "../../../../../common/CustomIcon/components/PartiallyCompleteIcon/partiallyCompleteIcon";
 import { RequiredIcon } from "../../../../../common/CustomIcon/components/RequiredIcon/requiredIcon";
+import { SourceStudyStatusBadge } from "./sourceStudyStatusCell.styles";
 
 export enum SOURCE_STUDY_STATUS {
-  DONE = "Yes",
-  IN_PROGRESS = "In progress",
-  REQUIRED = "No",
+  BLOCKED = "BLOCKED",
+  DONE = "DONE",
+  IN_PROGRESS = "IN_PROGRESS",
+  PARTIALLY_COMPLETE = "PARTIALLY_COMPLETE",
+  REQUIRED = "REQUIRED",
 }
 
-interface SourceStudyStatusCellProps {
-  value: string;
+export interface SourceStudyStatusCellProps {
+  label: string;
+  status: SOURCE_STUDY_STATUS;
 }
 
 export const SourceStudyStatusCell = ({
-  value,
+  label,
+  status,
 }: SourceStudyStatusCellProps): JSX.Element => {
-  return <Fragment>{switchStatusIcon(value)}</Fragment>;
+  return (
+    <SourceStudyStatusBadge
+      icon={switchStatusIcon(status)}
+      label={label}
+      color={switchStatusBadgeColor(status)}
+      variant="status"
+    />
+  );
 };
 
 /**
- * Switch status icon for the given value.
- * @param value - Task value.
+ * Switch status badge color for the given value.
+ * @param value - Status value.
  * @returns icon element for the status value.
  */
-function switchStatusIcon(value: string): JSX.Element {
+function switchStatusBadgeColor(
+  value: SOURCE_STUDY_STATUS
+): ChipProps["color"] {
   switch (value) {
+    case SOURCE_STUDY_STATUS.BLOCKED:
+      return "error";
     case SOURCE_STUDY_STATUS.DONE:
-      return <SuccessIcon color="success" fontSize="small" />;
+      return "success";
     case SOURCE_STUDY_STATUS.IN_PROGRESS:
-      return <InProgressIcon color="warning" fontSize="small" />;
+      return "info";
+    case SOURCE_STUDY_STATUS.PARTIALLY_COMPLETE:
+      return "warning";
+    case SOURCE_STUDY_STATUS.REQUIRED:
+      return "default";
+  }
+}
+
+/**
+ * Switch status icon for the given value.
+ * @param value - Status value.
+ * @returns icon element for the status value.
+ */
+function switchStatusIcon(value: SOURCE_STUDY_STATUS): JSX.Element {
+  switch (value) {
+    case SOURCE_STUDY_STATUS.BLOCKED:
+      return <ErrorIcon />;
+    case SOURCE_STUDY_STATUS.DONE:
+      return <SuccessIcon />;
+    case SOURCE_STUDY_STATUS.IN_PROGRESS:
+      return <InProgressIcon />;
+    case SOURCE_STUDY_STATUS.PARTIALLY_COMPLETE:
+      return <PartiallyCompleteIcon />;
     case SOURCE_STUDY_STATUS.REQUIRED:
       return <RequiredIcon />;
-    default:
-      return <span>-</span>;
   }
 }

--- a/app/components/Table/components/TableCell/components/SourceStudyStatusCell/sourceStudyStatusCell.tsx
+++ b/app/components/Table/components/TableCell/components/SourceStudyStatusCell/sourceStudyStatusCell.tsx
@@ -47,7 +47,7 @@ function switchStatusBadgeColor(
     case SOURCE_STUDY_STATUS.DONE:
       return "success";
     case SOURCE_STUDY_STATUS.IN_PROGRESS:
-      return "info";
+      return "caution";
     case SOURCE_STUDY_STATUS.PARTIALLY_COMPLETE:
       return "warning";
     case SOURCE_STUDY_STATUS.REQUIRED:

--- a/app/components/common/CustomIcon/components/PartiallyCompleteIcon/partiallyCompleteIcon.tsx
+++ b/app/components/common/CustomIcon/components/PartiallyCompleteIcon/partiallyCompleteIcon.tsx
@@ -1,5 +1,4 @@
-import { CustomSVGIconProps } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/common/entities";
-import { SvgIcon } from "@mui/material";
+import { SvgIcon, SvgIconProps } from "@mui/material";
 
 /**
  * Custom partially complete icon.
@@ -9,7 +8,7 @@ export const PartiallyCompleteIcon = ({
   fontSize = "small",
   viewBox = "0 0 18 18",
   ...props /* Spread props to allow for Mui SvgIconProps specific prop overrides e.g. "htmlColor". */
-}: CustomSVGIconProps): JSX.Element => {
+}: SvgIconProps): JSX.Element => {
   return (
     <SvgIcon viewBox={viewBox} fontSize={fontSize} {...props}>
       <path

--- a/app/components/common/CustomIcon/components/PartiallyCompleteIcon/partiallyCompleteIcon.tsx
+++ b/app/components/common/CustomIcon/components/PartiallyCompleteIcon/partiallyCompleteIcon.tsx
@@ -1,0 +1,21 @@
+import { CustomSVGIconProps } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/common/entities";
+import { SvgIcon } from "@mui/material";
+
+/**
+ * Custom partially complete icon.
+ */
+
+export const PartiallyCompleteIcon = ({
+  fontSize = "small",
+  viewBox = "0 0 18 18",
+  ...props /* Spread props to allow for Mui SvgIconProps specific prop overrides e.g. "htmlColor". */
+}: CustomSVGIconProps): JSX.Element => {
+  return (
+    <SvgIcon viewBox={viewBox} fontSize={fontSize} {...props}>
+      <path
+        d="m9 16.5c-1.0375 0-2.0125-0.1969-2.925-0.5906-0.9125-0.3938-1.7062-0.9282-2.3812-1.6032s-1.2094-1.4687-1.6031-2.3812-0.59062-1.8875-0.59062-2.925 0.19687-2.0125 0.59062-2.925 0.92813-1.7062 1.6031-2.3812 1.4688-1.2094 2.3812-1.6031 1.8875-0.59062 2.925-0.59062 2.0125 0.19687 2.925 0.59062 1.7062 0.92813 2.3812 1.6031 1.2094 1.4688 1.6032 2.3812c0.3937 0.9125 0.5906 1.8875 0.5906 2.925s-0.1969 2.0125-0.5906 2.925c-0.3938 0.9125-0.9282 1.7062-1.6032 2.3812s-1.4687 1.2094-2.3812 1.6032c-0.9125 0.3937-1.8875 0.5906-2.925 0.5906zm0-1.5v-12c-1.675 0-3.0938 0.58125-4.2562 1.7438s-1.7438 2.5812-1.7438 4.2562 0.58125 3.0937 1.7438 4.2562 2.5812 1.7438 4.2562 1.7438z"
+        fill="currentColor"
+      />
+    </SvgIcon>
+  );
+};

--- a/app/components/common/CustomIcon/components/RequiredIcon/requiredIcon.tsx
+++ b/app/components/common/CustomIcon/components/RequiredIcon/requiredIcon.tsx
@@ -1,19 +1,23 @@
-import { smokeDark } from "@databiosphere/findable-ui/lib/theme/common/palette";
+import { CustomSVGIconProps } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/common/entities";
 import { SvgIcon } from "@mui/material";
 
 /**
  * Custom required icon.
  */
 
-export const RequiredIcon = (): JSX.Element => {
+export const RequiredIcon = ({
+  fontSize = "small",
+  viewBox = "0 0 20 20",
+  ...props /* Spread props to allow for Mui SvgIconProps specific prop overrides e.g. "htmlColor". */
+}: CustomSVGIconProps): JSX.Element => {
   return (
-    <SvgIcon viewBox="0 0 20 20" fontSize="small">
+    <SvgIcon viewBox={viewBox} fontSize={fontSize} {...props}>
       <circle
         cx="10"
         cy="10"
         r="8"
         fill="transparent"
-        stroke={smokeDark}
+        stroke="currentColor"
         strokeWidth="2"
       />
     </SvgIcon>

--- a/app/components/common/CustomIcon/components/RequiredIcon/requiredIcon.tsx
+++ b/app/components/common/CustomIcon/components/RequiredIcon/requiredIcon.tsx
@@ -1,5 +1,4 @@
-import { CustomSVGIconProps } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/common/entities";
-import { SvgIcon } from "@mui/material";
+import { SvgIcon, SvgIconProps } from "@mui/material";
 
 /**
  * Custom required icon.
@@ -9,7 +8,7 @@ export const RequiredIcon = ({
   fontSize = "small",
   viewBox = "0 0 20 20",
   ...props /* Spread props to allow for Mui SvgIconProps specific prop overrides e.g. "htmlColor". */
-}: CustomSVGIconProps): JSX.Element => {
+}: SvgIconProps): JSX.Element => {
   return (
     <SvgIcon viewBox={viewBox} fontSize={fontSize} {...props}>
       <circle

--- a/app/theme/common/components.ts
+++ b/app/theme/common/components.ts
@@ -41,3 +41,25 @@ export const MuiButton = (theme: Theme): Components["MuiButton"] => {
     },
   };
 };
+
+export const MuiChip = (theme: Theme): Components<Theme>["MuiChip"] => {
+  return {
+    variants: [
+      ...(theme.components?.MuiChip?.variants ?? []),
+      {
+        props: { color: "default", variant: "status" },
+        style: {
+          backgroundColor: theme.palette.smoke.main,
+          color: theme.palette.ink.light,
+        },
+      },
+      {
+        props: { color: "caution" },
+        style: {
+          backgroundColor: theme.palette.caution.light,
+          color: theme.palette.caution.main,
+        },
+      },
+    ],
+  };
+};

--- a/app/theme/theme.ts
+++ b/app/theme/theme.ts
@@ -10,6 +10,7 @@ export function mergeAppTheme(theme: Theme): Theme {
   return createTheme(theme, {
     components: {
       MuiButton: C.MuiButton(theme),
+      MuiChip: C.MuiChip(theme),
     },
   });
 }

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -252,74 +252,6 @@ export const buildEntityType = (
 };
 
 /**
- * Build props for the "in CAP" SourceStudyStatusCell component.
- * @param sourceStudy - Source study entity.
- * @returns Props to be used for the SourceStudyStatusCell component.
- */
-export const buildInCap = (
-  sourceStudy: HCAAtlasTrackerSourceStudy
-): ComponentProps<typeof C.SourceStudyStatusCell> => {
-  return getSourceStudyStatusFromValidation(
-    sourceStudy,
-    VALIDATION_ID.SOURCE_STUDY_IN_CAP
-  );
-};
-
-/**
- * Build props for the "in CELLxGENE" SourceStudyStatusCell component.
- * @param sourceStudy - Source study entity.
- * @returns Props to be used for the SourceStudyStatusCell component.
- */
-export const buildInCellxGene = (
-  sourceStudy: HCAAtlasTrackerSourceStudy
-): ComponentProps<typeof C.SourceStudyStatusCell> => {
-  return getSourceStudyStatusFromValidation(
-    sourceStudy,
-    VALIDATION_ID.SOURCE_STUDY_IN_CELLXGENE
-  );
-};
-
-/**
- * Build props for the "in HCA data repository" SourceStudyStatusCell component.
- * @param sourceStudy - Source study entity.
- * @returns Props to be used for the SourceStudyStatusCell component.
- */
-export const buildInHcaDataRepository = (
-  sourceStudy: HCAAtlasTrackerSourceStudy
-): ComponentProps<typeof C.SourceStudyStatusCell> => {
-  const ingestStatus = getSourceStudyTaskStatus(
-    sourceStudy,
-    VALIDATION_ID.SOURCE_STUDY_IN_HCA_DATA_REPOSITORY
-  );
-  if (ingestStatus === TASK_STATUS.DONE) {
-    const primaryDataStatus = getSourceStudyTaskStatus(
-      sourceStudy,
-      VALIDATION_ID.SOURCE_STUDY_HCA_PROJECT_HAS_PRIMARY_DATA
-    );
-    if (primaryDataStatus === TASK_STATUS.DONE)
-      return {
-        label: SOURCE_STUDY_STATUS_LABEL.COMPLETE,
-        status: SOURCE_STUDY_STATUS.DONE,
-      };
-    else if (primaryDataStatus === TASK_STATUS.BLOCKED)
-      return {
-        label: SOURCE_STUDY_STATUS_LABEL.PRIMARY_DATA_BLOCKED,
-        status: SOURCE_STUDY_STATUS.BLOCKED,
-      };
-    else
-      return {
-        label: SOURCE_STUDY_STATUS_LABEL.NO_PRIMARY_DATA,
-        status: SOURCE_STUDY_STATUS.PARTIALLY_COMPLETE,
-      };
-  } else {
-    return {
-      label: SOURCE_STUDY_STATUS_LABEL.TODO,
-      status: SOURCE_STUDY_STATUS.REQUIRED,
-    };
-  }
-};
-
-/**
  * Build props for the CAP ingestion counts TaskCountsCell component.
  * @param atlas - Atlas entity.
  * @returns Props to be used for the TaskCountsCell.
@@ -447,6 +379,74 @@ export const buildSourceDatasetDownload = (
       ? `https://datasets.cellxgene.cziscience.com/${versionId}.h5ad`
       : undefined,
   };
+};
+
+/**
+ * Build props for the CAP SourceStudyStatusCell component.
+ * @param sourceStudy - Source study entity.
+ * @returns Props to be used for the SourceStudyStatusCell component.
+ */
+export const buildSourceStudyCapStatus = (
+  sourceStudy: HCAAtlasTrackerSourceStudy
+): ComponentProps<typeof C.SourceStudyStatusCell> => {
+  return getSourceStudyStatusFromValidation(
+    sourceStudy,
+    VALIDATION_ID.SOURCE_STUDY_IN_CAP
+  );
+};
+
+/**
+ * Build props for the CELLxGENE SourceStudyStatusCell component.
+ * @param sourceStudy - Source study entity.
+ * @returns Props to be used for the SourceStudyStatusCell component.
+ */
+export const buildSourceStudyCellxGeneStatus = (
+  sourceStudy: HCAAtlasTrackerSourceStudy
+): ComponentProps<typeof C.SourceStudyStatusCell> => {
+  return getSourceStudyStatusFromValidation(
+    sourceStudy,
+    VALIDATION_ID.SOURCE_STUDY_IN_CELLXGENE
+  );
+};
+
+/**
+ * Build props for the HCA Data Repository SourceStudyStatusCell component.
+ * @param sourceStudy - Source study entity.
+ * @returns Props to be used for the SourceStudyStatusCell component.
+ */
+export const buildSourceStudyHcaDataRepositoryStatus = (
+  sourceStudy: HCAAtlasTrackerSourceStudy
+): ComponentProps<typeof C.SourceStudyStatusCell> => {
+  const ingestStatus = getSourceStudyTaskStatus(
+    sourceStudy,
+    VALIDATION_ID.SOURCE_STUDY_IN_HCA_DATA_REPOSITORY
+  );
+  if (ingestStatus === TASK_STATUS.DONE) {
+    const primaryDataStatus = getSourceStudyTaskStatus(
+      sourceStudy,
+      VALIDATION_ID.SOURCE_STUDY_HCA_PROJECT_HAS_PRIMARY_DATA
+    );
+    if (primaryDataStatus === TASK_STATUS.DONE)
+      return {
+        label: SOURCE_STUDY_STATUS_LABEL.COMPLETE,
+        status: SOURCE_STUDY_STATUS.DONE,
+      };
+    else if (primaryDataStatus === TASK_STATUS.BLOCKED)
+      return {
+        label: SOURCE_STUDY_STATUS_LABEL.PRIMARY_DATA_BLOCKED,
+        status: SOURCE_STUDY_STATUS.BLOCKED,
+      };
+    else
+      return {
+        label: SOURCE_STUDY_STATUS_LABEL.NO_PRIMARY_DATA,
+        status: SOURCE_STUDY_STATUS.PARTIALLY_COMPLETE,
+      };
+  } else {
+    return {
+      label: SOURCE_STUDY_STATUS_LABEL.TODO,
+      status: SOURCE_STUDY_STATUS.REQUIRED,
+    };
+  }
 };
 
 /**
@@ -1154,9 +1154,9 @@ export function getAtlasSourceStudiesTableColumns(
       pathParameter,
       atlasLinkedDatasetCountsByStudyId
     ),
-    getSourceStudyInCELLxGENEColumnDef(),
-    getSourceStudyInCapColumnDef(),
-    getSourceStudyInHCADataRepositoryColumnDef(),
+    getSourceStudyCELLxGENEStatusColumnDef(),
+    getSourceStudyCapStatusColumnDef(),
+    getSourceStudyHCADataRepositoryStatusColumnDef(),
   ];
 }
 
@@ -1484,10 +1484,11 @@ function getSourceDatasetTitleColumnDef(
  * Returns source study is in Cap column def.
  * @returns Column def.
  */
-function getSourceStudyInCapColumnDef(): ColumnDef<HCAAtlasTrackerSourceStudy> {
+function getSourceStudyCapStatusColumnDef(): ColumnDef<HCAAtlasTrackerSourceStudy> {
   return {
-    accessorFn: (sourceStudy) => buildInCap(sourceStudy).label,
-    cell: ({ row }) => C.SourceStudyStatusCell(buildInCap(row.original)),
+    accessorFn: (sourceStudy) => buildSourceStudyCapStatus(sourceStudy).label,
+    cell: ({ row }) =>
+      C.SourceStudyStatusCell(buildSourceStudyCapStatus(row.original)),
     header: "CAP",
   };
 }
@@ -1496,10 +1497,12 @@ function getSourceStudyInCapColumnDef(): ColumnDef<HCAAtlasTrackerSourceStudy> {
  * Returns source study in CELLxGENE column def.
  * @returns Column def.
  */
-function getSourceStudyInCELLxGENEColumnDef(): ColumnDef<HCAAtlasTrackerSourceStudy> {
+function getSourceStudyCELLxGENEStatusColumnDef(): ColumnDef<HCAAtlasTrackerSourceStudy> {
   return {
-    accessorFn: (sourceStudy) => buildInCellxGene(sourceStudy).label,
-    cell: ({ row }) => C.SourceStudyStatusCell(buildInCellxGene(row.original)),
+    accessorFn: (sourceStudy) =>
+      buildSourceStudyCellxGeneStatus(sourceStudy).label,
+    cell: ({ row }) =>
+      C.SourceStudyStatusCell(buildSourceStudyCellxGeneStatus(row.original)),
     header: "CELLxGENE",
   };
 }
@@ -1508,11 +1511,14 @@ function getSourceStudyInCELLxGENEColumnDef(): ColumnDef<HCAAtlasTrackerSourceSt
  * Returns source study in HCA data repository column def.
  * @returns Column def.
  */
-function getSourceStudyInHCADataRepositoryColumnDef(): ColumnDef<HCAAtlasTrackerSourceStudy> {
+function getSourceStudyHCADataRepositoryStatusColumnDef(): ColumnDef<HCAAtlasTrackerSourceStudy> {
   return {
-    accessorFn: (sourceStudy) => buildInHcaDataRepository(sourceStudy).label,
+    accessorFn: (sourceStudy) =>
+      buildSourceStudyHcaDataRepositoryStatus(sourceStudy).label,
     cell: ({ row }) =>
-      C.SourceStudyStatusCell(buildInHcaDataRepository(row.original)),
+      C.SourceStudyStatusCell(
+        buildSourceStudyHcaDataRepositoryStatus(row.original)
+      ),
     header: "HCA Data Repository",
   };
 }

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -1486,7 +1486,6 @@ function getSourceDatasetTitleColumnDef(
  */
 function getSourceStudyCapStatusColumnDef(): ColumnDef<HCAAtlasTrackerSourceStudy> {
   return {
-    accessorFn: (sourceStudy) => buildSourceStudyCapStatus(sourceStudy).label,
     cell: ({ row }) =>
       C.SourceStudyStatusCell(buildSourceStudyCapStatus(row.original)),
     header: "CAP",
@@ -1499,8 +1498,6 @@ function getSourceStudyCapStatusColumnDef(): ColumnDef<HCAAtlasTrackerSourceStud
  */
 function getSourceStudyCELLxGENEStatusColumnDef(): ColumnDef<HCAAtlasTrackerSourceStudy> {
   return {
-    accessorFn: (sourceStudy) =>
-      buildSourceStudyCellxGeneStatus(sourceStudy).label,
     cell: ({ row }) =>
       C.SourceStudyStatusCell(buildSourceStudyCellxGeneStatus(row.original)),
     header: "CELLxGENE",
@@ -1513,8 +1510,6 @@ function getSourceStudyCELLxGENEStatusColumnDef(): ColumnDef<HCAAtlasTrackerSour
  */
 function getSourceStudyHCADataRepositoryStatusColumnDef(): ColumnDef<HCAAtlasTrackerSourceStudy> {
   return {
-    accessorFn: (sourceStudy) =>
-      buildSourceStudyHcaDataRepositoryStatus(sourceStudy).label,
     cell: ({ row }) =>
       C.SourceStudyStatusCell(
         buildSourceStudyHcaDataRepositoryStatus(row.original)

--- a/site-config/hca-atlas-tracker/local/config.ts
+++ b/site-config/hca-atlas-tracker/local/config.ts
@@ -104,6 +104,10 @@ export function makeConfig(
     redirectRootToPath: HOME_PAGE_PATH,
     themeOptions: {
       palette: {
+        caution: {
+          light: "#FFEB78",
+          main: "#956F00",
+        },
         primary: {
           dark: "#005EA9",
           main: "#1C7CC7",


### PR DESCRIPTION
Notes on contents:
- I've adjusted a couple of the labels ("To do" and "Complete") to be consistent with task statuses
- The HCA status is set as "Primary data blocked" if the ingest task is `DONE` and the primary data task is`BLOCKED` -- not certain this is exactly how it will end up working, as currently there's no way for the primary data task to have the `BLOCKED` status, but I believe the plan is to in the future allow primary data to be set as blocked
- Despite the mock showing "In progress" as a possibility for HCA status, I didn't include it as a possibility for HCA here, since to my knowledge there's no current or planned way of setting the HCA ingest task or the primary data task as being in progress

Other considerations:

The colors are not entirely accurate to the mock -- the foreground color for "To do" is noticeably lighter in the mock, and I've used the blue `info` color for "In progress" for now because we don't have a yellow available as far as I know

Here's a screenshot with test values showing all of the HCA statuses from the mock:

<img width="1280" alt="Screenshot 2025-02-24 at 10 48 19 PM" src="https://github.com/user-attachments/assets/9795df73-e99d-4c98-93f5-5f690d2ba0fd" />

---

Additional thought -- I have not pushed this, but I wonder if it would be good to show when CAP is blocked as in the below example, rather than just calling it "To do":

<img width="1280" alt="Screenshot 2025-02-25 at 1 19 26 PM" src="https://github.com/user-attachments/assets/b88f65b9-d80c-4f90-9846-567badaf1118" />
