### PR TITLE
feat: update banner help text for key entities (#819)

### DIFF
--- a/app/components/Detail/components/ViewAtlasSourceDatasets/components/Alert/alert.tsx
+++ b/app/components/Detail/components/ViewAtlasSourceDatasets/components/Alert/alert.tsx
@@ -9,13 +9,8 @@ export const Alert = (): JSX.Element => {
       <div>
         <p>
           A source dataset is a dataset (AnnData file) from a Source Study that
-          has been selected for integration into the atlas. Datasets are
-          considered &quot;Source Datasets&quot; if marked as &quot;In use&quot;
-          on the Source Study’s datasets tab.
-        </p>
-        <p>
-          Source datasets are downloadable from the CELLxGENE public collection
-          for the source study.
+          has been selected for integration into the atlas and uploaded into the
+          Tracker.
         </p>
       </div>
     </StyledAlert>

--- a/app/components/Detail/components/ViewSourceStudies/components/Alert/alert.tsx
+++ b/app/components/Detail/components/ViewSourceStudies/components/Alert/alert.tsx
@@ -8,20 +8,12 @@ export const Alert = (): JSX.Element => {
       <AlertTitle>What is a &quot;Source Study&quot;?</AlertTitle>
       <div>
         <p>
-          A Source Study is a publication (or pre-publication) containing one or
-          more datasets selected for Atlas integration. Source studies are
-          ingested into CELLxGENE as a &quot;CELLxGENE collection&quot; and into
-          the HCA Data Repository and CAP as &quot;projects.&quot; A dataset is
-          an AnnData file with a cell-by-gene count matrix and metadata.
-        </p>
-        <p>
-          Not all of the datasets in a source study are necessarily integrated
-          into a given atlas. The &quot;Datasets Used&quot; column indicates how
-          many of the source study’s datasets are used in this atlas.
-        </p>
-        <p>
-          Select a source study and view its &quot;Datasets&quot; list to
-          indicate which datasets are used in the atlas.
+          A Source Study is a publication, pre-publication, or unpublished study
+          that contains one or more datasets selected for integration into the
+          Atlas. Published or preprint studies are identified by their DOI.
+          Given a DOI, the system queries CrossRef to retrieve basic study
+          metadata, including authorship information. Unpublished source studies
+          are identified by the author&apos;s name.
         </p>
       </div>
     </StyledAlert>


### PR DESCRIPTION
Closes #819.

This pull request updates the explanatory text in the alert components for both "Source Study" and "Source Dataset" to provide clearer and more accurate definitions. The changes focus on improving user understanding of these concepts by refining the language and updating the descriptions to reflect current processes.

Content updates for alert components:

* Updated the description of a "Source Study" in `alert.tsx` to clarify its definition, explain how published, preprint, and unpublished studies are identified, and describe how metadata is retrieved using DOI and CrossRef.
* Revised the explanation of a "Source Dataset" in `alert.tsx` to state that it is a dataset selected for integration into the atlas and uploaded into the Tracker, removing outdated references to downloadability and selection status.

<img width="1238" height="996" alt="image" src="https://github.com/user-attachments/assets/f94a0db4-9eff-4e9b-80a9-888fc7b45fae" />

<img width="1237" height="707" alt="image" src="https://github.com/user-attachments/assets/8ae84c6e-c357-4050-a44d-36eb9df6d3ac" />
