### PR TITLE
feat: add api to get entry sheet validations of an atlas (#656)

### DIFF
--- a/__tests__/api-atlases-id-entry-sheet-validations.test.ts
+++ b/__tests__/api-atlases-id-entry-sheet-validations.test.ts
@@ -53,7 +53,7 @@ describe(TEST_ROUTE, () => {
   it("returns error 405 for POST request", async () => {
     expect(
       (
-        await doSyncRequest(
+        await doEntrySheetValidationsRequest(
           ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id,
           USER_CONTENT_ADMIN,
           METHOD.POST
@@ -65,7 +65,7 @@ describe(TEST_ROUTE, () => {
   it("returns error 401 when entry sheet validations are requested by logged out user", async () => {
     expect(
       (
-        await doSyncRequest(
+        await doEntrySheetValidationsRequest(
           ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id,
           undefined,
           METHOD.GET,
@@ -78,7 +78,7 @@ describe(TEST_ROUTE, () => {
   it("returns error 403 when entry sheet validations are requested by unregistered user", async () => {
     expect(
       (
-        await doSyncRequest(
+        await doEntrySheetValidationsRequest(
           ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id,
           USER_UNREGISTERED,
           METHOD.GET,
@@ -91,7 +91,7 @@ describe(TEST_ROUTE, () => {
   it("returns error 403 when entry sheet validations are requested by disabled user", async () => {
     expect(
       (
-        await doSyncRequest(
+        await doEntrySheetValidationsRequest(
           ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id,
           USER_DISABLED_CONTENT_ADMIN,
           METHOD.GET,
@@ -104,7 +104,7 @@ describe(TEST_ROUTE, () => {
   it("returns error 404 when entry sheet validations are requested from nonexistent atlas", async () => {
     expect(
       (
-        await doSyncRequest(
+        await doEntrySheetValidationsRequest(
           ATLAS_NONEXISTENT.id,
           USER_CONTENT_ADMIN,
           METHOD.GET,
@@ -137,7 +137,7 @@ describe(TEST_ROUTE, () => {
   }
 
   it("returns entry sheet validations when requested by content admin", async () => {
-    const res = await doSyncRequest(
+    const res = await doEntrySheetValidationsRequest(
       ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id,
       USER_CONTENT_ADMIN,
       METHOD.GET
@@ -185,7 +185,7 @@ function expectListEntrySheetValidationToMatchTest(
   );
 }
 
-async function doSyncRequest(
+async function doEntrySheetValidationsRequest(
   atlasId: string,
   user: TestUser | undefined,
   method: METHOD,

--- a/__tests__/api-atlases-id-entry-sheet-validations.test.ts
+++ b/__tests__/api-atlases-id-entry-sheet-validations.test.ts
@@ -1,0 +1,208 @@
+import { HCAAtlasTrackerListEntrySheetValidation } from "app/apis/catalog/hca-atlas-tracker/common/entities";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
+import { METHOD } from "../app/common/entities";
+import { endPgPool } from "../app/services/database";
+import entrySheetValidationsHandler from "../pages/api/atlases/[atlasId]/entry-sheet-validations";
+import {
+  ATLAS_NONEXISTENT,
+  ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A,
+  ENTRY_SHEET_VALIDATION_WITH_ERRORED_UPDATE,
+  ENTRY_SHEET_VALIDATION_WITH_FAILED_UPDATE,
+  ENTRY_SHEET_VALIDATION_WITH_UPDATE,
+  STAKEHOLDER_ANALOGOUS_ROLES,
+  USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
+  USER_UNREGISTERED,
+} from "../testing/constants";
+import { resetDatabase } from "../testing/db-utils";
+import { TestEntrySheetValidation, TestUser } from "../testing/entities";
+import {
+  expectIsDefined,
+  testApiRole,
+  withConsoleErrorHiding,
+} from "../testing/utils";
+
+jest.mock(
+  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config"
+);
+jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/cellxgene");
+jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("../app/utils/hca-validation-tools");
+
+jest.mock("next-auth");
+
+const TEST_ROUTE = "/api/atlases/[atlasId]/entry-sheet-validations";
+
+const EXPECTED_ENTRY_SHEET_VALIDATIONS_A = [
+  ENTRY_SHEET_VALIDATION_WITH_UPDATE,
+  ENTRY_SHEET_VALIDATION_WITH_ERRORED_UPDATE,
+  ENTRY_SHEET_VALIDATION_WITH_FAILED_UPDATE,
+];
+
+beforeAll(async () => {
+  await resetDatabase();
+});
+
+afterAll(async () => {
+  endPgPool();
+});
+
+describe(TEST_ROUTE, () => {
+  it("returns error 405 for POST request", async () => {
+    expect(
+      (
+        await doSyncRequest(
+          ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id,
+          USER_CONTENT_ADMIN,
+          METHOD.POST
+        )
+      )._getStatusCode()
+    ).toEqual(405);
+  });
+
+  it("returns error 401 when entry sheet validations are requested by logged out user", async () => {
+    expect(
+      (
+        await doSyncRequest(
+          ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id,
+          undefined,
+          METHOD.GET,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(401);
+  });
+
+  it("returns error 403 when entry sheet validations are requested by unregistered user", async () => {
+    expect(
+      (
+        await doSyncRequest(
+          ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id,
+          USER_UNREGISTERED,
+          METHOD.GET,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 when entry sheet validations are requested by disabled user", async () => {
+    expect(
+      (
+        await doSyncRequest(
+          ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id,
+          USER_DISABLED_CONTENT_ADMIN,
+          METHOD.GET,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 404 when entry sheet validations are requested from nonexistent atlas", async () => {
+    expect(
+      (
+        await doSyncRequest(
+          ATLAS_NONEXISTENT.id,
+          USER_CONTENT_ADMIN,
+          METHOD.GET,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(404);
+  });
+
+  for (const role of STAKEHOLDER_ANALOGOUS_ROLES) {
+    testApiRole(
+      "returns entry sheet validations",
+      TEST_ROUTE,
+      entrySheetValidationsHandler,
+      METHOD.GET,
+      role,
+      getQueryValues(ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id),
+      undefined,
+      false,
+      async (res) => {
+        expect(res._getStatusCode()).toEqual(200);
+        const validations =
+          res._getJSONData() as HCAAtlasTrackerListEntrySheetValidation[];
+        expectListEntrySheetValidationsToMatchTest(
+          validations,
+          EXPECTED_ENTRY_SHEET_VALIDATIONS_A
+        );
+      }
+    );
+  }
+
+  it("returns entry sheet validations when requested by content admin", async () => {
+    const res = await doSyncRequest(
+      ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id,
+      USER_CONTENT_ADMIN,
+      METHOD.GET
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const validations =
+      res._getJSONData() as HCAAtlasTrackerListEntrySheetValidation[];
+    expectListEntrySheetValidationsToMatchTest(
+      validations,
+      EXPECTED_ENTRY_SHEET_VALIDATIONS_A
+    );
+  });
+});
+
+function expectListEntrySheetValidationsToMatchTest(
+  listValidations: HCAAtlasTrackerListEntrySheetValidation[],
+  testValidations: TestEntrySheetValidation[]
+): void {
+  expect(listValidations).toHaveLength(testValidations.length);
+  for (const testValidation of testValidations) {
+    const listValidation = listValidations.find(
+      (v) => v.id === testValidation.id
+    );
+    if (expectIsDefined(listValidation))
+      expectListEntrySheetValidationToMatchTest(listValidation, testValidation);
+  }
+}
+
+function expectListEntrySheetValidationToMatchTest(
+  listValidation: HCAAtlasTrackerListEntrySheetValidation,
+  testValidation: TestEntrySheetValidation
+): void {
+  expect(listValidation.entrySheetId).toEqual(testValidation.entry_sheet_id);
+  expect(listValidation.entrySheetTitle).toEqual(
+    testValidation.entry_sheet_title
+  );
+  expect(listValidation.id).toEqual(testValidation.id);
+  expect(listValidation.lastSynced).toEqual(
+    testValidation.last_synced.toISOString()
+  );
+  expect(listValidation.lastUpdated).toEqual(testValidation.last_updated);
+  expect(listValidation.sourceStudyId).toEqual(testValidation.source_study_id);
+  expect(listValidation.validationSummary).toEqual(
+    testValidation.validation_summary
+  );
+}
+
+async function doSyncRequest(
+  atlasId: string,
+  user: TestUser | undefined,
+  method: METHOD,
+  hideConsoleError = false
+): Promise<httpMocks.MockResponse<NextApiResponse>> {
+  const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>({
+    headers: { authorization: user?.authorization },
+    method,
+    query: getQueryValues(atlasId),
+  });
+  await withConsoleErrorHiding(
+    () => entrySheetValidationsHandler(req, res),
+    hideConsoleError
+  );
+  return res;
+}
+
+function getQueryValues(atlasId: string): Record<string, string> {
+  return { atlasId };
+}

--- a/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
@@ -7,6 +7,7 @@ import {
   HCAAtlasTrackerDBAtlasWithComponentAtlases,
   HCAAtlasTrackerDBComment,
   HCAAtlasTrackerDBComponentAtlas,
+  HCAAtlasTrackerDBEntrySheetValidationListFields,
   HCAAtlasTrackerDBSourceDataset,
   HCAAtlasTrackerDBSourceDatasetWithStudyProperties,
   HCAAtlasTrackerDBSourceStudy,
@@ -14,6 +15,7 @@ import {
   HCAAtlasTrackerDBUserWithAssociatedResources,
   HCAAtlasTrackerDBValidation,
   HCAAtlasTrackerDBValidationWithAtlasProperties,
+  HCAAtlasTrackerListEntrySheetValidation,
   HCAAtlasTrackerSourceDataset,
   HCAAtlasTrackerSourceStudy,
   HCAAtlasTrackerUser,
@@ -197,6 +199,20 @@ function dbValidationToApiValidationWithoutAtlasProperties(
     validationId: validation.validation_id,
     validationStatus: validationInfo.validationStatus,
     validationType: validationInfo.validationType,
+  };
+}
+
+export function dbEntrySheetValidationToApiListModel(
+  entrySheetValidation: HCAAtlasTrackerDBEntrySheetValidationListFields
+): HCAAtlasTrackerListEntrySheetValidation {
+  return {
+    entrySheetId: entrySheetValidation.entry_sheet_id,
+    entrySheetTitle: entrySheetValidation.entry_sheet_title,
+    id: entrySheetValidation.id,
+    lastSynced: entrySheetValidation.last_synced.toISOString(),
+    lastUpdated: entrySheetValidation.last_updated,
+    sourceStudyId: entrySheetValidation.source_study_id,
+    validationSummary: entrySheetValidation.validation_summary,
   };
 }
 

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -172,7 +172,7 @@ export interface HCAAtlasTrackerListEntrySheetValidation {
   lastSynced: string;
   lastUpdated: GoogleLastUpdateInfo | null;
   sourceStudyId: string;
-  validationSummary: EntrySheetValidationSummary | null;
+  validationSummary: EntrySheetValidationSummary;
 }
 
 export interface HCAAtlasTrackerComment {

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -165,6 +165,16 @@ export type HCAAtlasTrackerValidationRecordWithoutAtlases = Omit<
   | "waves"
 >;
 
+export interface HCAAtlasTrackerListEntrySheetValidation {
+  entrySheetId: string;
+  entrySheetTitle: string | null;
+  id: string;
+  lastSynced: string;
+  lastUpdated: GoogleLastUpdateInfo | null;
+  sourceStudyId: string;
+  validationSummary: EntrySheetValidationSummary | null;
+}
+
 export interface HCAAtlasTrackerComment {
   createdAt: string;
   createdBy: number;
@@ -418,6 +428,18 @@ export interface HCAAtlasTrackerDBEntrySheetValidation {
   validation_report: EntrySheetValidationErrorInfo[];
   validation_summary: EntrySheetValidationSummary;
 }
+
+// Specified using `Pick` rather than `Omit` in order to correspond more closely to how it's queried in Postgres
+export type HCAAtlasTrackerDBEntrySheetValidationListFields = Pick<
+  HCAAtlasTrackerDBEntrySheetValidation,
+  | "entry_sheet_id"
+  | "entry_sheet_title"
+  | "id"
+  | "last_synced"
+  | "last_updated"
+  | "source_study_id"
+  | "validation_summary"
+>;
 
 export interface HCAAtlasTrackerDBComment {
   created_at: Date;

--- a/app/services/entry-sheets.ts
+++ b/app/services/entry-sheets.ts
@@ -20,17 +20,17 @@ export async function getAtlasEntrySheetValidations(
   const validationsResult =
     await query<HCAAtlasTrackerDBEntrySheetValidationListFields>(
       `
-      SELECT
-        entry_sheet_id,
-        entry_sheet_title,
-        id,
-        last_synced,
-        last_updated,
-        source_study_id,
-        validation_summary
-      FROM hat.entry_sheet_validations
-      WHERE source_study_id=ANY($1)
-    `,
+        SELECT
+          entry_sheet_id,
+          entry_sheet_title,
+          id,
+          last_synced,
+          last_updated,
+          source_study_id,
+          validation_summary
+        FROM hat.entry_sheet_validations
+        WHERE source_study_id=ANY($1)
+      `,
       [sourceStudies.map((study) => study.id)]
     );
   return validationsResult.rows;

--- a/app/services/entry-sheets.ts
+++ b/app/services/entry-sheets.ts
@@ -5,7 +5,7 @@ import {
   HCAAtlasTrackerDBEntrySheetValidationListFields,
 } from "../apis/catalog/hca-atlas-tracker/common/entities";
 import { doTransaction, query } from "./database";
-import { getAtlasSourceStudiesBaseModel } from "./source-studies";
+import { getBaseModelAtlasSourceStudies } from "./source-studies";
 
 interface CompletionPromiseContainer {
   completionPromise: Promise<void>;
@@ -16,7 +16,7 @@ type ValidationUpdateData = Omit<HCAAtlasTrackerDBEntrySheetValidation, "id">;
 export async function getAtlasEntrySheetValidations(
   atlasId: string
 ): Promise<HCAAtlasTrackerDBEntrySheetValidationListFields[]> {
-  const sourceStudies = await getAtlasSourceStudiesBaseModel(atlasId);
+  const sourceStudies = await getBaseModelAtlasSourceStudies(atlasId);
   const validationsResult =
     await query<HCAAtlasTrackerDBEntrySheetValidationListFields>(
       `
@@ -44,7 +44,7 @@ export async function getAtlasEntrySheetValidations(
 export async function startAtlasEntrySheetValidationsUpdate(
   atlasId: string
 ): Promise<CompletionPromiseContainer> {
-  const sourceStudies = await getAtlasSourceStudiesBaseModel(atlasId);
+  const sourceStudies = await getBaseModelAtlasSourceStudies(atlasId);
 
   const validationResultPromises: Promise<ValidationUpdateData>[] =
     sourceStudies

--- a/app/services/source-studies.ts
+++ b/app/services/source-studies.ts
@@ -77,7 +77,7 @@ export async function getAtlasSourceStudies(
   });
 }
 
-export async function getAtlasSourceStudiesBaseModel(
+export async function getBaseModelAtlasSourceStudies(
   atlasId: string
 ): Promise<HCAAtlasTrackerDBSourceStudy[]> {
   const atlasResult = await query<

--- a/app/services/source-studies.ts
+++ b/app/services/source-studies.ts
@@ -77,6 +77,26 @@ export async function getAtlasSourceStudies(
   });
 }
 
+export async function getAtlasSourceStudiesBaseModel(
+  atlasId: string
+): Promise<HCAAtlasTrackerDBSourceStudy[]> {
+  const atlasResult = await query<
+    Pick<HCAAtlasTrackerDBAtlas, "source_studies">
+  >("SELECT source_studies FROM hat.atlases WHERE id=$1", [atlasId]);
+
+  if (atlasResult.rows.length === 0)
+    throw new NotFoundError(`Atlas with ID ${atlasId} doesn't exist`);
+
+  const sourceStudyIds = atlasResult.rows[0].source_studies;
+
+  const studiesResult = await query<HCAAtlasTrackerDBSourceStudy>(
+    "SELECT * FROM hat.source_studies WHERE id=ANY($1)",
+    [sourceStudyIds]
+  );
+
+  return studiesResult.rows;
+}
+
 export async function getSourceStudy(
   atlasId: string,
   sourceStudyId: string,

--- a/pages/api/atlases/[atlasId]/entry-sheet-validations.ts
+++ b/pages/api/atlases/[atlasId]/entry-sheet-validations.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../../app/utils/api-handler";
 
 /**
- * API route for triggering validation of an atlas's entry sheets.
+ * API route to get entry sheet validations of an atlas.
  */
 export default handler(method(METHOD.GET), registeredUser, async (req, res) => {
   const atlasId = req.query.atlasId as string;

--- a/pages/api/atlases/[atlasId]/entry-sheet-validations.ts
+++ b/pages/api/atlases/[atlasId]/entry-sheet-validations.ts
@@ -1,0 +1,22 @@
+import { dbEntrySheetValidationToApiListModel } from "app/apis/catalog/hca-atlas-tracker/common/backend-utils";
+import { METHOD } from "../../../../app/common/entities";
+import { getAtlasEntrySheetValidations } from "../../../../app/services/entry-sheets";
+import {
+  handler,
+  method,
+  registeredUser,
+} from "../../../../app/utils/api-handler";
+
+/**
+ * API route for triggering validation of an atlas's entry sheets.
+ */
+export default handler(method(METHOD.GET), registeredUser, async (req, res) => {
+  const atlasId = req.query.atlasId as string;
+  res
+    .status(200)
+    .json(
+      (await getAtlasEntrySheetValidations(atlasId)).map(
+        dbEntrySheetValidationToApiListModel
+      )
+    );
+});


### PR DESCRIPTION
Closes #656