### PR TITLE
feat: remove cellxgene collections count from atlases list (#821)

### DIFF
--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -275,17 +275,6 @@ export const buildIngestionCountsCap = (
 };
 
 /**
- * Build props for the CELLxGENE ingestion counts TaskCountsCell component.
- * @param atlas - Atlas entity.
- * @returns Props to be used for the TaskCountsCell.
- */
-export const buildIngestionCountsCellxGene = (
-  atlas: HCAAtlasTrackerListAtlas
-): ComponentProps<typeof C.TaskCountsCell> => {
-  return buildIngestionCountsForSystem(atlas, SYSTEM.CELLXGENE);
-};
-
-/**
  * Build props for the ingestion counts TaskCountsCell component for the given system.
  * @param atlas - Atlas entity.
  * @param system - System.

--- a/site-config/hca-atlas-tracker/local/index/atlas/atlasEntityConfig.ts
+++ b/site-config/hca-atlas-tracker/local/index/atlas/atlasEntityConfig.ts
@@ -180,15 +180,6 @@ export const atlasEntityConfig: EntityConfig = {
       {
         componentConfig: {
           component: C.TaskCountsCell,
-          viewBuilder: V.buildIngestionCountsCellxGene,
-        } as ComponentConfig<typeof C.TaskCountsCell, HCAAtlasTrackerListAtlas>,
-        enableGrouping: false,
-        header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.INGESTION_COUNTS_CELLXGENE,
-        width: { max: "128px", min: "128px" },
-      },
-      {
-        componentConfig: {
-          component: C.TaskCountsCell,
           viewBuilder: V.buildIngestionCountsCap,
         } as ComponentConfig<typeof C.TaskCountsCell, HCAAtlasTrackerListAtlas>,
         enableGrouping: false,


### PR DESCRIPTION
Closes #821.

This pull request removes the support for displaying CELLxGENE ingestion counts in the HCA Atlas Tracker UI. The main changes involve deleting the related view builder and removing the corresponding column configuration.

UI configuration cleanup:

* Removed the `buildIngestionCountsCellxGene` function from `viewModelBuilders.ts`, which was responsible for building the props for CELLxGENE ingestion counts.
* Deleted the CELLxGENE ingestion counts column from the `atlasEntityConfig` table configuration in `atlasEntityConfig.ts`, so this data will no longer be shown in the UI.

<img width="1656" height="739" alt="image" src="https://github.com/user-attachments/assets/6e50d337-779b-4b30-a688-2552dedf0fdd" />
