### PR TITLE
feat: validation report - link column name to data dictionary (#723)

### DIFF
--- a/app/components/Detail/components/ViewAtlasSourceDatasets/constants.ts
+++ b/app/components/Detail/components/ViewAtlasSourceDatasets/constants.ts
@@ -4,6 +4,7 @@ import { HCAAtlasTrackerSourceDataset } from "../../../../apis/catalog/hca-atlas
 
 export const TABLE_OPTIONS: ListConfig<HCAAtlasTrackerSourceDataset>["tableOptions"] =
   {
+    getRowId: (row) => row.id,
     initialState: {
       columnVisibility: { [COLUMN_IDENTIFIER.ROW_POSITION]: true },
     },

--- a/app/components/Detail/components/ViewComponentAtlases/constants.ts
+++ b/app/components/Detail/components/ViewComponentAtlases/constants.ts
@@ -4,6 +4,7 @@ import { HCAAtlasTrackerComponentAtlas } from "../../../../apis/catalog/hca-atla
 
 export const TABLE_OPTIONS: ListConfig<HCAAtlasTrackerComponentAtlas>["tableOptions"] =
   {
+    getRowId: (row) => row.id,
     initialState: {
       columnVisibility: { [COLUMN_IDENTIFIER.ROW_POSITION]: true },
     },

--- a/app/components/Detail/components/ViewSourceDatasets/constants.ts
+++ b/app/components/Detail/components/ViewSourceDatasets/constants.ts
@@ -4,6 +4,7 @@ import { HCAAtlasTrackerSourceDataset } from "../../../../apis/catalog/hca-atlas
 
 export const TABLE_OPTIONS: ListConfig<HCAAtlasTrackerSourceDataset>["tableOptions"] =
   {
+    getRowId: (row) => row.id,
     initialState: {
       columnVisibility: { [COLUMN_IDENTIFIER.ROW_POSITION]: true },
     },

--- a/app/components/Detail/components/ViewSourceStudies/constants.ts
+++ b/app/components/Detail/components/ViewSourceStudies/constants.ts
@@ -4,6 +4,7 @@ import { HCAAtlasTrackerSourceStudy } from "../../../../apis/catalog/hca-atlas-t
 
 export const TABLE_OPTIONS: ListConfig<HCAAtlasTrackerSourceStudy>["tableOptions"] =
   {
+    getRowId: (row) => row.id,
     initialState: {
       columnVisibility: { [COLUMN_IDENTIFIER.ROW_POSITION]: true },
     },

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.styles.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.styles.ts
@@ -7,7 +7,6 @@ import { Alert } from "@mui/material";
 export const StyledAlert = styled(Alert)`
   align-items: center;
   border-radius: 4px;
-  cursor: pointer;
   gap: 24px;
   padding: 4px 16px;
 

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.tsx
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.tsx
@@ -1,5 +1,9 @@
+import {
+  ANCHOR_TARGET,
+  REL_ATTRIBUTE,
+} from "@databiosphere/findable-ui/lib/components/Links/common/entities";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
-import { Tooltip, Typography } from "@mui/material";
+import { Link, Tooltip, Typography } from "@mui/material";
 import { Fragment } from "react";
 import { isValueString } from "../../../../../../utils/typeGuards";
 import { StyledAlert, StyledDot } from "./alert.styles";
@@ -38,7 +42,15 @@ export const Alert = ({
         <Fragment>
           <StyledDot />
           <Tooltip arrow title={column}>
-            <Typography noWrap>{column}</Typography>
+            <Link
+              color="inherit"
+              href={`https://data.humancellatlas.dev.clevercanary.com/metadata/tier-1-schema-ann-data#${column}`}
+              onClick={(e) => e.stopPropagation()}
+              rel={REL_ATTRIBUTE.NO_OPENER_NO_REFERRER}
+              target={ANCHOR_TARGET.BLANK}
+            >
+              {column}
+            </Link>
           </Tooltip>
         </Fragment>
       )}

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entityValidationReport.tsx
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entityValidationReport.tsx
@@ -65,23 +65,23 @@ export const EntityValidationReport = ({
                       <Button
                         color={BUTTON_PROPS.COLOR.INHERIT}
                         endIcon={<OpenInNewIcon />}
+                        onClick={() => {
+                          window.open(
+                            buildSheetsUrl(
+                              entrySheetId,
+                              report.worksheet_id,
+                              report.cell,
+                              report.row
+                            ),
+                            ANCHOR_TARGET.BLANK,
+                            REL_ATTRIBUTE.NO_OPENER_NO_REFERRER
+                          );
+                        }}
                         variant={BUTTON_PROPS.VARIANT.TEXT}
                       >
                         Open
                       </Button>
                     }
-                    onClick={() => {
-                      window.open(
-                        buildSheetsUrl(
-                          entrySheetId,
-                          report.worksheet_id,
-                          report.cell,
-                          report.row
-                        ),
-                        ANCHOR_TARGET.BLANK,
-                        REL_ATTRIBUTE.NO_OPENER_NO_REFERRER
-                      );
-                    }}
                     validationReport={report}
                   />
                 ))}

--- a/app/views/AtlasMetadataEntrySheetsView/common/constants.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/common/constants.ts
@@ -22,6 +22,7 @@ export const METADATA_ENTRY_SHEETS_VIEW_TABLE: SectionConfig<typeof Table> = {
   componentProps: {
     tableOptions: {
       columns: COLUMNS,
+      getRowId: (row) => row.id,
       initialState: {
         sorting: [
           { desc: SORT_DIRECTION.ASCENDING, id: "publicationString" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "hca-atlas-tracker",
       "version": "1.24.0",
       "dependencies": {
-        "@databiosphere/findable-ui": "^38.2.0",
+        "@databiosphere/findable-ui": "^39.1.0",
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@hookform/resolvers": "^3.3.4",
@@ -1889,9 +1889,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "38.2.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-38.2.0.tgz",
-      "integrity": "sha512-NNnPRw0KGY2LhtTiV/8d83ENl/Iz7DmDqo+5iXPb2CnlHCEyJ7VIvon5fij0HZ655tpIbU5Ou8x61BPwlw9YYw==",
+      "version": "39.1.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-39.1.0.tgz",
+      "integrity": "sha512-4jCwf/uPHtAdSimJUGIkGt+6Sbm++Uw93tMYYvmRW8keTtIVztCf6qsVeV6WhuJvqE5uqirsQqf9JkXwhqXfOw==",
       "engines": {
         "node": "20.10.0"
       },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "migrate": "ts-node -O '{\"module\": \"commonjs\"}' ./scripts/migration-runner.ts -j ts"
   },
   "dependencies": {
-    "@databiosphere/findable-ui": "^38.2.0",
+    "@databiosphere/findable-ui": "^39.1.0",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@hookform/resolvers": "^3.3.4",


### PR DESCRIPTION
Closes #723.

This pull request introduces several updates across the codebase, focusing on improving table configurations, enhancing UI components, and updating dependencies. The most significant changes include adding `getRowId` to various table configurations, refactoring the `Alert` component to include clickable links, and upgrading the `@databiosphere/findable-ui` dependency.

### Table Configuration Enhancements:
* Added `getRowId` to the `TABLE_OPTIONS` in multiple files to standardize row identification for tables. (`app/components/Detail/components/ViewAtlasSourceDatasets/constants.ts`, `app/components/Detail/components/ViewComponentAtlases/constants.ts`, `app/components/Detail/components/ViewSourceDatasets/constants.ts`, `app/components/Detail/components/ViewSourceStudies/constants.ts`, `app/views/AtlasMetadataEntrySheetsView/common/constants.ts`) [[1]](diffhunk://#diff-f2a834f58ee5928424b2674b5c42d9a81816ec4a973857ea7467c2c9ce73ecefR7) [[2]](diffhunk://#diff-210684555d0a095eb05cf8813f25de2933f1df9f8c3058f4befdf8e350ba4b3dR7) [[3]](diffhunk://#diff-24930035ec067eda637648ac5f14156b9d7920ac216c35cc2c21800155e4531bR7) [[4]](diffhunk://#diff-3c96707a775b2965a9cef4bdcdf08368d41618246cf197ff2e9ac2b71bd5fe6aR25)

### UI Component Updates:
* Refactored the `Alert` component to replace plain text with clickable links, linking to metadata schema documentation. (`app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.tsx`) [[1]](diffhunk://#diff-ba56017eff7bca8df0f0aed1abc561aa4d55db1bccd41e3cb44210d806994150R1-R6) [[2]](diffhunk://#diff-ba56017eff7bca8df0f0aed1abc561aa4d55db1bccd41e3cb44210d806994150L41-R53)
* Removed the `cursor: pointer` style from the `StyledAlert` component to align with the updated behavior. (`app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.styles.ts`)
* Adjusted the `EntityValidationReport` component to fix the placement of the `Open` button's `variant` property. (`app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entityValidationReport.tsx`) [[1]](diffhunk://#diff-eda5f28a70e2dbc89b436107e937bf1069e36bfa6264f8be5a8f9410b7a59c76L68-L72) [[2]](diffhunk://#diff-eda5f28a70e2dbc89b436107e937bf1069e36bfa6264f8be5a8f9410b7a59c76R80-R84)

### Dependency Updates:
* Upgraded the `@databiosphere/findable-ui` dependency from version `^38.2.0` to `^39.1.0`. (`package.json`)

<img width="1351" height="780" alt="image" src="https://github.com/user-attachments/assets/34eaa1d4-7302-4bb3-b86f-14c3275543dc" />
