### PR TITLE
feat: add summary to metadata entry sheets (#682)

### DIFF
--- a/app/components/common/Paper/components/FluidPaper/fluidPaper.styles.ts
+++ b/app/components/common/Paper/components/FluidPaper/fluidPaper.styles.ts
@@ -1,0 +1,12 @@
+import { mediaTabletDown } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
+import styled from "@emotion/styled";
+import { RoundedPaper } from "../RoundedPaper/roundedPaper";
+
+export const StyledPaper = styled(RoundedPaper)`
+  ${mediaTabletDown} {
+    border-left: none;
+    border-radius: 0;
+    border-right: none;
+    box-shadow: none;
+  }
+`;

--- a/app/components/common/Paper/components/FluidPaper/fluidPaper.tsx
+++ b/app/components/common/Paper/components/FluidPaper/fluidPaper.tsx
@@ -1,0 +1,9 @@
+import { BaseComponentProps } from "@databiosphere/findable-ui/lib/components/types";
+import { PaperProps } from "@mui/material";
+import { StyledPaper } from "./fluidPaper.styles";
+
+export const FluidPaper = (
+  props: BaseComponentProps & PaperProps
+): JSX.Element => {
+  return <StyledPaper {...props} />;
+};

--- a/app/components/common/Paper/components/RoundedPaper/roundedPaper.styles.ts
+++ b/app/components/common/Paper/components/RoundedPaper/roundedPaper.styles.ts
@@ -1,0 +1,10 @@
+import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
+import styled from "@emotion/styled";
+import { Paper } from "@mui/material";
+
+export const StyledPaper = styled(Paper)`
+  align-self: stretch;
+  border: 1px solid ${PALETTE.SMOKE_MAIN};
+  border-radius: 8px;
+  overflow: hidden;
+`;

--- a/app/components/common/Paper/components/RoundedPaper/roundedPaper.tsx
+++ b/app/components/common/Paper/components/RoundedPaper/roundedPaper.tsx
@@ -1,0 +1,9 @@
+import { BaseComponentProps } from "@databiosphere/findable-ui/lib/components/types";
+import { PaperProps } from "@mui/material";
+import { StyledPaper } from "./roundedPaper.styles";
+
+export const RoundedPaper = (
+  props: BaseComponentProps & PaperProps
+): JSX.Element => {
+  return <StyledPaper {...props} />;
+};

--- a/app/views/AtlasMetadataEntrySheetsView/common/config.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/common/config.ts
@@ -1,6 +1,10 @@
 import { SectionConfig } from "../../../components/Entity/components/EntityView/components/Section/entities";
-import { METADATA_ENTRY_SHEETS_VIEW_TABLE } from "./constants";
+import {
+  METADATA_ENTRY_SHEETS_SUMMARY,
+  METADATA_ENTRY_SHEETS_VIEW_TABLE,
+} from "./constants";
 
 export const VIEW_METADATA_ENTRY_SHEETS_SECTION_CONFIGS: SectionConfig[] = [
+  METADATA_ENTRY_SHEETS_SUMMARY,
   METADATA_ENTRY_SHEETS_VIEW_TABLE,
 ];

--- a/app/views/AtlasMetadataEntrySheetsView/common/constants.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/common/constants.ts
@@ -1,7 +1,14 @@
 import { SORT_DIRECTION } from "@databiosphere/findable-ui/lib/config/entities";
 import { SectionConfig } from "../../../components/Entity/components/EntityView/components/Section/entities";
+import { Summary } from "../components/Summary/summary";
 import { Table } from "../components/Table/table";
 import { COLUMNS } from "./columns";
+
+export const METADATA_ENTRY_SHEETS_SUMMARY: SectionConfig<typeof Summary> = {
+  Component: Summary,
+  componentProps: {},
+  slotProps: { section: { fullWidth: true } },
+};
 
 export const METADATA_ENTRY_SHEETS_VIEW_TABLE: SectionConfig<typeof Table> = {
   Component: Table,

--- a/app/views/AtlasMetadataEntrySheetsView/components/Summary/constants.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/components/Summary/constants.ts
@@ -1,0 +1,15 @@
+import { SVG_ICON_PROPS as MUI_SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/svgIcon";
+import { SvgIconProps } from "@mui/material";
+import { EntrySheetValidationSummary } from "./entities";
+
+export const SUMMARY_KEY_VALUES: [keyof EntrySheetValidationSummary, string][] =
+  [
+    ["dataset_count", "Datasets"],
+    ["donor_count", "Donors"],
+    ["sample_count", "Samples"],
+    ["error_count", "Errors"],
+  ];
+
+export const SVG_ICON_PROPS: SvgIconProps = {
+  fontSize: MUI_SVG_ICON_PROPS.FONT_SIZE.XXSMALL,
+};

--- a/app/views/AtlasMetadataEntrySheetsView/components/Summary/entities.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/components/Summary/entities.ts
@@ -1,0 +1,4 @@
+import { HCAAtlasTrackerListEntrySheetValidation } from "../../../../apis/catalog/hca-atlas-tracker/common/entities";
+
+export type EntrySheetValidationSummary =
+  HCAAtlasTrackerListEntrySheetValidation["validationSummary"];

--- a/app/views/AtlasMetadataEntrySheetsView/components/Summary/summary.styles.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/components/Summary/summary.styles.ts
@@ -3,9 +3,11 @@ import { mediaTabletDown } from "@databiosphere/findable-ui/lib/styles/common/mi
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { Grid, Typography } from "@mui/material";
+import { EntrySheetValidationSummary } from "./entities";
 
 interface Props {
-  isError: boolean;
+  summaryCount: number;
+  summaryKey: keyof EntrySheetValidationSummary;
 }
 
 export const StyledGrid = styled(Grid)`
@@ -27,7 +29,7 @@ export const StyledGrid = styled(Grid)`
 `;
 
 export const StyledTypography = styled(Typography, {
-  shouldForwardProp: (prop) => prop !== "isError",
+  shouldForwardProp: (prop) => prop !== "summaryCount" && prop !== "summaryKey",
 })<Props>`
   align-items: center;
   display: grid;
@@ -35,9 +37,17 @@ export const StyledTypography = styled(Typography, {
   grid-auto-flow: column;
   justify-content: flex-start;
 
-  ${({ isError }) =>
-    isError &&
+  .MuiSvgIcon-root {
+    display: none;
+  }
+
+  ${({ summaryCount, summaryKey }) =>
+    summaryKey === "error_count" &&
     css`
-      color: ${PALETTE.ALERT_MAIN};
+      color: ${summaryCount > 0 ? PALETTE.ALERT_MAIN : PALETTE.SUCCESS_MAIN};
+
+      .MuiSvgIcon-root {
+        display: block;
+      }
     `}
 `;

--- a/app/views/AtlasMetadataEntrySheetsView/components/Summary/summary.styles.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/components/Summary/summary.styles.ts
@@ -1,0 +1,43 @@
+import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
+import { mediaTabletDown } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+import { Grid, Typography } from "@mui/material";
+
+interface Props {
+  isError: boolean;
+}
+
+export const StyledGrid = styled(Grid)`
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(4, 1fr);
+
+  .MuiPaper-root {
+    display: grid;
+    gap: 4px;
+    grid-template-rows: auto 1fr;
+    padding: 20px;
+  }
+
+  ${mediaTabletDown} {
+    grid-template-columns: repeat(2, 1fr);
+    padding: 0 16px;
+  }
+`;
+
+export const StyledTypography = styled(Typography, {
+  shouldForwardProp: (prop) => prop !== "isError",
+})<Props>`
+  align-items: center;
+  display: grid;
+  gap: 4px;
+  grid-auto-flow: column;
+  justify-content: flex-start;
+
+  ${({ isError }) =>
+    isError &&
+    css`
+      color: ${PALETTE.ALERT_MAIN};
+    `}
+`;

--- a/app/views/AtlasMetadataEntrySheetsView/components/Summary/summary.tsx
+++ b/app/views/AtlasMetadataEntrySheetsView/components/Summary/summary.tsx
@@ -1,0 +1,41 @@
+import { ErrorIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/ErrorIcon/errorIcon";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { Typography } from "@mui/material";
+import { RoundedPaper } from "../../../../components/common/Paper/components/RoundedPaper/roundedPaper";
+import { useEntity } from "../../../../providers/entity/hook";
+import { EntityData } from "../../entities";
+import { SUMMARY_KEY_VALUES, SVG_ICON_PROPS } from "./constants";
+import { StyledGrid, StyledTypography } from "./summary.styles";
+import { getValidationSummaryCounts } from "./utils";
+
+export const Summary = (): JSX.Element => {
+  const { data } = useEntity();
+  const { entrySheets = [] } = data as EntityData;
+  const summary = getValidationSummaryCounts(entrySheets);
+  return (
+    <StyledGrid>
+      {SUMMARY_KEY_VALUES.map(([key, value]) => {
+        const isErrorCount = key === "error_count";
+        return (
+          <RoundedPaper elevation={0} key={key}>
+            <Typography
+              color={TYPOGRAPHY_PROPS.COLOR.INK_LIGHT}
+              // TODO(cc) update heading variant with typography props
+              variant={"text-body-small-500"}
+            >
+              {value}
+            </Typography>
+            <StyledTypography
+              isError={isErrorCount}
+              // TODO(cc) update heading variant with typography props
+              variant={"text-heading"}
+            >
+              {summary[key]}
+              {isErrorCount && <ErrorIcon {...SVG_ICON_PROPS} />}
+            </StyledTypography>
+          </RoundedPaper>
+        );
+      })}
+    </StyledGrid>
+  );
+};

--- a/app/views/AtlasMetadataEntrySheetsView/components/Summary/summary.tsx
+++ b/app/views/AtlasMetadataEntrySheetsView/components/Summary/summary.tsx
@@ -1,4 +1,5 @@
 import { ErrorIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/ErrorIcon/errorIcon";
+import { SuccessIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/SuccessIcon/successIcon";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { Typography } from "@mui/material";
 import { RoundedPaper } from "../../../../components/common/Paper/components/RoundedPaper/roundedPaper";
@@ -15,7 +16,7 @@ export const Summary = (): JSX.Element => {
   return (
     <StyledGrid>
       {SUMMARY_KEY_VALUES.map(([key, value]) => {
-        const isErrorCount = key === "error_count";
+        const count = summary[key] ?? 0;
         return (
           <RoundedPaper elevation={0} key={key}>
             <Typography
@@ -26,12 +27,17 @@ export const Summary = (): JSX.Element => {
               {value}
             </Typography>
             <StyledTypography
-              isError={isErrorCount}
+              summaryCount={count}
+              summaryKey={key}
               // TODO(cc) update heading variant with typography props
               variant={"text-heading"}
             >
-              {summary[key]}
-              {isErrorCount && <ErrorIcon {...SVG_ICON_PROPS} />}
+              {count}
+              {count > 0 ? (
+                <ErrorIcon {...SVG_ICON_PROPS} />
+              ) : (
+                <SuccessIcon {...SVG_ICON_PROPS} />
+              )}
             </StyledTypography>
           </RoundedPaper>
         );

--- a/app/views/AtlasMetadataEntrySheetsView/components/Summary/utils.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/components/Summary/utils.ts
@@ -1,0 +1,22 @@
+import { MetadataEntrySheet } from "../../entities";
+import { EntrySheetValidationSummary } from "./entities";
+
+/**
+ * Returns the validation summary counts for the given entry sheets.
+ * @param entrySheets - Entry sheets.
+ * @returns Validation summary counts.
+ */
+export function getValidationSummaryCounts(
+  entrySheets: MetadataEntrySheet[]
+): EntrySheetValidationSummary {
+  return entrySheets.reduce(
+    (acc, entrySheet) => {
+      acc.dataset_count += entrySheet.validationSummary?.dataset_count || 0;
+      acc.donor_count += entrySheet.validationSummary?.donor_count || 0;
+      acc.error_count += entrySheet.validationSummary?.error_count || 0;
+      acc.sample_count += entrySheet.validationSummary?.sample_count || 0;
+      return acc;
+    },
+    { dataset_count: 0, donor_count: 0, error_count: 0, sample_count: 0 }
+  );
+}

--- a/app/views/AtlasMetadataEntrySheetsView/components/Table/table.tsx
+++ b/app/views/AtlasMetadataEntrySheetsView/components/Table/table.tsx
@@ -1,8 +1,6 @@
-import {
-  FluidPaper,
-  GridPaper,
-} from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
+import { GridPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
 import { useReactTable } from "@tanstack/react-table";
+import { FluidPaper } from "../../../../components/common/Paper/components/FluidPaper/fluidPaper";
 import { Table as CommonTable } from "../../../../components/Entity/components/common/Table/table";
 import { CORE_OPTIONS } from "../../../../components/Table/options/core/constants";
 import { SORTING_OPTIONS } from "../../../../components/Table/options/sorting/constants";
@@ -24,7 +22,7 @@ export const Table = (props: Props): JSX.Element => {
   });
 
   return (
-    <FluidPaper variant="table">
+    <FluidPaper elevation={0}>
       <GridPaper>
         <CommonTable table={table} />
       </GridPaper>


### PR DESCRIPTION
Closes #682.

This pull request introduces reusable styled components for `Paper` elements and integrates a new `Summary` component into the `AtlasMetadataEntrySheetsView`. The changes improve code modularity, reusability, and the visual presentation of metadata summaries.

### Reusable Styled Components for `Paper` Elements:
* Added `RoundedPaper` and `FluidPaper` components with custom styles for consistent UI elements. These components are now used in various parts of the application. (`fluidPaper.styles.ts` - [[1]](diffhunk://#diff-d43f85b88d9b96992adc1430a6514bd16f986d14a4cb487b28a399bb3ef568ecR1-R12) `fluidPaper.tsx` - [[2]](diffhunk://#diff-efc6a0fa9947624245fd603f0cad4d92bb1d59543777973f5626118c1a23cb74R1-R9) `roundedPaper.styles.ts` - [[3]](diffhunk://#diff-2610e590c09eaf9f254565a1c4993a56ea51c81e7a3b2e306cf2d40c47817f24R1-R10) `roundedPaper.tsx` - [[4]](diffhunk://#diff-91258ed3e9c13acfe92180508a30ee0b8abfc03d9421b33ac49b7984fdb4cb4bR1-R9)
* Updated `Table` component to use the new `FluidPaper` component for styling. (`table.tsx` - [[1]](diffhunk://#diff-133e1df9b1a4e32666c685eddd5fc55ff61c2cc14f2cdb23a9db907c5eb4ac7eL1-R3) [[2]](diffhunk://#diff-133e1df9b1a4e32666c685eddd5fc55ff61c2cc14f2cdb23a9db907c5eb4ac7eL27-R25)

### Integration of `Summary` Component:
* Introduced a `Summary` component to display validation summaries (e.g., dataset, donor, sample, and error counts) in a grid layout. (`summary.tsx` - [app/views/AtlasMetadataEntrySheetsView/components/Summary/summary.tsxR1-R41](diffhunk://#diff-bb2cd5b65f79d9e8376c4d57024ac76ba702c81ad651db4c0733b18401d7b2caR1-R41))
* Added supporting utilities and constants for the `Summary` component, including `SUMMARY_KEY_VALUES` and a helper function to calculate validation counts. (`constants.ts` - [[1]](diffhunk://#diff-1ba35e2f3e4b3c9a1efe418922968d4c580501206b4a7f11893ed69305233ceaR1-R15) `utils.ts` - [[2]](diffhunk://#diff-1f85ff57c9e6e91269b3928f943cdc6dce330cba82a63e54c3cbd4a4adf9874eR1-R22)
* Defined styles for the `Summary` component, including error-specific styling. (`summary.styles.ts` - [app/views/AtlasMetadataEntrySheetsView/components/Summary/summary.styles.tsR1-R43](diffhunk://#diff-23e6e0f05ee24eb468acd67f31ebda87437d5bd71e5d2dd430f2f2b5ad7ed66eR1-R43))

### Configuration Updates:
* Added `METADATA_ENTRY_SHEETS_SUMMARY` to the `VIEW_METADATA_ENTRY_SHEETS_SECTION_CONFIGS` for rendering the new `Summary` component in the metadata entry sheets view. (`config.ts` - [[1]](diffhunk://#diff-09005763dd2786a6daa80a3ef65e42e0ba5d3b2e4d06420e6f9d63b77226e223L2-R8) `constants.ts` - [[2]](diffhunk://#diff-3c96707a775b2965a9cef4bdcdf08368d41618246cf197ff2e9ac2b71bd5fe6aR3-R12)

<img width="1258" alt="image" src="https://github.com/user-attachments/assets/f2a91f8b-d235-4021-a874-db96a09595b0" />
