### PR TITLE
feat: query, save, and display metadata specification sheet title in atlas form (#602)

### DIFF
--- a/__mocks__/googleapis.ts
+++ b/__mocks__/googleapis.ts
@@ -1,0 +1,46 @@
+import { GaxiosError, GaxiosResponse } from "gaxios";
+import { sheets_v4 } from "googleapis";
+import {
+  TEST_GOOGLE_SHEET_TITLES_BY_ID,
+  TEST_UNSHARED_GOOGLE_SHEET_IDS,
+} from "../testing/constants";
+
+type TestGaxiosPromise<T> = Promise<Pick<GaxiosResponse<T>, "data">>;
+
+function GoogleAuth(): unknown {
+  return "TEST_GOOGLE_AUTH";
+}
+
+export const google = {
+  auth: {
+    GoogleAuth,
+  },
+
+  sheets(): unknown {
+    return {
+      spreadsheets: {
+        async get({
+          spreadsheetId,
+        }: {
+          spreadsheetId: string;
+        }): TestGaxiosPromise<sheets_v4.Schema$Spreadsheet> {
+          if (TEST_UNSHARED_GOOGLE_SHEET_IDS.has(spreadsheetId))
+            throw makeTestGaxiosError(403);
+          if (!(spreadsheetId in TEST_GOOGLE_SHEET_TITLES_BY_ID))
+            throw makeTestGaxiosError(404);
+          return {
+            data: {
+              properties: {
+                title: TEST_GOOGLE_SHEET_TITLES_BY_ID[spreadsheetId],
+              },
+            },
+          };
+        },
+      },
+    };
+  },
+};
+
+function makeTestGaxiosError(status: number): GaxiosError {
+  return new GaxiosError("", {}, { status } as GaxiosResponse);
+}

--- a/__tests__/get-sheet-title.test.ts
+++ b/__tests__/get-sheet-title.test.ts
@@ -1,0 +1,72 @@
+import { getSheetTitle, InvalidSheetError } from "app/utils/google-sheets";
+
+jest.mock("googleapis");
+
+describe("getSheetTitle", () => {
+  it("throws InvalidSheetError when URL is not a Google Sheets URL", async () => {
+    await expect(getSheetTitle("https://example.com")).rejects.toThrow(
+      InvalidSheetError
+    );
+  });
+
+  it("throws InvalidSheetError when has no ID following `/d/`", async () => {
+    await expect(
+      getSheetTitle("https://docs.google.com/spreadsheets/d/")
+    ).rejects.toThrow(InvalidSheetError);
+  });
+
+  it("throws InvalidSheetError when sheet doesn't exist", async () => {
+    await expect(
+      getSheetTitle("https://docs.google.com/spreadsheets/d/nonexistent/edit")
+    ).rejects.toThrow(InvalidSheetError);
+  });
+
+  it("throws InvalidSheetError when sheet isn't shared", async () => {
+    await expect(
+      getSheetTitle(
+        "https://docs.google.com/spreadsheets/d/sheet-unshared/edit"
+      )
+    ).rejects.toThrow(InvalidSheetError);
+  });
+
+  it("returns null when credentials are missing", async () => {
+    const credentials = process.env.GOOGLE_SERVICE_ACCOUNT_JSON;
+    process.env.GOOGLE_SERVICE_ACCOUNT_JSON = "";
+    await expect(
+      getSheetTitle("https://docs.google.com/spreadsheets/d/sheet-foo")
+    ).resolves.toBeNull();
+    process.env.GOOGLE_SERVICE_ACCOUNT_JSON = credentials;
+  });
+
+  it("returns sheet title for valid URL with nothing following ID", async () => {
+    await expect(
+      getSheetTitle("https://docs.google.com/spreadsheets/d/sheet-foo")
+    ).resolves.toEqual("Sheet Foo");
+  });
+
+  it("returns sheet title for valid URL with subpath following ID", async () => {
+    await expect(
+      getSheetTitle("https://docs.google.com/spreadsheets/d/sheet-foo/edit")
+    ).resolves.toEqual("Sheet Foo");
+  });
+
+  it("returns sheet title for valid URL with query string following ID", async () => {
+    await expect(
+      getSheetTitle("https://docs.google.com/spreadsheets/d/sheet-foo?gid=0")
+    ).resolves.toEqual("Sheet Foo");
+  });
+
+  it("returns sheet title for valid URL with fragment following ID", async () => {
+    await expect(
+      getSheetTitle("https://docs.google.com/spreadsheets/d/sheet-foo#gid=0")
+    ).resolves.toEqual("Sheet Foo");
+  });
+
+  it("returns sheet title for valid URL with subpath, query string, and fragment", async () => {
+    await expect(
+      getSheetTitle(
+        "https://docs.google.com/spreadsheets/d/sheet-foo/edit?gid=0#gid=0"
+      )
+    ).resolves.toEqual("Sheet Foo");
+  });
+});

--- a/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
@@ -47,6 +47,7 @@ export function dbAtlasToApiAtlas(
     ingestionTaskCounts: dbAtlas.overview.ingestionTaskCounts,
     integrationLead: dbAtlas.overview.integrationLead,
     metadataCorrectnessUrl: dbAtlas.overview.metadataCorrectnessUrl,
+    metadataSpecificationTitle: dbAtlas.overview.metadataSpecificationTitle,
     metadataSpecificationUrl: dbAtlas.overview.metadataSpecificationUrl,
     publications: dbAtlas.overview.publications,
     shortName: dbAtlas.overview.shortName,

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -26,6 +26,7 @@ export interface HCAAtlasTrackerAtlas {
   ingestionTaskCounts: IngestionTaskCounts;
   integrationLead: IntegrationLead[];
   metadataCorrectnessUrl: string | null;
+  metadataSpecificationTitle: string | null;
   metadataSpecificationUrl: string | null;
   publications: DoiPublicationInfo[];
   shortName: string;
@@ -223,6 +224,7 @@ export interface HCAAtlasTrackerDBAtlasOverview {
   ingestionTaskCounts: IngestionTaskCounts;
   integrationLead: IntegrationLead[];
   metadataCorrectnessUrl: string | null;
+  metadataSpecificationTitle: string | null;
   metadataSpecificationUrl: string | null;
   network: NetworkKey;
   publications: DoiPublicationInfo[];

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -13,7 +13,7 @@ import { NETWORK_KEYS, WAVES } from "./constants";
 import { ATLAS_STATUS, ROLE } from "./entities";
 
 export const GOOGLE_SHEETS_URL_OR_EMPTY_STRING_REGEX =
-  /^$|^https:\/\/docs\.google\.com\/spreadsheets\//;
+  /^$|^https:\/\/docs\.google\.com\/spreadsheets\/d\/./;
 
 /**
  * Schema for data used to create a new atlas.
@@ -55,7 +55,7 @@ export const newAtlasSchema = object({
   metadataSpecificationUrl: string()
     .matches(
       GOOGLE_SHEETS_URL_OR_EMPTY_STRING_REGEX,
-      "Metadata specification must be a Google Sheets URL"
+      'Metadata specification must be a Google Sheets URL of the form "https://docs.google.com/spreadsheets/d/..."'
     )
     .nullable(),
   network: string()

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -47,6 +47,7 @@ export function atlasInputMapper(
     integrationLeadEmail: apiAtlas.integrationLead.map(({ email }) => email),
     integrationLeadName: apiAtlas.integrationLead.map(({ name }) => name),
     metadataCorrectnessUrl: apiAtlas.metadataCorrectnessUrl,
+    metadataSpecificationTitle: apiAtlas.metadataSpecificationTitle,
     metadataSpecificationUrl: apiAtlas.metadataSpecificationUrl,
     name: getAtlasName(apiAtlas),
     publications: apiAtlas.publications,

--- a/app/components/Forms/components/Atlas/common/constants.ts
+++ b/app/components/Forms/components/Atlas/common/constants.ts
@@ -107,6 +107,9 @@ const METADATA_SPECIFICATION_URL: ControllerConfig<
   },
   labelLink: true,
   name: FIELD_NAME.METADATA_SPECIFICATION_URL,
+  renderHelperText(atlas) {
+    return atlas?.metadataSpecificationTitle;
+  },
 };
 
 const METADATA_CORRECTNESS_URL: ControllerConfig<

--- a/app/components/common/Form/components/Input/input.tsx
+++ b/app/components/common/Form/components/Input/input.tsx
@@ -52,7 +52,12 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
         {...props}
       />
       {helperText && (
-        <FormHelperText disabled={disabled} error={error} {...helperTextProps}>
+        <FormHelperText
+          disabled={disabled}
+          error={error}
+          noWrap={!error}
+          {...helperTextProps}
+        >
           {helperText}
         </FormHelperText>
       )}

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -18,6 +18,7 @@ import {
   NewAtlasData,
 } from "../apis/catalog/hca-atlas-tracker/common/schema";
 import { normalizeDoi } from "../utils/doi";
+import { getSheetTitle, InvalidSheetError } from "../utils/google-sheets";
 import { query } from "./database";
 import { confirmSourceDatasetStudyIsOnAtlas } from "./source-datasets";
 
@@ -95,6 +96,17 @@ export async function atlasInputDataToDbData(
   inputData: NewAtlasData | AtlasEditData
 ): Promise<AtlasInputDbData> {
   const publications = await getPublicationsFromInputDois(inputData.dois);
+  const metadataSpecificationTitle = inputData.metadataSpecificationUrl
+    ? await getSheetTitle(inputData.metadataSpecificationUrl).catch((err) => {
+        throw err instanceof InvalidSheetError
+          ? new ValidationError(
+              err.message,
+              undefined,
+              "metadataSpecificationUrl"
+            )
+          : err;
+      })
+    : null;
   return {
     overviewData: {
       cellxgeneAtlasCollection: inputData.cellxgeneAtlasCollection ?? null,
@@ -103,6 +115,7 @@ export async function atlasInputDataToDbData(
       highlights: inputData.highlights ?? "",
       integrationLead: inputData.integrationLead,
       metadataCorrectnessUrl: inputData.metadataCorrectnessUrl || null,
+      metadataSpecificationTitle,
       metadataSpecificationUrl: inputData.metadataSpecificationUrl || null,
       network: inputData.network,
       publications,

--- a/app/utils/google-sheets.ts
+++ b/app/utils/google-sheets.ts
@@ -1,0 +1,65 @@
+import { google } from "googleapis";
+import { GaxiosError } from "googleapis-common";
+
+export class InvalidSheetError extends Error {
+  name = "InvalidSheetError";
+}
+
+function getSpreadsheetIdFromUrl(urlString: string): string {
+  const spreadsheetId = urlString.match(/\/spreadsheets\/d\/([^/?#]+)/)?.[1];
+
+  if (!spreadsheetId) {
+    throw new InvalidSheetError(
+      "Invalid Google Sheets URL. Expected format: https://docs.google.com/spreadsheets/d/YOUR_SHEET_ID/..."
+    );
+  }
+
+  return spreadsheetId;
+}
+
+export async function getSheetTitle(
+  spreadsheetUrl: string
+): Promise<string | null> {
+  // Get credentials from environment variable
+  const credentialsJson = process.env.GOOGLE_SERVICE_ACCOUNT_JSON;
+  if (!credentialsJson) {
+    console.error("GOOGLE_SERVICE_ACCOUNT_JSON environment variable not found");
+    return null;
+  }
+  // Parse JSON credentials
+  const credentials = JSON.parse(credentialsJson);
+
+  // Create a JWT client
+  const auth = new google.auth.GoogleAuth({
+    credentials,
+    scopes: ["https://www.googleapis.com/auth/spreadsheets.readonly"],
+  });
+
+  // Create Sheets API client
+  const sheets = google.sheets({ auth, version: "v4" });
+
+  const spreadsheetId = getSpreadsheetIdFromUrl(spreadsheetUrl);
+
+  try {
+    // Get spreadsheet metadata
+    const response = await sheets.spreadsheets.get({
+      spreadsheetId: spreadsheetId,
+    });
+    return response.data.properties?.title ?? "Untitled";
+  } catch (error) {
+    if (error instanceof GaxiosError) {
+      if (error.response?.status === 404) {
+        throw new InvalidSheetError(
+          `The sheet with ID ${JSON.stringify(
+            spreadsheetId
+          )} does not exist. Please check if the URL is correct.`
+        );
+      } else if (error.response?.status === 403) {
+        throw new InvalidSheetError(
+          `To enable the tracker to read the spreadsheet, please share it with ${process.env.SERVICE_ACCOUNT_EMAIL}`
+        );
+      }
+    }
+    throw error;
+  }
+}

--- a/app/views/AtlasView/common/schema.ts
+++ b/app/views/AtlasView/common/schema.ts
@@ -19,7 +19,7 @@ export const atlasEditSchema = newAtlasSchema.concat(
       .notRequired()
       .matches(
         GOOGLE_SHEETS_URL_OR_EMPTY_STRING_REGEX,
-        "Metadata specification must be a Google Sheets URL"
+        'Metadata specification must be a Google Sheets URL of the form "https://docs.google.com/spreadsheets/d/..."'
       ),
     [FIELD_NAME.STATUS]: string()
       .default("")

--- a/migrations/1742536132066_metadata-specification-title.ts
+++ b/migrations/1742536132066_metadata-specification-title.ts
@@ -1,0 +1,13 @@
+import { MigrationBuilder } from "node-pg-migrate";
+
+export function up(pgm: MigrationBuilder): void {
+  pgm.sql(
+    `UPDATE hat.atlases SET overview=overview||'{"metadataSpecificationTitle":null}'`
+  );
+}
+
+export function down(pgm: MigrationBuilder): void {
+  pgm.sql(
+    `UPDATE hat.atlases SET overview=overview-'metadataSpecificationTitle'`
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@tanstack/react-table": "^8.19.2",
         "date-fns": "^3.6.0",
         "dequal": "^2.0.3",
+        "googleapis": "^146.0.0",
         "isomorphic-dompurify": "^2.22.0",
         "ky": "^1.7.2",
         "next": "^14.1.0",
@@ -6828,11 +6829,38 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
       "engines": {
         "node": "*"
       }
@@ -6914,6 +6942,11 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -6981,6 +7014,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -7905,6 +7953,14 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.682",
@@ -9497,6 +9553,66 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -9739,6 +9855,70 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "146.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-146.0.0.tgz",
+      "integrity": "sha512-NewqvhnBZOJsugCAOo636O0BGE/xY7Cg/v8Rjm1+5LkJCjcqAzLleJ6igd5vrRExJLSKrY9uHy9iKE7r0PrfhQ==",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -9774,6 +9954,18 @@
       },
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/hard-rejection": {
@@ -10640,7 +10832,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -12888,6 +13079,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -12979,6 +13178,25 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -15546,6 +15764,44 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -15829,10 +16085,12 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
-      "dev": true,
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -16716,6 +16974,20 @@
         "teleport": ">=0.2.0"
       }
     },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -17569,15 +17841,65 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
-      "dev": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -18881,6 +19203,11 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@tanstack/react-table": "^8.19.2",
     "date-fns": "^3.6.0",
     "dequal": "^2.0.3",
+    "googleapis": "^146.0.0",
     "isomorphic-dompurify": "^2.22.0",
     "ky": "^1.7.2",
     "next": "^14.1.0",

--- a/site-config/hca-atlas-tracker/dev/.env
+++ b/site-config/hca-atlas-tracker/dev/.env
@@ -1,1 +1,2 @@
 NEXT_PUBLIC_SITE_CONFIG='hca-atlas-tracker-dev'
+SERVICE_ACCOUNT_EMAIL='tracker-dev@hca-atlas-tracker-dev.iam.gserviceaccount.com'

--- a/site-config/hca-atlas-tracker/local/.env
+++ b/site-config/hca-atlas-tracker/local/.env
@@ -1,1 +1,2 @@
 NEXT_PUBLIC_SITE_CONFIG='hca-atlas-tracker-local'
+SERVICE_ACCOUNT_EMAIL='tracker-dev@hca-atlas-tracker-dev.iam.gserviceaccount.com'

--- a/site-config/hca-atlas-tracker/prod/.env
+++ b/site-config/hca-atlas-tracker/prod/.env
@@ -1,1 +1,2 @@
 NEXT_PUBLIC_SITE_CONFIG='hca-atlas-tracker-prod'
+SERVICE_ACCOUNT_EMAIL='tracker-prod@hca-atlas-tracker-prod-453500.iam.gserviceaccount.com'

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -2198,4 +2198,5 @@ export const TEST_GOOGLE_SHEET_TITLES_BY_ID: Record<string, string> = {
   "atlas-public-baz": "Atlas Public Baz Sheet",
   "new-atlas-with-metadata-specification":
     "New Atlas With Metadata Specification Sheet",
+  "sheet-foo": "Sheet Foo",
 };

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -1862,6 +1862,22 @@ export const ATLAS_WITH_METADATA_CORRECTNESS: TestAtlas = {
   wave: "3",
 };
 
+export const ATLAS_PUBLIC_BAZ: TestAtlas = {
+  cellxgeneAtlasCollection: null,
+  codeLinks: [],
+  description: "bar baz foo foo bar bar bar bar bar foo bar",
+  highlights: "",
+  id: "ca000a2b-8246-4694-8f21-f47bcbfe1852",
+  integrationLead: [],
+  network: "musculoskeletal",
+  publications: [],
+  shortName: "test-public-baz",
+  sourceStudies: [],
+  status: ATLAS_STATUS.IN_PROGRESS,
+  version: "5.2",
+  wave: "3",
+};
+
 export const ATLAS_NONEXISTENT = {
   id: "aa992f01-39ea-4906-ac12-053552561187",
 };
@@ -1877,6 +1893,7 @@ export const INITIAL_TEST_ATLASES = [
   ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_B,
   ATLAS_PUBLIC_BAR,
   ATLAS_WITH_METADATA_CORRECTNESS,
+  ATLAS_PUBLIC_BAZ,
 ];
 
 export const INITIAL_TEST_ATLASES_BY_SOURCE_STUDY = INITIAL_TEST_ATLASES.reduce(
@@ -2172,3 +2189,13 @@ export const TEST_COMMENTS_BY_THREAD_ID = TEST_COMMENTS.reduce(
   },
   {} as Record<string, TestComment[]>
 );
+
+// Google sheets
+
+export const TEST_UNSHARED_GOOGLE_SHEET_IDS = new Set(["sheet-unshared"]);
+
+export const TEST_GOOGLE_SHEET_TITLES_BY_ID: Record<string, string> = {
+  "atlas-public-baz": "Atlas Public Baz Sheet",
+  "new-atlas-with-metadata-specification":
+    "New Atlas With Metadata Specification Sheet",
+};

--- a/testing/setup.ts
+++ b/testing/setup.ts
@@ -1,3 +1,6 @@
 import { TextDecoder, TextEncoder } from "util";
 
 Object.assign(global, { TextDecoder, TextEncoder }); // https://stackoverflow.com/questions/68468203/why-am-i-getting-textencoder-is-not-defined-in-jest
+
+process.env.GOOGLE_SERVICE_ACCOUNT_JSON =
+  '"TEST_GOOGLE_SERVICE_ACCOUNT_CREDENTIALS"';

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -76,6 +76,7 @@ export function makeTestAtlasOverview(
     },
     integrationLead: atlas.integrationLead,
     metadataCorrectnessUrl: atlas.metadataCorrectnessUrl ?? null,
+    metadataSpecificationTitle: null,
     metadataSpecificationUrl: atlas.metadataSpecificationUrl ?? null,
     network: atlas.network,
     publications: atlas.publications,


### PR DESCRIPTION
Closes #602

Notes:
- The email specified in the error for when the sheet is unshared is determined by an environment variable so that it can vary between dev and prod
- In order to make it so the full error message is visible, I've made it so that all error messages on form inputs have wrapping text (however, other helper text still has hidden overflow by default -- see screenshots below)

One thing I'm wondering about -- does it matter that the form data has to be edited in order to save it and update the sheet title?

---

Example wrapping error message:

<img width="1728" alt="Screenshot 2025-03-20 at 3 26 30 PM" src="https://github.com/user-attachments/assets/fd6f4aaa-21fd-468b-b471-e2f96a60bf65" />

---

Example truncated sheet title:

<img width="1728" alt="Screenshot 2025-03-20 at 3 29 28 PM" src="https://github.com/user-attachments/assets/278c3bcf-374b-49d7-b8e1-5fb2afdd4f06" />