### PR TITLE
feat: update integrated object list columns to include file and status information (#754)

### DIFF
--- a/app/components/Detail/components/ViewComponentAtlases/viewComponentAtlases.tsx
+++ b/app/components/Detail/components/ViewComponentAtlases/viewComponentAtlases.tsx
@@ -30,7 +30,7 @@ export const ViewComponentAtlases = ({
         {componentAtlases.length > 0 && (
           <Table
             columns={getAtlasComponentAtlasesTableColumns(pathParameter)}
-            gridTemplateColumns="max-content minmax(260px, 1.2fr) repeat(5, minmax(180px, 1fr)) minmax(160px, 0.75fr)"
+            gridTemplateColumns="max-content minmax(140px, 1.2fr) repeat(8, minmax(120px, 1fr)) minmax(120px, 0.75fr)"
             items={componentAtlases}
             tableOptions={TABLE_OPTIONS}
           />

--- a/app/components/Table/components/TableCell/components/ChipCell/chipCell.styles.ts
+++ b/app/components/Table/components/TableCell/components/ChipCell/chipCell.styles.ts
@@ -1,4 +1,4 @@
-import { ChipCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/ChipCell/chipCell";
+import { ChipCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/ChipCell/ChipCell";
 import styled from "@emotion/styled";
 
 export const StyledChipCell = styled(ChipCell)`

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -16,6 +16,7 @@ export { Logo } from "@databiosphere/findable-ui/lib/components/Layout/component
 export { Link } from "@databiosphere/findable-ui/lib/components/Links/components/Link/link";
 export { ViewSupport } from "@databiosphere/findable-ui/lib/components/Support/components/ViewSupport/viewSupport";
 export { BasicCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/BasicCell/basicCell";
+export { ChipCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/ChipCell/ChipCell";
 export { NTagCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/NTagCell/nTagCell";
 export { RowDrawer } from "@databiosphere/findable-ui/lib/components/Table/components/TableToolbar/components/RowPreview/components/RowDrawer/rowDrawer";
 export { AlertTitle } from "@mui/material";


### PR DESCRIPTION
Closes #754.

This pull request expands and improves the `ViewComponentAtlases` table by adding new columns and updating supporting logic and components. The main focus is on displaying more detailed information about each component atlas, including file name, file size, and validation status, with improved styling and formatting.

**Table Enhancements**

* Added three new columns to the `ViewComponentAtlases` table: "File Name", "File Size", and "Validation Status", by updating `getAtlasComponentAtlasesTableColumns` and adding corresponding column definitions. [[1]](diffhunk://#diff-b40c9cfae34bbe2fe51e79be552b0af2ebf79552105c70236d5978760ebbe81aL1059-R1097) [[2]](diffhunk://#diff-b40c9cfae34bbe2fe51e79be552b0af2ebf79552105c70236d5978760ebbe81aR1474-R1518)
* Adjusted the table's `gridTemplateColumns` to accommodate the new columns, ensuring proper layout and readability.

**Validation Status Display**

* Implemented a new helper function, `buildIntegratedObjectValidationStatus`, which formats and styles the validation status using a warning-colored chip with capitalized text.
* Updated imports and exports for `ChipCell` to ensure consistent usage and styling across the app. [[1]](diffhunk://#diff-d864af40d6421607b83c4d0a0dbab18f77a448d108f2ddb9c8cf3453d4087842L1-R1) [[2]](diffhunk://#diff-ab5acd52d2bbe58facfe338cfed6cec00e93a9e328a89b7f9e0d9c6867745d8dR19)

**Other Improvements**

* Ensured that if a component atlas title is missing, a default "unspecified" label is used to prevent empty table cells.
* Added necessary utility imports for formatting file sizes and chip props.

<img width="1441" height="514" alt="image" src="https://github.com/user-attachments/assets/b5e2f8ec-bc0c-48a6-8d27-14ad1479f307" />
