### PR TITLE
feat: add api to get a full individual entry sheet validation (#658)

### DIFF
--- a/__tests__/api-atlases-id-entry-sheet-validations-id.test.ts
+++ b/__tests__/api-atlases-id-entry-sheet-validations-id.test.ts
@@ -1,0 +1,216 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
+import { HCAAtlasTrackerEntrySheetValidation } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "../app/common/entities";
+import { endPgPool } from "../app/services/database";
+import entrySheetValidationHandler from "../pages/api/atlases/[atlasId]/entry-sheet-validations/[entrySheetValidationId]";
+import {
+  ATLAS_NONEXISTENT,
+  ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A,
+  ENTRY_SHEET_VALIDATION_WITH_UPDATE,
+  STAKEHOLDER_ANALOGOUS_ROLES,
+  USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
+  USER_UNREGISTERED,
+} from "../testing/constants";
+import { resetDatabase } from "../testing/db-utils";
+import { TestEntrySheetValidation, TestUser } from "../testing/entities";
+import { testApiRole, withConsoleErrorHiding } from "../testing/utils";
+
+jest.mock(
+  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config"
+);
+jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/cellxgene");
+jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("../app/utils/hca-validation-tools");
+
+jest.mock("next-auth");
+
+const TEST_ROUTE =
+  "/api/atlases/[atlasId]/entry-sheet-validations/[entrySheetValidationId]";
+
+const ENTRY_SHEET_VALIDATION_ID_NONEXISTENT =
+  "754bef47-19ce-4296-9ed1-d1647cabacb7";
+
+beforeAll(async () => {
+  await resetDatabase();
+});
+
+afterAll(async () => {
+  endPgPool();
+});
+
+describe(TEST_ROUTE, () => {
+  it("returns error 405 for POST request", async () => {
+    expect(
+      (
+        await doEntrySheetValidationRequest(
+          ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id,
+          ENTRY_SHEET_VALIDATION_WITH_UPDATE.id,
+          USER_CONTENT_ADMIN,
+          METHOD.POST
+        )
+      )._getStatusCode()
+    ).toEqual(405);
+  });
+
+  it("returns error 401 when entry sheet validation is requested by logged out user", async () => {
+    expect(
+      (
+        await doEntrySheetValidationRequest(
+          ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id,
+          ENTRY_SHEET_VALIDATION_WITH_UPDATE.id,
+          undefined,
+          METHOD.GET,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(401);
+  });
+
+  it("returns error 403 when entry sheet validation is requested by unregistered user", async () => {
+    expect(
+      (
+        await doEntrySheetValidationRequest(
+          ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id,
+          ENTRY_SHEET_VALIDATION_WITH_UPDATE.id,
+          USER_UNREGISTERED,
+          METHOD.GET,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 403 when entry sheet validation is requested by disabled user", async () => {
+    expect(
+      (
+        await doEntrySheetValidationRequest(
+          ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id,
+          ENTRY_SHEET_VALIDATION_WITH_UPDATE.id,
+          USER_DISABLED_CONTENT_ADMIN,
+          METHOD.GET,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(403);
+  });
+
+  it("returns error 404 when entry sheet validation is requested from nonexistent atlas", async () => {
+    expect(
+      (
+        await doEntrySheetValidationRequest(
+          ATLAS_NONEXISTENT.id,
+          ENTRY_SHEET_VALIDATION_WITH_UPDATE.id,
+          USER_CONTENT_ADMIN,
+          METHOD.GET,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(404);
+  });
+
+  it("returns error 404 when nonexistent entry sheet validation is requested", async () => {
+    expect(
+      (
+        await doEntrySheetValidationRequest(
+          ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id,
+          ENTRY_SHEET_VALIDATION_ID_NONEXISTENT,
+          USER_CONTENT_ADMIN,
+          METHOD.GET,
+          true
+        )
+      )._getStatusCode()
+    ).toEqual(404);
+  });
+
+  for (const role of STAKEHOLDER_ANALOGOUS_ROLES) {
+    testApiRole(
+      "returns entry sheet validations",
+      TEST_ROUTE,
+      entrySheetValidationHandler,
+      METHOD.GET,
+      role,
+      getQueryValues(
+        ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id,
+        ENTRY_SHEET_VALIDATION_WITH_UPDATE.id
+      ),
+      undefined,
+      false,
+      async (res) => {
+        expect(res._getStatusCode()).toEqual(200);
+        const validation =
+          res._getJSONData() as HCAAtlasTrackerEntrySheetValidation;
+        expectEntrySheetValidationToMatchTest(
+          validation,
+          ENTRY_SHEET_VALIDATION_WITH_UPDATE
+        );
+      }
+    );
+  }
+
+  it("returns entry sheet validations when requested by content admin", async () => {
+    const res = await doEntrySheetValidationRequest(
+      ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id,
+      ENTRY_SHEET_VALIDATION_WITH_UPDATE.id,
+      USER_CONTENT_ADMIN,
+      METHOD.GET
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const validation =
+      res._getJSONData() as HCAAtlasTrackerEntrySheetValidation;
+    expectEntrySheetValidationToMatchTest(
+      validation,
+      ENTRY_SHEET_VALIDATION_WITH_UPDATE
+    );
+  });
+});
+
+function expectEntrySheetValidationToMatchTest(
+  listValidation: HCAAtlasTrackerEntrySheetValidation,
+  testValidation: TestEntrySheetValidation
+): void {
+  expect(listValidation.entrySheetId).toEqual(testValidation.entry_sheet_id);
+  expect(listValidation.entrySheetTitle).toEqual(
+    testValidation.entry_sheet_title
+  );
+  expect(listValidation.id).toEqual(testValidation.id);
+  expect(listValidation.lastSynced).toEqual(
+    testValidation.last_synced.toISOString()
+  );
+  expect(listValidation.lastUpdated).toEqual(testValidation.last_updated);
+  expect(listValidation.sourceStudyId).toEqual(testValidation.source_study_id);
+  expect(listValidation.validationReport).toEqual(
+    testValidation.validation_report
+  );
+  expect(listValidation.validationSummary).toEqual(
+    testValidation.validation_summary
+  );
+}
+
+async function doEntrySheetValidationRequest(
+  atlasId: string,
+  entrySheetValidationId: string,
+  user: TestUser | undefined,
+  method: METHOD,
+  hideConsoleError = false
+): Promise<httpMocks.MockResponse<NextApiResponse>> {
+  const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>({
+    headers: { authorization: user?.authorization },
+    method,
+    query: getQueryValues(atlasId, entrySheetValidationId),
+  });
+  await withConsoleErrorHiding(
+    () => entrySheetValidationHandler(req, res),
+    hideConsoleError
+  );
+  return res;
+}
+
+function getQueryValues(
+  atlasId: string,
+  entrySheetValidationId: string
+): Record<string, string> {
+  return { atlasId, entrySheetValidationId };
+}

--- a/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
@@ -7,6 +7,7 @@ import {
   HCAAtlasTrackerDBAtlasWithComponentAtlases,
   HCAAtlasTrackerDBComment,
   HCAAtlasTrackerDBComponentAtlas,
+  HCAAtlasTrackerDBEntrySheetValidation,
   HCAAtlasTrackerDBEntrySheetValidationListFields,
   HCAAtlasTrackerDBSourceDataset,
   HCAAtlasTrackerDBSourceDatasetWithStudyProperties,
@@ -15,6 +16,7 @@ import {
   HCAAtlasTrackerDBUserWithAssociatedResources,
   HCAAtlasTrackerDBValidation,
   HCAAtlasTrackerDBValidationWithAtlasProperties,
+  HCAAtlasTrackerEntrySheetValidation,
   HCAAtlasTrackerListEntrySheetValidation,
   HCAAtlasTrackerSourceDataset,
   HCAAtlasTrackerSourceStudy,
@@ -199,6 +201,21 @@ function dbValidationToApiValidationWithoutAtlasProperties(
     validationId: validation.validation_id,
     validationStatus: validationInfo.validationStatus,
     validationType: validationInfo.validationType,
+  };
+}
+
+export function dbEntrySheetValidationToApiModel(
+  entrySheetValidation: HCAAtlasTrackerDBEntrySheetValidation
+): HCAAtlasTrackerEntrySheetValidation {
+  return {
+    entrySheetId: entrySheetValidation.entry_sheet_id,
+    entrySheetTitle: entrySheetValidation.entry_sheet_title,
+    id: entrySheetValidation.id,
+    lastSynced: entrySheetValidation.last_synced.toISOString(),
+    lastUpdated: entrySheetValidation.last_updated,
+    sourceStudyId: entrySheetValidation.source_study_id,
+    validationReport: entrySheetValidation.validation_report,
+    validationSummary: entrySheetValidation.validation_summary,
   };
 }
 

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -165,15 +165,21 @@ export type HCAAtlasTrackerValidationRecordWithoutAtlases = Omit<
   | "waves"
 >;
 
-export interface HCAAtlasTrackerListEntrySheetValidation {
+export interface HCAAtlasTrackerEntrySheetValidation {
   entrySheetId: string;
   entrySheetTitle: string | null;
   id: string;
   lastSynced: string;
   lastUpdated: GoogleLastUpdateInfo | null;
   sourceStudyId: string;
+  validationReport: EntrySheetValidationErrorInfo[];
   validationSummary: EntrySheetValidationSummary;
 }
+
+export type HCAAtlasTrackerListEntrySheetValidation = Omit<
+  HCAAtlasTrackerEntrySheetValidation,
+  "validationReport"
+>;
 
 export interface HCAAtlasTrackerComment {
   createdAt: string;

--- a/app/services/entry-sheets.ts
+++ b/app/services/entry-sheets.ts
@@ -30,7 +30,7 @@ export async function getEntrySheetValidation(
     [atlasSourceStudies, entrySheetValidationId]
   );
   if (validationResult.rows.length === 0)
-    throw new Error(
+    throw new NotFoundError(
       `Entry sheet validation with ID ${entrySheetValidationId} doesn't exist on atlas with ID ${atlasId}`
     );
   return validationResult.rows[0];

--- a/app/services/entry-sheets.ts
+++ b/app/services/entry-sheets.ts
@@ -1,6 +1,8 @@
+import { NotFoundError } from "app/utils/api-handler";
 import { getSpreadsheetIdFromUrl } from "app/utils/google-sheets";
 import { validateEntrySheet } from "app/utils/hca-validation-tools";
 import {
+  HCAAtlasTrackerDBAtlas,
   HCAAtlasTrackerDBEntrySheetValidation,
   HCAAtlasTrackerDBEntrySheetValidationListFields,
 } from "../apis/catalog/hca-atlas-tracker/common/entities";
@@ -12,6 +14,27 @@ interface CompletionPromiseContainer {
 }
 
 type ValidationUpdateData = Omit<HCAAtlasTrackerDBEntrySheetValidation, "id">;
+
+export async function getEntrySheetValidation(
+  atlasId: string,
+  entrySheetValidationId: string
+): Promise<HCAAtlasTrackerDBEntrySheetValidation> {
+  const atlasResult = await query<
+    Pick<HCAAtlasTrackerDBAtlas, "source_studies">
+  >("SELECT source_studies FROM hat.atlases WHERE id=$1", [atlasId]);
+  if (atlasResult.rows.length === 0)
+    throw new NotFoundError(`Atlas with ID ${atlasId} doesn't exist`);
+  const atlasSourceStudies = atlasResult.rows[0].source_studies;
+  const validationResult = await query<HCAAtlasTrackerDBEntrySheetValidation>(
+    "SELECT * FROM hat.entry_sheet_validations WHERE source_study_id=ANY($1) AND id=$2",
+    [atlasSourceStudies, entrySheetValidationId]
+  );
+  if (validationResult.rows.length === 0)
+    throw new Error(
+      `Entry sheet validation with ID ${entrySheetValidationId} doesn't exist on atlas with ID ${atlasId}`
+    );
+  return validationResult.rows[0];
+}
 
 export async function getAtlasEntrySheetValidations(
   atlasId: string

--- a/pages/api/atlases/[atlasId]/entry-sheet-validations/[entrySheetValidationId].ts
+++ b/pages/api/atlases/[atlasId]/entry-sheet-validations/[entrySheetValidationId].ts
@@ -1,0 +1,23 @@
+import { dbEntrySheetValidationToApiModel } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
+import { METHOD } from "../../../../../app/common/entities";
+import { getEntrySheetValidation } from "../../../../../app/services/entry-sheets";
+import {
+  handler,
+  method,
+  registeredUser,
+} from "../../../../../app/utils/api-handler";
+
+/**
+ * API route to get an entry sheet validations.
+ */
+export default handler(method(METHOD.GET), registeredUser, async (req, res) => {
+  const atlasId = req.query.atlasId as string;
+  const entrySheetValidationId = req.query.entrySheetValidationId as string;
+  res
+    .status(200)
+    .json(
+      dbEntrySheetValidationToApiModel(
+        await getEntrySheetValidation(atlasId, entrySheetValidationId)
+      )
+    );
+});


### PR DESCRIPTION
Closes #658

The API route is `/api/atlases/[atlasId]/entry-sheet-validations/[entrySheetValidationId]`, notably deviating from the ticket (as I understand it) by using the ID of the saved entry sheet validation rather than the ID of the Google Sheet