### PR TITLE
feat: add alert to metadata entry sheets (#683)

### DIFF
--- a/app/components/common/Button/components/ButtonLink/buttonLink.tsx
+++ b/app/components/common/Button/components/ButtonLink/buttonLink.tsx
@@ -1,3 +1,4 @@
+import { LinkProps } from "next/link";
 import { ReactNode } from "react";
 import { Button, StartIcon } from "./buttonLink.styles";
 
@@ -15,7 +16,7 @@ export interface ButtonLinkProps {
   className?: string;
   color?: BUTTON_COLOR;
   disabled?: boolean;
-  href: string;
+  href: string | LinkProps["href"];
   startIcon?: ReactNode;
 }
 

--- a/app/views/AtlasMetadataEntrySheetsView/atlasMetadataEntrySheetsView.tsx
+++ b/app/views/AtlasMetadataEntrySheetsView/atlasMetadataEntrySheetsView.tsx
@@ -31,7 +31,11 @@ export const AtlasMetadataEntrySheetsView = ({
     access: { canView },
   } = formManager;
   return (
-    <EntityProvider data={{ atlas, entrySheets }} formManager={formManager}>
+    <EntityProvider
+      data={{ atlas, entrySheets }}
+      formManager={formManager}
+      pathParameter={pathParameter}
+    >
       <ConditionalComponent isIn={shouldRenderView(canView, Boolean(atlas))}>
         <DetailView
           breadcrumbs={

--- a/app/views/AtlasMetadataEntrySheetsView/common/config.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/common/config.ts
@@ -1,10 +1,12 @@
 import { SectionConfig } from "../../../components/Entity/components/EntityView/components/Section/entities";
 import {
+  METADATA_ENTRY_SHEETS_INFO,
   METADATA_ENTRY_SHEETS_SUMMARY,
   METADATA_ENTRY_SHEETS_VIEW_TABLE,
 } from "./constants";
 
 export const VIEW_METADATA_ENTRY_SHEETS_SECTION_CONFIGS: SectionConfig[] = [
+  METADATA_ENTRY_SHEETS_INFO,
   METADATA_ENTRY_SHEETS_SUMMARY,
   METADATA_ENTRY_SHEETS_VIEW_TABLE,
 ];

--- a/app/views/AtlasMetadataEntrySheetsView/common/constants.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/common/constants.ts
@@ -1,8 +1,15 @@
 import { SORT_DIRECTION } from "@databiosphere/findable-ui/lib/config/entities";
 import { SectionConfig } from "../../../components/Entity/components/EntityView/components/Section/entities";
+import { Alert } from "../components/Alert/alert";
 import { Summary } from "../components/Summary/summary";
 import { Table } from "../components/Table/table";
 import { COLUMNS } from "./columns";
+
+export const METADATA_ENTRY_SHEETS_INFO: SectionConfig<typeof Alert> = {
+  Component: Alert,
+  componentProps: {},
+  slotProps: { section: { fullWidth: true } },
+};
 
 export const METADATA_ENTRY_SHEETS_SUMMARY: SectionConfig<typeof Summary> = {
   Component: Summary,

--- a/app/views/AtlasMetadataEntrySheetsView/components/Alert/alert.styles.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/components/Alert/alert.styles.ts
@@ -1,0 +1,39 @@
+import { mediaTabletDown } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
+import { textBody4002Lines } from "@databiosphere/findable-ui/lib/styles/common/mixins/fonts";
+import styled from "@emotion/styled";
+import { Alert } from "@mui/material";
+
+export const StyledAlert = styled(Alert)`
+  display: grid;
+  gap: 16px 0;
+  grid-template-columns: auto 1fr;
+
+  .MuiAlert-icon {
+    position: relative;
+    top: 2px;
+  }
+
+  .MuiAlert-message {
+    ${textBody4002Lines};
+
+    .MuiAlertTitle-root {
+      font-size: 16px;
+      line-height: 24px;
+    }
+  }
+
+  .MuiAlert-action {
+    grid-column: 2;
+    margin: 0;
+    padding: 0;
+
+    a {
+      background-color: transparent;
+      padding: 10px 16px;
+    }
+  }
+
+  ${mediaTabletDown} {
+    margin: 0 16px;
+  }
+`;

--- a/app/views/AtlasMetadataEntrySheetsView/components/Alert/alert.tsx
+++ b/app/views/AtlasMetadataEntrySheetsView/components/Alert/alert.tsx
@@ -1,0 +1,33 @@
+import { ALERT_PROPS } from "@databiosphere/findable-ui/lib/components/common/Alert/constants";
+import { AlertTitle } from "@mui/material";
+import {
+  BUTTON_COLOR,
+  ButtonLink,
+} from "../../../../components/common/Button/components/ButtonLink/buttonLink";
+import { useEntity } from "../../../../providers/entity/hook";
+import { ROUTE } from "../../../../routes/constants";
+import { StyledAlert } from "./alert.styles";
+
+export const Alert = (): JSX.Element => {
+  const { pathParameter } = useEntity();
+  return (
+    <StyledAlert
+      {...ALERT_PROPS.STANDARD_INFO}
+      action={
+        <ButtonLink
+          color={BUTTON_COLOR.SECONDARY}
+          href={{
+            pathname: ROUTE.SOURCE_STUDIES,
+            query: { atlasId: pathParameter?.atlasId },
+          }}
+        >
+          Go to source studies
+        </ButtonLink>
+      }
+    >
+      <AlertTitle>Adding a new item to the list</AlertTitle>
+      To add a new sheet, open the related source study and add it there. It
+      will be added to the metadata entry list automatically.
+    </StyledAlert>
+  );
+};


### PR DESCRIPTION
Closes #683.

This pull request introduces updates to enhance the functionality and user experience of the `AtlasMetadataEntrySheetsView` and its related components. The key changes include improvements to the `ButtonLink` component, the addition of a new `Alert` component, and updates to the metadata entry sheets configuration.

### Updates to `ButtonLink` Component:

* Modified the `href` property in `ButtonLinkProps` to accept both `string` and `LinkProps["href"]`, improving flexibility when defining link destinations. (`app/components/common/Button/components/ButtonLink/buttonLink.tsx`, [app/components/common/Button/components/ButtonLink/buttonLink.tsxL18-R19](diffhunk://#diff-21dc7aa6064fc16c275916ec2c1e821ca0d4734500b243788be41d405db078dfL18-R19))

### Addition of `Alert` Component:

* Introduced a new `Alert` component with styled properties and an action button linking to the source studies route. This includes:
  - A styled implementation in `alert.styles.ts` for consistent design. (`app/views/AtlasMetadataEntrySheetsView/components/Alert/alert.styles.ts`, [app/views/AtlasMetadataEntrySheetsView/components/Alert/alert.styles.tsR1-R39](diffhunk://#diff-1244c472fbff1d00c2b21cbf0fc5e56923bbc4e3c7e74d390d9dbab1fe7b721dR1-R39))
  - The functional component `Alert` that uses `ButtonLink` for navigation and displays a message with a title. (`app/views/AtlasMetadataEntrySheetsView/components/Alert/alert.tsx`, [app/views/AtlasMetadataEntrySheetsView/components/Alert/alert.tsxR1-R33](diffhunk://#diff-f4239173c86d73d2e181a93ee4c019cf9c65c76cc845a08197cd03c117a8fb53R1-R33))

### Metadata Entry Sheets Configuration:

* Added a new metadata section configuration, `METADATA_ENTRY_SHEETS_INFO`, which uses the newly created `Alert` component for displaying information. (`app/views/AtlasMetadataEntrySheetsView/common/constants.ts`, [app/views/AtlasMetadataEntrySheetsView/common/constants.tsR3-R13](diffhunk://#diff-3c96707a775b2965a9cef4bdcdf08368d41618246cf197ff2e9ac2b71bd5fe6aR3-R13))
* Updated the `VIEW_METADATA_ENTRY_SHEETS_SECTION_CONFIGS` array to include the new `METADATA_ENTRY_SHEETS_INFO` configuration. (`app/views/AtlasMetadataEntrySheetsView/common/config.ts`, [app/views/AtlasMetadataEntrySheetsView/common/config.tsR3-R9](diffhunk://#diff-09005763dd2786a6daa80a3ef65e42e0ba5d3b2e4d06420e6f9d63b77226e223R3-R9))

### Updates to `AtlasMetadataEntrySheetsView`:

* Enhanced the `EntityProvider` in `AtlasMetadataEntrySheetsView` by adding a `pathParameter` prop, enabling better context management for the view. (`app/views/AtlasMetadataEntrySheetsView/atlasMetadataEntrySheetsView.tsx`, [app/views/AtlasMetadataEntrySheetsView/atlasMetadataEntrySheetsView.tsxL34-R38](diffhunk://#diff-67fc2ef7925ed4805c1c3d62a2034645507d90d9905c641d76d6fdc5e03b5f8cL34-R38))

<img width="1299" alt="image" src="https://github.com/user-attachments/assets/41086661-5ced-4765-997c-e3d104d35e21" />
