### PR TITLE
feat: update metadata entry sheet validation report (#720)

### DIFF
--- a/app/components/Entity/components/EntityView/components/Section/section.styles.ts
+++ b/app/components/Entity/components/EntityView/components/Section/section.styles.ts
@@ -22,20 +22,3 @@ export const StyledSection = styled.div<Props>`
       grid-template-columns: 1fr;
     `}
 `;
-
-export const SectionHero = styled.div<Props>`
-  display: grid;
-  gap: 8px;
-  padding: 0 16px;
-
-  ${mediaTabletUp} {
-    grid-column: span 4;
-    padding: 0;
-
-    ${({ fullWidth }) =>
-      fullWidth &&
-      css`
-        grid-column: 1 / -1;
-      `}
-  }
-`;

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.styles.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.styles.ts
@@ -6,9 +6,10 @@ import { Alert } from "@mui/material";
 
 export const StyledAlert = styled(Alert)`
   align-items: center;
+  border-radius: 4px;
   cursor: pointer;
   gap: 24px;
-  padding: 12px 16px;
+  padding: 4px 16px;
 
   .MuiAlert-message {
     ${textBody400};

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entities.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entities.ts
@@ -1,7 +1,7 @@
 import { EntityType, ValidationErrorInfo } from "../../entities";
 
 export interface Props {
+  columnValidationReports: Map<string, ValidationErrorInfo[]>;
   entityType: EntityType | "entrySheet";
   entrySheetId: string;
-  validationReports: ValidationErrorInfo[];
 }

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entityValidationReport.styles.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entityValidationReport.styles.ts
@@ -1,11 +1,14 @@
 import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/components/FluidPaper/fluidPaper";
 import { sectionPadding } from "@databiosphere/findable-ui/lib/components/common/Section/section.styles";
+import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
 import { mediaTabletDown } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
 import styled from "@emotion/styled";
+import { Grid, Typography } from "@mui/material";
 
 export const StyledFluidPaper = styled(FluidPaper)`
-  ${sectionPadding};
-  display: block;
+  background-color: ${PALETTE.SMOKE_MAIN};
+  display: grid;
+  gap: 1px;
   grid-column: 1 / -1;
 
   ${mediaTabletDown} {
@@ -13,6 +16,22 @@ export const StyledFluidPaper = styled(FluidPaper)`
   }
 
   .MuiDivider-root {
-    margin: 16px 0;
+    margin: 12px 0;
   }
