### PR TITLE
feat: source dataset column tweaks (#815)

### DIFF
--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -1066,7 +1066,7 @@ export function getAtlasSourceDatasetsTableColumns(
     getSuspensionTypeColumnDef(),
     getTissueColumnDef(),
     getDiseaseColumnDef(),
-    getCellCountColumnDef(),
+    getSourceDatasetCellCountColumnDef(),
   ];
 }
 
@@ -1412,6 +1412,20 @@ function getIntegratedObjectValidationStatusColumnDef(): ColumnDef<
 function getProgressValue(numerator: number, denominator: number): number {
   if (denominator === 0) return 0;
   return (numerator / denominator) * 100;
+}
+
+/**
+ * Returns the source dataset cell count column def.
+ * If the validation status is PENDING, returns an empty string.
+ * Otherwise, returns the cell count, formatted as a number.
+ * @returns ColumnDef.
+ */
+function getSourceDatasetCellCountColumnDef(): ColumnDef<HCAAtlasTrackerSourceDataset> {
+  return {
+    accessorKey: "cellCount",
+    cell: renderSourceDatasetCellCount,
+    header: "Cell Count",
+  };
 }
 
 /**
@@ -1764,4 +1778,19 @@ function getTissueColumnDef<
     cell: ({ row }) => C.NTagCell(buildTissue(row.original)),
     header: "Tissue",
   };
+}
+
+/**
+ * Returns the source dataset cell count.
+ * If the validation status is PENDING, returns an empty string.
+ * Otherwise, returns the cell count, formatted as a number.
+ * @param ctx - Cell context.
+ * @returns Cell count.
+ */
+function renderSourceDatasetCellCount(
+  ctx: CellContext<HCAAtlasTrackerSourceDataset, number>
+): string {
+  const { getValue, row } = ctx;
+  if (row.getValue("validationStatus") === INTEGRITY_STATUS.PENDING) return "";
+  return getValue().toLocaleString();
 }


### PR DESCRIPTION
Closes #815.

This pull request updates how the cell count is displayed for source datasets in the HCA Atlas Tracker. The main change is to show an empty cell when the validation status is PENDING, rather than displaying a number.

**Enhancements to cell count display in source datasets:**

* Replaced the use of `getCellCountColumnDef` with a new `getSourceDatasetCellCountColumnDef` in the columns definition to provide custom rendering logic for cell counts.
* Added the `getSourceDatasetCellCountColumnDef` function, which specifies the use of a new cell renderer for the cell count column.
* Implemented the `renderSourceDatasetCellCount` function to display an empty string when the validation status is PENDING, and otherwise format the cell count as a localized number.

<img width="1716" height="767" alt="image" src="https://github.com/user-attachments/assets/169a7006-f458-4575-b290-edfd8c8b3b0e" />
