### PR TITLE
feat: metadata completeness heatmap (#729)

### DIFF
--- a/app/apis/catalog/hca-atlas-tracker/common/api.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/api.ts
@@ -8,6 +8,7 @@ export enum API {
   ATLAS_ENTRY_SHEET_SYNC = "/api/atlases/[atlasId]/entry-sheet-validations/[entrySheetValidationId]/sync",
   ATLAS_ENTRY_SHEETS = "/api/atlases/[atlasId]/entry-sheet-validations",
   ATLAS_ENTRY_SHEETS_SYNC = "/api/atlases/[atlasId]/entry-sheet-validations/sync",
+  ATLAS_METADATA_CORRECTNESS = "/api/atlases/[atlasId]/heatmap",
   ATLAS_SOURCE_DATASET = "/api/atlases/[atlasId]/source-datasets/[sourceDatasetId]",
   ATLAS_SOURCE_DATASETS = "/api/atlases/[atlasId]/source-datasets",
   ATLAS_SOURCE_STUDIES = "/api/atlases/[atlasId]/source-studies",

--- a/app/components/Entity/components/common/Table/components/TableCell/components/EllipsisCell/constants.ts
+++ b/app/components/Entity/components/common/Table/components/TableCell/components/EllipsisCell/constants.ts
@@ -1,0 +1,21 @@
+import { TooltipProps } from "@mui/material";
+
+export const TOOLTIP_PROPS: Partial<TooltipProps> = {
+  arrow: true,
+  disableInteractive: true,
+  slotProps: {
+    popper: {
+      modifiers: [
+        {
+          name: "offset",
+          options: { offset: [0, -4] },
+        },
+        {
+          name: "preventOverflow",
+          options: { padding: 8 },
+        },
+      ],
+    },
+    tooltip: { sx: { maxWidth: 196 } },
+  },
+};

--- a/app/components/Entity/components/common/Table/components/TableCell/components/EllipsisCell/ellipsisCell.tsx
+++ b/app/components/Entity/components/common/Table/components/TableCell/components/EllipsisCell/ellipsisCell.tsx
@@ -1,0 +1,22 @@
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { Tooltip, Typography } from "@mui/material";
+import { CellContext, RowData } from "@tanstack/react-table";
+import { TOOLTIP_PROPS } from "./constants";
+
+export const EllipsisCell = ({
+  getValue,
+}: CellContext<RowData, string>): JSX.Element | null => {
+  const value = getValue();
+  return (
+    <Tooltip {...TOOLTIP_PROPS} title={value}>
+      <Typography
+        color={TYPOGRAPHY_PROPS.COLOR.INHERIT}
+        component="span"
+        noWrap
+        variant={TYPOGRAPHY_PROPS.VARIANT.INHERIT}
+      >
+        {value}
+      </Typography>
+    </Tooltip>
+  );
+};

--- a/app/components/Entity/components/common/Table/table.tsx
+++ b/app/components/Entity/components/common/Table/table.tsx
@@ -10,6 +10,7 @@ import { getRowDirection } from "./utils";
 
 export const Table = <T extends RowData>({
   className,
+  gridTemplateColumns,
   table,
 }: Props<T>): JSX.Element => {
   const bp = useCurrentBreakpoint();
@@ -18,9 +19,10 @@ export const Table = <T extends RowData>({
     <TableContainer className={className}>
       <GridTable
         collapsable
-        gridTemplateColumns={getColumnTrackSizing(
-          table.getVisibleFlatColumns()
-        )}
+        gridTemplateColumns={
+          gridTemplateColumns ||
+          getColumnTrackSizing(table.getVisibleFlatColumns())
+        }
       >
         <TableHead tableInstance={table} />
         <TableBody rowDirection={rowDirection} tableInstance={table} />

--- a/app/components/Entity/components/common/Table/types.ts
+++ b/app/components/Entity/components/common/Table/types.ts
@@ -2,5 +2,6 @@ import { BaseComponentProps } from "@databiosphere/findable-ui/lib/components/ty
 import { RowData, Table } from "@tanstack/react-table";
 
 export interface Props<T extends RowData> extends BaseComponentProps {
+  gridTemplateColumns?: string;
   table: Table<T>;
 }

--- a/app/components/Table/options/visibility/constants.ts
+++ b/app/components/Table/options/visibility/constants.ts
@@ -1,0 +1,5 @@
+import { VisibilityOptions } from "@tanstack/react-table";
+
+export const VISIBILITY_OPTIONS: Pick<VisibilityOptions, "enableHiding"> = {
+  enableHiding: true,
+};

--- a/app/views/AtlasMetadataCorrectnessView/atlasMetadataCorrectnessView.tsx
+++ b/app/views/AtlasMetadataCorrectnessView/atlasMetadataCorrectnessView.tsx
@@ -2,14 +2,20 @@ import { Breadcrumbs } from "@databiosphere/findable-ui/lib/components/common/Br
 import { ConditionalComponent } from "@databiosphere/findable-ui/lib/components/ComponentCreator/components/ConditionalComponent/conditionalComponent";
 import { getAtlasName } from "../../apis/catalog/hca-atlas-tracker/common/utils";
 import { PathParameter } from "../../common/entities";
+import { AccessDeniedPrompt } from "../../components/common/Form/components/FormManager/components/AccessDeniedPrompt/accessDeniedPrompt";
+import { AccessPrompt } from "../../components/common/Form/components/FormManager/components/AccessPrompt/accessPrompt";
 import { shouldRenderView } from "../../components/Detail/common/utils";
 import { Tabs } from "../../components/Detail/components/ViewAtlas/components/Tabs/tabs";
-import { ViewAtlasMetadataCorrectness } from "../../components/Detail/components/ViewAtlasMetadataCorrectness/viewAtlasMetadataCorrectness";
+import { EntityView } from "../../components/Entity/components/EntityView/entityView";
 import { AtlasStatus } from "../../components/Layout/components/Detail/components/DetailViewHero/components/AtlasStatus/atlasStatus";
 import { DetailView } from "../../components/Layout/components/Detail/detailView";
 import { useFetchAtlas } from "../../hooks/useFetchAtlas";
+import { FormManager } from "../../hooks/useFormManager/common/entities";
 import { useFormManager } from "../../hooks/useFormManager/useFormManager";
+import { EntityProvider } from "../../providers/entity/provider";
+import { VIEW_METADATA_CORRECTNESS_SECTION_CONFIGS } from "./common/config";
 import { getBreadcrumbs } from "./common/utils";
+import { useFetchMetadataCorrectness } from "./hooks/useFetchMetadataCorrectness";
 
 interface AtlasMetadataCorrectnessView {
   pathParameter: PathParameter;
@@ -19,26 +25,43 @@ export const AtlasMetadataCorrectnessView = ({
   pathParameter,
 }: AtlasMetadataCorrectnessView): JSX.Element => {
   const { atlas } = useFetchAtlas(pathParameter);
+  const { heatmap } = useFetchMetadataCorrectness(pathParameter);
   const formManager = useFormManager();
   const {
     access: { canView },
   } = formManager;
   return (
-    <ConditionalComponent isIn={shouldRenderView(canView, Boolean(atlas))}>
-      <DetailView
-        breadcrumbs={
-          <Breadcrumbs breadcrumbs={getBreadcrumbs(pathParameter, atlas)} />
-        }
-        mainColumn={
-          <ViewAtlasMetadataCorrectness
-            atlas={atlas}
-            formManager={formManager}
-          />
-        }
-        status={atlas && <AtlasStatus atlasStatus={atlas.status} />}
-        tabs={<Tabs atlas={atlas} pathParameter={pathParameter} />}
-        title={atlas ? getAtlasName(atlas) : "View Integration Objects"}
-      />
-    </ConditionalComponent>
+    <EntityProvider data={{ atlas, heatmap }} formManager={formManager}>
+      <ConditionalComponent isIn={shouldRenderView(canView, Boolean(heatmap))}>
+        <DetailView
+          breadcrumbs={
+            <Breadcrumbs breadcrumbs={getBreadcrumbs(pathParameter, atlas)} />
+          }
+          mainColumn={
+            <EntityView
+              accessFallback={renderAccessFallback(formManager)}
+              sectionConfigs={VIEW_METADATA_CORRECTNESS_SECTION_CONFIGS}
+            />
+          }
+          status={atlas && <AtlasStatus atlasStatus={atlas.status} />}
+          tabs={<Tabs atlas={atlas} pathParameter={pathParameter} />}
+          title={atlas ? getAtlasName(atlas) : "View Metadata Correctness"}
+        />
+      </ConditionalComponent>
+    </EntityProvider>
   );
 };
+
+/**
+ * Returns the access fallback component from the form manager access state.
+ * @param formManager - Form manager.
+ * @returns access fallback component.
+ */
+function renderAccessFallback(formManager: FormManager): JSX.Element | null {
+  const {
+    access: { canEdit, canView },
+  } = formManager;
+  if (!canView) return <AccessPrompt text="to view the metadata correctness" />;
+  if (!canEdit) return <AccessDeniedPrompt />;
+  return null;
+}

--- a/app/views/AtlasMetadataCorrectnessView/common/config.ts
+++ b/app/views/AtlasMetadataCorrectnessView/common/config.ts
@@ -1,0 +1,6 @@
+import { SectionConfig } from "../../../components/Entity/components/EntityView/components/Section/entities";
+import { METADATA_CORRECTNESS_VIEW_TABLES } from "./constants";
+
+export const VIEW_METADATA_CORRECTNESS_SECTION_CONFIGS: SectionConfig[] = [
+  METADATA_CORRECTNESS_VIEW_TABLES,
+];

--- a/app/views/AtlasMetadataCorrectnessView/common/constants.ts
+++ b/app/views/AtlasMetadataCorrectnessView/common/constants.ts
@@ -1,0 +1,8 @@
+import { SectionConfig } from "../../../components/Entity/components/EntityView/components/Section/entities";
+import { Tables } from "../components/Tables/tables";
+
+export const METADATA_CORRECTNESS_VIEW_TABLES: SectionConfig<typeof Tables> = {
+  Component: Tables,
+  componentProps: {},
+  slotProps: { section: { fullWidth: true } },
+};

--- a/app/views/AtlasMetadataCorrectnessView/components/Table/components/TableCell/components/GraphValueCell/constants.ts
+++ b/app/views/AtlasMetadataCorrectnessView/components/Table/components/TableCell/components/GraphValueCell/constants.ts
@@ -1,0 +1,20 @@
+import { TooltipProps } from "@mui/material";
+
+export const TOOLTIP_PROPS: Partial<TooltipProps> = {
+  arrow: true,
+  disableInteractive: true,
+  slotProps: {
+    popper: {
+      modifiers: [
+        {
+          name: "offset",
+          options: { offset: [0, -4] },
+        },
+        {
+          name: "preventOverflow",
+          options: { padding: 8 },
+        },
+      ],
+    },
+  },
+};

--- a/app/views/AtlasMetadataCorrectnessView/components/Table/components/TableCell/components/GraphValueCell/graphValueCell.styles.ts
+++ b/app/views/AtlasMetadataCorrectnessView/components/Table/components/TableCell/components/GraphValueCell/graphValueCell.styles.ts
@@ -1,0 +1,13 @@
+import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
+import styled from "@emotion/styled";
+import { Box } from "@mui/material";
+
+export const StyledBox = styled(Box)`
+  align-items: center;
+  align-self: stretch;
+  color: ${PALETTE.COMMON_WHITE};
+  display: flex;
+  flex: 1;
+  justify-content: center;
+  padding: 8px 12px;
+`;

--- a/app/views/AtlasMetadataCorrectnessView/components/Table/components/TableCell/components/GraphValueCell/graphValueCell.tsx
+++ b/app/views/AtlasMetadataCorrectnessView/components/Table/components/TableCell/components/GraphValueCell/graphValueCell.tsx
@@ -1,0 +1,33 @@
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { Tooltip, Typography } from "@mui/material";
+import { CellContext } from "@tanstack/react-table";
+import { HeatmapEntrySheet } from "../../../../../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { TOOLTIP_PROPS } from "./constants";
+import { StyledBox } from "./graphValueCell.styles";
+import {
+  formatValue,
+  getGraphColor,
+  getGraphValues,
+  renderTooltipTitle,
+} from "./utils";
+
+export const GraphValueCell = (
+  cellContext: CellContext<HeatmapEntrySheet, number>
+): JSX.Element | null => {
+  const [value, numerator, denominator] = getGraphValues(cellContext);
+  return (
+    <StyledBox sx={{ backgroundColor: getGraphColor(value) }}>
+      <Tooltip
+        {...TOOLTIP_PROPS}
+        title={renderTooltipTitle(value, numerator, denominator)}
+      >
+        <Typography
+          color={TYPOGRAPHY_PROPS.COLOR.INHERIT}
+          variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_BODY_500}
+        >
+          {formatValue(value)}
+        </Typography>
+      </Tooltip>
+    </StyledBox>
+  );
+};

--- a/app/views/AtlasMetadataCorrectnessView/components/Table/components/TableCell/components/GraphValueCell/utils.ts
+++ b/app/views/AtlasMetadataCorrectnessView/components/Table/components/TableCell/components/GraphValueCell/utils.ts
@@ -1,0 +1,79 @@
+import { CellContext } from "@tanstack/react-table";
+import { HeatmapEntrySheet } from "../../../../../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
+
+/**
+ * Return a formatted value (rounded to 2 decimal places if necessary).
+ * @param value - Value.
+ * @returns Formatted value.
+ */
+export function formatValue(value: number): string {
+  return value % 1 === 0 ? value.toString() : value.toFixed(2);
+}
+
+/**
+ * Get the row count as a denominator from the given cell context.
+ * @param cellContext - Cell context.
+ * @returns Denominator.
+ */
+export function getDenominator(
+  cellContext: CellContext<HeatmapEntrySheet, number>
+): number {
+  return cellContext.row.original.correctness?.rowCount || 0;
+}
+
+/**
+ * Get the graph color for the given value.
+ * @param value - Value.
+ * @returns Graph color.
+ */
+export function getGraphColor(value: number): string {
+  if (value < 0.25) return `#BF0003`;
+  if (value < 0.75) return `#B14A0A`;
+  return `#257A24`;
+}
+
+/**
+ * Returns graph values tuple [value, numerator, denominator] from the given cell context.
+ * @param cellContext - Cell context.
+ * @returns Graph values tuple [value, numerator, denominator].
+ */
+export function getGraphValues(
+  cellContext: CellContext<HeatmapEntrySheet, number>
+): [number, number, number] {
+  const numerator = getNumerator(cellContext);
+  const denominator = getDenominator(cellContext);
+
+  if (denominator === 0) return [0, numerator, denominator];
+
+  const value = numerator / denominator;
+
+  return [value, numerator, denominator];
+}
+
+/**
+ * Get the correct count as a numerator from the given cell context.
+ * @param cellContext - Cell context.
+ * @returns Numerator.
+ */
+export function getNumerator(
+  cellContext: CellContext<HeatmapEntrySheet, number>
+): number {
+  return cellContext.getValue();
+}
+
+/**
+ * Render the tooltip title.
+ * @param value - Value.
+ * @param numerator - Numerator.
+ * @param denominator - Denominator.
+ * @returns Tooltip title.
+ */
+export function renderTooltipTitle(
+  value: number,
+  numerator: number,
+  denominator: number
+): string | null {
+  if (value === 1) return null;
+
+  return `collected: ${numerator} / ${denominator}`;
+}

--- a/app/views/AtlasMetadataCorrectnessView/components/Table/components/ToggleButtonGroup/constants.ts
+++ b/app/views/AtlasMetadataCorrectnessView/components/Table/components/ToggleButtonGroup/constants.ts
@@ -1,0 +1,7 @@
+import { View } from "../../hooks/useTable/entities";
+
+export const OPTIONS: Record<View, string> = {
+  organSpecific: "Organ Specific",
+  recommended: "Recommended",
+  required: "Required",
+};

--- a/app/views/AtlasMetadataCorrectnessView/components/Table/components/ToggleButtonGroup/entities.ts
+++ b/app/views/AtlasMetadataCorrectnessView/components/Table/components/ToggleButtonGroup/entities.ts
@@ -1,0 +1,5 @@
+import { Table } from "../../hooks/useTable/entities";
+
+export interface Props {
+  table: Table;
+}

--- a/app/views/AtlasMetadataCorrectnessView/components/Table/components/ToggleButtonGroup/toggleButtonGroup.styles.ts
+++ b/app/views/AtlasMetadataCorrectnessView/components/Table/components/ToggleButtonGroup/toggleButtonGroup.styles.ts
@@ -1,0 +1,15 @@
+import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
+import styled from "@emotion/styled";
+import { ToggleButtonGroup } from "@mui/material";
+
+export const StyledToggleButtonGroup = styled(ToggleButtonGroup)`
+  grid-auto-columns: auto;
+
+  .MuiToggleButton-root {
+    text-transform: none;
+
+    &:not(.Mui-selected) {
+      color: ${PALETTE.INK_LIGHT};
+    }
+  }
+`;

--- a/app/views/AtlasMetadataCorrectnessView/components/Table/components/ToggleButtonGroup/toggleButtonGroup.tsx
+++ b/app/views/AtlasMetadataCorrectnessView/components/Table/components/ToggleButtonGroup/toggleButtonGroup.tsx
@@ -1,0 +1,39 @@
+import { useToggleButtonGroup } from "@databiosphere/findable-ui/lib/components/common/ToggleButtonGroup/hooks/UseToggleButtonGroup/hook";
+import { ToggleButton } from "@mui/material";
+import { View } from "../../hooks/useTable/entities";
+import { OPTIONS } from "./constants";
+import { Props } from "./entities";
+import { StyledToggleButtonGroup } from "./toggleButtonGroup.styles";
+
+export const ToggleButtonGroup = ({ table }: Props): JSX.Element | null => {
+  const { options } = table;
+  const { meta } = options;
+  const { viewVisibilityState } = meta || {};
+
+  // Each entry in the viewVisibilityState is a view type (required, recommended, organSpecific).
+  const values: View[] = [...viewVisibilityState.keys()];
+
+  // Initialize the toggle button group with the first value.
+  // We can take the first value as the default; the viewVisibilityState Map is initialized in order display preference.
+  // Any views with no visible columns are removed from the Map.
+  const { onChange, value } = useToggleButtonGroup<View>(values[0]);
+
+  if (values.length === 0) return null;
+
+  return (
+    <StyledToggleButtonGroup
+      exclusive
+      onChange={(event, value) => {
+        onChange?.(event, value);
+        table.setColumnVisibility(viewVisibilityState.get(value) || {});
+      }}
+      value={value}
+    >
+      {values.map((value) => (
+        <ToggleButton key={value} value={value}>
+          {OPTIONS[value]}
+        </ToggleButton>
+      ))}
+    </StyledToggleButtonGroup>
+  );
+};

--- a/app/views/AtlasMetadataCorrectnessView/components/Table/constants.ts
+++ b/app/views/AtlasMetadataCorrectnessView/components/Table/constants.ts
@@ -1,0 +1,14 @@
+export const TABLE_CONFIG = {
+  get AVAILABLE_COLUMN_COUNT() {
+    return this.COLUMN_COUNT - 1;
+  },
+  get AVAILABLE_WIDTH() {
+    return this.TABLE_WIDTH - this.FIRST_COLUMN_WIDTH - this.COLUMN_GAPS;
+  },
+  COLUMN_COUNT: 10,
+  get COLUMN_GAPS() {
+    return this.AVAILABLE_COLUMN_COUNT * 1;
+  },
+  FIRST_COLUMN_WIDTH: 156,
+  TABLE_WIDTH: 1230,
+} as const;

--- a/app/views/AtlasMetadataCorrectnessView/components/Table/entities.ts
+++ b/app/views/AtlasMetadataCorrectnessView/components/Table/entities.ts
@@ -1,0 +1,5 @@
+import { HeatmapClass } from "../../../../apis/catalog/hca-atlas-tracker/common/entities";
+
+export interface Props {
+  class: HeatmapClass;
+}

--- a/app/views/AtlasMetadataCorrectnessView/components/Table/hooks/useTable/entities.ts
+++ b/app/views/AtlasMetadataCorrectnessView/components/Table/hooks/useTable/entities.ts
@@ -1,0 +1,29 @@
+import {
+  ColumnDef as TanStackColumnDef,
+  Table as TanStackTable,
+  VisibilityState,
+} from "@tanstack/react-table";
+import { HeatmapEntrySheet } from "../../../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
+
+export type ColumnDef = TanStackColumnDef<HeatmapEntrySheet> & {
+  meta: ColumnMeta;
+};
+
+export interface ColumnMeta {
+  organSpecific: boolean;
+  required: boolean;
+}
+
+export type Table = TanStackTable<HeatmapEntrySheet> & {
+  options: TanStackTable<HeatmapEntrySheet>["options"] & {
+    meta: TableMeta;
+  };
+};
+
+export interface TableMeta {
+  viewVisibilityState: ViewVisibilityState;
+}
+
+export type View = "required" | "recommended" | "organSpecific";
+
+export type ViewVisibilityState = Map<View, VisibilityState>;

--- a/app/views/AtlasMetadataCorrectnessView/components/Table/hooks/useTable/hook.ts
+++ b/app/views/AtlasMetadataCorrectnessView/components/Table/hooks/useTable/hook.ts
@@ -1,0 +1,42 @@
+import { useReactTable, VisibilityState } from "@tanstack/react-table";
+import { useMemo, useState } from "react";
+import { HeatmapClass } from "../../../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { CORE_OPTIONS } from "../../../../../../../app/components/Table/options/core/constants";
+import { VISIBILITY_OPTIONS } from "../../../../../../../app/components/Table/options/visibility/constants";
+import { Table } from "./entities";
+import {
+  buildTableMeta,
+  filterSheet,
+  getRowId,
+  initVisibilityState,
+  makeColumns,
+} from "./utils";
+
+export const useTable = (cls: HeatmapClass): Table => {
+  // Create columns with metadata for visibility grouping (required, recommended, organSpecific).
+  const columns = makeColumns(cls.fields);
+
+  // Filter out sheets that don't have correctness data.
+  const data = useMemo(() => cls.sheets.filter(filterSheet), [cls.sheets]);
+
+  // Build table meta (column visibility state for each toggle view).
+  const meta = useMemo(() => buildTableMeta(columns), [columns]);
+
+  // Initialize column visibility state.
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(
+    initVisibilityState(meta)
+  );
+
+  const state = { columnVisibility };
+
+  return useReactTable({
+    ...CORE_OPTIONS,
+    ...VISIBILITY_OPTIONS,
+    columns,
+    data,
+    getRowId,
+    meta,
+    onColumnVisibilityChange: setColumnVisibility,
+    state,
+  }) as Table;
+};

--- a/app/views/AtlasMetadataCorrectnessView/components/Table/hooks/useTable/utils.ts
+++ b/app/views/AtlasMetadataCorrectnessView/components/Table/hooks/useTable/utils.ts
@@ -1,0 +1,137 @@
+import { VisibilityState } from "@tanstack/react-table";
+import {
+  HeatmapEntrySheet,
+  HeatmapField,
+} from "../../../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { EllipsisCell } from "../../../../../../../app/components/Entity/components/common/Table/components/TableCell/components/EllipsisCell/ellipsisCell";
+import { GraphValueCell } from "../../components/TableCell/components/GraphValueCell/graphValueCell";
+import { ColumnDef, TableMeta, View, ViewVisibilityState } from "./entities";
+
+/**
+ * Build table meta containing visibility states for each view type.
+ * Creates a Map of view types (required, recommended, organSpecific) to their
+ * corresponding column visibility states for toggle functionality.
+ * @param columns - Columns.
+ * @returns Meta.
+ */
+export function buildTableMeta(columns: ColumnDef[]): TableMeta {
+  const viewVisibilityState: ViewVisibilityState = new Map();
+
+  // Initialize the view state Map in order of "required", "recommended", "organSpecific".
+  // We use the Map order to render the toggle button group.
+  viewVisibilityState.set("required", {});
+  viewVisibilityState.set("recommended", {});
+  viewVisibilityState.set("organSpecific", {});
+
+  for (const column of columns) {
+    if (column.enableHiding === false) continue;
+    if (!column.id) continue;
+
+    // Grab the column meta.
+    const { meta } = column;
+    const { organSpecific, required } = meta;
+
+    // Set the view state for each column.
+    // We can assert that the view state exists because we initialized it above.
+    viewVisibilityState.get("organSpecific")![column.id] = organSpecific;
+    viewVisibilityState.get("recommended")![column.id] = !required;
+    viewVisibilityState.get("required")![column.id] = required;
+  }
+
+  // Remove views with no visible columns.
+  for (const [key, value] of viewVisibilityState.entries()) {
+    if (Object.values(value).some((v) => !!v)) continue;
+    viewVisibilityState.delete(key as View);
+  }
+
+  return { viewVisibilityState };
+}
+
+/**
+ * Filter out sheets that don't have correctness data.
+ * @param sheet - Sheet.
+ * @returns Whether the sheet has correctness data.
+ */
+export function filterSheet(sheet: HeatmapEntrySheet): boolean {
+  return sheet.correctness !== null;
+}
+
+/**
+ * Get the row id.
+ * @param row - Row.
+ * @returns Row id.
+ */
+export function getRowId(row: HeatmapEntrySheet): string {
+  return row.title;
+}
+
+/**
+ * Initialize the visibility state.
+ * @param meta - Meta.
+ * @returns Visibility state.
+ */
+export function initVisibilityState(meta: TableMeta): VisibilityState {
+  const { viewVisibilityState } = meta;
+
+  // Take the first entry.
+  const key = [...viewVisibilityState.keys()][0];
+
+  if (!key) return {};
+
+  // Return the visibility state for the first key.
+  return viewVisibilityState.get(key) || {};
+}
+
+/**
+ * Make an attribute column.
+ * Add field values "required" and "organSpecific" to the column meta for visibility grouping.
+ * @param field - Column field.
+ * @returns Attribute column.
+ */
+function makeAttributeColumn(field: HeatmapField): ColumnDef {
+  return {
+    accessorKey: `correctness.correctCounts.${field.name}`,
+    cell: GraphValueCell,
+    header: field.title,
+    id: field.name,
+    meta: {
+      header: field.title,
+      organSpecific: field.organSpecific,
+      required: field.required,
+    },
+  } as ColumnDef;
+}
+
+/**
+ * Make columns for the table.
+ * @param fields - Heatmap fields.
+ * @returns Table column definitions.
+ */
+export function makeColumns(fields: HeatmapField[]): ColumnDef[] {
+  // Start with the pinned column (title).
+  const titleColumn = makeTitleColumn();
+  const columns = [titleColumn];
+
+  // Add the attribute columns.
+  for (const field of fields) {
+    columns.push(makeAttributeColumn(field));
+  }
+
+  return columns;
+}
+
+/**
+ * Make a title column.
+ *
+ * @returns Title column.
+ */
+function makeTitleColumn(): ColumnDef {
+  return {
+    accessorKey: "title",
+    cell: EllipsisCell,
+    enableHiding: false,
+    header: "Title/Criteria",
+    id: "titleCriteria",
+    meta: { columnPinned: true, organSpecific: false, required: false },
+  } as ColumnDef;
+}

--- a/app/views/AtlasMetadataCorrectnessView/components/Table/table.styles.ts
+++ b/app/views/AtlasMetadataCorrectnessView/components/Table/table.styles.ts
@@ -1,0 +1,77 @@
+import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/components/FluidPaper/fluidPaper";
+import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
+import { mediaTabletDown } from "@databiosphere/findable-ui/lib/styles/common/mixins/breakpoints";
+import { textBody400 } from "@databiosphere/findable-ui/lib/styles/common/mixins/fonts";
+import styled from "@emotion/styled";
+import { Toolbar, Typography } from "@mui/material";
+import { Table } from "../../../../components/Entity/components/common/Table/table";
+
+export const StyledFluidPaper = styled(FluidPaper)`
+  background-color: ${PALETTE.SMOKE_MAIN};
+  display: grid;
+  gap: 1px;
+`;
+
+export const StyledToolbar = styled(Toolbar)`
+  & {
+    background-color: ${PALETTE.COMMON_WHITE};
+    flex-wrap: wrap;
+    gap: 16px 24px;
+    justify-content: space-between;
+    padding: 16px;
+  }
+`;
+
+export const StyledTypography = styled(Typography)`
+  & {
+    font-family: "Inter";
+    font-size: 20px;
+    font-weight: 500;
+    line-height: 28px;
+  }
+`;
+
+export const StyledTable = styled(Table)`
+  .MuiTable-root {
+    gap: 1px;
+
+    .MuiTableRow-root {
+      background-color: transparent;
+
+      .MuiTableCell-root {
+        background-color: ${PALETTE.COMMON_WHITE};
+        padding: 8px 12px;
+
+        &:first-of-type {
+          box-shadow: 1px 0 0 0 ${PALETTE.SMOKE_MAIN};
+          left: 0;
+          position: sticky;
+          word-break: break-word;
+          z-index: 2;
+        }
+      }
+
+      .MuiTableCell-head {
+        ${textBody400};
+      }
+
+      .MuiTableCell-body {
+        min-height: 36px;
+
+        &:not(:first-of-type) {
+          padding: 0;
+        }
+      }
+    }
+  }
+
+  ${mediaTabletDown} {
+    .MuiTableBody-root {
+      .MuiTableRow-root {
+        .MuiTableCell-root {
+          padding: 0;
+        }
+      }
+    }
+  }
+` as typeof Table;

--- a/app/views/AtlasMetadataCorrectnessView/components/Table/table.tsx
+++ b/app/views/AtlasMetadataCorrectnessView/components/Table/table.tsx
@@ -1,0 +1,30 @@
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { ToggleButtonGroup } from "./components/ToggleButtonGroup/toggleButtonGroup";
+import { Props } from "./entities";
+import { useTable } from "./hooks/useTable/hook";
+import {
+  StyledFluidPaper,
+  StyledTable,
+  StyledToolbar,
+  StyledTypography,
+} from "./table.styles";
+import { getColumnTrackSizing as getGridTemplateColumns } from "./utils";
+
+export const Table = (props: Props): JSX.Element => {
+  const { class: cls } = props;
+  const table = useTable(cls);
+  return (
+    <StyledFluidPaper elevation={0}>
+      <StyledToolbar>
+        <StyledTypography variant={TYPOGRAPHY_PROPS.VARIANT.TEXT_HEADING_SMALL}>
+          {cls.title}
+        </StyledTypography>
+        <ToggleButtonGroup table={table} />
+      </StyledToolbar>
+      <StyledTable
+        gridTemplateColumns={getGridTemplateColumns(table)}
+        table={table}
+      />
+    </StyledFluidPaper>
+  );
+};

--- a/app/views/AtlasMetadataCorrectnessView/components/Table/utils.ts
+++ b/app/views/AtlasMetadataCorrectnessView/components/Table/utils.ts
@@ -1,0 +1,20 @@
+import { TABLE_CONFIG } from "./constants";
+import { Table } from "./hooks/useTable/entities";
+
+/**
+ * Get the column track sizing for the table.
+ * @param table - Table.
+ * @returns Column track sizing.
+ */
+export function getColumnTrackSizing(table: Table): string {
+  // First column is a fixed width.
+  const firstColumnWidth = TABLE_CONFIG.FIRST_COLUMN_WIDTH;
+
+  // Calculate minimum width for attribute columns; additional columns are scrollable.
+  const attributeColumnCount = table.getVisibleFlatColumns().length - 1;
+  const availableWidth = TABLE_CONFIG.AVAILABLE_WIDTH;
+  const maxVisibleColumns = TABLE_CONFIG.AVAILABLE_COLUMN_COUNT;
+  const minAttributeWidth = availableWidth / maxVisibleColumns;
+
+  return `${firstColumnWidth}px repeat(${attributeColumnCount}, minmax(${minAttributeWidth}px, 1fr))`;
+}

--- a/app/views/AtlasMetadataCorrectnessView/components/Tables/tables.styles.ts
+++ b/app/views/AtlasMetadataCorrectnessView/components/Tables/tables.styles.ts
@@ -1,0 +1,13 @@
+import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/components/FluidPaper/fluidPaper";
+import { sectionPadding } from "@databiosphere/findable-ui/lib/components/common/Section/section.styles";
+import styled from "@emotion/styled";
+import { Grid } from "@mui/material";
+
+export const StyledGrid = styled(Grid)`
+  display: grid;
+  gap: 16px;
+`;
+
+export const StyledFluidPaper = styled(FluidPaper)`
+  ${sectionPadding};
+`;

--- a/app/views/AtlasMetadataCorrectnessView/components/Tables/tables.tsx
+++ b/app/views/AtlasMetadataCorrectnessView/components/Tables/tables.tsx
@@ -1,0 +1,27 @@
+import { useEntity } from "../../../../providers/entity/hook";
+import { EntityData } from "../../entities";
+import { Table } from "../Table/table";
+import { StyledFluidPaper, StyledGrid } from "./tables.styles";
+import { filterClasses } from "./utils";
+
+export const Tables = (): JSX.Element => {
+  const { data } = useEntity();
+  const { heatmap } = data as EntityData;
+  const classes = filterClasses(heatmap?.classes);
+
+  if (classes.length === 0) {
+    return (
+      <StyledFluidPaper>
+        No metadata entry sheets registered for this atlas
+      </StyledFluidPaper>
+    );
+  }
+
+  return (
+    <StyledGrid container>
+      {classes?.map((cls) => (
+        <Table key={cls.title} class={cls} />
+      ))}
+    </StyledGrid>
+  );
+};

--- a/app/views/AtlasMetadataCorrectnessView/components/Tables/utils.ts
+++ b/app/views/AtlasMetadataCorrectnessView/components/Tables/utils.ts
@@ -1,0 +1,10 @@
+import { HeatmapClass } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
+
+/**
+ * Filters out classes with no sheets.
+ * @param classes - Classes.
+ * @returns Classes with sheets.
+ */
+export function filterClasses(classes: HeatmapClass[] = []): HeatmapClass[] {
+  return classes.filter((cls) => cls.sheets.length > 0);
+}

--- a/app/views/AtlasMetadataCorrectnessView/entities.ts
+++ b/app/views/AtlasMetadataCorrectnessView/entities.ts
@@ -1,0 +1,9 @@
+import {
+  HCAAtlasTrackerAtlas,
+  Heatmap,
+} from "../../apis/catalog/hca-atlas-tracker/common/entities";
+
+export type EntityData = {
+  atlas: HCAAtlasTrackerAtlas | undefined;
+  heatmap: Heatmap | undefined;
+};

--- a/app/views/AtlasMetadataCorrectnessView/hooks/useFetchMetadataCorrectness.ts
+++ b/app/views/AtlasMetadataCorrectnessView/hooks/useFetchMetadataCorrectness.ts
@@ -1,0 +1,23 @@
+import { API } from "../../../apis/catalog/hca-atlas-tracker/common/api";
+import { Heatmap } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD, PathParameter } from "../../../common/entities";
+import { getRequestURL } from "../../../common/utils";
+import { useFetchData } from "../../../hooks/useFetchData";
+
+interface UseFetchMetadataCorrectness {
+  heatmap?: Heatmap;
+}
+
+export const useFetchMetadataCorrectness = (
+  pathParameter: PathParameter
+): UseFetchMetadataCorrectness => {
+  // Validate atlasId - required for API request.
+  if (!pathParameter.atlasId) throw new Error("Atlas ID is required");
+
+  const { data: heatmap } = useFetchData<Heatmap | undefined>(
+    getRequestURL(API.ATLAS_METADATA_CORRECTNESS, pathParameter),
+    METHOD.GET
+  );
+
+  return { heatmap };
+};


### PR DESCRIPTION
Closes #729.

This pull request introduces the new "Atlas Metadata Correctness" feature, which provides a heatmap-based view of metadata correctness for atlas entry sheets. The changes span backend data aggregation, API extensions, and frontend UI components to support interactive, color-coded tables with tooltips and access control. Below are the most important changes grouped by theme.

**Backend and API Enhancements**

* Added a new API endpoint `ATLAS_METADATA_CORRECTNESS` to the `API` enum for retrieving atlas heatmap data.
* Implemented the `getAtlasHeatmap` service and supporting types (`Heatmap`, `HeatmapClass`, etc.) to compute and return metadata correctness heatmaps based on entry sheet validations and the data dictionary. [[1]](diffhunk://#diff-2b500f4cdb22243e215faf60e9cf4edde2a792851d90751e1968b43ed0b99466R1-R107) [[2]](diffhunk://#diff-5f44a809c16663a1af0653ed07bd14aaa731919b13ae8990d6a8ffdb6a9bf96cR480-R504)
* Added helper function `getBaseModelAtlasEntrySheetValidations` to fetch validations for base model atlas source studies.

**Frontend Feature Integration**

* Created the `AtlasMetadataCorrectnessView` page, which uses the new heatmap API, provides access control, and renders the view using the generic `EntityView` component with section configs for metadata correctness tables. [[1]](diffhunk://#diff-31885438ab6d819e9085d3de73b6363c14757afbe315ad1dd6ab0c23315c97eeR5-R18) [[2]](diffhunk://#diff-31885438ab6d819e9085d3de73b6363c14757afbe315ad1dd6ab0c23315c97eeR28-R68) [[3]](diffhunk://#diff-1401ce6604c80664c79427463489f463b8ddb75ed3195140f4a73644a9de91a5R1-R6) [[4]](diffhunk://#diff-a505c90c5ab3298f3ac0a9ceb2fa8e989d2f51b28aa3ee826a37466e9b3a3648R1-R8)

**UI Components for Metadata Correctness**

* Implemented table cell components for displaying correctness values as color-coded graphs (`GraphValueCell`) with tooltips, and ellipsis text cells (`EllipsisCell`), including styling and utility functions for formatting and tooltips. [[1]](diffhunk://#diff-00917a61d96b3e16cbb2b8cd4186d204d55e42dc3af190500983d25b1b730023R1-R33) [[2]](diffhunk://#diff-c3e1dbcb8169a49ef2c65227046b094afe7ee0b42df9f6bcb0d6322415da7ed0R1-R13) [[3]](diffhunk://#diff-d39bb0f3212e238e5c92489d11e4379c961530eded99fba2813567df20f2c1bfR1-R20) [[4]](diffhunk://#diff-b48b10aa2c6289c716811d7fc6fe73e4ef3d73b96c7b1557e5a126cd21c09e2cR1-R79) [[5]](diffhunk://#diff-2c51ed595c876718e74638de83235d5c70d3c718180f794767fd9b83768039b5R1-R21) [[6]](diffhunk://#diff-9a65cecb7dae82e54c613a2d30ed16f240391c8ea9d729937171bd1def4dd4a0R1-R22)
* Added toggle button group UI for switching between different metadata correctness views (organ-specific, recommended, required), including constants and styling. [[1]](diffhunk://#diff-64cfae1e703ae9002237824617cf173d669e10ed5fb2a7eb0171916cd4777440R1-R7) [[2]](diffhunk://#diff-0c984460e4ee28f3bbb8367f39cee01827be219d142ab506e46065667e5210a8R1-R5) [[3]](diffhunk://#diff-5c726e471568ab87ba60b0ea9a34a298e2f8a81d2bb04434108272024e2f6a80R1-R15)

**Table Component Improvements**

* Updated the generic table component to accept a `gridTemplateColumns` prop for more flexible layout control, supporting the new metadata correctness tables. [[1]](diffhunk://#diff-f0c477ef4d0a825623e162642f263e0cfa4f535ed3fb992f7d8268e3b8bc3209R13) [[2]](diffhunk://#diff-f0c477ef4d0a825623e162642f263e0cfa4f535ed3fb992f7d8268e3b8bc3209L21-R25) [[3]](diffhunk://#diff-ffdcc458643e73417c6d57443e180b56bbcbf30d08790858fb9164afd795648bR5)
* Added visibility options constant for table column hiding.

**Miscellaneous**

* Updated `.prettierignore` to exclude downloaded catalog files.

These changes collectively enable a new, interactive, and visually informative way to assess metadata completeness and correctness for atlas entry sheets, supporting both backend data aggregation and frontend display.

<img width="1331" height="1273" alt="image" src="https://github.com/user-attachments/assets/27d7f966-3dbe-44a2-a02b-631bb8677d94" />

<img width="1330" height="1273" alt="image" src="https://github.com/user-attachments/assets/83e61e8d-a9b7-4adf-9964-25e8c77097b7" />

<img width="1329" height="1272" alt="image" src="https://github.com/user-attachments/assets/88165e57-f689-4604-9733-889dd1bb360b" />

<img width="1328" height="1271" alt="image" src="https://github.com/user-attachments/assets/b242ef5f-8047-4619-9c10-7d256434e821" />

<img width="1224" height="953" alt="image" src="https://github.com/user-attachments/assets/3d837d95-e3ce-457b-b205-fb5e0930a36f" />



