### PR TITLE
feat: remove the 'add integration object' button from the component atlases page (#749)

### DIFF
--- a/app/components/Detail/components/ViewComponentAtlases/viewComponentAtlases.tsx
+++ b/app/components/Detail/components/ViewComponentAtlases/viewComponentAtlases.tsx
@@ -1,19 +1,11 @@
-import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
-import { AddIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/AddIcon/addIcon";
 import { GridPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
 import { Table } from "@databiosphere/findable-ui/lib/components/Detail/components/Table/table";
-import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/svgIcon";
-import { Button } from "@mui/material";
-import Link from "next/link";
 import { HCAAtlasTrackerComponentAtlas } from "../../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { PathParameter } from "../../../../common/entities";
-import { getRouteURL } from "../../../../common/utils";
 import { FormManager } from "../../../../hooks/useFormManager/common/entities";
-import { ROUTE } from "../../../../routes/constants";
 import { getAtlasComponentAtlasesTableColumns } from "../../../../viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders";
 import { StyledFluidPaper } from "../../../Table/components/TablePaper/tablePaper.styles";
 import { TablePlaceholder } from "../../../Table/components/TablePlaceholder/tablePlaceholder";
-import { StyledToolbar } from "../../../Table/components/TableToolbar/tableToolbar.styles";
 import { RequestAccess } from "./components/RequestAccess/requestAccess";
 import { TABLE_OPTIONS } from "./constants";
 
@@ -35,23 +27,6 @@ export const ViewComponentAtlases = ({
   return (
     <StyledFluidPaper elevation={0}>
       <GridPaper>
-        {canEdit && (
-          <StyledToolbar>
-            <Button
-              {...BUTTON_PROPS.SECONDARY_CONTAINED}
-              component={Link}
-              href={getRouteURL(ROUTE.CREATE_COMPONENT_ATLAS, pathParameter)}
-              startIcon={
-                <AddIcon
-                  color={SVG_ICON_PROPS.COLOR.INK_LIGHT}
-                  fontSize={SVG_ICON_PROPS.FONT_SIZE.SMALL}
-                />
-              }
-            >
-              Add Integration Object
-            </Button>
-          </StyledToolbar>
-        )}
         {componentAtlases.length > 0 && (
           <Table
             columns={getAtlasComponentAtlasesTableColumns(pathParameter)}

--- a/app/hooks/useUserHasEditAuthorization/common/constants.ts
+++ b/app/hooks/useUserHasEditAuthorization/common/constants.ts
@@ -4,7 +4,6 @@ import { RouteValue } from "../../../routes/entities";
 export const ROUTES: RouteValue[] = [
   ROUTE.COMPONENT_ATLAS,
   ROUTE.COMPONENT_ATLASES,
-  ROUTE.CREATE_COMPONENT_ATLAS,
   ROUTE.CREATE_SOURCE_STUDY,
   ROUTE.SOURCE_DATASETS,
   ROUTE.SOURCE_STUDIES,

--- a/app/routes/constants.ts
+++ b/app/routes/constants.ts
@@ -7,7 +7,6 @@ export const ROUTE = {
   COMPONENT_ATLAS: "/atlases/[atlasId]/component-atlases/[componentAtlasId]",
   COMPONENT_ATLASES: "/atlases/[atlasId]/component-atlases",
   CREATE_ATLAS: "/atlases/create",
-  CREATE_COMPONENT_ATLAS: "/atlases/[atlasId]/component-atlases/create",
   CREATE_SOURCE_STUDY: "/atlases/[atlasId]/source-studies/create",
   CREATE_USER: "/team/create",
   LOGIN: "/login",


### PR DESCRIPTION
Closes #749.

This pull request removes the ability to create new component atlases from the UI. The changes clean up related code by eliminating the "Add Integration Object" button, its associated route, and related permissions.

UI Updates:

* Removed the "Add Integration Object" button from the `ViewComponentAtlases` component, so users can no longer initiate the creation of a new component atlas from the UI.

Routing and Permissions Cleanup:

* Removed the `CREATE_COMPONENT_ATLAS` route from the `ROUTE` constants and from the list of routes checked for edit authorization, ensuring the route is no longer referenced or accessible in the codebase. [[1]](diffhunk://#diff-4c9c6aa13d55240b1441d4edf7c24b623aba65762046687d4087ae69b7d57cc1L10) [[2]](diffhunk://#diff-0561d8ee4a1351369f6179b3226bf4bbe07de4e984637beeb742ae307df2c978L7)
* Cleaned up unused imports and related code in `viewComponentAtlases.tsx` that were only necessary for the removed button and route.