### PR TITLE
feat: rename tab to 'integrated objects' (instead of integration objects) (#752)

### DIFF
--- a/app/components/Detail/components/ViewAtlas/components/Tabs/tabs.tsx
+++ b/app/components/Detail/components/ViewAtlas/components/Tabs/tabs.tsx
@@ -50,7 +50,7 @@ export const Tabs = ({
         },
         {
           label: getTabLabelWithCount(
-            "Integration Objects",
+            "Integrated Objects",
             componentAtlasCount
           ),
           value: ROUTE.COMPONENT_ATLASES,


### PR DESCRIPTION
Closes #752.

This pull request makes a minor update to the `Tabs` component by renaming a tab label from "Integration Objects" to "Integrated Objects" for improved clarity and consistency.

* Renamed the tab label from "Integration Objects" to "Integrated Objects" in the `Tabs` component (`tabs.tsx`).