### PR TITLE
feat: add cell value to entry sheet validation report (#691)

### DIFF
--- a/app/utils/typeGuards.ts
+++ b/app/utils/typeGuards.ts
@@ -1,0 +1,8 @@
+/**
+ * Returns true if the value is a string, false otherwise.
+ * @param value - Value.
+ * @returns true if the value is a string, false otherwise.
+ */
+export function isValueString(value: unknown): value is string {
+  return typeof value === "string";
+}

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.tsx
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.tsx
@@ -1,6 +1,7 @@
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { Tooltip, Typography } from "@mui/material";
 import { Fragment } from "react";
+import { isValueString } from "../../../../../../utils/typeGuards";
 import { StyledAlert, StyledDot } from "./alert.styles";
 import { ALERT_PROPS } from "./constants";
 import { Props } from "./entities";
@@ -9,44 +10,61 @@ export const Alert = ({
   validationReport,
   ...props
 }: Props): JSX.Element | null => {
+  const {
+    cell,
+    column,
+    input: rawInput,
+    message,
+    primary_key,
+    row,
+  } = validationReport;
+  const input = rawInput ?? "";
   if (!validationReport.entity_type)
     return (
       <StyledAlert {...ALERT_PROPS} {...props}>
-        <Tooltip arrow title={validationReport.message}>
-          <Typography noWrap>{validationReport.message}</Typography>
+        <Tooltip arrow title={message}>
+          <Typography noWrap>{message}</Typography>
         </Tooltip>
       </StyledAlert>
     );
   return (
     <StyledAlert {...ALERT_PROPS} {...props}>
-      {validationReport.primary_key && (
+      {primary_key && (
         <Typography variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_500}>
-          {validationReport.primary_key?.replace(/^.*?:\s*/, "")}
+          {primary_key?.replace(/^.*?:\s*/, "")}
         </Typography>
       )}
-      {validationReport.column && (
+      {column && (
         <Fragment>
           <StyledDot />
-          <Tooltip arrow title={validationReport.column}>
-            <Typography noWrap>{validationReport.column}</Typography>
+          <Tooltip arrow title={column}>
+            <Typography noWrap>{column}</Typography>
+          </Tooltip>
+        </Fragment>
+      )}
+      {isValueString(input) && (
+        <Fragment>
+          <StyledDot />
+          <Tooltip arrow title={`Input is &quot;${input}&quot;`}>
+            <Typography noWrap>Input is &quot;{input}&quot;</Typography>
           </Tooltip>
         </Fragment>
       )}
       <Fragment>
         <StyledDot />
-        <Tooltip arrow title={validationReport.message}>
-          <Typography noWrap>{validationReport.message}</Typography>
+        <Tooltip arrow title={message}>
+          <Typography noWrap>{message}</Typography>
         </Tooltip>
       </Fragment>
-      {validationReport.cell ? (
+      {cell ? (
         <Fragment>
           <StyledDot />
-          <code>{validationReport.cell}</code>
+          <code>{cell}</code>
         </Fragment>
-      ) : validationReport.row ? (
+      ) : row ? (
         <Fragment>
           <StyledDot />
-          <code>row {validationReport.row + 1}</code>
+          <code>row {row + 1}</code>
         </Fragment>
       ) : null}
     </StyledAlert>


### PR DESCRIPTION
Closes #691.

This pull request introduces a utility function for type checking and refactors the `Alert` component in the validation report view to improve readability and maintainability. The changes include the addition of a type guard function and the restructuring of the `Alert` component to use destructured properties and conditional rendering.

### Utility Function Addition:

* [`app/utils/typeGuards.ts`](diffhunk://#diff-5d222fab26ffc9a83244f2e2376041fe753fd3309c5b2028ff017e2acadef9d1R1-R8): Added a new type guard function `isValueString` to check if a value is a string. This utility enhances type safety and simplifies conditional checks.

### Refactoring of `Alert` Component:

* `app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.tsx`: 
  - Imported the `isValueString` utility function to validate the `input` property.
  - Refactored the component to destructure `validationReport` properties (`cell`, `column`, `input`, `message`, `primary_key`, `row`) for improved code readability.
  - Added conditional rendering for `input` using the `isValueString` function, ensuring type-safe checks before displaying the input value. [[1]](diffhunk://#diff-ba56017eff7bca8df0f0aed1abc561aa4d55db1bccd41e3cb44210d806994150R4) [[2]](diffhunk://#diff-ba56017eff7bca8df0f0aed1abc561aa4d55db1bccd41e3cb44210d806994150R13-R67)

<img width="1145" height="806" alt="image" src="https://github.com/user-attachments/assets/8784c968-f601-4991-ba8b-430305d13dbf" />

<img width="1144" height="809" alt="image" src="https://github.com/user-attachments/assets/b0c924b7-17b7-4537-88e6-9a7576d746c1" />
