### PR TITLE
feat: rename datasets used to datasets on alas source studies (#795)

### DIFF
--- a/app/components/Detail/components/ViewSourceStudies/constants.ts
+++ b/app/components/Detail/components/ViewSourceStudies/constants.ts
@@ -6,6 +6,6 @@ export const TABLE_OPTIONS: ListConfig<HCAAtlasTrackerSourceStudy>["tableOptions
   {
     getRowId: (row) => row.id,
     initialState: {
-      columnVisibility: { [COLUMN_IDENTIFIER.ROW_POSITION]: true },
+      columnVisibility: { id: false, [COLUMN_IDENTIFIER.ROW_POSITION]: true },
     },
   };

--- a/app/components/Detail/components/ViewSourceStudies/constants.ts
+++ b/app/components/Detail/components/ViewSourceStudies/constants.ts
@@ -6,6 +6,6 @@ export const TABLE_OPTIONS: ListConfig<HCAAtlasTrackerSourceStudy>["tableOptions
   {
     getRowId: (row) => row.id,
     initialState: {
-      columnVisibility: { id: false, [COLUMN_IDENTIFIER.ROW_POSITION]: true },
+      columnVisibility: { [COLUMN_IDENTIFIER.ROW_POSITION]: true },
     },
   };

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -1262,11 +1262,13 @@ export function getAtlasSourceStudiesTableColumns(
   atlasLinkedDatasetsByStudyId: Map<string, HCAAtlasTrackerSourceDataset[]>
 ): ColumnDef<HCAAtlasTrackerSourceStudy>[] {
   return [
-    { accessorKey: "id" },
     getSourceStudyTitleColumnDef(pathParameter),
     getSourceStudyPublicationColumnDef(),
     getSourceStudyMetadataSpreadsheetColumnDef(),
-    getSourceStudySourceDatasetCountColumnDef(pathParameter),
+    getSourceStudySourceDatasetCountColumnDef(
+      pathParameter,
+      atlasLinkedDatasetsByStudyId
+    ),
     getSourceStudyCELLxGENEStatusColumnDef(atlasLinkedDatasetsByStudyId),
     getSourceStudyCapStatusColumnDef(),
     getSourceStudyHCADataRepositoryStatusColumnDef(),
@@ -1743,20 +1745,22 @@ function getSourceStudyPublicationColumnDef(): ColumnDef<HCAAtlasTrackerSourceSt
 /**
  * Returns source study source datasets count column def.
  * @param pathParameter - Path parameter.
+ * @param atlasLinkedDatasetsByStudyId - Arrays of atlas-linked datasets indexed by source study.
  * @returns Column def.
  */
 function getSourceStudySourceDatasetCountColumnDef(
-  pathParameter: PathParameter
+  pathParameter: PathParameter,
+  atlasLinkedDatasetsByStudyId: Map<string, HCAAtlasTrackerSourceDataset[]>
 ): ColumnDef<HCAAtlasTrackerSourceStudy> {
   return {
-    accessorKey: "sourceDatasetCount",
-    cell: (ctx) =>
+    cell: ({ row }) =>
       C.LinkCell({
         getValue: () => ({
-          children: ctx.getValue(),
+          children:
+            atlasLinkedDatasetsByStudyId.get(row.original.id)?.length ?? 0,
           href: getRouteURL(ROUTE.SOURCE_DATASETS, {
             ...pathParameter,
-            sourceStudyId: ctx.row.getValue("id"),
+            sourceStudyId: row.original.id,
           }),
         }),
       }),

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -632,33 +632,6 @@ export const buildSourceStudyCount = (
 };
 
 /**
- * Build props for the used source datasets cell component.
- * @param sourceStudy - Source study entity.
- * @param pathParameter - Path parameter.
- * @param atlasLinkedDatasetsByStudyId - Arrays of atlas-linked source datasets indexed by source study.
- * @returns Props to be used for the cell.
- */
-export const buildSourceStudySourceDatasetCount = (
-  sourceStudy: HCAAtlasTrackerSourceStudy,
-  pathParameter: PathParameter,
-  atlasLinkedDatasetsByStudyId: Map<string, HCAAtlasTrackerSourceDataset[]>
-): ComponentProps<typeof C.Link> => {
-  const label =
-    sourceStudy.sourceDatasetCount === 0
-      ? "--"
-      : `${
-          atlasLinkedDatasetsByStudyId.get(sourceStudy.id)?.length ?? 0
-        } of ${sourceStudy.sourceDatasetCount.toLocaleString()}`;
-  return {
-    label,
-    url: getRouteURL(ROUTE.SOURCE_DATASETS, {
-      ...pathParameter,
-      sourceStudyId: sourceStudy.id,
-    }),
-  };
-};
-
-/**
  * Build props for the status cell component.
  * @param atlas - Atlas entity.
  * @returns Props to be used for the cell.
@@ -1289,13 +1262,11 @@ export function getAtlasSourceStudiesTableColumns(
   atlasLinkedDatasetsByStudyId: Map<string, HCAAtlasTrackerSourceDataset[]>
 ): ColumnDef<HCAAtlasTrackerSourceStudy>[] {
   return [
+    { accessorKey: "id" },
     getSourceStudyTitleColumnDef(pathParameter),
     getSourceStudyPublicationColumnDef(),
     getSourceStudyMetadataSpreadsheetColumnDef(),
-    getSourceStudySourceDatasetCountColumnDef(
-      pathParameter,
-      atlasLinkedDatasetsByStudyId
-    ),
+    getSourceStudySourceDatasetCountColumnDef(pathParameter),
     getSourceStudyCELLxGENEStatusColumnDef(atlasLinkedDatasetsByStudyId),
     getSourceStudyCapStatusColumnDef(),
     getSourceStudyHCADataRepositoryStatusColumnDef(),
@@ -1772,24 +1743,24 @@ function getSourceStudyPublicationColumnDef(): ColumnDef<HCAAtlasTrackerSourceSt
 /**
  * Returns source study source datasets count column def.
  * @param pathParameter - Path parameter.
- * @param atlasLinkedDatasetsByStudyId - Arrays of atlas-linked datasets indexed by source study.
  * @returns Column def.
  */
 function getSourceStudySourceDatasetCountColumnDef(
-  pathParameter: PathParameter,
-  atlasLinkedDatasetsByStudyId: Map<string, HCAAtlasTrackerSourceDataset[]>
+  pathParameter: PathParameter
 ): ColumnDef<HCAAtlasTrackerSourceStudy> {
   return {
     accessorKey: "sourceDatasetCount",
-    cell: ({ row }) =>
-      C.Link(
-        buildSourceStudySourceDatasetCount(
-          row.original,
-          pathParameter,
-          atlasLinkedDatasetsByStudyId
-        )
-      ),
-    header: "Datasets Used",
+    cell: (ctx) =>
+      C.LinkCell({
+        getValue: () => ({
+          children: ctx.getValue(),
+          href: getRouteURL(ROUTE.SOURCE_DATASETS, {
+            ...pathParameter,
+            sourceStudyId: ctx.row.getValue("id"),
+          }),
+        }),
+      }),
+    header: "Datasets",
   };
 }
 


### PR DESCRIPTION
Closes #795.

This pull request refactors how the source study datasets count column is built and displayed in the HCA Atlas Tracker catalog. The main changes simplify the code by removing an unused builder function, updating how the datasets count link is rendered, and adjusting table column definitions and visibility.

**Table configuration and column definition updates:**

* The `id` column is now included in the table columns and hidden by default in the table options, improving internal row identification while keeping the UI clean. [[1]](diffhunk://#diff-24930035ec067eda637648ac5f14156b9d7920ac216c35cc2c21800155e4531bL9-R9) [[2]](diffhunk://#diff-b40c9cfae34bbe2fe51e79be552b0af2ebf79552105c70236d5978760ebbe81aR1265-R1269)

**Source datasets count column refactor:**

* The `buildSourceStudySourceDatasetCount` function was removed, and its logic was replaced by a simplified inline implementation in the column definition, reducing complexity and improving maintainability. [[1]](diffhunk://#diff-b40c9cfae34bbe2fe51e79be552b0af2ebf79552105c70236d5978760ebbe81aL634-L660) [[2]](diffhunk://#diff-b40c9cfae34bbe2fe51e79be552b0af2ebf79552105c70236d5978760ebbe81aL1773-R1761)
* The datasets count column header was renamed from "Datasets Used" to "Datasets" for clarity.
* The column definition for the source datasets count no longer requires `atlasLinkedDatasetsByStudyId`, streamlining function signatures and usage. [[1]](diffhunk://#diff-b40c9cfae34bbe2fe51e79be552b0af2ebf79552105c70236d5978760ebbe81aR1265-R1269) [[2]](diffhunk://#diff-b40c9cfae34bbe2fe51e79be552b0af2ebf79552105c70236d5978760ebbe81aL1773-R1761)

<img width="1170" height="1294" alt="image" src="https://github.com/user-attachments/assets/cc3792ff-f850-429a-bd91-f0aae71c0a66" />
