### PR TITLE
feat: remove the cellxgene column form the source studies page (#822)

### DIFF
--- a/app/components/Detail/components/ViewSourceStudies/viewSourceStudies.tsx
+++ b/app/components/Detail/components/ViewSourceStudies/viewSourceStudies.tsx
@@ -94,7 +94,7 @@ export const ViewSourceStudies = ({
                 pathParameter,
                 atlasLinkedDatasetsByStudyId
               )}
-              gridTemplateColumns="max-content minmax(280px, 1.2fr) minmax(120px, 0.4fr) minmax(200px, 1fr) minmax(180px, 0.75fr) minmax(180px, 0.75fr) minmax(180px, 0.75fr) minmax(180px, 0.75fr)"
+              gridTemplateColumns="max-content minmax(280px, 1.2fr) minmax(120px, 0.4fr) minmax(200px, 1fr) repeat(3, minmax(180px, 0.75fr))"
               items={sortedSourceStudies}
               tableOptions={TABLE_OPTIONS}
             />

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -39,12 +39,10 @@ import {
   NetworkKey,
   SYSTEM,
   TASK_STATUS,
-  TIER_ONE_METADATA_STATUS,
   VALIDATION_DESCRIPTION,
   VALIDATION_ID,
 } from "../../../../apis/catalog/hca-atlas-tracker/common/entities";
 import {
-  getSourceDatasetsTierOneMetadataStatus,
   getSourceStudyCitation,
   getSourceStudyTaskStatus,
   isTask,
@@ -428,60 +426,6 @@ export const buildSourceStudyCapStatus = (
     sourceStudy,
     VALIDATION_ID.SOURCE_STUDY_IN_CAP
   );
-};
-
-/**
- * Build props for the CELLxGENE IconStatusBadge component.
- * @param sourceStudy - Source study entity.
- * @param atlasLinkedDatasetsByStudyId - Atlas linked source datasets indexed by source study.
- * @returns Props to be used for the IconStatusBadge component.
- */
-export const buildSourceStudyCellxGeneStatus = (
-  sourceStudy: HCAAtlasTrackerSourceStudy,
-  atlasLinkedDatasetsByStudyId: Map<string, HCAAtlasTrackerSourceDataset[]>
-): ComponentProps<typeof C.IconStatusBadge> => {
-  const ingestStatus = getSourceStudyTaskStatus(
-    sourceStudy,
-    VALIDATION_ID.SOURCE_STUDY_IN_CELLXGENE
-  );
-  if (ingestStatus === TASK_STATUS.DONE) {
-    const sourceDatasets =
-      atlasLinkedDatasetsByStudyId.get(sourceStudy.id) ?? [];
-    if (sourceDatasets.length === 0)
-      return {
-        label: STATUS_LABEL.NO_DATASETS_USED,
-        status: ICON_STATUS.REQUIRED,
-      };
-    const tierOneMetadataStatus =
-      getSourceDatasetsTierOneMetadataStatus(sourceDatasets);
-    switch (tierOneMetadataStatus) {
-      case TIER_ONE_METADATA_STATUS.COMPLETE:
-        return {
-          label: STATUS_LABEL.TIER_ONE,
-          status: ICON_STATUS.DONE,
-        };
-      case TIER_ONE_METADATA_STATUS.INCOMPLETE:
-        return {
-          label: STATUS_LABEL.INCOMPLETE_TIER_ONE,
-          status: ICON_STATUS.PARTIALLY_COMPLETE,
-        };
-      case TIER_ONE_METADATA_STATUS.MISSING:
-        return {
-          label: STATUS_LABEL.NO_TIER_ONE,
-          status: ICON_STATUS.PARTIALLY_COMPLETE,
-        };
-      default:
-        return {
-          label: STATUS_LABEL.NEEDS_VALIDATION,
-          status: ICON_STATUS.REQUIRED,
-        };
-    }
-  } else {
-    return {
-      label: STATUS_LABEL.TODO,
-      status: ICON_STATUS.REQUIRED,
-    };
-  }
 };
 
 /**
@@ -1180,7 +1124,6 @@ export function getAtlasSourceStudiesTableColumns(
       pathParameter,
       atlasLinkedDatasetsByStudyId
     ),
-    getSourceStudyCELLxGENEStatusColumnDef(atlasLinkedDatasetsByStudyId),
     getSourceStudyCapStatusColumnDef(),
     getSourceStudyHCADataRepositoryStatusColumnDef(),
   ];
@@ -1555,26 +1498,6 @@ function getSourceStudyCapStatusColumnDef(): ColumnDef<HCAAtlasTrackerSourceStud
     cell: ({ row }) =>
       C.IconStatusBadge(buildSourceStudyCapStatus(row.original)),
     header: "CAP",
-  };
-}
-
-/**
- * Returns source study in CELLxGENE column def.
- * @param atlasLinkedDatasetsByStudyId - Arrays of atlas-linked source datasets indexed by source study.
- * @returns Column def.
- */
-function getSourceStudyCELLxGENEStatusColumnDef(
-  atlasLinkedDatasetsByStudyId: Map<string, HCAAtlasTrackerSourceDataset[]>
-): ColumnDef<HCAAtlasTrackerSourceStudy> {
-  return {
-    cell: ({ row }) =>
-      C.IconStatusBadge(
-        buildSourceStudyCellxGeneStatus(
-          row.original,
-          atlasLinkedDatasetsByStudyId
-        )
-      ),
-    header: "CELLxGENE",
   };
 }
 


### PR DESCRIPTION
Closes #822.

This pull request removes the "CELLxGENE" status column and its related logic from the source studies table in the HCA Atlas Tracker. The main changes involve deleting the code that built and displayed the CELLxGENE status, as well as cleaning up related imports and function calls.

**Removal of CELLxGENE status column and logic:**

- Deleted the `buildSourceStudyCellxGeneStatus` function and the `getSourceStudyCELLxGENEStatusColumnDef` function, which were responsible for generating and rendering the CELLxGENE status in the table. [[1]](diffhunk://#diff-b40c9cfae34bbe2fe51e79be552b0af2ebf79552105c70236d5978760ebbe81aL433-L486) [[2]](diffhunk://#diff-b40c9cfae34bbe2fe51e79be552b0af2ebf79552105c70236d5978760ebbe81aL1561-L1580)
- Removed the import of `getSourceDatasetsTierOneMetadataStatus` and related constants that were only used by the CELLxGENE status logic.
- Removed the call to `getSourceStudyCELLxGENEStatusColumnDef` from the `getAtlasSourceStudiesTableColumns` function, so the CELLxGENE column is no longer included in the table.
- Updated the `gridTemplateColumns` property in `ViewSourceStudies` to reflect the removal of the CELLxGENE column, using a `repeat(3, ...)` syntax for the remaining columns.

<img width="1652" height="1048" alt="image" src="https://github.com/user-attachments/assets/eafa7429-fd87-4c4b-9037-7b346d349bb6" />
