### PR TITLE
fix: retain metadata spreadsheet info when cellxgene dataset is updated (#629)

### DIFF
--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -1361,6 +1361,9 @@ export const SOURCE_DATASET_CELLXGENE_WITH_UPDATE: TestSourceDataset = {
   cellxgeneDatasetVersion: "cellxgene-version-dataset-with-update-a",
   disease: ["barbarfoo"],
   id: "04ccf7fd-22eb-4236-829c-9a0058580d36",
+  metadataSpreadsheetTitle: "Source Dataset CELLxGENE With Update Metadata",
+  metadataSpreadsheetUrl:
+    "https://docs.google.com/spreadsheets/d/source-dataset-cellxgene-with-update",
   sourceStudyId: SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
   suspensionType: ["foobazbarfoo"],
   tissue: ["bazbarfoo"],

--- a/testing/entities.ts
+++ b/testing/entities.ts
@@ -77,6 +77,7 @@ export interface TestSourceDataset {
   cellxgeneDatasetVersion?: string;
   disease?: string[];
   id: string;
+  metadataSpreadsheetTitle?: string;
   metadataSpreadsheetUrl?: string;
   sourceStudyId: string;
   suspensionType?: string[];

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -135,8 +135,8 @@ export function makeTestSourceDatasetInfo(
       ? `explorer-url-${sourceDataset.cellxgeneDatasetId}`
       : null,
     disease: sourceDataset.disease ?? [],
-    metadataSpreadsheetTitle: null,
-    metadataSpreadsheetUrl: null,
+    metadataSpreadsheetTitle: sourceDataset.metadataSpreadsheetTitle ?? null,
+    metadataSpreadsheetUrl: sourceDataset.metadataSpreadsheetUrl ?? null,
     suspensionType: sourceDataset.suspensionType ?? [],
     tissue: sourceDataset.tissue ?? [],
     title: sourceDataset.title,


### PR DESCRIPTION
Closes #629

- Updated test to check that metadata spreadsheet info is retained when a dataset is updated
- Made it so that source dataset info derived from CELLxGENE only includes the fields that actually come from CELLxGENE; for an updated dataset this gets merged into the existing info, and for a new dataset this is used to derive a full source dataset info object including metadata spreadsheet fields set to `null`