+
+  .MuiButton-textPrimary {
+    align-self: flex-start;
+    margin-top: 8px;
+    text-transform: none;
+  }
+`;
+
+export const StyledTypography = styled(Typography)`
+  ${sectionPadding};
+  background-color: ${PALETTE.COMMON_WHITE};
+` as typeof Typography;
+
+export const StyledGrid = styled(Grid)`
+  ${sectionPadding};
+  background-color: ${PALETTE.COMMON_WHITE};
 `;

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entityValidationReport.tsx
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entityValidationReport.tsx
@@ -5,61 +5,103 @@ import {
 } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/button";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
-import { Button, Divider, Grid, Typography } from "@mui/material";
+import { Button, Divider, Typography } from "@mui/material";
+import { Fragment, useMemo, useState } from "react";
 import { buildSheetsUrl } from "../../../../../../utils/google-sheets";
+import { COLUMN_KEY, MAX_REPORTS_TO_DISPLAY } from "../../constants";
 import { Alert } from "../Alert/alert";
 import { ENTITY_NAME, GRID_PROPS } from "./constants";
 import { Props } from "./entities";
-import { StyledFluidPaper } from "./entityValidationReport.styles";
+import {
+  StyledFluidPaper,
+  StyledGrid,
+  StyledTypography,
+} from "./entityValidationReport.styles";
+import { getEntityReportCount } from "./utils";
 
 export const EntityValidationReport = ({
+  columnValidationReports,
   entityType,
   entrySheetId,
-  validationReports,
 }: Props): JSX.Element => {
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({
+    [COLUMN_KEY.OTHER]: true, // "other" column is expanded by default
+  });
+  const entityCount = useMemo(
+    () => getEntityReportCount(columnValidationReports),
+    [columnValidationReports]
+  );
   return (
     <StyledFluidPaper elevation={0}>
-      <Typography
+      <StyledTypography
         component="h3"
         variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_500}
       >
-        {ENTITY_NAME[entityType]}
-      </Typography>
-      <Divider />
-      <Grid {...GRID_PROPS}>
-        <Typography variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_400}>
-          Errors found ({validationReports.length}):
-        </Typography>
-        {validationReports.map((validationReport, j) => {
-          return (
-            <Alert
-              key={j}
-              action={
-                <Button
-                  color={BUTTON_PROPS.COLOR.INHERIT}
-                  endIcon={<OpenInNewIcon />}
-                  variant={BUTTON_PROPS.VARIANT.TEXT}
+        {ENTITY_NAME[entityType]} ({entityCount})
+      </StyledTypography>
+      <StyledGrid {...GRID_PROPS}>
+        {[...columnValidationReports.entries()].map(
+          ([column, validationReports], j) => {
+            const isExpanded = expanded[column];
+            const reports = isExpanded
+              ? validationReports
+              : validationReports.slice(0, MAX_REPORTS_TO_DISPLAY);
+            const reportCount = validationReports.length;
+            return (
+              <Fragment key={j}>
+                {j > 0 && <Divider />}
+                <Typography
+                  component="div"
+                  gutterBottom
+                  variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_500}
                 >
-                  Open
-                </Button>
-              }
-              onClick={() => {
-                window.open(
-                  buildSheetsUrl(
-                    entrySheetId,
-                    validationReport.worksheet_id,
-                    validationReport.cell,
-                    validationReport.row
-                  ),
-                  ANCHOR_TARGET.BLANK,
-                  REL_ATTRIBUTE.NO_OPENER_NO_REFERRER
-                );
-              }}
-              validationReport={validationReport}
-            />
-          );
-        })}
-      </Grid>
+                  {column === COLUMN_KEY.OTHER ? "Other errors" : column} (
+                  {reportCount})
+                </Typography>
+                {reports.map((report, k) => (
+                  <Alert
+                    key={k}
+                    action={
+                      <Button
+                        color={BUTTON_PROPS.COLOR.INHERIT}
+                        endIcon={<OpenInNewIcon />}
+                        variant={BUTTON_PROPS.VARIANT.TEXT}
+                      >
+                        Open
+                      </Button>
+                    }
+                    onClick={() => {
+                      window.open(
+                        buildSheetsUrl(
+                          entrySheetId,
+                          report.worksheet_id,
+                          report.cell,
+                          report.row
+                        ),
+                        ANCHOR_TARGET.BLANK,
+                        REL_ATTRIBUTE.NO_OPENER_NO_REFERRER
+                      );
+                    }}
+                    validationReport={report}
+                  />
+                ))}
+                {column !== COLUMN_KEY.OTHER &&
+                  reportCount > MAX_REPORTS_TO_DISPLAY && (
+                    <Button
+                      color={BUTTON_PROPS.COLOR.PRIMARY}
+                      onClick={() =>
+                        setExpanded((e) => ({ ...e, [column]: !isExpanded }))
+                      }
+                      variant={BUTTON_PROPS.VARIANT.TEXT}
+                    >
+                      Show {isExpanded ? "less" : "more"}
+                    </Button>
+                  )}
+              </Fragment>
+            );
+          }
+        )}
+      </StyledGrid>
     </StyledFluidPaper>
   );
 };

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/utils.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/utils.ts
@@ -1,0 +1,15 @@
+import { ValidationErrorInfo } from "../../entities";
+
+/**
+ * Returns the total number of validation reports for an entity.
+ * @param columnValidationReports - Map of column to validation reports.
+ * @returns Total number of validation reports.
+ */
+export function getEntityReportCount(
+  columnValidationReports: Map<string, ValidationErrorInfo[]>
+): number {
+  return [...columnValidationReports.values()].reduce(
+    (acc, reports) => acc + reports.length,
+    0
+  );
+}

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/constants.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/constants.ts
@@ -1,0 +1,5 @@
+export const COLUMN_KEY = {
+  OTHER: "other",
+};
+
+export const MAX_REPORTS_TO_DISPLAY = 3;

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/validationReport.tsx
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/validationReport.tsx
@@ -1,7 +1,4 @@
-import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
-import { Typography } from "@mui/material";
 import { Fragment } from "react";
-import { SectionHero } from "../../../../components/Entity/components/EntityView/components/Section/section.styles";
 import { useEntity } from "../../../../providers/entity/hook";
 import { EntityData } from "../../entities";
 import { EntityValidationReport } from "./components/EntityValidationReport/entityValidationReport";
@@ -26,21 +23,13 @@ export const ValidationReport = (): JSX.Element | null => {
 
   return (
     <Fragment>
-      <SectionHero>
-        <Typography
-          component="h2"
-          variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_HEADING_XSMALL}
-        >
-          Validation Report
-        </Typography>
-      </SectionHero>
       {[...entityValidationReports].map(
         ([entityType, validationReports], i) => (
           <EntityValidationReport
             key={i}
+            columnValidationReports={validationReports}
             entityType={entityType}
             entrySheetId={entrySheetId}
-            validationReports={validationReports}
           />
         )
       )}


### PR DESCRIPTION
Closes #720.

This pull request focuses on improving the `EntityValidationReport` component by introducing column-based grouping for validation reports, enhancing the UI styling, and simplifying the codebase. The most notable changes include restructuring how validation reports are organized and displayed, adding new utility functions, and refining the component's styling for better user experience.

### Enhancements to validation report organization:

* Updated `EntityValidationReport` to group validation reports by column, with support for collapsing and expanding groups. Added logic to move small groups of reports into an "Other" category for better readability (`entityValidationReport.tsx`, `utils.ts`, [[1]](diffhunk://#diff-eda5f28a70e2dbc89b436107e937bf1069e36bfa6264f8be5a8f9410b7a59c76L8-R63) [[2]](diffhunk://#diff-4e74b942a5aa9215fd583bc04103fc5d598e877de6e06e83354d79af838ea478L30-R77).
* Introduced `COLUMN_KEY` and `MAX_REPORTS_TO_DISPLAY` constants to manage column grouping and display limits (`constants.ts`, [app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/constants.tsR1-R5](diffhunk://#diff-f6a001cacf4832ef9ed9830d1b2d6254fde5b7c369ad403ffa816528a727d4ecR1-R5)).
* Added a utility function `getEntityReportCount` to calculate the total number of validation reports for an entity (`utils.ts`, [app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/utils.tsR1-R15](diffhunk://#diff-bad378b2b7301dcce2a28735b4997f0b1c41c881755696200c6a1751fe9683a5R1-R15)).

### UI and styling improvements:

* Replaced `SectionHero` with a more compact and reusable `StyledTypography` and `StyledGrid` for displaying entity validation reports, improving visual consistency and reducing padding (`entityValidationReport.styles.ts`, [app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entityValidationReport.styles.tsR3-R37](diffhunk://#diff-40e9feddd43a825500c5528355ac3241f40b5e5dbc3d9317e30fb4d2af5ebb53R3-R37)).
* Adjusted the `StyledAlert` component to include a smaller padding and rounded borders for a more modern appearance (`alert.styles.ts`, [app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.styles.tsR9-R12](diffhunk://#diff-2a84770b303de9111789b3c77a6803384877e724a3cd013b152649168c8af718R9-R12)).

### Codebase simplifications:

* Removed the unused `validationReports` prop in favor of the new `columnValidationReports` map, streamlining the data structure used in `EntityValidationReport` (`entities.ts`, [app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entities.tsR4-L6](diffhunk://#diff-cb5a04a630d32a3a14d8550e4874d7bf0e7f739dcce7b4791c93fad1112266f2R4-L6)).
* Deleted the unused `SectionHero` component and its references, as it was no longer needed after the redesign (`validationReport.tsx`, [[1]](diffhunk://#diff-d5077bbc94a08bce73186a5dfee09b8634a6b18d9a04472fbc998429cdd9b3b2L1-L4) [[2]](diffhunk://#diff-d5077bbc94a08bce73186a5dfee09b8634a6b18d9a04472fbc998429cdd9b3b2L29-L43).

These changes collectively enhance the maintainability of the codebase and improve the user experience when interacting with validation reports.


<img width="1390" height="1121" alt="image" src="https://github.com/user-attachments/assets/88ee845c-c07d-42c4-addd-8cd299b017fb" />

<img width="1391" height="1150" alt="image" src="https://github.com/user-attachments/assets/05fe1539-e48d-4bf6-af46-202fac098aba" />
