### PR TITLE
feat: send bionetwork in validation tools requests (#674)

### DIFF
--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -54,6 +54,20 @@ export async function getAtlas(
   return queryResult.rows[0];
 }
 
+export async function getBaseModelAtlas(
+  id: string
+): Promise<HCAAtlasTrackerDBAtlas> {
+  const queryResult = await query<HCAAtlasTrackerDBAtlas>(
+    "SELECT * FROM hat.atlases WHERE id=$1",
+    [id]
+  );
+
+  if (queryResult.rows.length === 0)
+    throw new NotFoundError(`Atlas with ID ${id} doesn't exist`);
+
+  return queryResult.rows[0];
+}
+
 export async function createAtlas(
   inputData: NewAtlasData
 ): Promise<HCAAtlasTrackerDBAtlasWithComponentAtlases> {

--- a/app/utils/hca-validation-tools/hca-validation-tools-api.ts
+++ b/app/utils/hca-validation-tools/hca-validation-tools-api.ts
@@ -1,17 +1,21 @@
+import { NetworkKey } from "../../apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD } from "../../common/entities";
 import { EntrySheetValidationResponse } from "./hca-validation-tools";
 
 interface EntrySheetValidationRequestBody {
+  bionetwork: NetworkKey;
   sheet_id: string;
 }
 
 export async function fetchEntrySheetValidationResults(
-  googleSheetId: string
+  googleSheetId: string,
+  bioNetwork: NetworkKey
 ): Promise<EntrySheetValidationResponse> {
   const validationApiUrl = process.env.HCA_VALIDATION_TOOLS_URL;
   if (!validationApiUrl)
     throw new Error("HCA_VALIDATION_TOOLS_URL not specified in environment");
   const body: EntrySheetValidationRequestBody = {
+    bionetwork: bioNetwork,
     sheet_id: googleSheetId,
   };
   return await (

--- a/app/utils/hca-validation-tools/hca-validation-tools.ts
+++ b/app/utils/hca-validation-tools/hca-validation-tools.ts
@@ -1,4 +1,5 @@
 import { array, InferType, mixed, number, object, string } from "yup";
+import { NetworkKey } from "../../apis/catalog/hca-atlas-tracker/common/entities";
 import { fetchEntrySheetValidationResults } from "./hca-validation-tools-api";
 
 const googleLastUpdateInfoSchema = object({
@@ -72,9 +73,10 @@ export type EntrySheetValidationResponse =
   | EntrySheetValidationResponseError;
 
 export async function validateEntrySheet(
-  googleSheetId: string
+  googleSheetId: string,
+  bioNetwork: NetworkKey
 ): Promise<EntrySheetValidationResponse> {
   return await entrySheetValidationResponseSchema.validate(
-    await fetchEntrySheetValidationResults(googleSheetId)
+    await fetchEntrySheetValidationResults(googleSheetId, bioNetwork)
   );
 }


### PR DESCRIPTION
This pull request introduces changes to improve the handling of atlas-related data and validation processes. The key updates include the addition of a new function to retrieve atlas details, enhancements to source study retrieval logic, and modifications to validation tools to incorporate network-specific parameters.

### Atlas-related Enhancements:
* [`app/services/atlases.ts`](diffhunk://#diff-a1c3105bef5b2c384d969f03ebcad8efaa13292522f9e2fa19ee42a882fa3971R57-R70): Added `getBaseModelAtlas` function to retrieve atlas details by ID, including error handling for non-existent IDs.

### Source Study Retrieval Improvements:
* [`app/services/source-studies.ts`](diffhunk://#diff-e0d65380741c0fdf3ed85ad3832072c98c1e0a9f0e1c50178912c8f01caa1f59L83-R106): Refactored `getBaseModelAtlasSourceStudies` to use the new `getBaseModelAtlas` function and introduced `getBaseModelSourceStudies` for fetching source studies by IDs with improved error handling for missing study IDs.

### Validation Process Updates:
* [`app/utils/hca-validation-tools/hca-validation-tools-api.ts`](diffhunk://#diff-4e2d58598df23e8c6a2b308afb43a30cff297f154d17bc464993a4d1de700abdR1-R18): Updated `fetchEntrySheetValidationResults` to include a `bionetwork` parameter for network-specific validation.
* [`app/utils/hca-validation-tools/hca-validation-tools.ts`](diffhunk://#diff-74f179958fce4e9b4404de5e707e48c0eff3742c2d03b084f87d40a4f11b3aacL75-R80): Modified `validateEntrySheet` function to pass the `bionetwork` parameter to the validation API.
* [`app/services/entry-sheets.ts`](diffhunk://#diff-105443c099f4273e04fbcd54b7003035fb46551a14af79b5fd25930e2d09c1dcL88-R107): Enhanced `startAtlasEntrySheetValidationsUpdate` and `getSheetValidationResults` to incorporate the `bionetwork` parameter for validation. [[1]](diffhunk://#diff-105443c099f4273e04fbcd54b7003035fb46551a14af79b5fd25930e2d09c1dcL88-R107) [[2]](diffhunk://#diff-105443c099f4273e04fbcd54b7003035fb46551a14af79b5fd25930e2d09c1dcL190-R206)Closes #674

The network key is sent in the `bionetwork` field of the request body