### PR TITLE
feat: derive integrated object get api responses from files (#753)

### DIFF
--- a/__tests__/api-atlases-id-component-atlases-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id-source-datasets.test.ts
@@ -14,19 +14,16 @@ import sourceDatasetsHandler from "../pages/api/atlases/[atlasId]/component-atla
 import {
   ATLAS_DRAFT,
   ATLAS_PUBLIC,
-  COMPONENT_ATLAS_DRAFT_BAR,
   COMPONENT_ATLAS_DRAFT_FOO,
-  COMPONENT_ATLAS_MISC_FOO,
+  FILE_COMPONENT_ATLAS_DRAFT_BAR,
+  FILE_COMPONENT_ATLAS_DRAFT_FOO,
   SOURCE_DATASET_BAR,
-  SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE,
   SOURCE_DATASET_CELLXGENE_WITH_UPDATE,
   SOURCE_DATASET_FOO,
   SOURCE_DATASET_FOOBAR,
-  SOURCE_DATASET_FOOBAZ,
   SOURCE_DATASET_FOOFOO,
   STAKEHOLDER_ANALOGOUS_ROLES,
   STAKEHOLDER_ANALOGOUS_ROLES_WITHOUT_INTEGRATION_LEAD,
-  TEST_SOURCE_STUDIES,
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_INTEGRATION_LEAD_DRAFT,
@@ -34,11 +31,7 @@ import {
   USER_UNREGISTERED,
 } from "../testing/constants";
 import { resetDatabase } from "../testing/db-utils";
-import {
-  TestComponentAtlas,
-  TestSourceDataset,
-  TestUser,
-} from "../testing/entities";
+import { TestComponentAtlas, TestUser } from "../testing/entities";
 import { testApiRole, withConsoleErrorHiding } from "../testing/utils";
 
 jest.mock(
@@ -100,7 +93,7 @@ describe(TEST_ROUTE, () => {
       (
         await doSourceDatasetsRequest(
           ATLAS_DRAFT.id,
-          COMPONENT_ATLAS_DRAFT_FOO.id,
+          FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
           undefined,
           METHOD.PUT
         )
@@ -113,7 +106,7 @@ describe(TEST_ROUTE, () => {
       (
         await doSourceDatasetsRequest(
           ATLAS_DRAFT.id,
-          COMPONENT_ATLAS_DRAFT_FOO.id,
+          FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
           undefined,
           METHOD.GET,
           undefined,
@@ -128,7 +121,7 @@ describe(TEST_ROUTE, () => {
       (
         await doSourceDatasetsRequest(
           ATLAS_DRAFT.id,
-          COMPONENT_ATLAS_DRAFT_FOO.id,
+          FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
           USER_UNREGISTERED,
           METHOD.GET,
           undefined,
@@ -143,51 +136,43 @@ describe(TEST_ROUTE, () => {
       (
         await doSourceDatasetsRequest(
           ATLAS_DRAFT.id,
-          COMPONENT_ATLAS_DRAFT_FOO.id,
+          FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
           USER_DISABLED_CONTENT_ADMIN
         )
       )._getStatusCode()
     ).toEqual(403);
   });
 
+  // TODO: test for both fully-ingested and file-only component atlases once the former exists
+
   for (const role of STAKEHOLDER_ANALOGOUS_ROLES) {
     testApiRole(
-      "returns source datasets",
+      "returns empty source datasets",
       TEST_ROUTE,
       sourceDatasetsHandler,
       METHOD.GET,
       role,
-      getQueryValues(ATLAS_DRAFT.id, COMPONENT_ATLAS_DRAFT_FOO.id),
+      getQueryValues(ATLAS_DRAFT.id, FILE_COMPONENT_ATLAS_DRAFT_FOO.id),
       undefined,
       false,
       (res) => {
         expect(res._getStatusCode()).toEqual(200);
         const sourceDatasets =
           res._getJSONData() as HCAAtlasTrackerSourceDataset[];
-        expect(sourceDatasets).toHaveLength(3);
-        expectSourceDatasetsToMatch(sourceDatasets, [
-          SOURCE_DATASET_FOOFOO,
-          SOURCE_DATASET_FOOBAR,
-          SOURCE_DATASET_FOOBAZ,
-        ]);
+        expect(sourceDatasets).toEqual([]);
       }
     );
   }
 
-  it("returns source datasets when requested by logged in user with CONTENT_ADMIN role", async () => {
+  it("returns empty source datasets when requested by logged in user with CONTENT_ADMIN role", async () => {
     const res = await doSourceDatasetsRequest(
       ATLAS_DRAFT.id,
-      COMPONENT_ATLAS_DRAFT_FOO.id,
+      FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
       USER_CONTENT_ADMIN
     );
     expect(res._getStatusCode()).toEqual(200);
     const sourceDatasets = res._getJSONData() as HCAAtlasTrackerSourceDataset[];
-    expect(sourceDatasets).toHaveLength(3);
-    expectSourceDatasetsToMatch(sourceDatasets, [
-      SOURCE_DATASET_FOOFOO,
-      SOURCE_DATASET_FOOBAR,
-      SOURCE_DATASET_FOOBAZ,
-    ]);
+    expect(sourceDatasets).toEqual([]);
   });
 
   it("returns error 401 when POST requested from draft atlas by logged out user", async () => {
@@ -195,7 +180,7 @@ describe(TEST_ROUTE, () => {
       (
         await doSourceDatasetsRequest(
           ATLAS_DRAFT.id,
-          COMPONENT_ATLAS_DRAFT_FOO.id,
+          FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
           undefined,
           METHOD.POST,
           NEW_DATASETS_DATA,
@@ -211,7 +196,7 @@ describe(TEST_ROUTE, () => {
       (
         await doSourceDatasetsRequest(
           ATLAS_DRAFT.id,
-          COMPONENT_ATLAS_DRAFT_FOO.id,
+          FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
           USER_UNREGISTERED,
           METHOD.POST,
           NEW_DATASETS_DATA,
@@ -227,7 +212,7 @@ describe(TEST_ROUTE, () => {
       (
         await doSourceDatasetsRequest(
           ATLAS_DRAFT.id,
-          COMPONENT_ATLAS_DRAFT_FOO.id,
+          FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
           USER_DISABLED_CONTENT_ADMIN,
           METHOD.POST,
           NEW_DATASETS_DATA
@@ -244,7 +229,7 @@ describe(TEST_ROUTE, () => {
       sourceDatasetsHandler,
       METHOD.POST,
       role,
-      getQueryValues(ATLAS_DRAFT.id, COMPONENT_ATLAS_DRAFT_FOO.id),
+      getQueryValues(ATLAS_DRAFT.id, FILE_COMPONENT_ATLAS_DRAFT_FOO.id),
       NEW_DATASETS_DATA,
       false,
       async (res) => {
@@ -259,7 +244,7 @@ describe(TEST_ROUTE, () => {
       (
         await doSourceDatasetsRequest(
           ATLAS_DRAFT.id,
-          COMPONENT_ATLAS_DRAFT_FOO.id,
+          FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
           USER_INTEGRATION_LEAD_PUBLIC,
           METHOD.POST,
           NEW_DATASETS_DATA
@@ -274,7 +259,7 @@ describe(TEST_ROUTE, () => {
       (
         await doSourceDatasetsRequest(
           ATLAS_PUBLIC.id,
-          COMPONENT_ATLAS_DRAFT_FOO.id,
+          FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
           USER_CONTENT_ADMIN,
           METHOD.POST,
           NEW_DATASETS_DATA,
@@ -290,7 +275,7 @@ describe(TEST_ROUTE, () => {
       (
         await doSourceDatasetsRequest(
           ATLAS_DRAFT.id,
-          COMPONENT_ATLAS_DRAFT_FOO.id,
+          FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
           USER_CONTENT_ADMIN,
           METHOD.POST,
           NEW_DATASETS_WITH_EXISTING_DATA,
@@ -306,7 +291,7 @@ describe(TEST_ROUTE, () => {
       (
         await doSourceDatasetsRequest(
           ATLAS_DRAFT.id,
-          COMPONENT_ATLAS_DRAFT_FOO.id,
+          FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
           USER_CONTENT_ADMIN,
           METHOD.POST,
           NEW_DATASETS_WITH_NONEXISTENT_DATA,
@@ -317,59 +302,30 @@ describe(TEST_ROUTE, () => {
     await expectComponentAtlasToBeUnchanged(COMPONENT_ATLAS_DRAFT_FOO);
   });
 
-  it("adds source datasets when POST requested by user with INTEGRATION_LEAD role for the atlas", async () => {
-    const sourceDatasetsBefore = await getComponentAtlasSourceDatasets(
-      COMPONENT_ATLAS_DRAFT_BAR.id
-    );
+  // TODO: test for successful requests once the component_atlases table is used again
 
+  it("returns error 400 when POST requested by user with INTEGRATION_LEAD role for the atlas", async () => {
     const res = await doSourceDatasetsRequest(
       ATLAS_DRAFT.id,
-      COMPONENT_ATLAS_DRAFT_BAR.id,
+      FILE_COMPONENT_ATLAS_DRAFT_BAR.id,
       USER_INTEGRATION_LEAD_DRAFT,
       METHOD.POST,
-      NEW_DATASETS_DATA
+      NEW_DATASETS_DATA,
+      true
     );
-    expect(res._getStatusCode()).toEqual(201);
-    expectComponentAtlasToHaveSourceDatasets(COMPONENT_ATLAS_DRAFT_BAR, [
-      SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE,
-      SOURCE_DATASET_CELLXGENE_WITH_UPDATE,
-      SOURCE_DATASET_FOO,
-      SOURCE_DATASET_BAR,
-    ]);
-    await expectComponentAtlasToBeUnchanged(COMPONENT_ATLAS_MISC_FOO);
-
-    await setComponentAtlasDatasets(
-      COMPONENT_ATLAS_DRAFT_BAR,
-      sourceDatasetsBefore
-    );
+    expect(res._getStatusCode()).toEqual(400);
   });
 
-  it("adds source datasets when POST requested by user with CONTENT_ADMIN role", async () => {
-    const sourceDatasetsBefore = await getComponentAtlasSourceDatasets(
-      COMPONENT_ATLAS_DRAFT_FOO.id
-    );
-
+  it("returns error 400 when POST requested by user with CONTENT_ADMIN role", async () => {
     const res = await doSourceDatasetsRequest(
       ATLAS_DRAFT.id,
-      COMPONENT_ATLAS_DRAFT_FOO.id,
+      FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
       USER_CONTENT_ADMIN,
       METHOD.POST,
-      NEW_DATASETS_DATA
+      NEW_DATASETS_DATA,
+      true
     );
-    expect(res._getStatusCode()).toEqual(201);
-    expectComponentAtlasToHaveSourceDatasets(COMPONENT_ATLAS_DRAFT_FOO, [
-      SOURCE_DATASET_FOOFOO,
-      SOURCE_DATASET_FOOBAR,
-      SOURCE_DATASET_FOOBAZ,
-      SOURCE_DATASET_FOO,
-      SOURCE_DATASET_BAR,
-    ]);
-    await expectComponentAtlasToBeUnchanged(COMPONENT_ATLAS_MISC_FOO);
-
-    await setComponentAtlasDatasets(
-      COMPONENT_ATLAS_DRAFT_FOO,
-      sourceDatasetsBefore
-    );
+    expect(res._getStatusCode()).toEqual(400);
   });
 
   it("returns error 401 when DELETE requested from draft atlas by logged out user", async () => {
@@ -377,7 +333,7 @@ describe(TEST_ROUTE, () => {
       (
         await doSourceDatasetsRequest(
           ATLAS_DRAFT.id,
-          COMPONENT_ATLAS_DRAFT_FOO.id,
+          FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
           undefined,
           METHOD.DELETE,
           DELETE_DATASETS_DATA,
@@ -393,7 +349,7 @@ describe(TEST_ROUTE, () => {
       (
         await doSourceDatasetsRequest(
           ATLAS_DRAFT.id,
-          COMPONENT_ATLAS_DRAFT_FOO.id,
+          FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
           USER_UNREGISTERED,
           METHOD.DELETE,
           DELETE_DATASETS_DATA,
@@ -409,7 +365,7 @@ describe(TEST_ROUTE, () => {
       (
         await doSourceDatasetsRequest(
           ATLAS_DRAFT.id,
-          COMPONENT_ATLAS_DRAFT_FOO.id,
+          FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
           USER_DISABLED_CONTENT_ADMIN,
           METHOD.DELETE,
           DELETE_DATASETS_DATA
@@ -426,7 +382,7 @@ describe(TEST_ROUTE, () => {
       sourceDatasetsHandler,
       METHOD.DELETE,
       role,
-      getQueryValues(ATLAS_DRAFT.id, COMPONENT_ATLAS_DRAFT_FOO.id),
+      getQueryValues(ATLAS_DRAFT.id, FILE_COMPONENT_ATLAS_DRAFT_FOO.id),
       DELETE_DATASETS_DATA,
       false,
       async (res) => {
@@ -441,7 +397,7 @@ describe(TEST_ROUTE, () => {
       (
         await doSourceDatasetsRequest(
           ATLAS_DRAFT.id,
-          COMPONENT_ATLAS_DRAFT_FOO.id,
+          FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
           USER_INTEGRATION_LEAD_PUBLIC,
           METHOD.DELETE,
           DELETE_DATASETS_DATA
@@ -456,7 +412,7 @@ describe(TEST_ROUTE, () => {
       (
         await doSourceDatasetsRequest(
           ATLAS_PUBLIC.id,
-          COMPONENT_ATLAS_DRAFT_FOO.id,
+          FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
           USER_CONTENT_ADMIN,
           METHOD.DELETE,
           DELETE_DATASETS_DATA,
@@ -472,7 +428,7 @@ describe(TEST_ROUTE, () => {
       (
         await doSourceDatasetsRequest(
           ATLAS_DRAFT.id,
-          COMPONENT_ATLAS_DRAFT_FOO.id,
+          FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
           USER_CONTENT_ADMIN,
           METHOD.DELETE,
           DELETE_DATASETS_WITH_MISSING_DATA,
@@ -488,7 +444,7 @@ describe(TEST_ROUTE, () => {
       (
         await doSourceDatasetsRequest(
           ATLAS_DRAFT.id,
-          COMPONENT_ATLAS_DRAFT_FOO.id,
+          FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
           USER_CONTENT_ADMIN,
           METHOD.DELETE,
           DELETE_DATASETS_WITH_NONEXISTENT_DATA,
@@ -499,58 +455,36 @@ describe(TEST_ROUTE, () => {
     await expectComponentAtlasToBeUnchanged(COMPONENT_ATLAS_DRAFT_FOO);
   });
 
-  it("deletes source datasets when requested by user with INTERGRATION_LEAD role for the atlas", async () => {
-    const sourceDatasetsBefore = await getComponentAtlasSourceDatasets(
-      COMPONENT_ATLAS_DRAFT_BAR.id
-    );
+  // TODO: test for successful requests once the component_atlases table is used again
 
+  it("returns error 400 when requested by user with INTERGRATION_LEAD role for the atlas", async () => {
     expect(
       (
         await doSourceDatasetsRequest(
           ATLAS_DRAFT.id,
-          COMPONENT_ATLAS_DRAFT_BAR.id,
+          FILE_COMPONENT_ATLAS_DRAFT_BAR.id,
           USER_INTEGRATION_LEAD_DRAFT,
           METHOD.DELETE,
-          DELETE_DRAFT_BAR_DATASETS_DATA
+          DELETE_DRAFT_BAR_DATASETS_DATA,
+          true
         )
       )._getStatusCode()
-    ).toEqual(200);
-    expectComponentAtlasToHaveSourceDatasets(COMPONENT_ATLAS_DRAFT_BAR, [
-      SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE,
-    ]);
-    await expectComponentAtlasToBeUnchanged(COMPONENT_ATLAS_MISC_FOO);
-
-    await setComponentAtlasDatasets(
-      COMPONENT_ATLAS_DRAFT_BAR,
-      sourceDatasetsBefore
-    );
+    ).toEqual(400);
   });
 
-  it("deletes source datasets when requested by user with CONTENT_ADMIN role", async () => {
-    const sourceDatasetsBefore = await getComponentAtlasSourceDatasets(
-      COMPONENT_ATLAS_DRAFT_FOO.id
-    );
-
+  it("returns error 400 when requested by user with CONTENT_ADMIN role", async () => {
     expect(
       (
         await doSourceDatasetsRequest(
           ATLAS_DRAFT.id,
-          COMPONENT_ATLAS_DRAFT_FOO.id,
+          FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
           USER_CONTENT_ADMIN,
           METHOD.DELETE,
-          DELETE_DATASETS_DATA
+          DELETE_DATASETS_DATA,
+          true
         )
       )._getStatusCode()
-    ).toEqual(200);
-    expectComponentAtlasToHaveSourceDatasets(COMPONENT_ATLAS_DRAFT_FOO, [
-      SOURCE_DATASET_FOOBAZ,
-    ]);
-    await expectComponentAtlasToBeUnchanged(COMPONENT_ATLAS_MISC_FOO);
-
-    await setComponentAtlasDatasets(
-      COMPONENT_ATLAS_DRAFT_FOO,
-      sourceDatasetsBefore
-    );
+    ).toEqual(400);
   });
 });
 
@@ -594,55 +528,6 @@ async function expectComponentAtlasToBeUnchanged(
   expect(componentAtlasFromDb.title).toEqual(componentAtlas.title);
 }
 
-async function expectComponentAtlasToHaveSourceDatasets(
-  componentAtlas: TestComponentAtlas,
-  expectedSourceDatasets: TestSourceDataset[]
-): Promise<void> {
-  const sourceDatasets = await getComponentAtlasSourceDatasets(
-    componentAtlas.id
-  );
-  expect(sourceDatasets).toHaveLength(expectedSourceDatasets.length);
-  for (const expectedDataset of expectedSourceDatasets) {
-    expect(sourceDatasets).toContain(expectedDataset.id);
-  }
-}
-
-function expectSourceDatasetsToMatch(
-  sourceDatasets: HCAAtlasTrackerSourceDataset[],
-  expectedTestSourceDatasets: TestSourceDataset[]
-): void {
-  for (const testSourceDataset of expectedTestSourceDatasets) {
-    const sourceDataset = sourceDatasets.find(
-      (c) => c.id === testSourceDataset.id
-    );
-    expect(sourceDataset).toBeDefined();
-    if (!sourceDataset) continue;
-    expect(sourceDataset.sourceStudyId).toEqual(
-      testSourceDataset.sourceStudyId
-    );
-    expect(sourceDataset.title).toEqual(testSourceDataset.title);
-    const sourceStudy = TEST_SOURCE_STUDIES.find(
-      (s) => s.id === testSourceDataset.sourceStudyId
-    );
-    if (sourceStudy)
-      expect(sourceDataset.sourceStudyTitle).toEqual(
-        "publication" in sourceStudy
-          ? sourceStudy.publication?.title
-          : sourceStudy.unpublishedInfo?.title ?? null
-      );
-  }
-}
-
-async function setComponentAtlasDatasets(
-  componentAtlas: TestComponentAtlas,
-  sourceDatasetIds: string[]
-): Promise<void> {
-  await query(
-    "UPDATE hat.component_atlases SET source_datasets=$1 WHERE id=$2",
-    [sourceDatasetIds, componentAtlas.id]
-  );
-}
-
 async function getComponentAtlasFromDatabase(
   id: string
 ): Promise<HCAAtlasTrackerDBComponentAtlas | undefined> {
@@ -652,13 +537,4 @@ async function getComponentAtlasFromDatabase(
       [id]
     )
   ).rows[0];
-}
-
-async function getComponentAtlasSourceDatasets(id: string): Promise<string[]> {
-  return (
-    await query<HCAAtlasTrackerDBComponentAtlas>(
-      "SELECT * FROM hat.component_atlases WHERE id=$1",
-      [id]
-    )
-  ).rows[0].source_datasets;
 }

--- a/__tests__/api-atlases-id-component-atlases-id.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id.test.ts
@@ -8,6 +8,7 @@ import {
   ATLAS_DRAFT,
   ATLAS_PUBLIC,
   COMPONENT_ATLAS_DRAFT_FOO,
+  FILE_COMPONENT_ATLAS_DRAFT_FOO,
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
@@ -15,7 +16,11 @@ import {
 } from "../testing/constants";
 import { resetDatabase } from "../testing/db-utils";
 import { TestUser } from "../testing/entities";
-import { testApiRole, withConsoleErrorHiding } from "../testing/utils";
+import {
+  expectApiComponentAtlasToMatchTest,
+  testApiRole,
+  withConsoleErrorHiding,
+} from "../testing/utils";
 
 jest.mock(
   "../site-config/hca-atlas-tracker/local/authentication/next-auth-config"
@@ -141,16 +146,17 @@ describe(TEST_ROUTE, () => {
       componentAtlasHandler,
       METHOD.GET,
       role,
-      getQueryValues(ATLAS_DRAFT.id, COMPONENT_ATLAS_DRAFT_FOO.id),
+      getQueryValues(ATLAS_DRAFT.id, FILE_COMPONENT_ATLAS_DRAFT_FOO.id),
       undefined,
       false,
       (res) => {
         expect(res._getStatusCode()).toEqual(200);
         const componentAtlas =
           res._getJSONData() as HCAAtlasTrackerComponentAtlas;
-        expect(componentAtlas.title).toEqual(COMPONENT_ATLAS_DRAFT_FOO.title);
-        expect(componentAtlas.description).toEqual(
-          COMPONENT_ATLAS_DRAFT_FOO.description
+        expectApiComponentAtlasToMatchTest(
+          componentAtlas,
+          FILE_COMPONENT_ATLAS_DRAFT_FOO,
+          COMPONENT_ATLAS_DRAFT_FOO
         );
       }
     );
@@ -159,14 +165,15 @@ describe(TEST_ROUTE, () => {
   it("returns component atlas from draft atlas when GET requested by logged in user with CONTENT_ADMIN role", async () => {
     const res = await doComponentAtlasRequest(
       ATLAS_DRAFT.id,
-      COMPONENT_ATLAS_DRAFT_FOO.id,
+      FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
       USER_CONTENT_ADMIN
     );
     expect(res._getStatusCode()).toEqual(200);
     const componentAtlas = res._getJSONData() as HCAAtlasTrackerComponentAtlas;
-    expect(componentAtlas.title).toEqual(COMPONENT_ATLAS_DRAFT_FOO.title);
-    expect(componentAtlas.description).toEqual(
-      COMPONENT_ATLAS_DRAFT_FOO.description
+    expectApiComponentAtlasToMatchTest(
+      componentAtlas,
+      FILE_COMPONENT_ATLAS_DRAFT_FOO,
+      COMPONENT_ATLAS_DRAFT_FOO
     );
   });
 });

--- a/__tests__/api-atlases-id-component-atlases.test.ts
+++ b/__tests__/api-atlases-id-component-atlases.test.ts
@@ -8,14 +8,20 @@ import {
   ATLAS_DRAFT,
   COMPONENT_ATLAS_DRAFT_BAR,
   COMPONENT_ATLAS_DRAFT_FOO,
+  FILE_COMPONENT_ATLAS_DRAFT_BAR,
+  FILE_COMPONENT_ATLAS_DRAFT_FOO,
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
 } from "../testing/constants";
 import { resetDatabase } from "../testing/db-utils";
-import { TestComponentAtlas, TestUser } from "../testing/entities";
-import { testApiRole, withConsoleErrorHiding } from "../testing/utils";
+import { TestComponentAtlas, TestFile, TestUser } from "../testing/entities";
+import {
+  expectApiComponentAtlasToMatchTest,
+  testApiRole,
+  withConsoleErrorHiding,
+} from "../testing/utils";
 
 jest.mock(
   "../site-config/hca-atlas-tracker/local/authentication/next-auth-config"
@@ -97,10 +103,11 @@ describe(TEST_ROUTE, () => {
         const componentAtlases =
           res._getJSONData() as HCAAtlasTrackerComponentAtlas[];
         expect(componentAtlases).toHaveLength(2);
-        expectComponentAtlasesToMatch(componentAtlases, [
-          COMPONENT_ATLAS_DRAFT_FOO,
-          COMPONENT_ATLAS_DRAFT_BAR,
-        ]);
+        expectComponentAtlasesToMatch(
+          componentAtlases,
+          [FILE_COMPONENT_ATLAS_DRAFT_FOO, FILE_COMPONENT_ATLAS_DRAFT_BAR],
+          [COMPONENT_ATLAS_DRAFT_FOO, COMPONENT_ATLAS_DRAFT_BAR]
+        );
       }
     );
   }
@@ -114,10 +121,11 @@ describe(TEST_ROUTE, () => {
     const componentAtlases =
       res._getJSONData() as HCAAtlasTrackerComponentAtlas[];
     expect(componentAtlases).toHaveLength(2);
-    expectComponentAtlasesToMatch(componentAtlases, [
-      COMPONENT_ATLAS_DRAFT_FOO,
-      COMPONENT_ATLAS_DRAFT_BAR,
-    ]);
+    expectComponentAtlasesToMatch(
+      componentAtlases,
+      [FILE_COMPONENT_ATLAS_DRAFT_FOO, FILE_COMPONENT_ATLAS_DRAFT_BAR],
+      [COMPONENT_ATLAS_DRAFT_FOO, COMPONENT_ATLAS_DRAFT_BAR]
+    );
   });
 });
 
@@ -145,16 +153,18 @@ function getQueryValues(atlasId: string): Record<string, string> {
 
 function expectComponentAtlasesToMatch(
   componentAtlases: HCAAtlasTrackerComponentAtlas[],
+  expectedTestFiles: TestFile[],
   expectedTestComponentAtlases: TestComponentAtlas[]
 ): void {
-  for (const testComponentAtlas of expectedTestComponentAtlases) {
-    const componentAtlas = componentAtlases.find(
-      (c) => c.id === testComponentAtlas.id
-    );
+  for (const [i, testFile] of expectedTestFiles.entries()) {
+    const testComponentAtlas = expectedTestComponentAtlases[i];
+    const componentAtlas = componentAtlases.find((c) => c.id === testFile.id);
     expect(componentAtlas).toBeDefined();
     if (!componentAtlas) continue;
-    expect(componentAtlas.atlasId).toEqual(testComponentAtlas.atlasId);
-    expect(componentAtlas.title).toEqual(testComponentAtlas.title);
-    expect(componentAtlas.description).toEqual(testComponentAtlas.description);
+    expectApiComponentAtlasToMatchTest(
+      componentAtlas,
+      testFile,
+      testComponentAtlas
+    );
   }
 }

--- a/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
@@ -100,7 +100,6 @@ export function dbComponentAtlasToApiComponentAtlas(
 export function dbComponentAtlasFileToApiComponentAtlas(
   dbComponentAtlasFile: HCAAtlasTrackerDBComponentAtlasFile
 ): HCAAtlasTrackerComponentAtlas {
-  const fileName = parseS3KeyPath(dbComponentAtlasFile.key).filename;
   return {
     assay: [],
     atlasId: dbComponentAtlasFile.atlas_id,
@@ -109,14 +108,14 @@ export function dbComponentAtlasFileToApiComponentAtlas(
     cellxgeneDatasetVersion: null,
     description: "",
     disease: [],
-    fileName,
+    fileName: parseS3KeyPath(dbComponentAtlasFile.key).filename,
     id: dbComponentAtlasFile.id,
     integrityStatus: dbComponentAtlasFile.integrity_status,
     sizeBytes: Number(dbComponentAtlasFile.size_bytes),
     sourceDatasetCount: 0,
     suspensionType: [],
     tissue: [],
-    title: fileName,
+    title: "",
     validationStatus: INTEGRITY_STATUS.PENDING,
   };
 }

--- a/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
@@ -7,7 +7,6 @@ import {
   HCAAtlasTrackerComponentAtlas,
   HCAAtlasTrackerDBAtlasWithComponentAtlases,
   HCAAtlasTrackerDBComment,
-  HCAAtlasTrackerDBComponentAtlas,
   HCAAtlasTrackerDBComponentAtlasFile,
   HCAAtlasTrackerDBEntrySheetValidation,
   HCAAtlasTrackerDBEntrySheetValidationListFields,
@@ -69,31 +68,6 @@ export function dbAtlasToApiAtlas(
     title: "",
     version: dbAtlas.overview.version,
     wave: dbAtlas.overview.wave,
-  };
-}
-
-// TODO remove this once it's no longer used (issues #750 and #753)
-export function dbComponentAtlasToApiComponentAtlas(
-  dbComponentAtlas: HCAAtlasTrackerDBComponentAtlas
-): HCAAtlasTrackerComponentAtlas {
-  return {
-    assay: dbComponentAtlas.component_info.assay,
-    atlasId: dbComponentAtlas.atlas_id,
-    cellCount: dbComponentAtlas.component_info.cellCount,
-    cellxgeneDatasetId: dbComponentAtlas.component_info.cellxgeneDatasetId,
-    cellxgeneDatasetVersion:
-      dbComponentAtlas.component_info.cellxgeneDatasetVersion,
-    description: dbComponentAtlas.component_info.description,
-    disease: dbComponentAtlas.component_info.disease,
-    fileName: "",
-    id: dbComponentAtlas.id,
-    integrityStatus: INTEGRITY_STATUS.PENDING,
-    sizeBytes: 0,
-    sourceDatasetCount: dbComponentAtlas.source_datasets.length,
-    suspensionType: dbComponentAtlas.component_info.suspensionType,
-    tissue: dbComponentAtlas.component_info.tissue,
-    title: dbComponentAtlas.title,
-    validationStatus: INTEGRITY_STATUS.PENDING,
   };
 }
 

--- a/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
@@ -1,3 +1,4 @@
+import { parseS3KeyPath } from "app/services/s3-notification";
 import savedCellxgeneInfo from "../../../../../catalog/output/cellxgene-info.json";
 import { getCellxGeneCollectionInfoById } from "../../../../services/cellxgene";
 import {
@@ -7,6 +8,7 @@ import {
   HCAAtlasTrackerDBAtlasWithComponentAtlases,
   HCAAtlasTrackerDBComment,
   HCAAtlasTrackerDBComponentAtlas,
+  HCAAtlasTrackerDBComponentAtlasFile,
   HCAAtlasTrackerDBEntrySheetValidation,
   HCAAtlasTrackerDBEntrySheetValidationListFields,
   HCAAtlasTrackerDBSourceDataset,
@@ -23,6 +25,7 @@ import {
   HCAAtlasTrackerUser,
   HCAAtlasTrackerValidationRecord,
   HCAAtlasTrackerValidationRecordWithoutAtlases,
+  INTEGRITY_STATUS,
   TIER_ONE_METADATA_STATUS,
   WithSourceStudyInfo,
 } from "./entities";
@@ -69,6 +72,7 @@ export function dbAtlasToApiAtlas(
   };
 }
 
+// TODO remove this once it's no longer used (issues #750 and #753)
 export function dbComponentAtlasToApiComponentAtlas(
   dbComponentAtlas: HCAAtlasTrackerDBComponentAtlas
 ): HCAAtlasTrackerComponentAtlas {
@@ -81,11 +85,39 @@ export function dbComponentAtlasToApiComponentAtlas(
       dbComponentAtlas.component_info.cellxgeneDatasetVersion,
     description: dbComponentAtlas.component_info.description,
     disease: dbComponentAtlas.component_info.disease,
+    fileName: "",
     id: dbComponentAtlas.id,
+    integrityStatus: INTEGRITY_STATUS.PENDING,
+    sizeBytes: 0,
     sourceDatasetCount: dbComponentAtlas.source_datasets.length,
     suspensionType: dbComponentAtlas.component_info.suspensionType,
     tissue: dbComponentAtlas.component_info.tissue,
     title: dbComponentAtlas.title,
+    validationStatus: INTEGRITY_STATUS.PENDING,
+  };
+}
+
+export function dbComponentAtlasFileToApiComponentAtlas(
+  dbComponentAtlasFile: HCAAtlasTrackerDBComponentAtlasFile
+): HCAAtlasTrackerComponentAtlas {
+  const fileName = parseS3KeyPath(dbComponentAtlasFile.key).filename;
+  return {
+    assay: [],
+    atlasId: dbComponentAtlasFile.atlas_id,
+    cellCount: 0,
+    cellxgeneDatasetId: null,
+    cellxgeneDatasetVersion: null,
+    description: "",
+    disease: [],
+    fileName,
+    id: dbComponentAtlasFile.id,
+    integrityStatus: dbComponentAtlasFile.integrity_status,
+    sizeBytes: Number(dbComponentAtlasFile.size_bytes),
+    sourceDatasetCount: 0,
+    suspensionType: [],
+    tissue: [],
+    title: fileName,
+    validationStatus: INTEGRITY_STATUS.PENDING,
   };
 }
 

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -55,11 +55,15 @@ export interface HCAAtlasTrackerComponentAtlas {
   cellxgeneDatasetVersion: string | null;
   description: string;
   disease: string[];
+  fileName: string;
   id: string;
+  integrityStatus: INTEGRITY_STATUS;
+  sizeBytes: number;
   sourceDatasetCount: number;
   suspensionType: string[];
   tissue: string[];
   title: string;
+  validationStatus: INTEGRITY_STATUS;
 }
 
 export interface HCAAtlasTrackerNetworkCoordinator {
@@ -282,6 +286,12 @@ export interface HCAAtlasTrackerDBComponentAtlasInfo {
   suspensionType: string[];
   tissue: string[];
 }
+
+export type HCAAtlasTrackerDBComponentAtlasFile = Pick<
+  HCAAtlasTrackerDBFile,
+  "id" | "integrity_status" | "key" | "size_bytes" | "status"
+> &
+  Pick<HCAAtlasTrackerDBComponentAtlas, "atlas_id">;
 
 export interface HCAAtlasTrackerDBPublishedSourceStudy {
   created_at: Date;

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -383,6 +383,28 @@ export type HCAAtlasTrackerDBSourceDatasetWithCellxGeneId =
 export type HCAAtlasTrackerDBSourceDatasetWithStudyProperties =
   WithSourceStudyInfo<HCAAtlasTrackerDBSourceDataset>;
 
+export interface HCAAtlasTrackerDBFile {
+  atlas_id: string | null;
+  bucket: string;
+  created_at: Date;
+  etag: string;
+  event_info: FileEventInfo;
+  file_type: FILE_TYPE;
+  id: string;
+  integrity_checked_at: Date | null;
+  integrity_error: string | null;
+  integrity_status: INTEGRITY_STATUS;
+  is_latest: boolean;
+  key: string;
+  sha256_client: string | null;
+  sha256_server: string | null;
+  size_bytes: string;
+  source_study_id: string | null;
+  status: FILE_STATUS;
+  updated_at: Date;
+  version_id: string | null;
+}
+
 export interface HCAAtlasTrackerListValidationRecord
   extends Omit<HCAAtlasTrackerValidationRecord, "targetCompletion" | "doi"> {
   doi: string;
@@ -588,6 +610,11 @@ export enum TIER_ONE_METADATA_STATUS {
   NEEDS_VALIDATION = "NEEDS_VALIDATION",
 }
 
+export interface FileEventInfo {
+  eventName: string;
+  eventTime: string;
+}
+
 export type UserId = number;
 
 export interface ValidationDifference {
@@ -600,6 +627,24 @@ export enum ENTITY_TYPE {
   ATLAS = "ATLAS",
   COMPONENT_ATLAS = "COMPONENT_ATLAS",
   SOURCE_STUDY = "SOURCE_STUDY",
+}
+
+export enum FILE_STATUS {
+  UPLOADED = "uploaded",
+}
+
+export enum FILE_TYPE {
+  INGEST_MANIFEST = "ingest_manifest",
+  INTEGRATED_OBJECT = "integrated_object",
+  SOURCE_DATASET = "source_dataset",
+}
+
+export enum INTEGRITY_STATUS {
+  ERROR = "error",
+  INVALID = "invalid",
+  PENDING = "pending",
+  VALID = "valid",
+  VALIDATING = "validating",
 }
 
 export enum SYSTEM {

--- a/app/components/Detail/components/ViewSourceStudiesSourceDatasets/viewSourceStudiesSourceDatasets.tsx
+++ b/app/components/Detail/components/ViewSourceStudiesSourceDatasets/viewSourceStudiesSourceDatasets.tsx
@@ -22,11 +22,14 @@ export const ViewSourceStudiesSourceDatasets = ({
   const [open, setOpen] = useState<boolean>(false);
   const onClose = (): void => setOpen(false);
   const onOpen = (): void => setOpen(true);
+  const hasComponentAtlasesEntry = false; // TODO: base this on something once it's possible for it to be true
   return (
     <Fragment>
       <Button
         {...BUTTON_PROPS.SECONDARY_CONTAINED}
-        disabled={sourceStudiesSourceDatasets.length === 0}
+        disabled={
+          !hasComponentAtlasesEntry || sourceStudiesSourceDatasets.length === 0
+        }
         onClick={onOpen}
         startIcon={
           <AddLinkIcon

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -41,7 +41,7 @@ export async function getAllAtlases(
         COUNT(DISTINCT c.id)::int AS component_atlas_count,
         COUNT(DISTINCT e.id)::int AS entry_sheet_validation_count
       FROM hat.atlases a
-      LEFT JOIN hat.component_atlases c ON c.atlas_id=a.id
+      LEFT JOIN hat.files c ON c.file_type = 'integrated_object' AND c.atlas_id=a.id
       LEFT JOIN hat.entry_sheet_validations e ON a.source_studies ? e.source_study_id::text
       GROUP BY a.id
     `,
@@ -61,7 +61,7 @@ export async function getAtlas(
         COUNT(DISTINCT c.id)::int AS component_atlas_count,
         COUNT(DISTINCT e.id)::int AS entry_sheet_validation_count
       FROM hat.atlases a
-      LEFT JOIN hat.component_atlases c ON c.atlas_id=a.id
+      LEFT JOIN hat.files c ON c.file_type = 'integrated_object' AND c.atlas_id=a.id
       LEFT JOIN hat.entry_sheet_validations e ON a.source_studies ? e.source_study_id::text
       WHERE a.id=$1 GROUP BY a.id
     `,

--- a/app/services/component-atlases.ts
+++ b/app/services/component-atlases.ts
@@ -74,14 +74,16 @@ export async function getComponentAtlas(
 /**
  * Add the given source datasets to the specified comonent atlas.
  * @param atlasId - Atlas that the component atlas is accessed through.
- * @param componentAtlasId - Component atlas ID.
+ * @param fileId - Component atlas file ID.
  * @param sourceDatasetIds - IDs of source datasets to add.
  */
 export async function addSourceDatasetsToComponentAtlas(
   atlasId: string,
-  componentAtlasId: string,
+  fileId: string,
   sourceDatasetIds: string[]
 ): Promise<void> {
+  const componentAtlasId = await getPresentComponentAtlasIdForFile(fileId);
+
   await confirmSourceDatasetsExist(sourceDatasetIds);
 
   const existingDatasetsResult = await query<{ array: string[] }>(
@@ -117,14 +119,16 @@ export async function addSourceDatasetsToComponentAtlas(
 /**
  * Remove the given source datasets from the specified comonent atlas.
  * @param atlasId - Atlas that the component atlas is accessed through.
- * @param componentAtlasId - Component atlas ID.
+ * @param fileId - Component atlas file ID.
  * @param sourceDatasetIds - IDs of source datasets to remove.
  */
 export async function deleteSourceDatasetsFromComponentAtlas(
   atlasId: string,
-  componentAtlasId: string,
+  fileId: string,
   sourceDatasetIds: string[]
 ): Promise<void> {
+  const componentAtlasId = await getPresentComponentAtlasIdForFile(fileId);
+
   await confirmSourceDatasetsExist(sourceDatasetIds);
 
   const missingDatasetsResult = await query<{ array: string[] }>(
@@ -291,6 +295,34 @@ export async function getComponentAtlasIdsHavingSourceDatasets(
       client
     )
   ).rows.map(({ id }) => id);
+}
+
+/**
+ * Get the ID of the component atlas associated with the given file, throwing an error if there is none.
+ * @param fileId - ID of the file to get the associated component atlas of.
+ * @returns component atlas ID.
+ */
+export async function getPresentComponentAtlasIdForFile(
+  fileId: string
+): Promise<string> {
+  const componentAtlasId = await getComponentAtlasIdForFile(fileId);
+  if (componentAtlasId === null)
+    throw new InvalidOperationError(
+      `File with ID ${fileId} has no associated component atlas`
+    );
+  return componentAtlasId;
+}
+
+/**
+ * Get the ID of the component atlas associated with the given file, or null if there is none.
+ * @param fileId - ID of the file to get the associated component atlas of.
+ * @returns component atlas ID or null.
+ */
+export async function getComponentAtlasIdForFile(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Placeholder until we actually link files to component atlases
+  fileId: string
+): Promise<string | null> {
+  return null;
 }
 
 export function getComponentAtlasNotFoundError(

--- a/app/services/component-atlases.ts
+++ b/app/services/component-atlases.ts
@@ -6,6 +6,7 @@ import {
 import { InvalidOperationError, NotFoundError } from "../utils/api-handler";
 import { confirmAtlasExists } from "./atlases";
 import { doTransaction, query } from "./database";
+import { confirmFileExistsOnAtlas } from "./files";
 import {
   confirmSourceDatasetsExist,
   UpdatedSourceDatasetsInfo,
@@ -82,6 +83,8 @@ export async function addSourceDatasetsToComponentAtlas(
   fileId: string,
   sourceDatasetIds: string[]
 ): Promise<void> {
+  await confirmFileExistsOnAtlas(fileId, atlasId, "Component atlas file");
+
   const componentAtlasId = await getPresentComponentAtlasIdForFile(fileId);
 
   await confirmSourceDatasetsExist(sourceDatasetIds);
@@ -127,6 +130,8 @@ export async function deleteSourceDatasetsFromComponentAtlas(
   fileId: string,
   sourceDatasetIds: string[]
 ): Promise<void> {
+  await confirmFileExistsOnAtlas(fileId, atlasId, "Component atlas file");
+
   const componentAtlasId = await getPresentComponentAtlasIdForFile(fileId);
 
   await confirmSourceDatasetsExist(sourceDatasetIds);

--- a/app/services/component-atlases.ts
+++ b/app/services/component-atlases.ts
@@ -31,7 +31,7 @@ export async function getAtlasComponentAtlases(
           size_bytes,
           status
         FROM hat.files
-        WHERE entity_type='integrated_object' AND atlas_id=$1
+        WHERE file_type='integrated_object' AND atlas_id=$1
       `,
     [atlasId]
   );

--- a/app/services/files.ts
+++ b/app/services/files.ts
@@ -1,0 +1,23 @@
+import { NotFoundError } from "app/utils/api-handler";
+import { query } from "./database";
+
+/**
+ * Check that the specified file exists and has the specified atlas ID, throwing and error otherwise.
+ * @param fileId - ID of the file to check.
+ * @param atlasId - ID of the atlas to check for.
+ * @param fileTypeDescription - Wording to use to refer to the file in the error message.
+ */
+export async function confirmFileExistsOnAtlas(
+  fileId: string,
+  atlasId: string,
+  fileTypeDescription = "File"
+): Promise<void> {
+  const result = await query(
+    "SELECT 1 FROM hat.files WHERE id=$1 AND atlas_id=$2",
+    [fileId, atlasId]
+  );
+  if (result.rows.length === 0)
+    throw new NotFoundError(
+      `${fileTypeDescription} with id ${fileId} doesn't exist on atlas with ID ${atlasId}`
+    );
+}

--- a/app/services/s3-notification.ts
+++ b/app/services/s3-notification.ts
@@ -63,7 +63,7 @@ interface S3KeyPathComponents {
  * parseS3KeyPath('bio_network/gut-v1/integrated-objects/file.h5ad')
  * // Returns: { network: 'bio_network', atlasName: 'gut-v1', folderType: 'integrated-objects', filename: 'file.h5ad' }
  */
-function parseS3KeyPath(s3Key: string): S3KeyPathComponents {
+export function parseS3KeyPath(s3Key: string): S3KeyPathComponents {
   const pathParts = s3Key.split("/");
 
   if (pathParts.length < 4) {

--- a/db_scripts/generate-test-files.ts
+++ b/db_scripts/generate-test-files.ts
@@ -197,7 +197,7 @@ async function generateAndAddFile(
       INTEGRITY_STATUS.PENDING,
       FILE_STATUS.UPLOADED,
       fileType,
-      fileType === "source_dataset" ? null : atlas.id,
+      fileType === FILE_TYPE.SOURCE_DATASET ? null : atlas.id,
     ]
   );
 }

--- a/db_scripts/generate-test-files.ts
+++ b/db_scripts/generate-test-files.ts
@@ -5,9 +5,13 @@ import {
 } from "../app/apis/catalog/hca-atlas-tracker/common/constants";
 import {
   ATLAS_STATUS,
+  FILE_STATUS,
+  FILE_TYPE,
+  FileEventInfo,
   HCAAtlasTrackerDBAtlas,
   HCAAtlasTrackerDBAtlasOverview,
   IntegrationLead,
+  INTEGRITY_STATUS,
   NetworkKey,
   SYSTEM,
   Wave,
@@ -125,7 +129,7 @@ async function generateAndAddFilesForAtlas(
       bucketName,
       versioned,
       "manifests",
-      "ingest_manifest",
+      FILE_TYPE.INGEST_MANIFEST,
       ".json"
     );
   }
@@ -136,7 +140,7 @@ async function generateAndAddFilesForAtlas(
       bucketName,
       versioned,
       "integrated-objects",
-      "integrated_object",
+      FILE_TYPE.INTEGRATED_OBJECT,
       ".h5ad"
     );
   }
@@ -147,7 +151,7 @@ async function generateAndAddFilesForAtlas(
       bucketName,
       versioned,
       "source-datasets",
-      "source_dataset",
+      FILE_TYPE.SOURCE_DATASET,
       ".h5ad"
     );
   }
@@ -161,7 +165,7 @@ async function generateAndAddFile(
   bucketName: string,
   versioned: boolean,
   folderName: string,
-  fileType: string,
+  fileType: FILE_TYPE,
   extension: string
 ): Promise<void> {
   const fileName = crypto.randomUUID() + extension;
@@ -172,9 +176,9 @@ async function generateAndAddFile(
     ? randomInRange(0, 999999).toString().padStart(6, "0")
     : null;
   const eTag = crypto.randomUUID().replaceAll("-", "");
-  const eventInfo = {
+  const eventInfo: FileEventInfo = {
     eventName: "ObjectCreated:*",
-    eventTime: new Date(randomInRange(1755755554042, Date.now())),
+    eventTime: new Date(randomInRange(1755755554042, Date.now())).toISOString(),
   };
 
   await client.query(
@@ -190,8 +194,8 @@ async function generateAndAddFile(
       randomInRange(1e3, 1e12),
       JSON.stringify(eventInfo),
       null,
-      "pending",
-      "uploaded",
+      INTEGRITY_STATUS.PENDING,
+      FILE_STATUS.UPLOADED,
       fileType,
       fileType === "source_dataset" ? null : atlas.id,
     ]

--- a/pages/api/atlases/[atlasId]/component-atlases.ts
+++ b/pages/api/atlases/[atlasId]/component-atlases.ts
@@ -1,4 +1,4 @@
-import { dbComponentAtlasToApiComponentAtlas } from "../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
+import { dbComponentAtlasFileToApiComponentAtlas } from "../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE_GROUP } from "../../../../app/apis/catalog/hca-atlas-tracker/common/constants";
 import { METHOD } from "../../../../app/common/entities";
 import { getAtlasComponentAtlases } from "../../../../app/services/component-atlases";
@@ -16,7 +16,7 @@ export default handler(
       .status(200)
       .json(
         (await getAtlasComponentAtlases(atlasId)).map(
-          dbComponentAtlasToApiComponentAtlas
+          dbComponentAtlasFileToApiComponentAtlas
         )
       );
   }

--- a/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId].ts
+++ b/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId].ts
@@ -1,4 +1,4 @@
-import { dbComponentAtlasToApiComponentAtlas } from "app/apis/catalog/hca-atlas-tracker/common/backend-utils";
+import { dbComponentAtlasFileToApiComponentAtlas } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE_GROUP } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/constants";
 import { METHOD } from "../../../../../app/common/entities";
 import { getComponentAtlas } from "../../../../../app/services/component-atlases";
@@ -13,7 +13,7 @@ export default handler(
     res
       .status(200)
       .json(
-        dbComponentAtlasToApiComponentAtlas(
+        dbComponentAtlasFileToApiComponentAtlas(
           await getComponentAtlas(atlasId, componentAtlasId)
         )
       );

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -2,6 +2,7 @@ import { ProjectsResponse } from "../app/apis/azul/hca-dcp/common/responses";
 import {
   ATLAS_STATUS,
   DOI_STATUS,
+  FILE_TYPE,
   PublicationInfo,
   ROLE,
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
@@ -16,6 +17,7 @@ import {
   TestComment,
   TestComponentAtlas,
   TestEntrySheetValidation,
+  TestFile,
   TestPublishedSourceStudy,
   TestSourceDataset,
   TestUnpublishedSourceStudy,
@@ -2341,6 +2343,89 @@ export const INITIAL_TEST_ATLASES_BY_SOURCE_STUDY = INITIAL_TEST_ATLASES.reduce(
   },
   {} as Record<string, TestAtlas[]>
 );
+
+// FILES
+
+export const FILE_COMPONENT_ATLAS_DRAFT_FOO = {
+  atlas: ATLAS_DRAFT,
+  bucket: "bucket-draft-foo",
+  etag: "6b8f00707b574ca28e43a7568a2eaca1",
+  eventTime: "2025-08-22T05:45:49.432Z",
+  fileName: "component-atlas-draft-foo.h5ad",
+  fileType: FILE_TYPE.INTEGRATED_OBJECT,
+  id: "2dfcd615-391f-452c-b981-d0124583c97f",
+  sizeBytes: "2342325",
+  versionId: null,
+} satisfies TestFile;
+
+export const FILE_COMPONENT_ATLAS_DRAFT_BAR = {
+  atlas: ATLAS_DRAFT,
+  bucket: "bucket-draft-bar",
+  etag: "7c9f11808c685db39f54b8679b3fbcb2",
+  eventTime: "2025-08-22T05:46:12.567Z",
+  fileName: "component-atlas-draft-bar.h5ad",
+  fileType: FILE_TYPE.INTEGRATED_OBJECT,
+  id: "3efde726-402f-563d-c092-e1235694d08f",
+  sizeBytes: "1987456",
+  versionId: null,
+} satisfies TestFile;
+
+export const FILE_COMPONENT_ATLAS_MISC_FOO = {
+  atlas: ATLAS_WITH_MISC_SOURCE_STUDIES,
+  bucket: "bucket-misc-foo",
+  etag: "8d0a22919d796ec40a65c9780c4acdbe",
+  eventTime: "2025-08-22T05:46:35.891Z",
+  fileName: "component-atlas-misc-foo.h5ad",
+  fileType: FILE_TYPE.INTEGRATED_OBJECT,
+  id: "4faef837-513a-674e-d103-f2346705e19b",
+  sizeBytes: "3456789",
+  versionId: null,
+} satisfies TestFile;
+
+export const FILE_COMPONENT_ATLAS_WITH_CELLXGENE_DATASETS = {
+  atlas: ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_B,
+  bucket: "bucket-cellxgene-datasets",
+  etag: "9e1b33020e807fd51b76d0891d5bdef4",
+  eventTime: "2025-08-22T05:46:58.234Z",
+  fileName: "component-atlas-with-cellxgene-datasets.h5ad",
+  fileType: FILE_TYPE.INTEGRATED_OBJECT,
+  id: "5abfa948-624b-785f-e214-a3457816f20c",
+  sizeBytes: "2789123",
+  versionId: null,
+} satisfies TestFile;
+
+export const FILE_COMPONENT_ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_FOO = {
+  atlas: ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A,
+  bucket: "bucket-entry-sheet-validations-foo",
+  etag: "0f2c44131f918ae62c87e1902e6cafe5",
+  eventTime: "2025-08-22T05:47:21.456Z",
+  fileName: "component-atlas-with-entry-sheet-validations-foo.h5ad",
+  fileType: FILE_TYPE.INTEGRATED_OBJECT,
+  id: "6bcac059-735c-896a-f325-b4568927a31d",
+  sizeBytes: "1654321",
+  versionId: null,
+} satisfies TestFile;
+
+export const FILE_COMPONENT_ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_BAR = {
+  atlas: ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A,
+  bucket: "bucket-entry-sheet-validations-bar",
+  etag: "1a3d55242a029bf73d98f2013f7dbab6",
+  eventTime: "2025-08-22T05:47:44.789Z",
+  fileName: "component-atlas-with-entry-sheet-validations-bar.h5ad",
+  fileType: FILE_TYPE.INTEGRATED_OBJECT,
+  id: "7cdbd160-846d-907b-a436-c5679038b42e",
+  sizeBytes: "2123456",
+  versionId: null,
+} satisfies TestFile;
+
+export const INITIAL_TEST_FILES: TestFile[] = [
+  FILE_COMPONENT_ATLAS_DRAFT_FOO,
+  FILE_COMPONENT_ATLAS_DRAFT_BAR,
+  FILE_COMPONENT_ATLAS_MISC_FOO,
+  FILE_COMPONENT_ATLAS_WITH_CELLXGENE_DATASETS,
+  FILE_COMPONENT_ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_FOO,
+  FILE_COMPONENT_ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_BAR,
+];
 
 // COMPONENT ATLASES
 

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -3,7 +3,6 @@ import migrate from "node-pg-migrate";
 import { MigrationDirection } from "node-pg-migrate/dist/types";
 import pg from "pg";
 import {
-  FILE_STATUS,
   FILE_TYPE,
   FileEventInfo,
   HCAAtlasTrackerDBAtlas,
@@ -16,7 +15,6 @@ import {
   HCAAtlasTrackerDBUser,
   HCAAtlasTrackerDBValidation,
   HCAAtlasTrackerSourceStudy,
-  INTEGRITY_STATUS,
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { updateTaskCounts } from "../app/services/atlases";
 import { query } from "../app/services/database";
@@ -41,6 +39,7 @@ import {
   expectApiValidationsToMatchDb,
   expectDbSourceDatasetToMatchTest,
   expectIsDefined,
+  fillTestFileDefaults,
   makeTestAtlasOverview,
   makeTestSourceDatasetInfo,
   makeTestSourceStudyOverview,
@@ -189,22 +188,22 @@ async function initFiles(client: pg.PoolClient): Promise<void> {
       atlas,
       bucket,
       etag,
-      eventName = "ObjectCreated:*",
+      eventName,
       eventTime,
       fileName,
       fileType,
       id,
-      integrityCheckedAt = null,
-      integrityError = null,
-      integrityStatus = INTEGRITY_STATUS.PENDING,
-      isLatest = true,
-      sha256Client = null,
-      sha256Server = null,
+      integrityCheckedAt,
+      integrityError,
+      integrityStatus,
+      isLatest,
+      sha256Client,
+      sha256Server,
       sizeBytes,
-      sourceStudyId = null,
-      status = FILE_STATUS.UPLOADED,
+      sourceStudyId,
+      status,
       versionId,
-    } = file;
+    } = fillTestFileDefaults(file);
     let folderName: string;
     switch (fileType) {
       case FILE_TYPE.INGEST_MANIFEST:

--- a/testing/entities.ts
+++ b/testing/entities.ts
@@ -102,14 +102,14 @@ export interface TestFile {
   fileName: string;
   fileType: FILE_TYPE;
   id: string;
-  integrityCheckedAt?: string;
-  integrityError?: string;
+  integrityCheckedAt?: string | null;
+  integrityError?: string | null;
   integrityStatus?: INTEGRITY_STATUS;
   isLatest?: boolean;
-  sha256Client?: string;
-  sha256Server?: string;
+  sha256Client?: string | null;
+  sha256Server?: string | null;
   sizeBytes: string;
-  sourceStudyId?: string;
+  sourceStudyId?: string | null;
   status?: FILE_STATUS;
   versionId: string | null;
 }

--- a/testing/entities.ts
+++ b/testing/entities.ts
@@ -2,10 +2,13 @@ import {
   ATLAS_STATUS,
   DOI_STATUS,
   DoiPublicationInfo,
+  FILE_STATUS,
+  FILE_TYPE,
   GoogleSheetInfo,
   HCAAtlasTrackerDBEntrySheetValidation,
   HCAAtlasTrackerDBUnpublishedSourceStudyInfo,
   IntegrationLead,
+  INTEGRITY_STATUS,
   LinkInfo,
   NetworkKey,
   PublicationInfo,
@@ -88,6 +91,27 @@ export interface TestSourceDataset {
   suspensionType?: string[];
   tissue?: string[];
   title: string;
+}
+
+export interface TestFile {
+  atlas: TestAtlas;
+  bucket: string;
+  etag: string;
+  eventName?: string;
+  eventTime: string;
+  fileName: string;
+  fileType: FILE_TYPE;
+  id: string;
+  integrityCheckedAt?: string;
+  integrityError?: string;
+  integrityStatus?: INTEGRITY_STATUS;
+  isLatest?: boolean;
+  sha256Client?: string;
+  sha256Server?: string;
+  sizeBytes: string;
+  sourceStudyId?: string;
+  status?: FILE_STATUS;
+  versionId: string | null;
 }
 
 export type TestEntrySheetValidation = HCAAtlasTrackerDBEntrySheetValidation;

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -3,7 +3,9 @@ import httpMocks from "node-mocks-http";
 import { ProjectsResponse } from "../app/apis/azul/hca-dcp/common/responses";
 import {
   DOI_STATUS,
+  FILE_STATUS,
   HCAAtlasTrackerAtlas,
+  HCAAtlasTrackerComponentAtlas,
   HCAAtlasTrackerDBAtlas,
   HCAAtlasTrackerDBAtlasOverview,
   HCAAtlasTrackerDBComponentAtlas,
@@ -18,6 +20,7 @@ import {
   HCAAtlasTrackerSourceStudy,
   HCAAtlasTrackerUser,
   HCAAtlasTrackerValidationRecordWithoutAtlases,
+  INTEGRITY_STATUS,
   ROLE,
   SYSTEM,
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
@@ -42,6 +45,8 @@ import {
 } from "./constants";
 import {
   TestAtlas,
+  TestComponentAtlas,
+  TestFile,
   TestSourceDataset,
   TestSourceStudy,
   TestUser,
@@ -203,6 +208,33 @@ export function makeTestProjectsResponse(
     protocols: [],
     samples: [],
     specimens: [],
+  };
+}
+
+export function fillTestFileDefaults(file: TestFile): Required<TestFile> {
+  const {
+    eventName = "ObjectCreated:*",
+    integrityCheckedAt = null,
+    integrityError = null,
+    integrityStatus = INTEGRITY_STATUS.PENDING,
+    isLatest = true,
+    sha256Client = null,
+    sha256Server = null,
+    sourceStudyId = null,
+    status = FILE_STATUS.UPLOADED,
+    ...restFields
+  } = file;
+  return {
+    eventName,
+    integrityCheckedAt,
+    integrityError,
+    integrityStatus,
+    isLatest,
+    sha256Client,
+    sha256Server,
+    sourceStudyId,
+    status,
+    ...restFields,
   };
 }
 
@@ -465,6 +497,20 @@ export function expectDbSourceDatasetToMatchTest(
     testSourceDataset.tissue ?? []
   );
   expect(dbSourceDataset.sd_info.title).toEqual(testSourceDataset.title);
+}
+
+export function expectApiComponentAtlasToMatchTest(
+  apiComponentAtlas: HCAAtlasTrackerComponentAtlas,
+  sourceTestFile: TestFile,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Placeholder
+  testComponentAtlas: TestComponentAtlas
+): void {
+  const testFile = fillTestFileDefaults(sourceTestFile);
+  expect(apiComponentAtlas.atlasId).toEqual(testFile.atlas.id);
+  expect(apiComponentAtlas.fileName).toEqual(testFile.fileName);
+  expect(apiComponentAtlas.integrityStatus).toEqual(testFile.integrityStatus);
+  expect(apiComponentAtlas.sizeBytes).toEqual(Number(testFile.sizeBytes));
+  // TODO: check for test component atlas fields once they're included
 }
 
 export function expectAtlasDatasetsToHaveDifference(


### PR DESCRIPTION
Closes #753

Still needs updated tests, and may need some attention after #756 is merged

Notes:
1. I didn't change existing field types on the API response, so some fields contain non-null but "empty" values, such as cell count being set to 0
1. I've created an enum for integrity status (among other type definitions), which I've also used for the `validationStatus` field -- not sure if that's the right choice
1. All integrated object APIs are updated to take file IDs instead of IDs for the `component_atlases` table
1. The dataset list API returns an empty array when there's no associated `component_atlases` entry (which is always at the moment), but attempting to link a dataset, which is still possible in the UI, will return an error
    1. A simple solution to this might be to set the button as always disabled for now? Or perhaps we could add something to the API response that indicates whether an integrated object is just a file, and disable the button based on that
1. The file size is stored in the database as a bigint, which can represent sizes up to several exabytes, but is converted in the API response to a JS number, which can "only" represent several petabytes
1. ~~The file name is used as the integrated object title~~ The title is set to empty string, which currently means that there's nothing to click on to get to the detail page