### PR TITLE
fix: accept project urls for cap id rather than dataset urls (#649)

### DIFF
--- a/__tests__/api-atlases-id-source-studies-id.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id.test.ts
@@ -105,7 +105,7 @@ const SOURCE_STUDY_PUBLIC_NO_CROSSREF_EDIT: SourceStudyEditData = {
 };
 
 const SOURCE_STUDY_DRAFT_OK_EDIT: SourceStudyEditData = {
-  capId: "https://celltype.info/project/12345/dataset/54321",
+  capId: "https://celltype.info/project/223439",
   cellxgeneCollectionId: null,
   contactEmail: "bar@example.com",
   hcaProjectId: null,
@@ -118,7 +118,7 @@ const SOURCE_STUDY_DRAFT_OK_EDIT: SourceStudyEditData = {
 };
 
 const SOURCE_STUDY_DRAFT_OK_CAP_ID_EDIT: SourceStudyEditData = {
-  capId: "cap-id-source-study-draft-ok-edit",
+  capId: "https://celltype.info/project/627199",
   doi: DOI_DRAFT_OK,
   metadataSpreadsheets: [],
 };
@@ -492,6 +492,25 @@ describe(`${TEST_ROUTE} (PUT)`, () => {
               },
               ...SOURCE_STUDY_DRAFT_OK_EDIT.metadataSpreadsheets,
             ],
+          },
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(400);
+    await expectStudyToBeUnchanged(SOURCE_STUDY_DRAFT_OK);
+  });
+
+  it("returns error 400 when CAP ID is dataset URL rather than project URL", async () => {
+    expect(
+      (
+        await doStudyRequest(
+          ATLAS_DRAFT.id,
+          SOURCE_STUDY_DRAFT_OK.id,
+          USER_CONTENT_ADMIN,
+          METHOD.PUT,
+          {
+            ...SOURCE_STUDY_DRAFT_OK_EDIT,
+            capId: "https://celltype.info/project/223439/dataset/552505",
           },
           true
         )

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -1,3 +1,4 @@
+import { escapeRegExp } from "@databiosphere/findable-ui/lib/common/utils";
 import {
   array,
   boolean,
@@ -11,6 +12,10 @@ import {
 import { isDoi, normalizeDoi } from "../../../../utils/doi";
 import { NETWORK_KEYS, WAVES } from "./constants";
 import { ATLAS_STATUS, ROLE } from "./entities";
+
+export const CAP_PROJECT_URL_REGEXP = new RegExp(
+  `^(?:${escapeRegExp("https://celltype.info/project/")}\\d+)?$`
+);
 
 export const GOOGLE_SHEETS_URL_OR_EMPTY_STRING_REGEX =
   /^$|^https:\/\/docs\.google\.com\/spreadsheets\/d\/./;
@@ -252,7 +257,10 @@ export const metadataSpreadsheetUrlsSchema = array(
 });
 
 export const publishedSourceStudyEditSchema = object({
-  capId: string().defined("CAP ID is required").nullable(),
+  capId: string()
+    .matches(CAP_PROJECT_URL_REGEXP, "Invalid CAP ID")
+    .defined("CAP ID is required")
+    .nullable(),
   doi: string()
     .required()
     .test(
@@ -268,7 +276,10 @@ export const publishedSourceStudyEditSchema = object({
   .strict(true);
 
 export const unpublishedSourceStudyEditSchema = object({
-  capId: string().defined("CAP ID is required").nullable(),
+  capId: string()
+    .matches(CAP_PROJECT_URL_REGEXP, "Invalid CAP ID")
+    .defined("CAP ID is required")
+    .nullable(),
   cellxgeneCollectionId: string()
     .defined("CELLxGENE collection ID is required when DOI is absent")
     .nullable(),

--- a/app/components/Form/components/Input/components/CapId/capId.tsx
+++ b/app/components/Form/components/Input/components/CapId/capId.tsx
@@ -1,12 +1,12 @@
 import { Link } from "@databiosphere/findable-ui/lib/components/Links/components/Link/link";
 import { forwardRef, Fragment } from "react";
+import { CAP_PROJECT_URL_REGEXP } from "../../../../../../apis/catalog/hca-atlas-tracker/common/schema";
 import {
   Input,
   InputProps,
 } from "../../../../../common/Form/components/Input/input";
 import { TypographyNoWrap } from "../../../../../common/Typography/components/TypographyNoWrap/typographyNoWrap";
 import { isNonEmptyString } from "../../../../common/utils";
-import { CAP_ID_REGEXP } from "./common/constants";
 
 export const CapId = forwardRef<HTMLInputElement, InputProps>(function CapId(
   {
@@ -23,7 +23,7 @@ export const CapId = forwardRef<HTMLInputElement, InputProps>(function CapId(
       label={
         <Fragment>
           <TypographyNoWrap>{label}</TypographyNoWrap>
-          {isNonEmptyString(value) && CAP_ID_REGEXP.test(value) && (
+          {isNonEmptyString(value) && CAP_PROJECT_URL_REGEXP.test(value) && (
             <Link label="Visit link" url={value} />
           )}
         </Fragment>

--- a/app/components/Form/components/Input/components/CapId/common/constants.ts
+++ b/app/components/Form/components/Input/components/CapId/common/constants.ts
@@ -1,5 +1,0 @@
-import { escapeRegExp } from "@databiosphere/findable-ui/lib/common/utils";
-
-export const CAP_ID_REGEXP = new RegExp(
-  `^(?:${escapeRegExp("https://celltype.info/project/")}\\d+/dataset/\\d+)?$`
-);

--- a/app/views/SourceStudyView/common/schema.ts
+++ b/app/views/SourceStudyView/common/schema.ts
@@ -1,17 +1,19 @@
 import { object, string } from "yup";
-import { metadataSpreadsheetUrlsSchema } from "../../../apis/catalog/hca-atlas-tracker/common/schema";
+import {
+  CAP_PROJECT_URL_REGEXP,
+  metadataSpreadsheetUrlsSchema,
+} from "../../../apis/catalog/hca-atlas-tracker/common/schema";
 import {
   CELLXGENE_COLLECTION_ID_REGEX,
   HCA_PROJECT_ID_REGEX,
 } from "../../../common/constants";
-import { CAP_ID_REGEXP } from "../../../components/Form/components/Input/components/CapId/common/constants";
 import { newSourceStudySchema } from "../../AddNewSourceStudyView/common/schema";
 import { FIELD_NAME } from "./constants";
 
 export const sourceStudyEditSchema = newSourceStudySchema.concat(
   object({
     [FIELD_NAME.CAP_ID]: string()
-      .matches(CAP_ID_REGEXP, "Invalid CAP ID")
+      .matches(CAP_PROJECT_URL_REGEXP, "Invalid CAP ID")
       .default("")
       .notRequired(),
     [FIELD_NAME.CELLXGENE_COLLECTION_ID]: string()

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -988,7 +988,7 @@ export const SOURCE_STUDY_PUBLISHED_WITH_NO_HCA_OR_CELLXGENE: TestPublishedSourc
 
 export const SOURCE_STUDY_PUBLISHED_WITH_CAP_AND_NO_CELLXGENE: TestPublishedSourceStudy =
   {
-    capId: "cap-id-published-with-cap-and-no-cellxgene",
+    capId: "https://celltype.info/project/741640",
     doi: "10.123/published-with-cap-and-no-cellxgene",
     doiStatus: DOI_STATUS.OK,
     id: "0461d2ee-e41c-4f91-97a2-fcb0cb62d6d9",
@@ -1009,7 +1009,7 @@ export const SOURCE_STUDY_PUBLISHED_WITH_CAP_AND_NO_CELLXGENE: TestPublishedSour
 
 export const SOURCE_STUDY_PUBLISHED_WITH_CAP_AND_CELLXGENE: TestPublishedSourceStudy =
   {
-    capId: "cap-id-published-with-cap-and-cellxgene",
+    capId: "https://celltype.info/project/718611",
     doi: DOI_PUBLISHED_WITH_CAP_AND_CELLXGENE,
     doiStatus: DOI_STATUS.OK,
     id: "17b397df-6443-4c02-9c78-b2ab9ba86052",


### PR DESCRIPTION
Closes #649

Also updates the backend to restrict CAP URLs by the regex, which was not being done before -- was there a reason for that?