### PR TITLE
feat: make the title not editable on the integrated object detail page general Info section  #755 (#755)

### DIFF
--- a/app/components/common/Form/components/Controllers/common/entities.ts
+++ b/app/components/common/Form/components/Controllers/common/entities.ts
@@ -17,7 +17,9 @@ type PickedInputProps =
   | "label"
   | "helperTextProps"
   | "isFullWidth"
-  | "placeholder";
+  | "placeholder"
+  | "readOnly";
+
 type PickedSelectProps = "displayEmpty" | "label";
 
 export interface ControllerConfig<T extends FieldValues, R = undefined> {

--- a/app/views/ComponentAtlasView/common/controllers.ts
+++ b/app/views/ComponentAtlasView/common/controllers.ts
@@ -12,6 +12,7 @@ const TITLE: CommonControllerConfig = {
   inputProps: {
     isFullWidth: true,
     label: "Title",
+    readOnly: true,
   },
   name: FIELD_NAME.TITLE,
 };


### PR DESCRIPTION
Closes #755.

This pull request introduces a minor update to the form controller configuration by adding a new property to the allowed input props and updating the title field to be read-only.

- **Form Input Props Update:**
  - Added `readOnly` to the list of allowed properties in the `PickedInputProps` type in `entities.ts`, enabling form inputs to be set as read-only.

- **Controller Configuration Update:**
  - Set the `readOnly` property to `true` for the `TITLE` field in the controller configuration, making the title input non-editable.