### PR TITLE
feat: add back source datasets tab to atlas (#794)

### DIFF
--- a/app/components/Detail/components/ViewAtlas/components/Tabs/tabs.tsx
+++ b/app/components/Detail/components/ViewAtlas/components/Tabs/tabs.tsx
@@ -22,8 +22,12 @@ export const Tabs = ({
   pathParameter,
 }: TabsProps): JSX.Element => {
   const { route } = useRouter();
-  const { componentAtlasCount, entrySheetValidationCount, sourceStudyCount } =
-    atlas || {};
+  const {
+    componentAtlasCount,
+    entrySheetValidationCount,
+    sourceDatasetCount,
+    sourceStudyCount,
+  } = atlas || {};
 
   const onChange = useCallback(
     (tabValue: TabValue): void => {
@@ -47,6 +51,10 @@ export const Tabs = ({
             entrySheetValidationCount
           ),
           value: ROUTE.METADATA_ENTRY_SHEETS,
+        },
+        {
+          label: getTabLabelWithCount("Source Datasets", sourceDatasetCount),
+          value: ROUTE.ATLAS_SOURCE_DATASETS,
         },
         {
           label: getTabLabelWithCount(

--- a/app/components/Detail/components/ViewAtlasSourceDatasets/viewAtlasSourceDatasets.tsx
+++ b/app/components/Detail/components/ViewAtlasSourceDatasets/viewAtlasSourceDatasets.tsx
@@ -26,7 +26,7 @@ export const ViewAtlasSourceDatasets = ({
   formManager,
 }: ViewSourceDatasetsProps): JSX.Element => {
   const {
-    access: { canEdit, canView },
+    access: { canView },
   } = formManager;
   if (!canView) return <RequestAccess />;
   return (
@@ -38,13 +38,12 @@ export const ViewAtlasSourceDatasets = ({
           {atlas && atlasSourceDatasets.length > 0 && (
             <Table
               columns={getAtlasSourceDatasetsTableColumns(atlas)}
-              gridTemplateColumns="max-content minmax(110px, auto) minmax(180px, 0.4fr) minmax(200px, 1fr) minmax(110px, 120px) minmax(175px, 195px) minmax(200px, 1fr) repeat(4, minmax(110px, 0.5fr)) auto"
+              gridTemplateColumns="max-content minmax(110px, auto) minmax(180px, 0.4fr) minmax(200px, 1fr) minmax(110px, 120px) minmax(175px, 195px) minmax(200px, 1fr) repeat(7, minmax(120px, 0.5fr))"
               items={atlasSourceDatasets.sort(sortLinkedSourceDataset)}
               tableOptions={TABLE_OPTIONS}
             />
           )}
           <TablePlaceholder
-            canEdit={canEdit}
             message="No source datasets"
             rowCount={atlasSourceDatasets.length}
           />

--- a/app/components/Detail/components/ViewAtlasSourceDatasets/viewAtlasSourceDatasets.tsx
+++ b/app/components/Detail/components/ViewAtlasSourceDatasets/viewAtlasSourceDatasets.tsx
@@ -38,7 +38,7 @@ export const ViewAtlasSourceDatasets = ({
           {atlas && atlasSourceDatasets.length > 0 && (
             <Table
               columns={getAtlasSourceDatasetsTableColumns(atlas)}
-              gridTemplateColumns="max-content minmax(110px, auto) minmax(180px, 0.4fr) minmax(200px, 1fr) minmax(110px, 120px) minmax(175px, 195px) minmax(200px, 1fr) repeat(7, minmax(120px, 0.5fr))"
+              gridTemplateColumns="max-content minmax(110px, auto) minmax(160px, 0.4fr) minmax(180px, 1fr) minmax(110px, 120px) minmax(200px, 1fr) repeat(7, minmax(120px, 0.5fr))"
               items={atlasSourceDatasets.sort(sortLinkedSourceDataset)}
               tableOptions={TABLE_OPTIONS}
             />

--- a/app/components/Index/components/FileDownload/fileDownload.tsx
+++ b/app/components/Index/components/FileDownload/fileDownload.tsx
@@ -1,29 +1,30 @@
 import { DownloadIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/DownloadIcon/downloadIcon";
 import { IconButton } from "@databiosphere/findable-ui/lib/components/common/IconButton/iconButton";
-import { useRef } from "react";
+import { useCallback } from "react";
+import { downloadFile } from "./utils";
 
 export interface FileDownloadProps {
+  disabled?: boolean;
   fileName: string;
   fileUrl?: string;
 }
 
 export const FileDownload = ({
+  disabled,
   fileName,
   fileUrl,
 }: FileDownloadProps): JSX.Element => {
-  const downloadRef = useRef<HTMLAnchorElement>(null);
+  const onDownload = useCallback((): void => {
+    downloadFile(fileName, fileUrl);
+  }, [fileName, fileUrl]);
 
   return (
-    <a download={fileName} href={fileUrl}>
-      <IconButton
-        color="primary"
-        disabled={!fileUrl}
-        Icon={DownloadIcon}
-        onClick={(): void => {
-          downloadRef.current?.click();
-        }}
-        size="medium"
-      />
-    </a>
+    <IconButton
+      color="primary"
+      disabled={disabled}
+      Icon={DownloadIcon}
+      onClick={onDownload}
+      size="medium"
+    />
   );
 };

--- a/app/components/Index/components/FileDownload/utils.ts
+++ b/app/components/Index/components/FileDownload/utils.ts
@@ -1,0 +1,14 @@
+/**
+ * Download the given file.
+ * @param fileName - File name.
+ * @param fileUrl - File URL.
+ */
+export function downloadFile(fileName?: string, fileUrl?: string): void {
+  if (!fileName || !fileUrl) return;
+  const anchorEl = document.createElement("a");
+  anchorEl.href = fileUrl;
+  anchorEl.download = fileName;
+  document.body.appendChild(anchorEl);
+  anchorEl.click();
+  document.body.removeChild(anchorEl);
+}

--- a/app/components/Table/components/TablePlaceholder/tablePlaceholder.tsx
+++ b/app/components/Table/components/TablePlaceholder/tablePlaceholder.tsx
@@ -3,7 +3,7 @@ import { TypographyTextBody400 } from "../../../common/Typography/components/Typ
 import { GridPaperSection } from "./tablePlaceholder.styles";
 
 interface TablePlaceholderProps {
-  canEdit: boolean;
+  canEdit?: boolean;
   message: ReactNode | ReactNode[];
   rowCount: number;
 }

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -1111,7 +1111,7 @@ export function getAtlasComponentSourceDatasetsTableColumns(
  */
 export function getAtlasSourceDatasetsTableColumns(
   atlas: HCAAtlasTrackerAtlas
-): ColumnDef<HCAAtlasTrackerSourceDataset>[] {
+): ColumnDef<HCAAtlasTrackerSourceDataset, unknown>[] {
   return [
     getSourceDatasetDownloadColumnDef(),
     getAtlasSourceDatasetTitleColumnDef(atlas),
@@ -1124,7 +1124,9 @@ export function getAtlasSourceDatasetsTableColumns(
     getTissueColumnDef(),
     getDiseaseColumnDef(),
     getCellCountColumnDef(),
-  ];
+    getCreatedAtColumnDef(),
+    getUpdatedAtColumnDef(),
+  ] as ColumnDef<HCAAtlasTrackerSourceDataset, unknown>[];
 }
 
 /**
@@ -1393,6 +1395,21 @@ function getComponentAtlasTitleColumnDef(): ColumnDef<HCAAtlasTrackerComponentAt
   return {
     accessorKey: "title",
     header: "Title",
+  };
+}
+
+/**
+ * Returns created at column def.
+ * @returns ColumnDef.
+ */
+function getCreatedAtColumnDef(): ColumnDef<
+  HCAAtlasTrackerSourceDataset,
+  string
+> {
+  return {
+    accessorKey: "createdAt",
+    cell: (ctx) => getDateFromIsoString(ctx.getValue()),
+    header: "Created At",
   };
 }
 
@@ -1878,5 +1895,20 @@ function getTissueColumnDef<
     accessorKey: "tissue",
     cell: ({ row }) => C.NTagCell(buildTissue(row.original)),
     header: "Tissue",
+  };
+}
+
+/**
+ * Returns updated at column def.
+ * @returns ColumnDef.
+ */
+function getUpdatedAtColumnDef(): ColumnDef<
+  HCAAtlasTrackerSourceDataset,
+  string
+> {
+  return {
+    accessorKey: "updatedAt",
+    cell: (ctx) => getDateFromIsoString(ctx.getValue()),
+    header: "Updated At",
   };
 }

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -420,23 +420,6 @@ export const buildSourceDatasetCount = (
 };
 
 /**
- * Build props for the source dataset download component.
- * @param sourceDataset - Source dataset entity.
- * @returns Props to be used for the cell.
- */
-export const buildSourceDatasetDownload = (
-  sourceDataset: HCAAtlasTrackerSourceDataset
-): ComponentProps<typeof C.FileDownload> => {
-  const versionId = sourceDataset.cellxgeneDatasetVersion;
-  return {
-    fileName: `${versionId}.h5ad`,
-    fileUrl: versionId
-      ? `https://datasets.cellxgene.cziscience.com/${versionId}.h5ad`
-      : undefined,
-  };
-};
-
-/**
  * Build props for the source dataset Tier 1 metadata StatusBadge component.
  * @param sourceDataset - Source dataset entity.
  * @returns Props to be used for the StatusBadge component.
@@ -1118,7 +1101,6 @@ export function getAtlasSourceDatasetsTableColumns(
     getSourceDatasetSourceStudyColumnDef(atlas),
     getAtlasSourceDatasetPublicationColumnDef(),
     getSourceDatasetTierOneMetadataStatusColumnDef(),
-    getSourceDatasetMetadataSpreadsheetColumnDef(),
     getAssayColumnDef(),
     getSuspensionTypeColumnDef(),
     getTissueColumnDef(),
@@ -1526,12 +1508,10 @@ function getProgressValue(numerator: number, denominator: number): number {
  */
 function getSourceDatasetDownloadColumnDef(): ColumnDef<HCAAtlasTrackerSourceDataset> {
   return {
-    accessorKey: "cellxgeneDatasetVersion",
-    cell: ({ row }): JSX.Element => {
-      return C.FileDownload(buildSourceDatasetDownload(row.original));
-    },
+    accessorKey: "download",
+    cell: (): JSX.Element => C.FileDownload({ disabled: true, fileName: "" }),
     enableSorting: false,
-    header: "Download from CELLxGENE",
+    header: "Download",
   };
 }
 
@@ -1586,27 +1566,6 @@ function getSourceDatasetLinkedColumnDef(
       }),
     enableSorting: false,
     header: "Used In Atlas",
-  };
-}
-
-/**
- * Returns source dataset metadata spreadsheet column def.
- * @returns Column def.
- */
-function getSourceDatasetMetadataSpreadsheetColumnDef(): ColumnDef<HCAAtlasTrackerSourceDataset> {
-  return {
-    accessorKey: "metadataSpreadsheetUrl",
-    cell: ({ row }): JSX.Element => {
-      return C.Link({
-        label:
-          row.original.metadataSpreadsheetTitle ||
-          row.original.metadataSpreadsheetUrl,
-        target: ANCHOR_TARGET.BLANK,
-        url: row.original.metadataSpreadsheetUrl ?? "",
-      });
-    },
-    enableSorting: false,
-    header: "Metadata Entry Sheet",
   };
 }
 

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -1108,7 +1108,7 @@ export function getAtlasSourceDatasetsTableColumns(
     getCellCountColumnDef(),
     getCreatedAtColumnDef(),
     getUpdatedAtColumnDef(),
-  ] as ColumnDef<HCAAtlasTrackerSourceDataset, unknown>[];
+  ];
 }
 
 /**
@@ -1384,13 +1384,10 @@ function getComponentAtlasTitleColumnDef(): ColumnDef<HCAAtlasTrackerComponentAt
  * Returns created at column def.
  * @returns ColumnDef.
  */
-function getCreatedAtColumnDef(): ColumnDef<
-  HCAAtlasTrackerSourceDataset,
-  string
-> {
+function getCreatedAtColumnDef(): ColumnDef<HCAAtlasTrackerSourceDataset> {
   return {
     accessorKey: "createdAt",
-    cell: (ctx) => getDateFromIsoString(ctx.getValue()),
+    cell: ({ row }) => getDateFromIsoString(row.original.createdAt),
     header: "Created At",
   };
 }
@@ -1861,13 +1858,10 @@ function getTissueColumnDef<
  * Returns updated at column def.
  * @returns ColumnDef.
  */
-function getUpdatedAtColumnDef(): ColumnDef<
-  HCAAtlasTrackerSourceDataset,
-  string
-> {
+function getUpdatedAtColumnDef(): ColumnDef<HCAAtlasTrackerSourceDataset> {
   return {
     accessorKey: "updatedAt",
-    cell: (ctx) => getDateFromIsoString(ctx.getValue()),
+    cell: ({ row }) => getDateFromIsoString(row.original.updatedAt),
     header: "Updated At",
   };
 }


### PR DESCRIPTION
Closes #794.

This pull request updates the Atlas Tracker UI to enhance the Source Datasets tab and its table, and refactors the file download logic. The changes add a new "Source Datasets" tab, expand the table with new columns, and simplify the file download component, while also removing some unused or redundant code.

**Atlas Tracker UI Enhancements:**

* Added a new "Source Datasets" tab to the Atlas view and included a count of source datasets in the tab label. (`app/components/Detail/components/ViewAtlas/components/Tabs/tabs.tsx`) [[1]](diffhunk://#diff-1108c3d735aac7a45e5785895f31fe25f2f91e87827bcdc7a21d6d0a0f9d9e83L25-R30) [[2]](diffhunk://#diff-1108c3d735aac7a45e5785895f31fe25f2f91e87827bcdc7a21d6d0a0f9d9e83R55-R58)
* Expanded the Source Datasets table with new columns: "Created At" and "Updated At", and removed the "Metadata Entry Sheet" column. (`app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts`) [[1]](diffhunk://#diff-b40c9cfae34bbe2fe51e79be552b0af2ebf79552105c70236d5978760ebbe81aL1141-R1138) [[2]](diffhunk://#diff-b40c9cfae34bbe2fe51e79be552b0af2ebf79552105c70236d5978760ebbe81aR1410-R1424) [[3]](diffhunk://#diff-b40c9cfae34bbe2fe51e79be552b0af2ebf79552105c70236d5978760ebbe81aR1884-R1898) [[4]](diffhunk://#diff-b40c9cfae34bbe2fe51e79be552b0af2ebf79552105c70236d5978760ebbe81aL1602-L1622)
* Updated the table layout to accommodate the new columns and removed the unused `canEdit` prop from the table placeholder. (`app/components/Detail/components/ViewAtlasSourceDatasets/viewAtlasSourceDatasets.tsx`, `app/components/Table/components/TablePlaceholder/tablePlaceholder.tsx`) [[1]](diffhunk://#diff-13d1285271765848350da9519d79a7f519f5c5b8fbac8e953137c83186bf38d0L29-R29) [[2]](diffhunk://#diff-13d1285271765848350da9519d79a7f519f5c5b8fbac8e953137c83186bf38d0L41-L47) [[3]](diffhunk://#diff-dc5ecda63dd30e585caef95c6f1dffa35989b1411d10d6b45c760681a6603938L6-R6)

**File Download Refactor:**

* Refactored the `FileDownload` component to use a utility function for downloading files and added a `disabled` prop for better control. (`app/components/Index/components/FileDownload/fileDownload.tsx`, `app/components/Index/components/FileDownload/utils.ts`) [[1]](diffhunk://#diff-8a0af30f4890a35088c423f0286f87c87d562890b43a1a760594e9dc26e924d8L3-L27) [[2]](diffhunk://#diff-942d9e7a75f7eb5233baf5e4d122e0959c6e6a500ff0b141573d5f2affe305e7R1-R14)
* Updated the Source Dataset table to show a disabled download button (pending future implementation) and removed the now-unused download builder function. (`app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts`) [[1]](diffhunk://#diff-b40c9cfae34bbe2fe51e79be552b0af2ebf79552105c70236d5978760ebbe81aL1539-R1541) [[2]](diffhunk://#diff-b40c9cfae34bbe2fe51e79be552b0af2ebf79552105c70236d5978760ebbe81aL422-L438)

These improvements streamline the UI, prepare for future enhancements, and clean up unused code.

<img width="1713" height="935" alt="image" src="https://github.com/user-attachments/assets/78faac76-a32b-4fad-a6c2-a47ea938a6c1" />


<img width="1716" height="568" alt="image" src="https://github.com/user-attachments/assets/96c7681e-13cd-40ac-ba04-b5f225d281af" />

