### PR TITLE
feat: return entry sheet validation count from atlas apis (#678)

### DIFF
--- a/__tests__/api-atlases-id.test.ts
+++ b/__tests__/api-atlases-id.test.ts
@@ -17,6 +17,7 @@ import {
   ATLAS_PUBLIC_BAR,
   ATLAS_PUBLIC_BAZ,
   ATLAS_WITH_CAP_ID,
+  ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A,
   ATLAS_WITH_IL,
   ATLAS_WITH_METADATA_CORRECTNESS,
   ATLAS_WITH_MISC_SOURCE_STUDIES,
@@ -288,6 +289,7 @@ describe(TEST_ROUTE, () => {
         const atlas = res._getJSONData() as HCAAtlasTrackerAtlas;
         expectApiAtlasToMatchTest(atlas, ATLAS_DRAFT);
         expect(atlas.componentAtlasCount).toEqual(2);
+        expect(atlas.entrySheetValidationCount).toEqual(0);
       }
     );
   }
@@ -298,6 +300,19 @@ describe(TEST_ROUTE, () => {
     const atlas = res._getJSONData() as HCAAtlasTrackerAtlas;
     expectApiAtlasToMatchTest(atlas, ATLAS_DRAFT);
     expect(atlas.componentAtlasCount).toEqual(2);
+    expect(atlas.entrySheetValidationCount).toEqual(0);
+  });
+
+  it("returns atlas with both component atlases and entry sheet validations when GET requested by logged in user with CONTENT_ADMIN role", async () => {
+    const res = await doAtlasRequest(
+      ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id,
+      USER_CONTENT_ADMIN
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const atlas = res._getJSONData() as HCAAtlasTrackerAtlas;
+    expectApiAtlasToMatchTest(atlas, ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A);
+    expect(atlas.componentAtlasCount).toEqual(2);
+    expect(atlas.entrySheetValidationCount).toEqual(3);
   });
 
   it("returns error 401 when public atlas is PUT requested by logged out user", async () => {

--- a/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
@@ -48,6 +48,7 @@ export function dbAtlasToApiAtlas(
     completedTaskCount: dbAtlas.overview.completedTaskCount,
     componentAtlasCount: dbAtlas.component_atlas_count,
     description: dbAtlas.overview.description,
+    entrySheetValidationCount: dbAtlas.entry_sheet_validation_count,
     highlights: dbAtlas.overview.highlights,
     id: dbAtlas.id,
     ingestionTaskCounts: dbAtlas.overview.ingestionTaskCounts,

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -27,6 +27,7 @@ export interface HCAAtlasTrackerAtlas {
   completedTaskCount: number;
   componentAtlasCount: number;
   description: string;
+  entrySheetValidationCount: number;
   highlights: string;
   id: string;
   ingestionTaskCounts: IngestionTaskCounts;
@@ -238,6 +239,7 @@ export interface HCAAtlasTrackerDBAtlas {
 export interface HCAAtlasTrackerDBAtlasWithComponentAtlases
   extends HCAAtlasTrackerDBAtlas {
   component_atlas_count: number;
+  entry_sheet_validation_count: number;
 }
 
 export interface HCAAtlasTrackerDBAtlasOverview {

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -42,6 +42,7 @@ export function atlasInputMapper(
     completedTaskCount: apiAtlas.completedTaskCount,
     componentAtlasCount: apiAtlas.componentAtlasCount,
     description: apiAtlas.description,
+    entrySheetValidationCount: apiAtlas.entrySheetValidationCount,
     highlights: apiAtlas.highlights,
     id: apiAtlas.id,
     ingestionTaskCounts: apiAtlas.ingestionTaskCounts,

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -35,7 +35,16 @@ export async function getAllAtlases(
   client?: pg.PoolClient
 ): Promise<HCAAtlasTrackerDBAtlasWithComponentAtlases[]> {
   const queryResult = await query<HCAAtlasTrackerDBAtlasWithComponentAtlases>(
-    "SELECT a.*, COUNT(c.*)::int AS component_atlas_count FROM hat.atlases a LEFT JOIN hat.component_atlases c ON c.atlas_id=a.id GROUP BY a.id",
+    `
+      SELECT
+        a.*,
+        COUNT(DISTINCT c.id)::int AS component_atlas_count,
+        COUNT(DISTINCT e.id)::int AS entry_sheet_validation_count
+      FROM hat.atlases a
+      LEFT JOIN hat.component_atlases c ON c.atlas_id=a.id
+      LEFT JOIN hat.entry_sheet_validations e ON a.source_studies ? e.source_study_id::text
+      GROUP BY a.id
+    `,
     undefined,
     client
   );
@@ -46,7 +55,16 @@ export async function getAtlas(
   id: string
 ): Promise<HCAAtlasTrackerDBAtlasWithComponentAtlases> {
   const queryResult = await query<HCAAtlasTrackerDBAtlasWithComponentAtlases>(
-    "SELECT a.*, COUNT(c.*)::int AS component_atlas_count FROM hat.atlases a LEFT JOIN hat.component_atlases c ON c.atlas_id=a.id WHERE a.id=$1 GROUP BY a.id",
+    `
+      SELECT
+        a.*,
+        COUNT(DISTINCT c.id)::int AS component_atlas_count,
+        COUNT(DISTINCT e.id)::int AS entry_sheet_validation_count
+      FROM hat.atlases a
+      LEFT JOIN hat.component_atlases c ON c.atlas_id=a.id
+      LEFT JOIN hat.entry_sheet_validations e ON a.source_studies ? e.source_study_id::text
+      WHERE a.id=$1 GROUP BY a.id
+    `,
     [id]
   );
   if (queryResult.rows.length === 0)

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -2295,12 +2295,32 @@ export const COMPONENT_ATLAS_WITH_CELLXGENE_DATASETS: TestComponentAtlas = {
   title: "Component Atlas Misc Foo",
 };
 
+export const COMPONENT_ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_FOO: TestComponentAtlas =
+  {
+    atlasId: ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id,
+    description: "foo barbaz bazbar foofoobar",
+    id: "ea9f4b7a-a2a9-4fe8-a20a-5de4f11e60b8",
+    sourceDatasets: [],
+    title: "Component Atlas With Entry Sheet Validations Foo",
+  };
+
+export const COMPONENT_ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_BAR: TestComponentAtlas =
+  {
+    atlasId: ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id,
+    description: "foobazbaz barfoo barfoo baz",
+    id: "f3551bcf-31ae-4640-9bd5-68d8cdcb586b",
+    sourceDatasets: [],
+    title: "Component Atlas With Entry Sheet Validations Bar",
+  };
+
 // Component atlases to initialize in the database before tests
 export const INITIAL_TEST_COMPONENT_ATLASES = [
   COMPONENT_ATLAS_DRAFT_FOO,
   COMPONENT_ATLAS_DRAFT_BAR,
   COMPONENT_ATLAS_MISC_FOO,
   COMPONENT_ATLAS_WITH_CELLXGENE_DATASETS,
+  COMPONENT_ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_FOO,
+  COMPONENT_ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_BAR,
 ];
 
 // ENTRY SHEET VALIDATIONS


### PR DESCRIPTION
Closes #678

I initially thought that getting entry sheet validation count would be awkward and would require involving the source studies table, but it's actually relatively simple since both atlases and entry sheet validations store source study IDs and so you can just join based on that, which is what I've done