### PR TITLE
feat: add sync button to entry sheet validation view (#713)

### DIFF
--- a/app/apis/catalog/hca-atlas-tracker/common/api.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/api.ts
@@ -5,6 +5,7 @@ export enum API {
   ATLAS_COMPONENT_ATLAS_SOURCE_DATASETS = "/api/atlases/[atlasId]/component-atlases/[componentAtlasId]/source-datasets",
   ATLAS_COMPONENT_ATLASES = "/api/atlases/[atlasId]/component-atlases",
   ATLAS_ENTRY_SHEET = "/api/atlases/[atlasId]/entry-sheet-validations/[entrySheetValidationId]",
+  ATLAS_ENTRY_SHEET_SYNC = "/api/atlases/[atlasId]/entry-sheet-validations/[entrySheetValidationId]/sync",
   ATLAS_ENTRY_SHEETS = "/api/atlases/[atlasId]/entry-sheet-validations",
   ATLAS_ENTRY_SHEETS_SYNC = "/api/atlases/[atlasId]/entry-sheet-validations/sync",
   ATLAS_SOURCE_DATASET = "/api/atlases/[atlasId]/source-datasets/[sourceDatasetId]",

--- a/app/views/AtlasMetadataEntrySheetValidationView/atlasMetadataEntrySheetValidationView.tsx
+++ b/app/views/AtlasMetadataEntrySheetValidationView/atlasMetadataEntrySheetValidationView.tsx
@@ -14,6 +14,7 @@ import { useFormManager } from "../../hooks/useFormManager/useFormManager";
 import { EntityProvider } from "../../providers/entity/provider";
 import { VIEW_METADATA_ENTRY_SHEET_SECTION_CONFIGS } from "./common/config";
 import { Actions } from "./components/Actions/actions";
+import { useEntrySheetSync } from "./hooks/UseEntrySheetSync/hook";
 import { useFetchEntrySheetValidation } from "./hooks/useFetchEntrySheetValidations";
 import { renderSubTitle, renderTitle } from "./utils";
 
@@ -30,6 +31,7 @@ export const AtlasMetadataEntrySheetValidationView = ({
   const {
     access: { canView },
   } = formManager;
+  const syncInfo = useEntrySheetSync(pathParameter);
   return (
     <EntityProvider
       data={{ atlas, entrySheetValidation }}
@@ -39,7 +41,7 @@ export const AtlasMetadataEntrySheetValidationView = ({
         isIn={shouldRenderView(canView, Boolean(entrySheetValidation))}
       >
         <DetailView
-          actions={<Actions />}
+          actions={<Actions {...syncInfo} />}
           mainColumn={
             <EntityView
               accessFallback={renderAccessFallback(formManager)}

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/Actions/actions.tsx
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/Actions/actions.tsx
@@ -7,10 +7,16 @@ import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/b
 import { Button } from "@mui/material";
 import { useEntity } from "../../../../providers/entity/hook";
 import { EntityData } from "../../entities";
+import { UseEntrySheetSync } from "../../hooks/UseEntrySheetSync/types";
 import { HeroActions } from "./actions.styles";
 import { buildSheetsUrl } from "./utils";
 
-export const Actions = (): JSX.Element | null => {
+type Props = UseEntrySheetSync;
+
+export const Actions = ({
+  entrySheetSyncState,
+  onSyncEntrySheets,
+}: Props): JSX.Element | null => {
   const { data } = useEntity();
 
   // Coerce the entity data provided by EntityProvider to the EntityData type -- safe to assume that the data structure conforms to EntityData.
@@ -23,6 +29,15 @@ export const Actions = (): JSX.Element | null => {
 
   return (
     <HeroActions>
+      <Button
+        color={BUTTON_PROPS.COLOR.SECONDARY}
+        disabled={entrySheetSyncState.started}
+        onClick={onSyncEntrySheets}
+        size={BUTTON_PROPS.SIZE.MEDIUM}
+        variant={BUTTON_PROPS.VARIANT.CONTAINED}
+      >
+        {entrySheetSyncState.started ? "Sync started" : "Sync entry sheet"}
+      </Button>
       <Button
         color={BUTTON_PROPS.COLOR.PRIMARY}
         href={buildSheetsUrl(entrySheetId, null, null, null)}

--- a/app/views/AtlasMetadataEntrySheetValidationView/hooks/UseEntrySheetSync/hook.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/hooks/UseEntrySheetSync/hook.ts
@@ -1,0 +1,24 @@
+import { useCallback, useEffect, useState } from "react";
+import { PathParameter } from "../../../../common/entities";
+import { EntrySheetSyncState, UseEntrySheetSync } from "./types";
+import { startEntrySheetSync } from "./utils";
+
+export const useEntrySheetSync = (
+  pathParameter: PathParameter
+): UseEntrySheetSync => {
+  const [entrySheetSyncState, setEntrySheetSyncState] =
+    useState<EntrySheetSyncState>({ started: false });
+
+  const onSyncEntrySheets = useCallback(() => {
+    setEntrySheetSyncState({ started: true });
+    startEntrySheetSync(pathParameter).catch((error: unknown) => {
+      setEntrySheetSyncState({ error, started: true });
+    });
+  }, [pathParameter]);
+
+  useEffect(() => {
+    if (entrySheetSyncState.error) throw entrySheetSyncState.error;
+  }, [entrySheetSyncState]);
+
+  return { entrySheetSyncState, onSyncEntrySheets };
+};

--- a/app/views/AtlasMetadataEntrySheetValidationView/hooks/UseEntrySheetSync/types.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/hooks/UseEntrySheetSync/types.ts
@@ -1,0 +1,9 @@
+export interface EntrySheetSyncState {
+  error?: unknown;
+  started: boolean;
+}
+
+export interface UseEntrySheetSync {
+  entrySheetSyncState: EntrySheetSyncState;
+  onSyncEntrySheets: () => void;
+}

--- a/app/views/AtlasMetadataEntrySheetValidationView/hooks/UseEntrySheetSync/utils.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/hooks/UseEntrySheetSync/utils.ts
@@ -1,0 +1,31 @@
+import { getRequestURL } from "app/common/utils";
+import { API } from "../../../../apis/catalog/hca-atlas-tracker/common/api";
+import {
+  FETCH_STATUS,
+  METHOD,
+  PathParameter,
+} from "../../../../common/entities";
+
+/**
+ * Starts the sync process for an entry sheet validation.
+ * @param pathParameter - Path parameter.
+ * @returns Promise that resolves when the entry sheet sync process is started.
+ */
+export async function startEntrySheetSync(
+  pathParameter: PathParameter
+): Promise<void> {
+  const res = await fetch(
+    getRequestURL(API.ATLAS_ENTRY_SHEET_SYNC, pathParameter),
+    { method: METHOD.POST }
+  );
+  if (res.status !== FETCH_STATUS.ACCEPTED) {
+    const responseText = await res.text();
+    let responseError: unknown;
+    try {
+      responseError = new Error(JSON.parse(responseText).message);
+    } finally {
+      if (!responseError) responseError = new Error(responseText);
+    }
+    throw responseError;
+  }
+}

--- a/app/views/AtlasMetadataEntrySheetsView/atlasMetadataEntrySheetsView.tsx
+++ b/app/views/AtlasMetadataEntrySheetsView/atlasMetadataEntrySheetsView.tsx
@@ -17,7 +17,7 @@ import { useFormManager } from "../../hooks/useFormManager/useFormManager";
 import { EntityProvider } from "../../providers/entity/provider";
 import { VIEW_METADATA_ENTRY_SHEETS_SECTION_CONFIGS } from "./common/config";
 import { getBreadcrumbs } from "./common/utils";
-import { useEntrySheetSync } from "./hooks/UseEntrySheetSync/hook";
+import { useAtlasEntrySheetsSync } from "./hooks/UseEntrySheetSync/hook";
 import { useFetchEntrySheetsValidations } from "./hooks/useFetchEntrySheetValidations";
 
 interface AtlasMetadataEntrySheetsViewProps {
@@ -34,7 +34,7 @@ export const AtlasMetadataEntrySheetsView = ({
     access: { canView },
   } = formManager;
   const { entrySheetSyncState, onSyncEntrySheets } =
-    useEntrySheetSync(pathParameter);
+    useAtlasEntrySheetsSync(pathParameter);
   return (
     <EntityProvider
       data={{ atlas, entrySheets }}

--- a/app/views/AtlasMetadataEntrySheetsView/hooks/UseEntrySheetSync/hook.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/hooks/UseEntrySheetSync/hook.ts
@@ -1,17 +1,17 @@
 import { useCallback, useEffect, useState } from "react";
 import { PathParameter } from "../../../../common/entities";
-import { EntrySheetSyncState, UseEntrySheetSync } from "./types";
-import { startEntrySheetSync } from "./utils";
+import { AtlasEntrySheetsSyncState, UseAtlasEntrySheetsSync } from "./types";
+import { startAtlasEntrySheetsSync } from "./utils";
 
-export const useEntrySheetSync = (
+export const useAtlasEntrySheetsSync = (
   pathParameter: PathParameter
-): UseEntrySheetSync => {
+): UseAtlasEntrySheetsSync => {
   const [entrySheetSyncState, setEntrySheetSyncState] =
-    useState<EntrySheetSyncState>({ started: false });
+    useState<AtlasEntrySheetsSyncState>({ started: false });
 
   const onSyncEntrySheets = useCallback(() => {
     setEntrySheetSyncState({ started: true });
-    startEntrySheetSync(pathParameter).catch((error: unknown) => {
+    startAtlasEntrySheetsSync(pathParameter).catch((error: unknown) => {
       setEntrySheetSyncState({ error, started: true });
     });
   }, [pathParameter]);

--- a/app/views/AtlasMetadataEntrySheetsView/hooks/UseEntrySheetSync/types.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/hooks/UseEntrySheetSync/types.ts
@@ -1,9 +1,9 @@
-export interface EntrySheetSyncState {
+export interface AtlasEntrySheetsSyncState {
   error?: unknown;
   started: boolean;
 }
 
-export interface UseEntrySheetSync {
-  entrySheetSyncState: EntrySheetSyncState;
+export interface UseAtlasEntrySheetsSync {
+  entrySheetSyncState: AtlasEntrySheetsSyncState;
   onSyncEntrySheets: () => void;
 }

--- a/app/views/AtlasMetadataEntrySheetsView/hooks/UseEntrySheetSync/utils.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/hooks/UseEntrySheetSync/utils.ts
@@ -7,11 +7,11 @@ import {
 } from "../../../../common/entities";
 
 /**
- * Starts the entry sheet sync process.
+ * Starts the entry sheets sync process for an atlas.
  * @param pathParameter - Path parameter.
  * @returns Promise that resolves when the entry sheet sync process is started.
  */
-export async function startEntrySheetSync(
+export async function startAtlasEntrySheetsSync(
   pathParameter: PathParameter
 ): Promise<void> {
   const res = await fetch(


### PR DESCRIPTION
Closes #713

Note: I renamed some existing things from the atlas entry sheets sync to avoid ambiguity