### PR TITLE
feat: create validation report ui (#659)

### DIFF
--- a/app/apis/catalog/hca-atlas-tracker/common/api.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/api.ts
@@ -4,6 +4,7 @@ export enum API {
   ATLAS_COMPONENT_ATLAS = "/api/atlases/[atlasId]/component-atlases/[componentAtlasId]",
   ATLAS_COMPONENT_ATLAS_SOURCE_DATASETS = "/api/atlases/[atlasId]/component-atlases/[componentAtlasId]/source-datasets",
   ATLAS_COMPONENT_ATLASES = "/api/atlases/[atlasId]/component-atlases",
+  ATLAS_ENTRY_SHEET = "/api/atlases/[atlasId]/entry-sheet-validations/[entrySheetValidationId]",
   ATLAS_ENTRY_SHEETS = "/api/atlases/[atlasId]/entry-sheet-validations",
   ATLAS_ENTRY_SHEETS_SYNC = "/api/atlases/[atlasId]/entry-sheet-validations/sync",
   ATLAS_SOURCE_DATASET = "/api/atlases/[atlasId]/source-datasets/[sourceDatasetId]",

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -481,6 +481,8 @@ export type AtlasId = HCAAtlasTrackerAtlas["id"];
 
 export type ComponentAtlasId = string;
 
+export type EntrySheetValidationId = HCAAtlasTrackerEntrySheetValidation["id"];
+
 export enum DOI_STATUS {
   DOI_NOT_ON_CROSSREF = "DOI_NOT_ON_CROSSREF",
   NA = "NA",

--- a/app/common/entities.ts
+++ b/app/common/entities.ts
@@ -1,6 +1,7 @@
 import {
   AtlasId,
   ComponentAtlasId,
+  EntrySheetValidationId,
   SourceDatasetId,
   SourceStudyId,
   UserId,
@@ -25,6 +26,7 @@ export enum METHOD {
 export interface PathParameter {
   atlasId?: AtlasId;
   componentAtlasId?: ComponentAtlasId;
+  entrySheetValidationId?: EntrySheetValidationId;
   sourceDatasetId?: SourceDatasetId;
   sourceStudyId?: SourceStudyId;
   userId?: UserId;

--- a/app/components/Entity/components/EntityView/components/Section/entities.ts
+++ b/app/components/Entity/components/EntityView/components/Section/entities.ts
@@ -7,6 +7,7 @@ export interface Props<C extends ElementType> {
 export interface SectionConfig<C extends ElementType = ElementType> {
   Component: C;
   componentProps: ComponentProps<C>;
+  showDivider?: boolean;
   slotProps?: SlotProps;
 }
 

--- a/app/components/Entity/components/EntityView/components/Section/section.styles.ts
+++ b/app/components/Entity/components/EntityView/components/Section/section.styles.ts
@@ -1,12 +1,11 @@
 import { mediaTabletUp } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-
 interface Props {
   fullWidth?: boolean;
 }
 
-export const StyledSection = styled.section<Props>`
+export const StyledSection = styled.div<Props>`
   align-items: flex-start;
   display: grid;
   gap: 16px;
@@ -22,4 +21,21 @@ export const StyledSection = styled.section<Props>`
     css`
       grid-template-columns: 1fr;
     `}
+`;
+
+export const SectionHero = styled.div<Props>`
+  display: grid;
+  gap: 8px;
+  padding: 0 16px;
+
+  ${mediaTabletUp} {
+    grid-column: span 4;
+    padding: 0;
+
+    ${({ fullWidth }) =>
+      fullWidth &&
+      css`
+        grid-column: 1 / -1;
+      `}
+  }
 `;

--- a/app/components/Entity/components/EntityView/entityView.tsx
+++ b/app/components/Entity/components/EntityView/entityView.tsx
@@ -1,4 +1,5 @@
 import { ElementType, Fragment } from "react";
+import { Divider } from "../../../Detail/components/TrackerForm/components/Divider/divider.styles";
 import { Section } from "./components/Section/section";
 import { Props } from "./entities";
 
@@ -10,7 +11,10 @@ export const EntityView = <C extends ElementType>({
   return (
     <Fragment>
       {sectionConfigs.map((sectionConfig, i) => (
-        <Section key={i} sectionConfig={sectionConfig} />
+        <Fragment key={i}>
+          {sectionConfig.showDivider && <Divider />}
+          <Section sectionConfig={sectionConfig} />
+        </Fragment>
       ))}
     </Fragment>
   );

--- a/app/routes/constants.ts
+++ b/app/routes/constants.ts
@@ -12,6 +12,8 @@ export const ROUTE = {
   CREATE_USER: "/team/create",
   LOGIN: "/login",
   METADATA_CORRECTNESS: "/atlases/[atlasId]/metadata-correctness",
+  METADATA_ENTRY_SHEET:
+    "/atlases/[atlasId]/metadata-entry-sheets/[entrySheetValidationId]",
   METADATA_ENTRY_SHEETS: "/atlases/[atlasId]/metadata-entry-sheets",
   REPORTS: "/reports",
   REQUESTING_ELEVATED_PERMISSIONS: "/requesting-elevated-permissions",

--- a/app/views/AtlasMetadataEntrySheetValidationView/atlasMetadataEntrySheetValidationView.tsx
+++ b/app/views/AtlasMetadataEntrySheetValidationView/atlasMetadataEntrySheetValidationView.tsx
@@ -1,0 +1,89 @@
+import { ConditionalComponent } from "@databiosphere/findable-ui/lib/components/ComponentCreator/components/ConditionalComponent/conditionalComponent";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { Typography } from "@mui/material";
+import { PathParameter } from "../../common/entities";
+import { AccessDeniedPrompt } from "../../components/common/Form/components/FormManager/components/AccessDeniedPrompt/accessDeniedPrompt";
+import { AccessPrompt } from "../../components/common/Form/components/FormManager/components/AccessPrompt/accessPrompt";
+import { shouldRenderView } from "../../components/Detail/common/utils";
+import { Divider } from "../../components/Detail/components/TrackerForm/components/Divider/divider.styles";
+import { EntityView } from "../../components/Entity/components/EntityView/entityView";
+import { DetailView } from "../../components/Layout/components/Detail/detailView";
+import { useFetchAtlas } from "../../hooks/useFetchAtlas";
+import { FormManager } from "../../hooks/useFormManager/common/entities";
+import { useFormManager } from "../../hooks/useFormManager/useFormManager";
+import { EntityProvider } from "../../providers/entity/provider";
+import { VIEW_METADATA_ENTRY_SHEET_SECTION_CONFIGS } from "./common/config";
+import { Actions } from "./components/Actions/actions";
+import { useFetchEntrySheetValidation } from "./hooks/useFetchEntrySheetValidations";
+import { renderSubTitle, renderTitle } from "./utils";
+
+interface AtlasMetadataEntrySheetValidationViewProps {
+  pathParameter: PathParameter;
+}
+
+export const AtlasMetadataEntrySheetValidationView = ({
+  pathParameter,
+}: AtlasMetadataEntrySheetValidationViewProps): JSX.Element => {
+  const { atlas } = useFetchAtlas(pathParameter);
+  const { entrySheetValidation } = useFetchEntrySheetValidation(pathParameter);
+  const formManager = useFormManager();
+  const {
+    access: { canView },
+  } = formManager;
+  return (
+    <EntityProvider
+      data={{ atlas, entrySheetValidation }}
+      formManager={formManager}
+    >
+      <ConditionalComponent
+        isIn={shouldRenderView(canView, Boolean(entrySheetValidation))}
+      >
+        <DetailView
+          actions={<Actions />}
+          mainColumn={
+            <EntityView
+              accessFallback={renderAccessFallback(formManager)}
+              sectionConfigs={VIEW_METADATA_ENTRY_SHEET_SECTION_CONFIGS}
+            />
+          }
+          subTitle={
+            <Typography
+              color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
+              variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400}
+            >
+              {renderSubTitle(entrySheetValidation)}
+            </Typography>
+          }
+          title={
+            <>
+              {/* TODO(cc) update heading variant with typography props */}
+              <Typography component="h1" variant="text-heading">
+                {renderTitle(entrySheetValidation)}
+              </Typography>
+            </>
+          }
+        />
+      </ConditionalComponent>
+    </EntityProvider>
+  );
+};
+
+/**
+ * Returns the access fallback component from the form manager access state.
+ * @param formManager - Form manager.
+ * @returns access fallback component.
+ */
+function renderAccessFallback(formManager: FormManager): JSX.Element | null {
+  const {
+    access: { canEdit, canView },
+  } = formManager;
+  if (!canView)
+    return (
+      <AccessPrompt
+        divider={<Divider />}
+        text="to view metadata entry sheet validation"
+      />
+    );
+  if (!canEdit) return <AccessDeniedPrompt divider={<Divider />} />;
+  return null;
+}

--- a/app/views/AtlasMetadataEntrySheetValidationView/common/config.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/common/config.ts
@@ -1,0 +1,6 @@
+import { SectionConfig } from "../../../components/Entity/components/EntityView/components/Section/entities";
+import { METADATA_ENTRY_SHEET_VALIDATION_REPORT } from "./constants";
+
+export const VIEW_METADATA_ENTRY_SHEET_SECTION_CONFIGS: SectionConfig[] = [
+  METADATA_ENTRY_SHEET_VALIDATION_REPORT,
+];

--- a/app/views/AtlasMetadataEntrySheetValidationView/common/constants.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/common/constants.ts
@@ -1,0 +1,10 @@
+import { SectionConfig } from "../../../components/Entity/components/EntityView/components/Section/entities";
+import { ValidationReport } from "../components/ValidationReport/validationReport";
+
+export const METADATA_ENTRY_SHEET_VALIDATION_REPORT: SectionConfig<
+  typeof ValidationReport
+> = {
+  Component: ValidationReport,
+  componentProps: {},
+  showDivider: true,
+};

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/Actions/actions.styles.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/Actions/actions.styles.ts
@@ -1,0 +1,14 @@
+import { mediaDesktopSmallUp } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
+import styled from "@emotion/styled";
+import { HeroActions as DetailViewActions } from "../../../../components/Layout/components/Detail/components/DetailViewHero/detailViewHero.styles";
+
+export const HeroActions = styled(DetailViewActions)`
+  .MuiButton-root {
+    padding: 8px 16px;
+  }
+
+  ${mediaDesktopSmallUp} {
+    align-self: flex-start;
+    margin: 8px 0;
+  }
+`;

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/Actions/actions.tsx
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/Actions/actions.tsx
@@ -1,0 +1,39 @@
+import { OpenInNewIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/OpenInNewIcon/openInNewIcon";
+import {
+  ANCHOR_TARGET,
+  REL_ATTRIBUTE,
+} from "@databiosphere/findable-ui/lib/components/Links/common/entities";
+import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/button";
+import { Button } from "@mui/material";
+import { useEntity } from "../../../../providers/entity/hook";
+import { EntityData } from "../../entities";
+import { HeroActions } from "./actions.styles";
+import { buildSheetsUrl } from "./utils";
+
+export const Actions = (): JSX.Element | null => {
+  const { data } = useEntity();
+
+  // Coerce the entity data provided by EntityProvider to the EntityData type -- safe to assume that the data structure conforms to EntityData.
+  const entityData = data as EntityData;
+
+  const { entrySheetValidation } = entityData;
+  const { entrySheetId } = entrySheetValidation || {};
+
+  if (!entrySheetId) return null;
+
+  return (
+    <HeroActions>
+      <Button
+        color={BUTTON_PROPS.COLOR.PRIMARY}
+        href={buildSheetsUrl(entrySheetId, null, null, null)}
+        startIcon={<OpenInNewIcon />}
+        rel={REL_ATTRIBUTE.NO_OPENER_NO_REFERRER}
+        size={BUTTON_PROPS.SIZE.MEDIUM}
+        target={ANCHOR_TARGET.BLANK}
+        variant={BUTTON_PROPS.VARIANT.CONTAINED}
+      >
+        Open Sheet
+      </Button>
+    </HeroActions>
+  );
+};

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/Actions/utils.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/Actions/utils.ts
@@ -1,0 +1,32 @@
+const SPREADSHEET_URL_PREFIX = "https://docs.google.com/spreadsheets/d/";
+
+/**
+ * Generates a Google Sheets URL pointing to a specific sheet tab and optionally to a specific cell or row.
+ *
+ * The generated URL includes the `/edit` path and a fragment with the sheet `gid` and a `range` if a cell or row is specified.
+ * - If both `cell` and `row` are provided, `cell` takes precedence.
+ * - If neither `cell` nor `row` is provided, the URL will point only to the sheet/tab (or just the sheet if no `gid`).
+ *
+ * @param entrySheetId - The Google Sheets document ID (from the URL).
+ * @param gid - The numeric worksheet (tab) ID. If null, no sheet will be specified.
+ * @param cell - A specific cell to link to (e.g. "B7"). Takes precedence over `row` if provided.
+ * @param row - A row number to highlight (e.g. 5). Used only if `cell` is null.
+ * @returns A complete URL string that opens the Google Sheet at the desired location.
+ */
+export function buildSheetsUrl(
+  entrySheetId: string,
+  gid: number | null,
+  cell: string | null,
+  row: number | null
+): string {
+  const base = `${SPREADSHEET_URL_PREFIX}${entrySheetId}/edit`;
+
+  const fragments: string[] = [];
+  if (gid !== null) fragments.push(`gid=${gid}`);
+  if (cell) fragments.push(`range=${cell}`);
+  else if (row !== null) fragments.push(`range=${row + 1}:${row + 1}`);
+
+  const fragmentString = fragments.length ? `#${fragments.join("&")}` : "";
+
+  return `${base}${fragmentString}`;
+}

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.styles.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.styles.ts
@@ -1,0 +1,52 @@
+import { Dot } from "@databiosphere/findable-ui/lib/components/common/Dot/dot";
+import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
+import { textBody400 } from "@databiosphere/findable-ui/lib/styles/common/mixins/fonts";
+import styled from "@emotion/styled";
+import { Alert } from "@mui/material";
+
+export const StyledAlert = styled(Alert)`
+  align-items: center;
+  cursor: pointer;
+  gap: 24px;
+  padding: 12px 16px;
+
+  .MuiAlert-message {
+    ${textBody400};
+    align-items: center;
+    flex: 1;
+    gap: 4px;
+    grid-auto-flow: column;
+    justify-content: flex-start;
+
+    code {
+      background-color: ${PALETTE.ALERT_LIGHT};
+      border-radius: 4px;
+      font-size: 14px;
+      font-weight: 500;
+      line-height: 20px;
+      padding: 0 4px;
+    }
+  }
+
+  .MuiAlert-action {
+    margin: 0;
+    padding: 0;
+
+    .MuiButton-text {
+      color: ${PALETTE.ALERT_MAIN};
+      gap: 4px;
+
+      &:hover {
+        background-color: transparent;
+      }
+
+      .MuiButton-endIcon {
+        margin: 0;
+      }
+    }
+  }
+`;
+
+export const StyledDot = styled(Dot)`
+  background-color: ${PALETTE.INK_MAIN};
+`;

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.tsx
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.tsx
@@ -1,0 +1,46 @@
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { Tooltip, Typography } from "@mui/material";
+import { Fragment } from "react";
+import { StyledAlert, StyledDot } from "./alert.styles";
+import { ALERT_PROPS } from "./constants";
+import { Props } from "./entities";
+
+export const Alert = ({
+  validationReport,
+  ...props
+}: Props): JSX.Element | null => {
+  return (
+    <StyledAlert {...ALERT_PROPS} {...props}>
+      {validationReport.primary_key && (
+        <Typography variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_500}>
+          {validationReport.primary_key?.replace(/^.*?:\s*/, "")}
+        </Typography>
+      )}
+      {validationReport.column && (
+        <Fragment>
+          <StyledDot />
+          <Tooltip arrow title={validationReport.column}>
+            <Typography noWrap>{validationReport.column}</Typography>
+          </Tooltip>
+        </Fragment>
+      )}
+      <Fragment>
+        <StyledDot />
+        <Tooltip arrow title={validationReport.message}>
+          <Typography noWrap>{validationReport.message}</Typography>
+        </Tooltip>
+      </Fragment>
+      {validationReport.cell ? (
+        <Fragment>
+          <StyledDot />
+          <code>{validationReport.cell}</code>
+        </Fragment>
+      ) : validationReport.row ? (
+        <Fragment>
+          <StyledDot />
+          <code>row {validationReport.row + 1}</code>
+        </Fragment>
+      ) : null}
+    </StyledAlert>
+  );
+};

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/constants.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/constants.ts
@@ -1,0 +1,12 @@
+import {
+  COLOR,
+  VARIANT,
+} from "@databiosphere/findable-ui/lib/styles/common/mui/alert";
+import { AlertProps } from "@mui/material";
+
+export const ALERT_PROPS: Partial<AlertProps> = {
+  elevation: 0,
+  icon: false,
+  severity: COLOR.ERROR,
+  variant: VARIANT.STANDARD,
+};

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/entities.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/entities.ts
@@ -1,0 +1,6 @@
+import { AlertProps } from "@mui/material";
+import { ValidationErrorInfo } from "../../entities";
+
+export interface Props extends AlertProps {
+  validationReport: ValidationErrorInfo;
+}

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/constants.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/constants.ts
@@ -1,0 +1,14 @@
+import { GridProps } from "@mui/material";
+import { EntityType } from "../../entities";
+
+export const ENTITY_NAME: Record<EntityType, string> = {
+  dataset: "Datasets",
+  donor: "Donors",
+  sample: "Samples",
+};
+
+export const GRID_PROPS: GridProps = {
+  container: true,
+  direction: "column",
+  gap: 2,
+};

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entities.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entities.ts
@@ -1,0 +1,7 @@
+import { EntityType, ValidationErrorInfo } from "../../entities";
+
+export interface Props {
+  entityType: EntityType;
+  entrySheetId: string;
+  validationReports: ValidationErrorInfo[];
+}

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entityValidationReport.styles.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entityValidationReport.styles.ts
@@ -1,0 +1,18 @@
+import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
+import { sectionPadding } from "@databiosphere/findable-ui/lib/components/common/Section/section.styles";
+import { mediaTabletDown } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
+import styled from "@emotion/styled";
+
+export const StyledFluidPaper = styled(FluidPaper)`
+  ${sectionPadding};
+  display: block;
+  grid-column: 1 / -1;
+
+  ${mediaTabletDown} {
+    grid-column: 1 / -1;
+  }
+
+  .MuiDivider-root {
+    margin: 16px 0;
+  }
+`;

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entityValidationReport.tsx
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entityValidationReport.tsx
@@ -1,0 +1,65 @@
+import { OpenInNewIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/OpenInNewIcon/openInNewIcon";
+import {
+  ANCHOR_TARGET,
+  REL_ATTRIBUTE,
+} from "@databiosphere/findable-ui/lib/components/Links/common/entities";
+import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/button";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { Button, Divider, Grid, Typography } from "@mui/material";
+import { buildSheetsUrl } from "../../../Actions/utils";
+import { Alert } from "../Alert/alert";
+import { ENTITY_NAME, GRID_PROPS } from "./constants";
+import { Props } from "./entities";
+import { StyledFluidPaper } from "./entityValidationReport.styles";
+
+export const EntityValidationReport = ({
+  entityType,
+  entrySheetId,
+  validationReports,
+}: Props): JSX.Element => {
+  return (
+    <StyledFluidPaper>
+      <Typography
+        component="h3"
+        variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_500}
+      >
+        {ENTITY_NAME[entityType]}
+      </Typography>
+      <Divider />
+      <Grid {...GRID_PROPS}>
+        <Typography variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400}>
+          Errors found ({validationReports.length}):
+        </Typography>
+        {validationReports.map((validationReport, j) => {
+          return (
+            <Alert
+              key={j}
+              action={
+                <Button
+                  color={BUTTON_PROPS.COLOR.INHERIT}
+                  endIcon={<OpenInNewIcon />}
+                  variant={BUTTON_PROPS.VARIANT.TEXT}
+                >
+                  Open
+                </Button>
+              }
+              onClick={() => {
+                window.open(
+                  buildSheetsUrl(
+                    entrySheetId,
+                    validationReport.worksheet_id,
+                    validationReport.cell,
+                    validationReport.row
+                  ),
+                  ANCHOR_TARGET.BLANK,
+                  REL_ATTRIBUTE.NO_OPENER_NO_REFERRER
+                );
+              }}
+              validationReport={validationReport}
+            />
+          );
+        })}
+      </Grid>
+    </StyledFluidPaper>
+  );
+};

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/entities.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/entities.ts
@@ -1,0 +1,12 @@
+export type EntityType = "dataset" | "donor" | "sample";
+
+export interface ValidationErrorInfo {
+  cell: string | null;
+  column: string | null;
+  entity_type: EntityType | null;
+  input: string | Record<string, unknown> | null;
+  message: string;
+  primary_key: string | null;
+  row: number | null;
+  worksheet_id: number | null;
+}

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/utils.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/utils.ts
@@ -1,0 +1,68 @@
+import { COLLATOR_CASE_INSENSITIVE } from "@databiosphere/findable-ui/lib/common/constants";
+import { EntityData } from "../../entities";
+import { EntityType, ValidationErrorInfo } from "./entities";
+
+/**
+ * Builds entity validation reports for each entity type.
+ * @param data - Entity data.
+ * @returns Map of entity type to validation report.
+ */
+export function buildEntityValidationReports(
+  data: EntityData
+): Map<EntityType, ValidationErrorInfo[]> | undefined {
+  if (!data.entrySheetValidation) return;
+
+  return data.entrySheetValidation.validationReport
+    .filter(filterReport)
+    .sort(sortReport)
+    .reduce(mapReport, new Map<EntityType, ValidationErrorInfo[]>());
+}
+
+/**
+ * Filters validation report.
+ * @param report - Validation report.
+ * @returns True if report has entity type, false otherwise.
+ */
+function filterReport(report: ValidationErrorInfo): boolean {
+  return Boolean(report.entity_type);
+}
+
+/**
+ * Maps validation report to entity reports.
+ * @param acc - Accumulator of entity reports.
+ * @param report - Validation report.
+ * @returns Map of entity type to validation report.
+ */
+function mapReport(
+  acc: Map<EntityType, ValidationErrorInfo[]>,
+  report: ValidationErrorInfo
+): Map<EntityType, ValidationErrorInfo[]> {
+  const entityReports = acc.get(report.entity_type!) || [];
+  entityReports.push(report);
+  acc.set(report.entity_type!, entityReports);
+  return acc;
+}
+
+/**
+ * Sorts validation report.
+ * Sorting is by `entity_type` and then `cell` property.
+ * @param r01 - First validation report.
+ * @param r02 - Second validation report.
+ * @returns -1 if a should come before b, 1 if b should come before a, 0 otherwise.
+ */
+function sortReport(
+  r01: ValidationErrorInfo,
+  r02: ValidationErrorInfo
+): number {
+  // Sort by entity type first.
+  const firstCompare = COLLATOR_CASE_INSENSITIVE.compare(
+    r01.entity_type ?? "",
+    r02.entity_type ?? ""
+  );
+
+  // If entity types are different, return the comparison result.
+  if (firstCompare !== 0) return firstCompare;
+
+  // Sort by cell and return the result.
+  return COLLATOR_CASE_INSENSITIVE.compare(r01.cell ?? "", r02.cell ?? "");
+}

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/validationReport.tsx
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/validationReport.tsx
@@ -1,0 +1,49 @@
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { Typography } from "@mui/material";
+import { Fragment } from "react";
+import { SectionHero } from "../../../../components/Entity/components/EntityView/components/Section/section.styles";
+import { useEntity } from "../../../../providers/entity/hook";
+import { EntityData } from "../../entities";
+import { EntityValidationReport } from "./components/EntityValidationReport/entityValidationReport";
+import { buildEntityValidationReports } from "./utils";
+
+export const ValidationReport = (): JSX.Element | null => {
+  const { data } = useEntity();
+
+  // Coerce the entity data provided by EntityProvider to the EntityData type -- safe to assume that the data structure conforms to EntityData.
+  const entityData = data as EntityData;
+
+  // Build validation reports for each entity.
+  const entityValidationReports = buildEntityValidationReports(entityData);
+
+  if (!entityValidationReports) return null;
+
+  const { entrySheetValidation } = entityData;
+  const { entrySheetId } = entrySheetValidation || {};
+
+  // If entry sheet ID is not available, return null.
+  if (!entrySheetId) return null;
+
+  return (
+    <Fragment>
+      <SectionHero>
+        <Typography
+          component="h2"
+          variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_HEADING_XSMALL}
+        >
+          Validation Report
+        </Typography>
+      </SectionHero>
+      {[...entityValidationReports].map(
+        ([entityType, validationReports], i) => (
+          <EntityValidationReport
+            key={i}
+            entityType={entityType}
+            entrySheetId={entrySheetId}
+            validationReports={validationReports}
+          />
+        )
+      )}
+    </Fragment>
+  );
+};

--- a/app/views/AtlasMetadataEntrySheetValidationView/entities.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/entities.ts
@@ -1,0 +1,9 @@
+import {
+  HCAAtlasTrackerAtlas,
+  HCAAtlasTrackerEntrySheetValidation,
+} from "../../apis/catalog/hca-atlas-tracker/common/entities";
+
+export type EntityData = {
+  atlas: HCAAtlasTrackerAtlas | undefined;
+  entrySheetValidation: HCAAtlasTrackerEntrySheetValidation | undefined;
+};

--- a/app/views/AtlasMetadataEntrySheetValidationView/hooks/useFetchEntrySheetValidations.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/hooks/useFetchEntrySheetValidations.ts
@@ -1,0 +1,24 @@
+import { API } from "../../../apis/catalog/hca-atlas-tracker/common/api";
+import { HCAAtlasTrackerEntrySheetValidation } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD, PathParameter } from "../../../common/entities";
+import { getRequestURL } from "../../../common/utils";
+import { useFetchData } from "../../../hooks/useFetchData";
+
+interface UseFetchEntrySheetValidation {
+  entrySheetValidation?: HCAAtlasTrackerEntrySheetValidation;
+}
+
+export const useFetchEntrySheetValidation = (
+  pathParameter: PathParameter
+): UseFetchEntrySheetValidation => {
+  // Validate atlasId and entrySheetValidationId - required for API request.
+  if (!pathParameter.atlasId) throw new Error("Atlas ID is required");
+  if (!pathParameter.entrySheetValidationId)
+    throw new Error("Entry sheet validation ID is required");
+
+  const { data: entrySheetValidation } = useFetchData<
+    HCAAtlasTrackerEntrySheetValidation | undefined
+  >(getRequestURL(API.ATLAS_ENTRY_SHEET, pathParameter), METHOD.GET);
+
+  return { entrySheetValidation };
+};

--- a/app/views/AtlasMetadataEntrySheetValidationView/utils.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/utils.ts
@@ -1,0 +1,29 @@
+import { formatDistanceToNowStrict } from "date-fns";
+import { HCAAtlasTrackerEntrySheetValidation } from "../../apis/catalog/hca-atlas-tracker/common/entities";
+
+/**
+ * Returns subtitle for entry sheet validation view.
+ * @param entrySheetValidation - Entry sheet validation.
+ * @returns Subtitle.
+ */
+export function renderSubTitle(
+  entrySheetValidation?: HCAAtlasTrackerEntrySheetValidation
+): string | null {
+  if (!entrySheetValidation || !entrySheetValidation.lastUpdated) return null;
+  const { lastUpdated: { by, date } = {} } = entrySheetValidation;
+  // Return null if by or date is undefined.
+  if (!by || !date) return null;
+  return `Last updated by ${by} ${formatDistanceToNowStrict(date)} ago`;
+}
+
+/**
+ * Returns title for entry sheet validation view.
+ * @param entrySheetValidation - Entry sheet validation.
+ * @returns Title.
+ */
+export function renderTitle(
+  entrySheetValidation?: HCAAtlasTrackerEntrySheetValidation
+): string {
+  if (!entrySheetValidation) return "Metadata Entry Sheet Validation";
+  return `Report: ${entrySheetValidation.entrySheetTitle}`;
+}

--- a/app/views/AtlasMetadataEntrySheetsView/atlasMetadataEntrySheetsView.tsx
+++ b/app/views/AtlasMetadataEntrySheetsView/atlasMetadataEntrySheetsView.tsx
@@ -13,7 +13,7 @@ import { useFetchAtlas } from "../../hooks/useFetchAtlas";
 import { FormManager } from "../../hooks/useFormManager/common/entities";
 import { useFormManager } from "../../hooks/useFormManager/useFormManager";
 import { EntityProvider } from "../../providers/entity/provider";
-import { VIEW_METADATA_ENTRY_SHEET_SECTION_CONFIGS } from "./common/config";
+import { VIEW_METADATA_ENTRY_SHEETS_SECTION_CONFIGS } from "./common/config";
 import { getBreadcrumbs } from "./common/utils";
 import { useFetchEntrySheetsValidations } from "./hooks/useFetchEntrySheetValidations";
 
@@ -21,7 +21,7 @@ interface AtlasMetadataEntrySheetsViewProps {
   pathParameter: PathParameter;
 }
 
-export const AtlasMetadataEntrySheetView = ({
+export const AtlasMetadataEntrySheetsView = ({
   pathParameter,
 }: AtlasMetadataEntrySheetsViewProps): JSX.Element => {
   const { atlas } = useFetchAtlas(pathParameter);
@@ -40,7 +40,7 @@ export const AtlasMetadataEntrySheetView = ({
           mainColumn={
             <EntityView
               accessFallback={renderAccessFallback(formManager)}
-              sectionConfigs={VIEW_METADATA_ENTRY_SHEET_SECTION_CONFIGS}
+              sectionConfigs={VIEW_METADATA_ENTRY_SHEETS_SECTION_CONFIGS}
             />
           }
           status={atlas && <AtlasStatus atlasStatus={atlas.status} />}

--- a/app/views/AtlasMetadataEntrySheetsView/common/columns.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/common/columns.ts
@@ -1,7 +1,7 @@
 import { LinkCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/LinkCell/linkCell";
 import { ColumnDef } from "@tanstack/react-table";
-import { ChipCell } from "../../../components/Table/components/TableCell/components/ChipCell/chipCell";
 import { KeyValueCell } from "../../../components/Table/components/TableCell/components/KeyValueCell/keyValueCell";
+import { ValidationSummaryCell } from "../components/Table/components/TableCell/components/ValidationSummaryCell/validationSummaryCell";
 import { MetadataEntrySheet } from "../entities";
 import {
   buildDataSummary,
@@ -47,7 +47,7 @@ const COLUMN_PUBLICATION_STRING = {
 
 const COLUMN_VALIDATION_SUMMARY: ColumnDef<MetadataEntrySheet> = {
   accessorKey: "validationSummary.error_count",
-  cell: (props) => ChipCell(buildValidationSummary(props)),
+  cell: (props) => ValidationSummaryCell(buildValidationSummary(props)),
   enableSorting: false,
   header: "Validation",
   id: "validationSummary",

--- a/app/views/AtlasMetadataEntrySheetsView/common/config.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/common/config.ts
@@ -1,6 +1,6 @@
 import { SectionConfig } from "../../../components/Entity/components/EntityView/components/Section/entities";
-import { METADATA_ENTRY_SHEET_VIEW_TABLE } from "./constants";
+import { METADATA_ENTRY_SHEETS_VIEW_TABLE } from "./constants";
 
-export const VIEW_METADATA_ENTRY_SHEET_SECTION_CONFIGS: SectionConfig[] = [
-  METADATA_ENTRY_SHEET_VIEW_TABLE,
+export const VIEW_METADATA_ENTRY_SHEETS_SECTION_CONFIGS: SectionConfig[] = [
+  METADATA_ENTRY_SHEETS_VIEW_TABLE,
 ];

--- a/app/views/AtlasMetadataEntrySheetsView/common/constants.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/common/constants.ts
@@ -3,7 +3,7 @@ import { SectionConfig } from "../../../components/Entity/components/EntityView/
 import { Table } from "../components/Table/table";
 import { COLUMNS } from "./columns";
 
-export const METADATA_ENTRY_SHEET_VIEW_TABLE: SectionConfig<typeof Table> = {
+export const METADATA_ENTRY_SHEETS_VIEW_TABLE: SectionConfig<typeof Table> = {
   Component: Table,
   componentProps: {
     tableOptions: {

--- a/app/views/AtlasMetadataEntrySheetsView/common/viewBuilders.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/common/viewBuilders.ts
@@ -1,13 +1,11 @@
-import { ErrorIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/ErrorIcon/errorIcon";
-import { SuccessIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/SuccessIcon/successIcon";
 import { KeyValuePairsProps } from "@databiosphere/findable-ui/lib/components/common/KeyValuePairs/keyValuePairs";
-import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
-import { ChipProps, LinkProps } from "@mui/material";
+import { LinkProps } from "@mui/material";
 import { CellContext } from "@tanstack/react-table";
 import { formatDistanceToNowStrict } from "date-fns";
 import { getRouteURL } from "../../../common/utils";
 import { getPartialCellContext } from "../../../components/Table/components/utils";
 import { ROUTE } from "../../../routes/constants";
+import { ValidationSummaryCellProps } from "../components/Table/components/TableCell/components/ValidationSummaryCell/types";
 import { MetadataEntrySheet } from "../entities";
 
 /**
@@ -92,14 +90,17 @@ export function buildPublicationString(
  */
 export function buildValidationSummary(
   cellContext: CellContext<MetadataEntrySheet, unknown>
-): CellContext<MetadataEntrySheet, ChipProps> {
+): CellContext<MetadataEntrySheet, ValidationSummaryCellProps> {
   const { row } = cellContext;
-  const { validationSummary } = row.original;
-  const { error_count } = validationSummary;
+  const {
+    atlasId,
+    id: entrySheetValidationId,
+    validationSummary,
+  } = row.original;
+  const { error_count: errorCount } = validationSummary;
   return getPartialCellContext({
-    color: error_count ? CHIP_PROPS.COLOR.ERROR : CHIP_PROPS.COLOR.SUCCESS,
-    icon: error_count ? ErrorIcon({}) : SuccessIcon({}),
-    label: error_count ? `${error_count} errors` : "Valid",
-    variant: CHIP_PROPS.VARIANT.STATUS,
+    atlasId,
+    entrySheetValidationId,
+    errorCount,
   });
 }

--- a/app/views/AtlasMetadataEntrySheetsView/components/Table/components/TableCell/components/ValidationSummaryCell/types.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/components/Table/components/TableCell/components/ValidationSummaryCell/types.ts
@@ -1,0 +1,10 @@
+import {
+  AtlasId,
+  EntrySheetValidationId,
+} from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
+
+export interface ValidationSummaryCellProps {
+  atlasId: AtlasId;
+  entrySheetValidationId: EntrySheetValidationId;
+  errorCount: number;
+}

--- a/app/views/AtlasMetadataEntrySheetsView/components/Table/components/TableCell/components/ValidationSummaryCell/utils.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/components/Table/components/TableCell/components/ValidationSummaryCell/utils.ts
@@ -1,0 +1,52 @@
+import { ErrorIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/ErrorIcon/errorIcon";
+import { SuccessIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/SuccessIcon/successIcon";
+import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
+import { ChipProps } from "@mui/material";
+
+/**
+ * Returns the color for the MuiChip component.
+ * @param errorCount - Error count.
+ * @returns Chip color.
+ */
+export function getErrorCountColor(errorCount: number): ChipProps["color"] {
+  switch (errorCount) {
+    case 0:
+      return CHIP_PROPS.COLOR.SUCCESS;
+    case 1:
+      return CHIP_PROPS.COLOR.WARNING;
+    default:
+      return CHIP_PROPS.COLOR.ERROR;
+  }
+}
+
+/**
+ * Returns the label for the MuiChip component.
+ * @param errorCount - Error count.
+ * @returns Chip label.
+ */
+export function getErrorCountLabel(errorCount: number): ChipProps["label"] {
+  switch (errorCount) {
+    case 0:
+      return "Valid";
+    case 1:
+      return `${errorCount} error`;
+    default:
+      return `${errorCount} errors`;
+  }
+}
+
+/**
+ * Returns the icon for the MuiChip component.
+ * @param errorCount - Error count.
+ * @returns Chip icon.
+ */
+export function getErrorCountIcon(errorCount: number): ChipProps["icon"] {
+  switch (errorCount) {
+    case 0:
+      return SuccessIcon({});
+    case 1:
+      return ErrorIcon({});
+    default:
+      return ErrorIcon({});
+  }
+}

--- a/app/views/AtlasMetadataEntrySheetsView/components/Table/components/TableCell/components/ValidationSummaryCell/validationSummaryCell.tsx
+++ b/app/views/AtlasMetadataEntrySheetsView/components/Table/components/TableCell/components/ValidationSummaryCell/validationSummaryCell.tsx
@@ -1,0 +1,42 @@
+import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
+import { Chip, Grid, Link as MLink } from "@mui/material";
+import { CellContext } from "@tanstack/react-table";
+import Link from "next/link";
+import { ROUTE } from "../../../../../../../../routes/constants";
+import { MetadataEntrySheet } from "../../../../../../entities";
+import { ValidationSummaryCellProps } from "./types";
+import {
+  getErrorCountColor,
+  getErrorCountIcon,
+  getErrorCountLabel,
+} from "./utils";
+
+export const ValidationSummaryCell = ({
+  getValue,
+}: CellContext<
+  MetadataEntrySheet,
+  ValidationSummaryCellProps
+>): JSX.Element | null => {
+  const { atlasId, entrySheetValidationId, errorCount } = getValue();
+  return (
+    <Grid container direction="column" gap={1}>
+      <Chip
+        color={getErrorCountColor(errorCount)}
+        icon={getErrorCountIcon(errorCount)}
+        label={getErrorCountLabel(errorCount)}
+        variant={CHIP_PROPS.VARIANT.STATUS}
+      />
+      {errorCount > 0 && (
+        <MLink
+          component={Link}
+          href={{
+            pathname: ROUTE.METADATA_ENTRY_SHEET,
+            query: { atlasId, entrySheetValidationId },
+          }}
+        >
+          View Report
+        </MLink>
+      )}
+    </Grid>
+  );
+};

--- a/app/views/AtlasMetadataEntrySheetsView/entities.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/entities.ts
@@ -1,4 +1,5 @@
 import {
+  AtlasId,
   HCAAtlasTrackerAtlas,
   HCAAtlasTrackerListEntrySheetValidation,
 } from "../../apis/catalog/hca-atlas-tracker/common/entities";
@@ -10,5 +11,5 @@ export type EntityData = {
 
 export interface MetadataEntrySheet
   extends HCAAtlasTrackerListEntrySheetValidation {
-  atlasId: string;
+  atlasId: AtlasId;
 }

--- a/pages/atlases/[atlasId]/metadata-entry-sheets/[entrySheetValidationId]/index.tsx
+++ b/pages/atlases/[atlasId]/metadata-entry-sheets/[entrySheetValidationId]/index.tsx
@@ -1,0 +1,40 @@
+import { GetServerSideProps, GetServerSidePropsContext } from "next";
+import { ParsedUrlQuery } from "querystring";
+import {
+  AtlasId,
+  EntrySheetValidationId,
+} from "../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { PathParameter } from "../../../../../app/common/entities";
+import { AtlasMetadataEntrySheetValidationView } from "../../../../../app/views/AtlasMetadataEntrySheetValidationView/atlasMetadataEntrySheetValidationView";
+
+interface MetadataEntrySheetValidationPageUrlParams extends ParsedUrlQuery {
+  atlasId: AtlasId;
+  entrySheetValidationId: EntrySheetValidationId;
+}
+
+interface MetadataEntrySheetValidationPageProps {
+  pathParameter: PathParameter;
+}
+
+export const getServerSideProps: GetServerSideProps = async (
+  context: GetServerSidePropsContext
+) => {
+  const { atlasId, entrySheetValidationId } =
+    context.params as MetadataEntrySheetValidationPageUrlParams;
+  return {
+    props: {
+      pageTitle: "Metadata Entry Sheet Validation",
+      pathParameter: { atlasId, entrySheetValidationId },
+    },
+  };
+};
+
+const ViewMetadataEntrySheetValidationPage = ({
+  pathParameter,
+}: MetadataEntrySheetValidationPageProps): JSX.Element => {
+  return (
+    <AtlasMetadataEntrySheetValidationView pathParameter={pathParameter} />
+  );
+};
+
+export default ViewMetadataEntrySheetValidationPage;

--- a/pages/atlases/[atlasId]/metadata-entry-sheets/index.tsx
+++ b/pages/atlases/[atlasId]/metadata-entry-sheets/index.tsx
@@ -1,10 +1,11 @@
 import { GetServerSideProps, GetServerSidePropsContext } from "next";
 import { ParsedUrlQuery } from "querystring";
+import { AtlasId } from "../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { PathParameter } from "../../../../app/common/entities";
-import { AtlasMetadataEntrySheetView } from "../../../../app/views/AtlasMetadataEntrySheetsView/atlasMetadataEntrySheetsView";
+import { AtlasMetadataEntrySheetsView } from "../../../../app/views/AtlasMetadataEntrySheetsView/atlasMetadataEntrySheetsView";
 
 interface MetadataEntrySheetsPageUrlParams extends ParsedUrlQuery {
-  atlasId: string;
+  atlasId: AtlasId;
 }
 
 interface MetadataEntrySheetsPageProps {
@@ -26,7 +27,7 @@ export const getServerSideProps: GetServerSideProps = async (
 const ViewMetadataEntrySheetsPage = ({
   pathParameter,
 }: MetadataEntrySheetsPageProps): JSX.Element => {
-  return <AtlasMetadataEntrySheetView pathParameter={pathParameter} />;
+  return <AtlasMetadataEntrySheetsView pathParameter={pathParameter} />;
 };
 
 export default ViewMetadataEntrySheetsPage;


### PR DESCRIPTION
Closes #659.

<img width="1527" alt="image" src="https://github.com/user-attachments/assets/6ac62772-292f-4374-ac95-50937a2cbf82" />

This pull request introduces a new `AtlasMetadataEntrySheetValidationView` feature and includes changes across multiple files to support this functionality. Key updates include the addition of new APIs, types, and routes, enhancements to the `EntityView` component, and the implementation of the `ValidationReport` and `Actions` components. Below is a summary of the most important changes, grouped by theme:

### API and Type Updates
* Added new API endpoints for entry sheet validations in `API` enum (`ATLAS_ENTRY_SHEET`, `ATLAS_ENTRY_SHEETS`) in `app/apis/catalog/hca-atlas-tracker/common/api.ts`.
* Introduced a new type `EntrySheetValidationId` in `app/apis/catalog/hca-atlas-tracker/common/entities.ts`.
* Updated `PathParameter` to include `entrySheetValidationId` in `app/common/entities.ts`.

### Routing and Navigation
* Added new routes for metadata entry sheets in `ROUTE` constants (`METADATA_ENTRY_SHEET`, `METADATA_ENTRY_SHEETS`) in `app/routes/constants.ts`.

### Component Enhancements
* Enhanced `EntityView` to support optional dividers between sections via the `showDivider` property in `SectionConfig` and updated rendering logic in `entityView.tsx`. [[1]](diffhunk://#diff-dd7bae66da5d40d307c82a52c6d5d7ac0baaaf7dba6dd39c569c70d94fbf3278R10) [[2]](diffhunk://#diff-59ccb7c322d511972e9f6ab29b3a9b5c2d020cca6597e4ed1f7824f8036ae8b4L13-R17)
* Updated `StyledSection` to use a `div` instead of a `section`, and added a new `SectionHero` styled component in `section.styles.ts`. [[1]](diffhunk://#diff-18eaddc91352357ef241a6218fbdd35468b16af212614a0236a6d821bc1b7231L4-R8) [[2]](diffhunk://#diff-18eaddc91352357ef241a6218fbdd35468b16af212614a0236a6d821bc1b7231R25-R41)

### New Feature: AtlasMetadataEntrySheetValidationView
* Implemented the `AtlasMetadataEntrySheetValidationView` component, which includes logic for fetching and displaying entry sheet validation data, along with access control handling.
* Added configuration for `VIEW_METADATA_ENTRY_SHEET_SECTION_CONFIGS` to define sections for the view in `common/config.ts`.

### Validation Report and Actions Components
* Created `ValidationReport` components, including `Alert` and `EntityValidationReport`, with associated styles and constants for displaying validation errors. [[1]](diffhunk://#diff-ba56017eff7bca8df0f0aed1abc561aa4d55db1bccd41e3cb44210d806994150R1-R46) [[2]](diffhunk://#diff-97bb26dc65546ee4ceb681f21270cc610d69dd8499a79af57f9d1fd75f0a4844R1-R14) [[3]](diffhunk://#diff-40e9feddd43a825500c5528355ac3241f40b5e5dbc3d9317e30fb4d2af5ebb53R1-R18)
* Added `Actions` component with a button to open the Google Sheet for the entry sheet validation, including utility functions for URL generation. [[1]](diffhunk://#diff-dd14a439f1c5c9935d911e52ee097d6253c4617f8c9ec49045c257abc304ff2eR1-R39) [[2]](diffhunk://#diff-89043da2d7ff0f1244b5b213ab473edb56238ce650e33c4459d8493e6fb1c0ceR1-R32)

These changes collectively enable the new metadata entry sheet validation feature while improving the modularity and reusability of components across the codebase.