### PR TITLE
feat: provide a proper "no integrated objects" message for the atlas integrated objects (#820)

### DIFF
--- a/app/components/Detail/components/ViewComponentAtlases/viewComponentAtlases.tsx
+++ b/app/components/Detail/components/ViewComponentAtlases/viewComponentAtlases.tsx
@@ -18,7 +18,7 @@ export const ViewComponentAtlases = ({
   formManager,
 }: ViewComponentAtlasesProps): JSX.Element => {
   const {
-    access: { canEdit, canView },
+    access: { canView },
   } = formManager;
   if (!canView) return <RequestAccess />;
   return (
@@ -33,7 +33,6 @@ export const ViewComponentAtlases = ({
           />
         )}
         <TablePlaceholder
-          canEdit={canEdit}
           message="No integrated objects"
           rowCount={componentAtlases.length}
         />


### PR DESCRIPTION
Closes #820.

This pull request makes a minor update to the `ViewComponentAtlases` component by removing the unused `canEdit` property. This simplifies the component's props and cleans up the code.

- Removed the `canEdit` property from the destructured `access` object in `formManager` and stopped passing it to the `TablePlaceholder` component in `viewComponentAtlases.tsx`. [[1]](diffhunk://#diff-dcb56eb650b39c9a6176faa52c042ef6a53a6ca3091a7a2d8d2a334ca696b919L21-R21) [[2]](diffhunk://#diff-dcb56eb650b39c9a6176faa52c042ef6a53a6ca3091a7a2d8d2a334ca696b919L36)

<img width="1655" height="566" alt="image" src="https://github.com/user-attachments/assets/5105fe0b-925c-48ee-adc0-2d359a0f5541" />
