### PR TITLE
fix: update metadata report link to data dictionary tier 1 (#732)

### DIFF
--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.tsx
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.tsx
@@ -8,10 +8,11 @@ import { Fragment } from "react";
 import slugify from "slugify";
 import { isValueString } from "../../../../../../utils/typeGuards";
 import { StyledAlert, StyledDot } from "./alert.styles";
-import { ALERT_PROPS, METADATA_TIER_1_URL } from "./constants";
+import { ALERT_PROPS } from "./constants";
 import { Props } from "./entities";
 
 export const Alert = ({
+  metadataUrl,
   validationReport,
   ...props
 }: Props): JSX.Element | null => {
@@ -45,7 +46,7 @@ export const Alert = ({
           <Tooltip arrow title={column}>
             <Link
               color="inherit"
-              href={`${METADATA_TIER_1_URL}#${slugify(column)}`}
+              href={`${metadataUrl}#${slugify(column)}`}
               onClick={(e) => e.stopPropagation()}
               rel={REL_ATTRIBUTE.NO_OPENER_NO_REFERRER}
               target={ANCHOR_TARGET.BLANK}

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.tsx
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.tsx
@@ -5,9 +5,10 @@ import {
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { Link, Tooltip, Typography } from "@mui/material";
 import { Fragment } from "react";
+import slugify from "slugify";
 import { isValueString } from "../../../../../../utils/typeGuards";
 import { StyledAlert, StyledDot } from "./alert.styles";
-import { ALERT_PROPS } from "./constants";
+import { ALERT_PROPS, METADATA_TIER_1_URL } from "./constants";
 import { Props } from "./entities";
 
 export const Alert = ({
@@ -44,7 +45,7 @@ export const Alert = ({
           <Tooltip arrow title={column}>
             <Link
               color="inherit"
-              href={`https://data.humancellatlas.dev.clevercanary.com/metadata/tier-1-schema-ann-data#${column}`}
+              href={`${METADATA_TIER_1_URL}#${slugify(column)}`}
               onClick={(e) => e.stopPropagation()}
               rel={REL_ATTRIBUTE.NO_OPENER_NO_REFERRER}
               target={ANCHOR_TARGET.BLANK}

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/constants.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/constants.ts
@@ -10,6 +10,3 @@ export const ALERT_PROPS: Partial<AlertProps> = {
   severity: COLOR.ERROR,
   variant: VARIANT.STANDARD,
 };
-
-export const METADATA_TIER_1_URL =
-  "https://data.humancellatlas.dev.clevercanary.com/metadata/tier-1";

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/constants.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/constants.ts
@@ -10,3 +10,6 @@ export const ALERT_PROPS: Partial<AlertProps> = {
   severity: COLOR.ERROR,
   variant: VARIANT.STANDARD,
 };
+
+export const METADATA_TIER_1_URL =
+  "https://data.humancellatlas.dev.clevercanary.com/metadata/tier-1";

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/entities.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/entities.ts
@@ -2,5 +2,6 @@ import { AlertProps } from "@mui/material";
 import { ValidationErrorInfo } from "../../entities";
 
 export interface Props extends AlertProps {
+  metadataUrl: string;
   validationReport: ValidationErrorInfo;
 }

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entityValidationReport.tsx
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entityValidationReport.tsx
@@ -3,10 +3,12 @@ import {
   ANCHOR_TARGET,
   REL_ATTRIBUTE,
 } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
+import { useConfig } from "@databiosphere/findable-ui/lib/hooks/useConfig";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/button";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { Button, Divider, Typography } from "@mui/material";
 import { Fragment, useMemo, useState } from "react";
+import { SiteConfig } from "../../../../../../../site-config/common/entities";
 import { buildSheetsUrl } from "../../../../../../utils/google-sheets";
 import { COLUMN_KEY, MAX_REPORTS_TO_DISPLAY } from "../../constants";
 import { Alert } from "../Alert/alert";
@@ -31,6 +33,9 @@ export const EntityValidationReport = ({
     () => getEntityReportCount(columnValidationReports),
     [columnValidationReports]
   );
+  const { config } = useConfig();
+  const { portalURL } = config as SiteConfig;
+  const metadataUrl = `${portalURL}/metadata/tier-1`;
   return (
     <StyledFluidPaper elevation={0}>
       <StyledTypography
@@ -82,6 +87,7 @@ export const EntityValidationReport = ({
                         Open
                       </Button>
                     }
+                    metadataUrl={metadataUrl}
                     validationReport={report}
                   />
                 ))}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "remark-gfm": "^3.0.1",
         "remark-parse": "^10.0.2",
         "remark-rehype": "^10.1.0",
+        "slugify": "^1.6.6",
         "string-strip-html": "^13.4.8",
         "unified": "^10.1.2",
         "uuid": "8.3.2",
@@ -22066,6 +22067,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "remark-gfm": "^3.0.1",
     "remark-parse": "^10.0.2",
     "remark-rehype": "^10.1.0",
+    "slugify": "^1.6.6",
     "string-strip-html": "^13.4.8",
     "unified": "^10.1.2",
     "uuid": "8.3.2",


### PR DESCRIPTION
Closes #732.

This pull request introduces changes to improve the handling of metadata URLs in the `AtlasMetadataEntrySheetValidationView` component. The key updates include dynamically generating metadata URLs using the portal configuration, ensuring proper URL formatting with the `slugify` library, and passing the `metadataUrl` as a prop to the `Alert` component.

### Enhancements to metadata URL handling:

* [`app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entityValidationReport.tsx`](diffhunk://#diff-eda5f28a70e2dbc89b436107e937bf1069e36bfa6264f8be5a8f9410b7a59c76R6-R11): Integrated `useConfig` to retrieve the portal URL from the site configuration, constructed the `metadataUrl` dynamically, and passed it as a prop to the `Alert` component. [[1]](diffhunk://#diff-eda5f28a70e2dbc89b436107e937bf1069e36bfa6264f8be5a8f9410b7a59c76R6-R11) [[2]](diffhunk://#diff-eda5f28a70e2dbc89b436107e937bf1069e36bfa6264f8be5a8f9410b7a59c76R36-R38) [[3]](diffhunk://#diff-eda5f28a70e2dbc89b436107e937bf1069e36bfa6264f8be5a8f9410b7a59c76R90)

* [`app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.tsx`](diffhunk://#diff-ba56017eff7bca8df0f0aed1abc561aa4d55db1bccd41e3cb44210d806994150L47-R49): Updated the `href` attribute of the `Link` component to use the `metadataUrl` prop combined with a slugified column name for proper URL formatting.

### Code improvements:

* [`app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/entities.ts`](diffhunk://#diff-ff09ebe9aa23f5261840291181b87dc642bd59ea0cbb0482e0457e1bb3cdaac3R5): Added `metadataUrl` as a required property in the `Props` interface of the `Alert` component.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R51): Added the `slugify` library as a dependency to handle the creation of URL-friendly strings.