### PR TITLE
feat: add count to metadata entry sheet tab (#676)

### DIFF
--- a/app/components/Detail/components/ViewAtlas/components/Tabs/tabs.tsx
+++ b/app/components/Detail/components/ViewAtlas/components/Tabs/tabs.tsx
@@ -22,7 +22,8 @@ export const Tabs = ({
   pathParameter,
 }: TabsProps): JSX.Element => {
   const { route } = useRouter();
-  const { componentAtlasCount, sourceStudyCount } = atlas || {};
+  const { componentAtlasCount, entrySheetValidationCount, sourceStudyCount } =
+    atlas || {};
 
   const onChange = useCallback(
     (tabValue: TabValue): void => {
@@ -41,7 +42,10 @@ export const Tabs = ({
           value: ROUTE.SOURCE_STUDIES,
         },
         {
-          label: "Metadata Entry Sheets",
+          label: getTabLabelWithCount(
+            "Metadata Entry Sheets",
+            entrySheetValidationCount
+          ),
           value: ROUTE.METADATA_ENTRY_SHEETS,
         },
         {


### PR DESCRIPTION
Closes #676.

This pull request updates the `Tabs` component in `tabs.tsx` to enhance the display of tab labels by including dynamic counts for entry sheet validations. The most important changes are as follows:

### Enhancements to Tab Labels:

* Updated the destructuring of the `atlas` object to include `entrySheetValidationCount`, enabling the use of this count in the tab labels. (`[app/components/Detail/components/ViewAtlas/components/Tabs/tabs.tsxL25-R26](diffhunk://#diff-1108c3d735aac7a45e5785895f31fe25f2f91e87827bcdc7a21d6d0a0f9d9e83L25-R26)`)
* Modified the "Metadata Entry Sheets" tab label to dynamically display the count of entry sheet validations using the `getTabLabelWithCount` function. (`[app/components/Detail/components/ViewAtlas/components/Tabs/tabs.tsxL44-R48](diffhunk://#diff-1108c3d735aac7a45e5785895f31fe25f2f91e87827bcdc7a21d6d0a0f9d9e83L44-R48)`)

<img width="911" alt="image" src="https://github.com/user-attachments/assets/ca63db76-6f66-484d-b16e-5e6770a86b05" />
