### PR TITLE
feat: provide a "no metadata entry sheets" message when there are no entry sheets (#757)

### DIFF
--- a/app/views/AtlasMetadataEntrySheetsView/components/Table/table.tsx
+++ b/app/views/AtlasMetadataEntrySheetsView/components/Table/table.tsx
@@ -2,6 +2,7 @@ import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Pap
 import { GridPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/paper.styles";
 import { useReactTable } from "@tanstack/react-table";
 import { Table as CommonTable } from "../../../../components/Entity/components/common/Table/table";
+import { TablePlaceholder } from "../../../../components/Table/components/TablePlaceholder/tablePlaceholder";
 import { CORE_OPTIONS } from "../../../../components/Table/options/core/constants";
 import { SORTING_OPTIONS } from "../../../../components/Table/options/sorting/constants";
 import { useEntity } from "../../../../providers/entity/hook";
@@ -24,7 +25,11 @@ export const Table = (props: Props): JSX.Element => {
   return (
     <FluidPaper elevation={0}>
       <GridPaper>
-        <CommonTable table={table} />
+        {table.getRowCount() > 0 && <CommonTable table={table} />}
+        <TablePlaceholder
+          message="No metadata entry sheets"
+          rowCount={table.getRowCount()}
+        />
       </GridPaper>
     </FluidPaper>
   );


### PR DESCRIPTION
Closes #757.

<img width="1722" height="815" alt="image" src="https://github.com/user-attachments/assets/e1caeb37-6d6a-496e-a8d5-3f4f17a8f97a" />
