### PR TITLE
feat: handle validation result sns messages (#803)

### DIFF
--- a/__tests__/api-sns-with-s3-event.test.ts
+++ b/__tests__/api-sns-with-s3-event.test.ts
@@ -1,8 +1,3 @@
-// Mock HTTP wrapper for outbound requests BEFORE any imports
-jest.mock("../app/utils/http", () => {
-  return { httpGet: jest.fn() };
-});
-
 // Set up AWS resource configuration BEFORE any other imports
 const TEST_S3_BUCKET = "hca-atlas-tracker-data-dev";
 const TEST_GUT_ATLAS_ID = "550e8400-e29b-41d4-a716-446655440000";
@@ -31,20 +26,11 @@ import {
   countSourceDatasets,
   resetDatabase,
 } from "../testing/db-utils";
-import {
-  withConsoleErrorHiding,
-  withConsoleMessageHiding,
-} from "../testing/utils";
+import { withConsoleMessageHiding } from "../testing/utils";
 
 // Additional imports for direct service testing
 import { updateSourceDataset } from "../app/services/s3-notification";
 import { InvalidOperationError } from "../app/utils/api-handler";
-
-// Retrieve the mock function created in the jest.mock factory above
-const { httpGet } = jest.requireMock("../app/utils/http") as {
-  httpGet: jest.Mock;
-};
-const mockHttpGet = httpGet as jest.Mock;
 
 // Test file path constants
 const TEST_PATH_SEGMENTS = {
@@ -253,19 +239,7 @@ afterAll(() => {
   endPgPool();
 });
 
-describe(TEST_ROUTE, () => {
-  // HTTP Method Validation Tests
-  it("returns error 405 for non-POST request", async () => {
-    const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>(
-      {
-        method: METHOD.GET,
-      }
-    );
-
-    await snsHandler(req, res);
-
-    expect(res.statusCode).toBe(405);
-  });
+describe(`${TEST_ROUTE} (S3 event)`, () => {
   it("rejects S3 record when eventTime is missing", async () => {
     // Start with a valid event and then remove eventTime to simulate missing timestamp
     const s3Event = createS3Event({
@@ -306,24 +280,6 @@ describe(TEST_ROUTE, () => {
       TEST_FILE_PATHS.SOURCE_DATASET_TEST,
     ]);
     expect(fileRows.rows).toHaveLength(0);
-  });
-
-  // SNS Message Structure Validation Tests
-  it("returns error 400 for invalid SNS message payload", async () => {
-    const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>(
-      {
-        body: {
-          invalid: "payload",
-        },
-        method: METHOD.POST,
-      }
-    );
-
-    await withConsoleErrorHiding(async () => {
-      await snsHandler(req, res);
-    });
-
-    expect(res.statusCode).toBe(400);
   });
 
   // SHA256 Integrity Validation Tests
@@ -737,129 +693,6 @@ describe(TEST_ROUTE, () => {
     );
   });
 
-  // Security and Authentication Tests
-  it("rejects SNS messages with invalid signatures", async () => {
-    const s3Event = createS3Event({
-      etag: "invalid-signature-test",
-      eventTime: TEST_TIMESTAMP_ALT,
-      key: TEST_FILE_PATHS.SOURCE_DATASET_AUTH,
-      size: 256000,
-      versionId: "auth-test-version",
-    });
-
-    const snsMessageWithInvalidSignature = createSNSMessage({
-      messageId: "auth-test-message",
-      s3Event,
-      signature: TEST_SIGNATURE_INVALID,
-      timestamp: TEST_TIMESTAMP_ALT,
-    });
-
-    const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>(
-      {
-        body: snsMessageWithInvalidSignature,
-        method: "POST",
-      }
-    );
-
-    await withConsoleErrorHiding(async () => {
-      await snsHandler(req, res);
-    });
-
-    // Should reject with 401 Unauthorized due to invalid signature
-    expect(res.statusCode).toBe(401);
-    expect(JSON.parse(res._getData())).toEqual({
-      message: "SNS signature validation failed",
-    });
-
-    // Verify no file was saved to database
-    const fileRows = await query(SQL_QUERIES.SELECT_FILE_BY_BUCKET_AND_KEY, [
-      TEST_S3_BUCKET,
-      TEST_FILE_PATHS.SOURCE_DATASET_AUTH,
-    ]);
-
-    expect(fileRows.rows).toHaveLength(0);
-  });
-
-  // Test data for SNS validator edge cases
-  const snsValidatorEdgeCases = [
-    {
-      expectedMessage: "SNS validation returned no message",
-      mockBehavior: (
-        message: Record<string, unknown>,
-        callback: (err: Error | null, result?: Record<string, unknown>) => void
-      ): void => callback(null, undefined),
-      size: 128000,
-      testId: "no-validated-message",
-      testName:
-        "rejects SNS messages when validator returns no validated message",
-    },
-  ];
-
-  test.each(snsValidatorEdgeCases)(
-    "$testName",
-    async ({ expectedMessage, mockBehavior, size, testId }) => {
-      // Temporarily override the mock with specific behavior
-      const MockedMessageValidator = jest.mocked(
-        jest.requireMock(TEST_MODULE_SNS_VALIDATOR)
-      );
-      MockedMessageValidator.mockImplementation(() => ({
-        validate: jest.fn(mockBehavior),
-      }));
-
-      const s3Event = createS3Event({
-        etag: `${testId}-test`,
-        eventTime: TEST_TIMESTAMP_ALT,
-        key: TEST_FILE_PATHS.SOURCE_DATASET_AUTH,
-        size,
-        versionId: `${testId}-version`,
-      });
-
-      const snsMessage = createSNSMessage({
-        messageId: `${testId}-test`,
-        s3Event,
-        signature: TEST_SIGNATURE_VALID,
-        timestamp: TEST_TIMESTAMP_ALT,
-      });
-
-      const { req, res } = httpMocks.createMocks<
-        NextApiRequest,
-        NextApiResponse
-      >({
-        body: snsMessage,
-        method: "POST",
-      });
-
-      await withConsoleErrorHiding(async () => {
-        await snsHandler(req, res);
-      });
-
-      // Should reject with 400 Bad Request
-      expect(res.statusCode).toBe(400);
-      expect(JSON.parse(res._getData())).toEqual({
-        message: expectedMessage,
-      });
-
-      // Verify no file was saved to database
-      const fileRows = await query(SQL_QUERIES.SELECT_FILE_BY_BUCKET_AND_KEY, [
-        TEST_S3_BUCKET,
-        TEST_FILE_PATHS.SOURCE_DATASET_AUTH,
-      ]);
-
-      expect(fileRows.rows).toHaveLength(0);
-
-      // Restore original mock
-      MockedMessageValidator.mockImplementation(() => ({
-        validate: jest.fn((message, callback) => {
-          if (message.Signature === TEST_SIGNATURE_INVALID) {
-            callback(new Error(TEST_ERROR_MESSAGE_INVALID_SIGNATURE));
-            return;
-          }
-          callback(null, message);
-        }),
-      }));
-    }
-  );
-
   it("rejects notifications with ETag mismatches for existing files", async () => {
     const s3Event = createS3Event({
       etag: "original-etag-12345",
@@ -1092,42 +925,6 @@ describe(TEST_ROUTE, () => {
     expect(latestOnly.rows[0].etag).toBe(
       "ooo-version2-etag-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     );
-  });
-
-  it("rejects notifications from unauthorized SNS topics", async () => {
-    await withConsoleMessageHiding(async () => {
-      const s3Event = createS3Event({
-        etag: "d41d8cd98f00b204e9800998ecf8427e",
-        key: "test-file.h5ad",
-        size: 1024000,
-        versionId: TEST_VERSION_IDS.DEFAULT,
-      });
-
-      const unauthorizedSnsMessage = createSNSMessage({
-        messageId: "unauthorized-topic-test",
-        s3Event,
-        signature: TEST_SIGNATURE,
-        subject: SNS_MESSAGE_DEFAULTS.SUBJECT,
-        timestamp: TEST_TIMESTAMP,
-        topicArn: UNAUTHORIZED_TOPIC_ARN,
-      });
-
-      const { req, res } = httpMocks.createMocks<
-        NextApiRequest,
-        NextApiResponse
-      >({
-        body: unauthorizedSnsMessage,
-        method: METHOD.POST,
-      });
-
-      const handler = (await import("../pages/api/sns")).default;
-      await handler(req, res);
-
-      expect(res._getStatusCode()).toBe(403);
-      expect(JSON.parse(res._getData())).toEqual({
-        message: `Unauthorized SNS topic: ${UNAUTHORIZED_TOPIC_ARN}`,
-      });
-    });
   });
 
   it("rejects notifications from unauthorized S3 buckets", async () => {
@@ -1631,221 +1428,6 @@ describe(TEST_ROUTE, () => {
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res._getData())).toEqual({
       message: "Expected exactly 1 S3 record, but received 2 records",
-    });
-  });
-
-  // SNS Test Constants (shared across subscription tests)
-  const SUBSCRIPTION_CONFIRMATION_SUBJECT =
-    "AWS Notification - Subscription Confirmation";
-  const SUBSCRIPTION_CONFIRMATION_MESSAGE =
-    "You have chosen to subscribe to the topic";
-  const SNS_SIGNATURE_VERSION = "1";
-  const SIGNING_CERT_URL =
-    "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-test.pem";
-  const SUBSCRIPTION_CONFIRMATION_TYPE = "SubscriptionConfirmation";
-  const SUBSCRIBE_URL_BASE =
-    "https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription&TopicArn=";
-  const SUBSCRIBE_URL = `${SUBSCRIBE_URL_BASE}test&Token=test-token`;
-  const UNAUTHORIZED_TOPIC_ARN =
-    "arn:aws:sns:us-east-1:123456789012:unauthorized-topic";
-  const UNSUBSCRIBE_MESSAGE = "You have unsubscribed from the topic";
-
-  describe("SNS SubscriptionConfirmation handling", () => {
-    beforeEach(() => {
-      // Reset HTTP wrapper mock before each test
-      mockHttpGet.mockClear();
-      mockHttpGet.mockResolvedValue({ ok: true });
-    });
-
-    describe("SubscriptionConfirmation", () => {
-      it("handles valid subscription confirmation with proper topic authorization", async () => {
-        const subscriptionConfirmationMessage = {
-          Message: SUBSCRIPTION_CONFIRMATION_MESSAGE,
-          MessageId: "subscription-test-message-id",
-          Signature: TEST_SIGNATURE,
-          SignatureVersion: SNS_SIGNATURE_VERSION,
-          SigningCertURL: SIGNING_CERT_URL,
-          Subject: SUBSCRIPTION_CONFIRMATION_SUBJECT,
-          SubscribeURL: SUBSCRIBE_URL,
-          Timestamp: TEST_TIMESTAMP,
-          TopicArn: TEST_AWS_CONFIG.sns_topics[0], // Use authorized topic
-          Type: SUBSCRIPTION_CONFIRMATION_TYPE,
-        };
-
-        const { req, res } = httpMocks.createMocks<
-          NextApiRequest,
-          NextApiResponse
-        >({
-          body: subscriptionConfirmationMessage,
-          method: METHOD.POST,
-        });
-
-        const handler = (await import("../pages/api/sns")).default;
-        await withConsoleMessageHiding(async () => {
-          await handler(req, res);
-        });
-
-        expect(res.statusCode).toBe(200);
-        // HTTP call verification: The 200 response indicates the SubscribeURL was successfully called
-      });
-
-      it("rejects subscription confirmation from unauthorized topic", async () => {
-        const unauthorizedSubscriptionMessage = {
-          Message: SUBSCRIPTION_CONFIRMATION_MESSAGE,
-          MessageId: "unauthorized-subscription-message-id",
-          Signature: TEST_SIGNATURE,
-          SignatureVersion: SNS_SIGNATURE_VERSION,
-          SigningCertURL: SIGNING_CERT_URL,
-          Subject: SUBSCRIPTION_CONFIRMATION_SUBJECT,
-          SubscribeURL: SUBSCRIBE_URL,
-          Timestamp: TEST_TIMESTAMP,
-          TopicArn: UNAUTHORIZED_TOPIC_ARN,
-          Type: SUBSCRIPTION_CONFIRMATION_TYPE,
-        };
-
-        const { req, res } = httpMocks.createMocks<
-          NextApiRequest,
-          NextApiResponse
-        >({
-          body: unauthorizedSubscriptionMessage,
-          method: METHOD.POST,
-        });
-
-        const handler = (await import("../pages/api/sns")).default;
-        await withConsoleMessageHiding(async () => {
-          await handler(req, res);
-        });
-
-        expect(res.statusCode).toBe(403);
-        expect(JSON.parse(res._getData())).toEqual({
-          message: `Unauthorized SNS topic: ${UNAUTHORIZED_TOPIC_ARN}`,
-        });
-      });
-
-      it("rejects subscription confirmation with missing SubscribeURL", async () => {
-        const subscriptionMessageWithoutURL = {
-          Message: SUBSCRIPTION_CONFIRMATION_MESSAGE,
-          MessageId: "missing-url-test-message-id",
-          Signature: TEST_SIGNATURE,
-          SignatureVersion: SNS_SIGNATURE_VERSION,
-          SigningCertURL: SIGNING_CERT_URL,
-          Subject: SUBSCRIPTION_CONFIRMATION_SUBJECT,
-          // SubscribeURL is intentionally missing
-          Timestamp: TEST_TIMESTAMP,
-          TopicArn: TEST_AWS_CONFIG.sns_topics[0],
-          Type: SUBSCRIPTION_CONFIRMATION_TYPE,
-        };
-
-        const { req, res } = httpMocks.createMocks<
-          NextApiRequest,
-          NextApiResponse
-        >({
-          body: subscriptionMessageWithoutURL,
-          method: METHOD.POST,
-        });
-
-        const handler = (await import("../pages/api/sns")).default;
-        await withConsoleMessageHiding(async () => {
-          await handler(req, res);
-        });
-
-        expect(res.statusCode).toBe(400);
-        expect(JSON.parse(res._getData())).toEqual({
-          message: "SubscribeURL is required for subscription confirmation",
-        });
-      });
-    });
-
-    describe("UnsubscribeConfirmation", () => {
-      it("handles valid unsubscribe confirmation with proper topic authorization", async () => {
-        const unsubscribeConfirmationMessage = {
-          Message: UNSUBSCRIBE_MESSAGE,
-          MessageId: "unsubscribe-test-message-id",
-          Signature: TEST_SIGNATURE,
-          SignatureVersion: SNS_SIGNATURE_VERSION,
-          SigningCertURL: SIGNING_CERT_URL,
-          Subject: "AWS Notification - Unsubscribe Confirmation",
-          Timestamp: TEST_TIMESTAMP,
-          TopicArn: TEST_AWS_CONFIG.sns_topics[0], // Use authorized topic
-          Type: "UnsubscribeConfirmation",
-        };
-
-        const { req, res } = httpMocks.createMocks<
-          NextApiRequest,
-          NextApiResponse
-        >({
-          body: unsubscribeConfirmationMessage,
-          method: METHOD.POST,
-        });
-
-        const handler = (await import("../pages/api/sns")).default;
-        await withConsoleMessageHiding(async () => {
-          await handler(req, res);
-        });
-
-        expect(res.statusCode).toBe(200);
-      });
-
-      it("rejects unsubscribe confirmation from unauthorized topic", async () => {
-        const unauthorizedUnsubscribeMessage = {
-          Message: UNSUBSCRIBE_MESSAGE,
-          MessageId: "unauthorized-unsubscribe-message-id",
-          Signature: TEST_SIGNATURE,
-          SignatureVersion: SNS_SIGNATURE_VERSION,
-          SigningCertURL: SIGNING_CERT_URL,
-          Subject: "AWS Notification - Unsubscribe Confirmation",
-          Timestamp: TEST_TIMESTAMP,
-          TopicArn: UNAUTHORIZED_TOPIC_ARN,
-          Type: "UnsubscribeConfirmation",
-        };
-
-        const { req, res } = httpMocks.createMocks<
-          NextApiRequest,
-          NextApiResponse
-        >({
-          body: unauthorizedUnsubscribeMessage,
-          method: METHOD.POST,
-        });
-
-        const handler = (await import("../pages/api/sns")).default;
-        await withConsoleMessageHiding(async () => {
-          await handler(req, res);
-        });
-
-        expect(res.statusCode).toBe(403);
-        expect(JSON.parse(res._getData())).toEqual({
-          message: `Unauthorized SNS topic: ${UNAUTHORIZED_TOPIC_ARN}`,
-        });
-      });
-
-      it("handles unsubscribe confirmation without Subject field", async () => {
-        const unsubscribeMessageWithoutSubject = {
-          Message: UNSUBSCRIBE_MESSAGE,
-          MessageId: "no-subject-unsubscribe-message-id",
-          Signature: TEST_SIGNATURE,
-          SignatureVersion: SNS_SIGNATURE_VERSION,
-          SigningCertURL: SIGNING_CERT_URL,
-          // Subject is intentionally missing
-          Timestamp: TEST_TIMESTAMP,
-          TopicArn: TEST_AWS_CONFIG.sns_topics[0],
-          Type: "UnsubscribeConfirmation",
-        };
-
-        const { req, res } = httpMocks.createMocks<
-          NextApiRequest,
-          NextApiResponse
-        >({
-          body: unsubscribeMessageWithoutSubject,
-          method: METHOD.POST,
-        });
-
-        const handler = (await import("../pages/api/sns")).default;
-        await withConsoleMessageHiding(async () => {
-          await handler(req, res);
-        });
-
-        expect(res.statusCode).toBe(200);
-      });
     });
   });
 });

--- a/__tests__/api-sns-with-s3-event.test.ts
+++ b/__tests__/api-sns-with-s3-event.test.ts
@@ -1,23 +1,33 @@
+import {
+  createS3Event,
+  createSNSMessage,
+  createTestAtlasData,
+  setUpAwsConfig,
+  SNS_MESSAGE_DEFAULTS,
+  SQL_QUERIES,
+  TEST_AWS_CONFIG,
+  TEST_FILE_PATHS,
+  TEST_GUT_ATLAS_ID,
+  TEST_MODULE_SNS_VALIDATOR,
+  TEST_S3_BUCKET,
+  TEST_S3_EVENT_NAME_OBJECT_CREATED,
+  TEST_SIGNATURE,
+  TEST_SIGNATURE_VALID,
+  TEST_SIGNATURE_VALID_FOR_TESTING,
+  TEST_TIMESTAMP,
+  TEST_TIMESTAMP_ALT,
+  TEST_TIMESTAMP_PLUS_1H,
+  TEST_VERSION_IDS,
+  validateTestSnsMessage,
+} from "../testing/sns-testing";
+
 // Set up AWS resource configuration BEFORE any other imports
-const TEST_S3_BUCKET = "hca-atlas-tracker-data-dev";
-const TEST_GUT_ATLAS_ID = "550e8400-e29b-41d4-a716-446655440000";
-const TEST_S3_EVENT_NAME = "s3:ObjectCreated:Put";
-const TEST_AWS_CONFIG = {
-  s3_buckets: [TEST_S3_BUCKET],
-  sns_topics: [
-    "arn:aws:sns:us-east-1:123456789012:hca-atlas-tracker-s3-notifications",
-  ],
-};
-process.env.AWS_RESOURCE_CONFIG = JSON.stringify(TEST_AWS_CONFIG);
+setUpAwsConfig();
 
 // Imports
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
-import {
-  S3Event,
-  S3Object,
-  SNSMessage,
-} from "../app/apis/catalog/hca-atlas-tracker/aws/schemas";
+import { SNSMessage } from "../app/apis/catalog/hca-atlas-tracker/aws/schemas";
 import { METHOD } from "../app/common/entities";
 import { resetConfigCache } from "../app/config/aws-resources";
 import { endPgPool, query } from "../app/services/database";
@@ -31,117 +41,6 @@ import { withConsoleMessageHiding } from "../testing/utils";
 // Additional imports for direct service testing
 import { updateSourceDataset } from "../app/services/s3-notification";
 import { InvalidOperationError } from "../app/utils/api-handler";
-
-// Test file path constants
-const TEST_PATH_SEGMENTS = {
-  GUT_V1_INTEGRATED_OBJECTS: "gut/gut-v1/integrated-objects",
-  GUT_V1_MANIFESTS: "gut/gut-v1/manifests",
-  GUT_V1_SOURCE_DATASETS: "gut/gut-v1/source-datasets",
-} as const;
-
-const TEST_FILE_PATHS = {
-  INTEGRATED_OBJECT: `${TEST_PATH_SEGMENTS.GUT_V1_INTEGRATED_OBJECTS}/atlas.h5ad`,
-  MANIFEST: `${TEST_PATH_SEGMENTS.GUT_V1_MANIFESTS}/upload-manifest.json`,
-  SOURCE_DATASET_AUTH: `${TEST_PATH_SEGMENTS.GUT_V1_SOURCE_DATASETS}/auth-test.h5ad`,
-  SOURCE_DATASET_DUPLICATE: `${TEST_PATH_SEGMENTS.GUT_V1_SOURCE_DATASETS}/duplicate-test.h5ad`,
-  SOURCE_DATASET_ETAG: `${TEST_PATH_SEGMENTS.GUT_V1_SOURCE_DATASETS}/etag-test.h5ad`,
-  SOURCE_DATASET_TEST: `${TEST_PATH_SEGMENTS.GUT_V1_SOURCE_DATASETS}/test-file.h5ad`,
-  SOURCE_DATASET_VERSIONED: `${TEST_PATH_SEGMENTS.GUT_V1_SOURCE_DATASETS}/versioned-file.h5ad`,
-} as const;
-
-// SQL query constants
-const SQL_QUERIES = {
-  SELECT_FILE_BY_BUCKET_AND_KEY:
-    "SELECT * FROM hat.files WHERE bucket = $1 AND key = $2",
-  SELECT_FILE_BY_BUCKET_AND_KEY_ORDERED:
-    "SELECT * FROM hat.files WHERE bucket = $1 AND key = $2 ORDER BY created_at ASC",
-  SELECT_LATEST_FILE_BY_BUCKET_AND_KEY:
-    "SELECT * FROM hat.files WHERE bucket = $1 AND key = $2 AND is_latest = true",
-} as const;
-
-// SNS message constants
-const SNS_MESSAGE_DEFAULTS = {
-  SUBJECT: "Amazon S3 Notification",
-} as const;
-
-// Test data constants
-const TEST_VERSION_IDS = {
-  DEFAULT: "096fKKXTRTtl3on89fVO.nfljtsv6qko",
-} as const;
-
-const TEST_TIMESTAMP = "2024-01-01T12:00:00.000Z";
-const TEST_TIMESTAMP_PLUS_1H = "2024-01-01T13:00:00.000Z";
-const TEST_TIMESTAMP_ALT = "2023-01-01T00:00:00.000Z";
-const TEST_SIGNATURE = "fake-signature-for-testing";
-const TEST_SIGNATURE_VALID = "valid-signature";
-const TEST_SIGNATURE_VALID_FOR_TESTING = "valid-signature-for-testing";
-const TEST_SIGNATURE_INVALID = "INVALID-SIGNATURE-SHOULD-BE-REJECTED";
-const TEST_ERROR_MESSAGE_INVALID_SIGNATURE = "Invalid signature";
-const TEST_MODULE_SNS_VALIDATOR = "sns-validator";
-const TEST_S3_EVENT_NAME_OBJECT_CREATED = "ObjectCreated:Put";
-
-// S3 Event and SNS Message Factory Functions
-interface S3EventOptions {
-  bucket?: string;
-  etag: string;
-  eventName?: string;
-  eventTime?: string;
-  key: string;
-  sha256?: string; // Optional to support tests that intentionally omit SHA256
-  size: number;
-  versionId: string;
-}
-
-function createS3Event(options: S3EventOptions): S3Event {
-  const objectData: S3Object = {
-    eTag: options.etag,
-    key: options.key,
-    size: options.size,
-    versionId: options.versionId,
-  };
-
-  return {
-    Records: [
-      {
-        eventName: options.eventName || TEST_S3_EVENT_NAME,
-        eventSource: "aws:s3",
-        eventTime: options.eventTime || TEST_TIMESTAMP,
-        s3: {
-          bucket: {
-            name: options.bucket || TEST_S3_BUCKET,
-          },
-          object: objectData,
-        },
-      },
-    ],
-  };
-}
-
-interface SNSMessageOptions {
-  messageId?: string;
-  s3Event: S3Event;
-  signature?: string;
-  signingCertURL?: string;
-  subject?: string;
-  timestamp?: string;
-  topicArn?: string;
-}
-
-function createSNSMessage(options: SNSMessageOptions): SNSMessage {
-  return {
-    Message: JSON.stringify(options.s3Event),
-    MessageId: options.messageId || "test-message-id",
-    Signature: options.signature || TEST_SIGNATURE,
-    SignatureVersion: "1",
-    SigningCertURL:
-      options.signingCertURL ||
-      "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-fake.pem",
-    Subject: options.subject || SNS_MESSAGE_DEFAULTS.SUBJECT,
-    Timestamp: options.timestamp || TEST_TIMESTAMP,
-    TopicArn: options.topicArn || TEST_AWS_CONFIG.sns_topics[0],
-    Type: "Notification",
-  };
-}
 
 jest.mock(
   "../site-config/hca-atlas-tracker/local/authentication/next-auth-config"
@@ -161,74 +60,13 @@ afterEach(() => {
 
 jest.mock("sns-validator", () => {
   return jest.fn().mockImplementation(() => ({
-    validate: jest.fn((message, callback) => {
-      // Check if this is our test case for invalid signatures
-      if (message.Signature === TEST_SIGNATURE_INVALID) {
-        callback(new Error(TEST_ERROR_MESSAGE_INVALID_SIGNATURE));
-        return;
-      }
-
-      // For all other test cases, simulate successful validation
-      callback(null, message);
-    }),
+    validate: jest.fn(validateTestSnsMessage),
   }));
 });
 
 const TEST_ROUTE = "/api/sns";
 
 import snsHandler from "../pages/api/sns";
-
-// Helper function to create test atlas data
-async function createTestAtlasData(): Promise<void> {
-  // Create multiple test atlases to cover different network/version scenarios
-  const atlases = [
-    {
-      id: TEST_GUT_ATLAS_ID,
-      overview: {
-        description: "Test gut atlas for S3 notification integration tests",
-        network: "gut", // Matches S3 path 'gut/gut-v1/...'
-        shortName: "Gut", // Case-insensitive match with S3 atlas base name 'gut'
-        title: "Test Gut Atlas v1",
-        version: "1", // DB version format (S3 'v1' -> DB '1')
-      },
-    },
-    {
-      id: "550e8400-e29b-41d4-a716-446655440001",
-      overview: {
-        description: "Test retina atlas for S3 notification integration tests",
-        network: "eye", // Matches S3 path 'eye/retina-v1/...'
-        shortName: "Retina", // Case-insensitive match with S3 atlas base name 'retina'
-        title: "Test Retina Atlas v1",
-        version: "1", // DB version format (S3 'v1' -> DB '1')
-      },
-    },
-    {
-      id: "550e8400-e29b-41d4-a716-446655440002",
-      overview: {
-        description:
-          "Test gut atlas v1.1 for S3 notification integration tests",
-        network: "gut", // Same network as first gut atlas
-        shortName: "Gut", // Same shortName but different version
-        title: "Test Gut Atlas v1.1",
-        version: "1.1", // DB version format (S3 'v1-1' -> DB '1.1')
-      },
-    },
-  ];
-
-  // Insert all test atlases
-  for (const atlas of atlases) {
-    await query(
-      `INSERT INTO hat.atlases (id, overview, source_studies, status, created_at, updated_at)
-       VALUES ($1, $2, $3, $4, NOW(), NOW())`,
-      [
-        atlas.id,
-        JSON.stringify(atlas.overview),
-        JSON.stringify([]), // Empty source studies array
-        "draft", // Status field
-      ]
-    );
-  }
-}
 
 beforeEach(async () => {
   await resetDatabase();

--- a/__tests__/api-sns-with-validation-results.test.ts
+++ b/__tests__/api-sns-with-validation-results.test.ts
@@ -1,0 +1,141 @@
+import {
+  createSNSMessage,
+  createValidationResults,
+  setUpAwsConfig,
+  SNS_MESSAGE_DEFAULTS,
+  TEST_SIGNATURE_VALID,
+  TEST_SNS_TOPIC_VALIDATION_RESULTS,
+  TEST_TIMESTAMP,
+  validateTestSnsMessage,
+} from "../testing/sns-testing";
+
+// Set up AWS resource configuration BEFORE any other imports
+setUpAwsConfig();
+
+// Imports
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
+import { SNSMessage } from "../app/apis/catalog/hca-atlas-tracker/aws/schemas";
+import {
+  HCAAtlasTrackerDBFileDatasetInfo,
+  INTEGRITY_STATUS,
+} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "../app/common/entities";
+import { resetConfigCache } from "../app/config/aws-resources";
+import { endPgPool } from "../app/services/database";
+import { SOURCE_DATASET_FOO } from "../testing/constants";
+import { getFileFromDatabase, resetDatabase } from "../testing/db-utils";
+import {
+  expectIsDefined,
+  fillTestFileDefaults,
+  getTestFileKey,
+  withConsoleErrorHiding,
+} from "../testing/utils";
+
+jest.mock(
+  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config"
+);
+jest.mock("../app/utils/crossref/crossref-api");
+jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/cellxgene");
+jest.mock("../app/utils/pg-app-connect-config");
+
+jest.mock("next-auth");
+
+afterEach(() => {
+  resetConfigCache();
+});
+
+jest.mock("sns-validator", () => {
+  return jest.fn().mockImplementation(() => ({
+    validate: jest.fn(validateTestSnsMessage),
+  }));
+});
+
+const TEST_ROUTE = "/api/sns";
+
+import snsHandler from "../pages/api/sns";
+
+const FILE_SOURCE_DATASET_FOO = fillTestFileDefaults(SOURCE_DATASET_FOO.file);
+
+beforeAll(async () => {
+  await resetDatabase();
+});
+
+afterAll(() => {
+  endPgPool();
+});
+
+describe(`${TEST_ROUTE} (validation results)`, () => {
+  it("rejects SNS messages with unparseable JSON in Message field", async () => {
+    // Create SNS message with malformed JSON that will fail parsing in service layer
+    const malformedSNSMessage: SNSMessage = {
+      Message: "{", // Truncated/invalid JSON
+      MessageId: "malformed-json-test",
+      Signature: TEST_SIGNATURE_VALID,
+      SignatureVersion: "1",
+      SigningCertURL:
+        "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-fake.pem",
+      Subject: SNS_MESSAGE_DEFAULTS.SUBJECT,
+      Timestamp: TEST_TIMESTAMP,
+      TopicArn: TEST_SNS_TOPIC_VALIDATION_RESULTS,
+      Type: "Notification",
+    };
+
+    const res = await doSnsRequest(malformedSNSMessage);
+
+    // Should reject with 400 Bad Request due to JSON parsing error
+    expect(res.statusCode).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      message: "Failed to parse validation results from SNS message",
+    });
+  });
+
+  it("successfully saves validation results for dataset file", async () => {
+    const timestamp = "2025-09-13T22:53:03.314Z";
+    const metadata: HCAAtlasTrackerDBFileDatasetInfo = {
+      assay: ["assay-dataset-successful-a", "assay-dataset-successful-b"],
+      cellCount: 2232,
+      disease: ["disease-dataset-successful"],
+      suspensionType: ["suspension-dataset-type-successful"],
+      tissue: ["tissue-dataset-successful"],
+      title: "Dataset Successful",
+    };
+    const validationResults = createValidationResults({
+      fileId: FILE_SOURCE_DATASET_FOO.id,
+      integrityStatus: INTEGRITY_STATUS.VALID,
+      key: getTestFileKey(
+        FILE_SOURCE_DATASET_FOO,
+        FILE_SOURCE_DATASET_FOO.resolvedAtlas
+      ),
+      metadata,
+      timestamp,
+    });
+    const snsMessage = createSNSMessage({
+      message: validationResults,
+      messageId: "test-message-successful",
+      topicArn: TEST_SNS_TOPIC_VALIDATION_RESULTS,
+    });
+
+    expect((await doSnsRequest(snsMessage)).statusCode).toEqual(200);
+
+    const file = await getFileFromDatabase(FILE_SOURCE_DATASET_FOO.id);
+    if (!expectIsDefined(file)) return;
+
+    expect(file.dataset_info).toEqual(metadata);
+    expect(file.integrity_checked_at?.toISOString()).toEqual(timestamp);
+    expect(file.integrity_status).toEqual(INTEGRITY_STATUS.VALID);
+  });
+});
+
+async function doSnsRequest(
+  body: Record<string, unknown>,
+  hideConsoleError = false
+): Promise<httpMocks.MockResponse<NextApiResponse>> {
+  const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>({
+    body,
+    method: METHOD.POST,
+  });
+  await withConsoleErrorHiding(() => snsHandler(req, res), hideConsoleError);
+  return res;
+}

--- a/__tests__/api-sns-with-validation-results.test.ts
+++ b/__tests__/api-sns-with-validation-results.test.ts
@@ -92,7 +92,10 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
   });
 
   it("successfully saves validation results for dataset file", async () => {
-    const timestamp = "2025-09-13T22:53:03.314Z";
+    const snsMessageId = "sns-message-dataset-successfull";
+    const snsMessageTime = "2025-09-14T00:00:36.672Z";
+    const batchJobId = "batch-job-dataset-successful";
+    const validationTime = "2025-09-13T22:53:03.314Z";
     const metadata: HCAAtlasTrackerDBFileDatasetInfo = {
       assay: ["assay-dataset-successful-a", "assay-dataset-successful-b"],
       cellCount: 2232,
@@ -102,6 +105,7 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
       title: "Dataset Successful",
     };
     const validationResults = createValidationResults({
+      batchJobId,
       fileId: FILE_SOURCE_DATASET_FOO.id,
       integrityStatus: INTEGRITY_STATUS.VALID,
       key: getTestFileKey(
@@ -109,11 +113,12 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
         FILE_SOURCE_DATASET_FOO.resolvedAtlas
       ),
       metadata,
-      timestamp,
+      timestamp: validationTime,
     });
     const snsMessage = createSNSMessage({
       message: validationResults,
-      messageId: "test-message-successful",
+      messageId: snsMessageId,
+      timestamp: snsMessageTime,
       topicArn: TEST_SNS_TOPIC_VALIDATION_RESULTS,
     });
 
@@ -123,8 +128,13 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
     if (!expectIsDefined(file)) return;
 
     expect(file.dataset_info).toEqual(metadata);
-    expect(file.integrity_checked_at?.toISOString()).toEqual(timestamp);
+    expect(file.integrity_checked_at?.toISOString()).toEqual(validationTime);
     expect(file.integrity_status).toEqual(INTEGRITY_STATUS.VALID);
+    expect(file.validation_info).toEqual({
+      batchJobId,
+      snsMessageId,
+      snsMessageTime,
+    });
   });
 });
 

--- a/__tests__/api-sns-with-validation-results.test.ts
+++ b/__tests__/api-sns-with-validation-results.test.ts
@@ -29,7 +29,7 @@ import {
   expectIsDefined,
   fillTestFileDefaults,
   getTestFileKey,
-  withConsoleErrorHiding,
+  withConsoleMessageHiding,
 } from "../testing/utils";
 
 jest.mock(
@@ -82,7 +82,7 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
       Type: "Notification",
     };
 
-    const res = await doSnsRequest(malformedSNSMessage);
+    const res = await doSnsRequest(malformedSNSMessage, true);
 
     // Should reject with 400 Bad Request due to JSON parsing error
     expect(res.statusCode).toBe(400);
@@ -122,7 +122,7 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
       topicArn: TEST_SNS_TOPIC_VALIDATION_RESULTS,
     });
 
-    expect((await doSnsRequest(snsMessage)).statusCode).toEqual(200);
+    expect((await doSnsRequest(snsMessage, true)).statusCode).toEqual(200);
 
     const file = await getFileFromDatabase(FILE_SOURCE_DATASET_FOO.id);
     if (!expectIsDefined(file)) return;
@@ -140,12 +140,15 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
 
 async function doSnsRequest(
   body: Record<string, unknown>,
-  hideConsoleError = false
+  hideConsoleMessages = false
 ): Promise<httpMocks.MockResponse<NextApiResponse>> {
   const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>({
     body,
     method: METHOD.POST,
   });
-  await withConsoleErrorHiding(() => snsHandler(req, res), hideConsoleError);
+  await withConsoleMessageHiding(
+    () => snsHandler(req, res),
+    hideConsoleMessages
+  );
   return res;
 }

--- a/__tests__/api-sns.test.ts
+++ b/__tests__/api-sns.test.ts
@@ -1,0 +1,650 @@
+// Mock HTTP wrapper for outbound requests BEFORE any imports
+jest.mock("../app/utils/http", () => {
+  return { httpGet: jest.fn() };
+});
+
+// Set up AWS resource configuration BEFORE any other imports
+const TEST_S3_BUCKET = "hca-atlas-tracker-data-dev";
+const TEST_GUT_ATLAS_ID = "550e8400-e29b-41d4-a716-446655440000";
+const TEST_S3_EVENT_NAME = "s3:ObjectCreated:Put";
+const TEST_AWS_CONFIG = {
+  s3_buckets: [TEST_S3_BUCKET],
+  sns_topics: [
+    "arn:aws:sns:us-east-1:123456789012:hca-atlas-tracker-s3-notifications",
+  ],
+};
+process.env.AWS_RESOURCE_CONFIG = JSON.stringify(TEST_AWS_CONFIG);
+
+// Imports
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
+import {
+  S3Event,
+  S3Object,
+  SNSMessage,
+} from "../app/apis/catalog/hca-atlas-tracker/aws/schemas";
+import { METHOD } from "../app/common/entities";
+import { resetConfigCache } from "../app/config/aws-resources";
+import { endPgPool, query } from "../app/services/database";
+import { resetDatabase } from "../testing/db-utils";
+import {
+  withConsoleErrorHiding,
+  withConsoleMessageHiding,
+} from "../testing/utils";
+
+// Retrieve the mock function created in the jest.mock factory above
+const { httpGet } = jest.requireMock("../app/utils/http") as {
+  httpGet: jest.Mock;
+};
+const mockHttpGet = httpGet as jest.Mock;
+
+// Test file path constants
+const TEST_PATH_SEGMENTS = {
+  GUT_V1_INTEGRATED_OBJECTS: "gut/gut-v1/integrated-objects",
+  GUT_V1_MANIFESTS: "gut/gut-v1/manifests",
+  GUT_V1_SOURCE_DATASETS: "gut/gut-v1/source-datasets",
+} as const;
+
+const TEST_FILE_PATHS = {
+  INTEGRATED_OBJECT: `${TEST_PATH_SEGMENTS.GUT_V1_INTEGRATED_OBJECTS}/atlas.h5ad`,
+  MANIFEST: `${TEST_PATH_SEGMENTS.GUT_V1_MANIFESTS}/upload-manifest.json`,
+  SOURCE_DATASET_AUTH: `${TEST_PATH_SEGMENTS.GUT_V1_SOURCE_DATASETS}/auth-test.h5ad`,
+  SOURCE_DATASET_DUPLICATE: `${TEST_PATH_SEGMENTS.GUT_V1_SOURCE_DATASETS}/duplicate-test.h5ad`,
+  SOURCE_DATASET_ETAG: `${TEST_PATH_SEGMENTS.GUT_V1_SOURCE_DATASETS}/etag-test.h5ad`,
+  SOURCE_DATASET_TEST: `${TEST_PATH_SEGMENTS.GUT_V1_SOURCE_DATASETS}/test-file.h5ad`,
+  SOURCE_DATASET_VERSIONED: `${TEST_PATH_SEGMENTS.GUT_V1_SOURCE_DATASETS}/versioned-file.h5ad`,
+} as const;
+
+// SQL query constants
+const SQL_QUERIES = {
+  SELECT_FILE_BY_BUCKET_AND_KEY:
+    "SELECT * FROM hat.files WHERE bucket = $1 AND key = $2",
+  SELECT_FILE_BY_BUCKET_AND_KEY_ORDERED:
+    "SELECT * FROM hat.files WHERE bucket = $1 AND key = $2 ORDER BY created_at ASC",
+  SELECT_LATEST_FILE_BY_BUCKET_AND_KEY:
+    "SELECT * FROM hat.files WHERE bucket = $1 AND key = $2 AND is_latest = true",
+} as const;
+
+// SNS message constants
+const SNS_MESSAGE_DEFAULTS = {
+  SUBJECT: "Amazon S3 Notification",
+} as const;
+
+// Test data constants
+const TEST_VERSION_IDS = {
+  DEFAULT: "096fKKXTRTtl3on89fVO.nfljtsv6qko",
+} as const;
+
+const TEST_TIMESTAMP = "2024-01-01T12:00:00.000Z";
+const TEST_TIMESTAMP_ALT = "2023-01-01T00:00:00.000Z";
+const TEST_SIGNATURE = "fake-signature-for-testing";
+const TEST_SIGNATURE_VALID = "valid-signature";
+const TEST_SIGNATURE_INVALID = "INVALID-SIGNATURE-SHOULD-BE-REJECTED";
+const TEST_ERROR_MESSAGE_INVALID_SIGNATURE = "Invalid signature";
+const TEST_MODULE_SNS_VALIDATOR = "sns-validator";
+
+// S3 Event and SNS Message Factory Functions
+interface S3EventOptions {
+  bucket?: string;
+  etag: string;
+  eventName?: string;
+  eventTime?: string;
+  key: string;
+  sha256?: string; // Optional to support tests that intentionally omit SHA256
+  size: number;
+  versionId: string;
+}
+
+function createS3Event(options: S3EventOptions): S3Event {
+  const objectData: S3Object = {
+    eTag: options.etag,
+    key: options.key,
+    size: options.size,
+    versionId: options.versionId,
+  };
+
+  return {
+    Records: [
+      {
+        eventName: options.eventName || TEST_S3_EVENT_NAME,
+        eventSource: "aws:s3",
+        eventTime: options.eventTime || TEST_TIMESTAMP,
+        s3: {
+          bucket: {
+            name: options.bucket || TEST_S3_BUCKET,
+          },
+          object: objectData,
+        },
+      },
+    ],
+  };
+}
+
+interface SNSMessageOptions {
+  messageId?: string;
+  s3Event: S3Event;
+  signature?: string;
+  signingCertURL?: string;
+  subject?: string;
+  timestamp?: string;
+  topicArn?: string;
+}
+
+function createSNSMessage(options: SNSMessageOptions): SNSMessage {
+  return {
+    Message: JSON.stringify(options.s3Event),
+    MessageId: options.messageId || "test-message-id",
+    Signature: options.signature || TEST_SIGNATURE,
+    SignatureVersion: "1",
+    SigningCertURL:
+      options.signingCertURL ||
+      "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-fake.pem",
+    Subject: options.subject || SNS_MESSAGE_DEFAULTS.SUBJECT,
+    Timestamp: options.timestamp || TEST_TIMESTAMP,
+    TopicArn: options.topicArn || TEST_AWS_CONFIG.sns_topics[0],
+    Type: "Notification",
+  };
+}
+
+jest.mock(
+  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config"
+);
+jest.mock("../app/utils/crossref/crossref-api");
+jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/cellxgene");
+jest.mock("../app/utils/pg-app-connect-config");
+
+jest.mock("next-auth");
+
+// (Removed ky mock) Using http wrapper mock at top of file instead
+
+afterEach(() => {
+  resetConfigCache();
+});
+
+jest.mock("sns-validator", () => {
+  return jest.fn().mockImplementation(() => ({
+    validate: jest.fn((message, callback) => {
+      // Check if this is our test case for invalid signatures
+      if (message.Signature === TEST_SIGNATURE_INVALID) {
+        callback(new Error(TEST_ERROR_MESSAGE_INVALID_SIGNATURE));
+        return;
+      }
+
+      // For all other test cases, simulate successful validation
+      callback(null, message);
+    }),
+  }));
+});
+
+const TEST_ROUTE = "/api/sns";
+
+import snsHandler from "../pages/api/sns";
+
+// Helper function to create test atlas data
+async function createTestAtlasData(): Promise<void> {
+  // Create multiple test atlases to cover different network/version scenarios
+  const atlases = [
+    {
+      id: TEST_GUT_ATLAS_ID,
+      overview: {
+        description: "Test gut atlas for S3 notification integration tests",
+        network: "gut", // Matches S3 path 'gut/gut-v1/...'
+        shortName: "Gut", // Case-insensitive match with S3 atlas base name 'gut'
+        title: "Test Gut Atlas v1",
+        version: "1", // DB version format (S3 'v1' -> DB '1')
+      },
+    },
+    {
+      id: "550e8400-e29b-41d4-a716-446655440001",
+      overview: {
+        description: "Test retina atlas for S3 notification integration tests",
+        network: "eye", // Matches S3 path 'eye/retina-v1/...'
+        shortName: "Retina", // Case-insensitive match with S3 atlas base name 'retina'
+        title: "Test Retina Atlas v1",
+        version: "1", // DB version format (S3 'v1' -> DB '1')
+      },
+    },
+    {
+      id: "550e8400-e29b-41d4-a716-446655440002",
+      overview: {
+        description:
+          "Test gut atlas v1.1 for S3 notification integration tests",
+        network: "gut", // Same network as first gut atlas
+        shortName: "Gut", // Same shortName but different version
+        title: "Test Gut Atlas v1.1",
+        version: "1.1", // DB version format (S3 'v1-1' -> DB '1.1')
+      },
+    },
+  ];
+
+  // Insert all test atlases
+  for (const atlas of atlases) {
+    await query(
+      `INSERT INTO hat.atlases (id, overview, source_studies, status, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, NOW(), NOW())`,
+      [
+        atlas.id,
+        JSON.stringify(atlas.overview),
+        JSON.stringify([]), // Empty source studies array
+        "draft", // Status field
+      ]
+    );
+  }
+}
+
+beforeEach(async () => {
+  await resetDatabase();
+  await createTestAtlasData();
+});
+
+afterAll(() => {
+  endPgPool();
+});
+
+describe(TEST_ROUTE, () => {
+  // HTTP Method Validation Tests
+  it("returns error 405 for non-POST request", async () => {
+    const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>(
+      {
+        method: METHOD.GET,
+      }
+    );
+
+    await snsHandler(req, res);
+
+    expect(res.statusCode).toBe(405);
+  });
+
+  // SNS Message Structure Validation Tests
+  it("returns error 400 for invalid SNS message payload", async () => {
+    const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>(
+      {
+        body: {
+          invalid: "payload",
+        },
+        method: METHOD.POST,
+      }
+    );
+
+    await withConsoleErrorHiding(async () => {
+      await snsHandler(req, res);
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  // Security and Authentication Tests
+  it("rejects SNS messages with invalid signatures", async () => {
+    const s3Event = createS3Event({
+      etag: "invalid-signature-test",
+      eventTime: TEST_TIMESTAMP_ALT,
+      key: TEST_FILE_PATHS.SOURCE_DATASET_AUTH,
+      size: 256000,
+      versionId: "auth-test-version",
+    });
+
+    const snsMessageWithInvalidSignature = createSNSMessage({
+      messageId: "auth-test-message",
+      s3Event,
+      signature: TEST_SIGNATURE_INVALID,
+      timestamp: TEST_TIMESTAMP_ALT,
+    });
+
+    const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>(
+      {
+        body: snsMessageWithInvalidSignature,
+        method: "POST",
+      }
+    );
+
+    await withConsoleErrorHiding(async () => {
+      await snsHandler(req, res);
+    });
+
+    // Should reject with 401 Unauthorized due to invalid signature
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res._getData())).toEqual({
+      message: "SNS signature validation failed",
+    });
+
+    // Verify no file was saved to database
+    const fileRows = await query(SQL_QUERIES.SELECT_FILE_BY_BUCKET_AND_KEY, [
+      TEST_S3_BUCKET,
+      TEST_FILE_PATHS.SOURCE_DATASET_AUTH,
+    ]);
+
+    expect(fileRows.rows).toHaveLength(0);
+  });
+
+  // Test data for SNS validator edge cases
+  const snsValidatorEdgeCases = [
+    {
+      expectedMessage: "SNS validation returned no message",
+      mockBehavior: (
+        message: Record<string, unknown>,
+        callback: (err: Error | null, result?: Record<string, unknown>) => void
+      ): void => callback(null, undefined),
+      size: 128000,
+      testId: "no-validated-message",
+      testName:
+        "rejects SNS messages when validator returns no validated message",
+    },
+  ];
+
+  test.each(snsValidatorEdgeCases)(
+    "$testName",
+    async ({ expectedMessage, mockBehavior, size, testId }) => {
+      // Temporarily override the mock with specific behavior
+      const MockedMessageValidator = jest.mocked(
+        jest.requireMock(TEST_MODULE_SNS_VALIDATOR)
+      );
+      MockedMessageValidator.mockImplementation(() => ({
+        validate: jest.fn(mockBehavior),
+      }));
+
+      const s3Event = createS3Event({
+        etag: `${testId}-test`,
+        eventTime: TEST_TIMESTAMP_ALT,
+        key: TEST_FILE_PATHS.SOURCE_DATASET_AUTH,
+        size,
+        versionId: `${testId}-version`,
+      });
+
+      const snsMessage = createSNSMessage({
+        messageId: `${testId}-test`,
+        s3Event,
+        signature: TEST_SIGNATURE_VALID,
+        timestamp: TEST_TIMESTAMP_ALT,
+      });
+
+      const { req, res } = httpMocks.createMocks<
+        NextApiRequest,
+        NextApiResponse
+      >({
+        body: snsMessage,
+        method: "POST",
+      });
+
+      await withConsoleErrorHiding(async () => {
+        await snsHandler(req, res);
+      });
+
+      // Should reject with 400 Bad Request
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res._getData())).toEqual({
+        message: expectedMessage,
+      });
+
+      // Verify no file was saved to database
+      const fileRows = await query(SQL_QUERIES.SELECT_FILE_BY_BUCKET_AND_KEY, [
+        TEST_S3_BUCKET,
+        TEST_FILE_PATHS.SOURCE_DATASET_AUTH,
+      ]);
+
+      expect(fileRows.rows).toHaveLength(0);
+
+      // Restore original mock
+      MockedMessageValidator.mockImplementation(() => ({
+        validate: jest.fn((message, callback) => {
+          if (message.Signature === TEST_SIGNATURE_INVALID) {
+            callback(new Error(TEST_ERROR_MESSAGE_INVALID_SIGNATURE));
+            return;
+          }
+          callback(null, message);
+        }),
+      }));
+    }
+  );
+
+  it("rejects notifications from unauthorized SNS topics", async () => {
+    await withConsoleMessageHiding(async () => {
+      const s3Event = createS3Event({
+        etag: "d41d8cd98f00b204e9800998ecf8427e",
+        key: "test-file.h5ad",
+        size: 1024000,
+        versionId: TEST_VERSION_IDS.DEFAULT,
+      });
+
+      const unauthorizedSnsMessage = createSNSMessage({
+        messageId: "unauthorized-topic-test",
+        s3Event,
+        signature: TEST_SIGNATURE,
+        subject: SNS_MESSAGE_DEFAULTS.SUBJECT,
+        timestamp: TEST_TIMESTAMP,
+        topicArn: UNAUTHORIZED_TOPIC_ARN,
+      });
+
+      const { req, res } = httpMocks.createMocks<
+        NextApiRequest,
+        NextApiResponse
+      >({
+        body: unauthorizedSnsMessage,
+        method: METHOD.POST,
+      });
+
+      const handler = (await import("../pages/api/sns")).default;
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(403);
+      expect(JSON.parse(res._getData())).toEqual({
+        message: `Unauthorized SNS topic: ${UNAUTHORIZED_TOPIC_ARN}`,
+      });
+    });
+  });
+
+  // SNS Test Constants (shared across subscription tests)
+  const SUBSCRIPTION_CONFIRMATION_SUBJECT =
+    "AWS Notification - Subscription Confirmation";
+  const SUBSCRIPTION_CONFIRMATION_MESSAGE =
+    "You have chosen to subscribe to the topic";
+  const SNS_SIGNATURE_VERSION = "1";
+  const SIGNING_CERT_URL =
+    "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-test.pem";
+  const SUBSCRIPTION_CONFIRMATION_TYPE = "SubscriptionConfirmation";
+  const SUBSCRIBE_URL_BASE =
+    "https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription&TopicArn=";
+  const SUBSCRIBE_URL = `${SUBSCRIBE_URL_BASE}test&Token=test-token`;
+  const UNAUTHORIZED_TOPIC_ARN =
+    "arn:aws:sns:us-east-1:123456789012:unauthorized-topic";
+  const UNSUBSCRIBE_MESSAGE = "You have unsubscribed from the topic";
+
+  describe("SNS SubscriptionConfirmation handling", () => {
+    beforeEach(() => {
+      // Reset HTTP wrapper mock before each test
+      mockHttpGet.mockClear();
+      mockHttpGet.mockResolvedValue({ ok: true });
+    });
+
+    describe("SubscriptionConfirmation", () => {
+      it("handles valid subscription confirmation with proper topic authorization", async () => {
+        const subscriptionConfirmationMessage = {
+          Message: SUBSCRIPTION_CONFIRMATION_MESSAGE,
+          MessageId: "subscription-test-message-id",
+          Signature: TEST_SIGNATURE,
+          SignatureVersion: SNS_SIGNATURE_VERSION,
+          SigningCertURL: SIGNING_CERT_URL,
+          Subject: SUBSCRIPTION_CONFIRMATION_SUBJECT,
+          SubscribeURL: SUBSCRIBE_URL,
+          Timestamp: TEST_TIMESTAMP,
+          TopicArn: TEST_AWS_CONFIG.sns_topics[0], // Use authorized topic
+          Type: SUBSCRIPTION_CONFIRMATION_TYPE,
+        };
+
+        const { req, res } = httpMocks.createMocks<
+          NextApiRequest,
+          NextApiResponse
+        >({
+          body: subscriptionConfirmationMessage,
+          method: METHOD.POST,
+        });
+
+        const handler = (await import("../pages/api/sns")).default;
+        await withConsoleMessageHiding(async () => {
+          await handler(req, res);
+        });
+
+        expect(res.statusCode).toBe(200);
+        // HTTP call verification: The 200 response indicates the SubscribeURL was successfully called
+      });
+
+      it("rejects subscription confirmation from unauthorized topic", async () => {
+        const unauthorizedSubscriptionMessage = {
+          Message: SUBSCRIPTION_CONFIRMATION_MESSAGE,
+          MessageId: "unauthorized-subscription-message-id",
+          Signature: TEST_SIGNATURE,
+          SignatureVersion: SNS_SIGNATURE_VERSION,
+          SigningCertURL: SIGNING_CERT_URL,
+          Subject: SUBSCRIPTION_CONFIRMATION_SUBJECT,
+          SubscribeURL: SUBSCRIBE_URL,
+          Timestamp: TEST_TIMESTAMP,
+          TopicArn: UNAUTHORIZED_TOPIC_ARN,
+          Type: SUBSCRIPTION_CONFIRMATION_TYPE,
+        };
+
+        const { req, res } = httpMocks.createMocks<
+          NextApiRequest,
+          NextApiResponse
+        >({
+          body: unauthorizedSubscriptionMessage,
+          method: METHOD.POST,
+        });
+
+        const handler = (await import("../pages/api/sns")).default;
+        await withConsoleMessageHiding(async () => {
+          await handler(req, res);
+        });
+
+        expect(res.statusCode).toBe(403);
+        expect(JSON.parse(res._getData())).toEqual({
+          message: `Unauthorized SNS topic: ${UNAUTHORIZED_TOPIC_ARN}`,
+        });
+      });
+
+      it("rejects subscription confirmation with missing SubscribeURL", async () => {
+        const subscriptionMessageWithoutURL = {
+          Message: SUBSCRIPTION_CONFIRMATION_MESSAGE,
+          MessageId: "missing-url-test-message-id",
+          Signature: TEST_SIGNATURE,
+          SignatureVersion: SNS_SIGNATURE_VERSION,
+          SigningCertURL: SIGNING_CERT_URL,
+          Subject: SUBSCRIPTION_CONFIRMATION_SUBJECT,
+          // SubscribeURL is intentionally missing
+          Timestamp: TEST_TIMESTAMP,
+          TopicArn: TEST_AWS_CONFIG.sns_topics[0],
+          Type: SUBSCRIPTION_CONFIRMATION_TYPE,
+        };
+
+        const { req, res } = httpMocks.createMocks<
+          NextApiRequest,
+          NextApiResponse
+        >({
+          body: subscriptionMessageWithoutURL,
+          method: METHOD.POST,
+        });
+
+        const handler = (await import("../pages/api/sns")).default;
+        await withConsoleMessageHiding(async () => {
+          await handler(req, res);
+        });
+
+        expect(res.statusCode).toBe(400);
+        expect(JSON.parse(res._getData())).toEqual({
+          message: "SubscribeURL is required for subscription confirmation",
+        });
+      });
+    });
+
+    describe("UnsubscribeConfirmation", () => {
+      it("handles valid unsubscribe confirmation with proper topic authorization", async () => {
+        const unsubscribeConfirmationMessage = {
+          Message: UNSUBSCRIBE_MESSAGE,
+          MessageId: "unsubscribe-test-message-id",
+          Signature: TEST_SIGNATURE,
+          SignatureVersion: SNS_SIGNATURE_VERSION,
+          SigningCertURL: SIGNING_CERT_URL,
+          Subject: "AWS Notification - Unsubscribe Confirmation",
+          Timestamp: TEST_TIMESTAMP,
+          TopicArn: TEST_AWS_CONFIG.sns_topics[0], // Use authorized topic
+          Type: "UnsubscribeConfirmation",
+        };
+
+        const { req, res } = httpMocks.createMocks<
+          NextApiRequest,
+          NextApiResponse
+        >({
+          body: unsubscribeConfirmationMessage,
+          method: METHOD.POST,
+        });
+
+        const handler = (await import("../pages/api/sns")).default;
+        await withConsoleMessageHiding(async () => {
+          await handler(req, res);
+        });
+
+        expect(res.statusCode).toBe(200);
+      });
+
+      it("rejects unsubscribe confirmation from unauthorized topic", async () => {
+        const unauthorizedUnsubscribeMessage = {
+          Message: UNSUBSCRIBE_MESSAGE,
+          MessageId: "unauthorized-unsubscribe-message-id",
+          Signature: TEST_SIGNATURE,
+          SignatureVersion: SNS_SIGNATURE_VERSION,
+          SigningCertURL: SIGNING_CERT_URL,
+          Subject: "AWS Notification - Unsubscribe Confirmation",
+          Timestamp: TEST_TIMESTAMP,
+          TopicArn: UNAUTHORIZED_TOPIC_ARN,
+          Type: "UnsubscribeConfirmation",
+        };
+
+        const { req, res } = httpMocks.createMocks<
+          NextApiRequest,
+          NextApiResponse
+        >({
+          body: unauthorizedUnsubscribeMessage,
+          method: METHOD.POST,
+        });
+
+        const handler = (await import("../pages/api/sns")).default;
+        await withConsoleMessageHiding(async () => {
+          await handler(req, res);
+        });
+
+        expect(res.statusCode).toBe(403);
+        expect(JSON.parse(res._getData())).toEqual({
+          message: `Unauthorized SNS topic: ${UNAUTHORIZED_TOPIC_ARN}`,
+        });
+      });
+
+      it("handles unsubscribe confirmation without Subject field", async () => {
+        const unsubscribeMessageWithoutSubject = {
+          Message: UNSUBSCRIBE_MESSAGE,
+          MessageId: "no-subject-unsubscribe-message-id",
+          Signature: TEST_SIGNATURE,
+          SignatureVersion: SNS_SIGNATURE_VERSION,
+          SigningCertURL: SIGNING_CERT_URL,
+          // Subject is intentionally missing
+          Timestamp: TEST_TIMESTAMP,
+          TopicArn: TEST_AWS_CONFIG.sns_topics[0],
+          Type: "UnsubscribeConfirmation",
+        };
+
+        const { req, res } = httpMocks.createMocks<
+          NextApiRequest,
+          NextApiResponse
+        >({
+          body: unsubscribeMessageWithoutSubject,
+          method: METHOD.POST,
+        });
+
+        const handler = (await import("../pages/api/sns")).default;
+        await withConsoleMessageHiding(async () => {
+          await handler(req, res);
+        });
+
+        expect(res.statusCode).toBe(200);
+      });
+    });
+  });
+});

--- a/__tests__/api-sns.test.ts
+++ b/__tests__/api-sns.test.ts
@@ -3,26 +3,33 @@ jest.mock("../app/utils/http", () => {
   return { httpGet: jest.fn() };
 });
 
+import {
+  createS3Event,
+  createSNSMessage,
+  createTestAtlasData,
+  setUpAwsConfig,
+  SNS_MESSAGE_DEFAULTS,
+  SQL_QUERIES,
+  TEST_AWS_CONFIG,
+  TEST_ERROR_MESSAGE_INVALID_SIGNATURE,
+  TEST_FILE_PATHS,
+  TEST_MODULE_SNS_VALIDATOR,
+  TEST_S3_BUCKET,
+  TEST_SIGNATURE,
+  TEST_SIGNATURE_INVALID,
+  TEST_SIGNATURE_VALID,
+  TEST_TIMESTAMP,
+  TEST_TIMESTAMP_ALT,
+  TEST_VERSION_IDS,
+  validateTestSnsMessage,
+} from "../testing/sns-testing";
+
 // Set up AWS resource configuration BEFORE any other imports
-const TEST_S3_BUCKET = "hca-atlas-tracker-data-dev";
-const TEST_GUT_ATLAS_ID = "550e8400-e29b-41d4-a716-446655440000";
-const TEST_S3_EVENT_NAME = "s3:ObjectCreated:Put";
-const TEST_AWS_CONFIG = {
-  s3_buckets: [TEST_S3_BUCKET],
-  sns_topics: [
-    "arn:aws:sns:us-east-1:123456789012:hca-atlas-tracker-s3-notifications",
-  ],
-};
-process.env.AWS_RESOURCE_CONFIG = JSON.stringify(TEST_AWS_CONFIG);
+setUpAwsConfig();
 
 // Imports
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
-import {
-  S3Event,
-  S3Object,
-  SNSMessage,
-} from "../app/apis/catalog/hca-atlas-tracker/aws/schemas";
 import { METHOD } from "../app/common/entities";
 import { resetConfigCache } from "../app/config/aws-resources";
 import { endPgPool, query } from "../app/services/database";
@@ -37,114 +44,6 @@ const { httpGet } = jest.requireMock("../app/utils/http") as {
   httpGet: jest.Mock;
 };
 const mockHttpGet = httpGet as jest.Mock;
-
-// Test file path constants
-const TEST_PATH_SEGMENTS = {
-  GUT_V1_INTEGRATED_OBJECTS: "gut/gut-v1/integrated-objects",
-  GUT_V1_MANIFESTS: "gut/gut-v1/manifests",
-  GUT_V1_SOURCE_DATASETS: "gut/gut-v1/source-datasets",
-} as const;
-
-const TEST_FILE_PATHS = {
-  INTEGRATED_OBJECT: `${TEST_PATH_SEGMENTS.GUT_V1_INTEGRATED_OBJECTS}/atlas.h5ad`,
-  MANIFEST: `${TEST_PATH_SEGMENTS.GUT_V1_MANIFESTS}/upload-manifest.json`,
-  SOURCE_DATASET_AUTH: `${TEST_PATH_SEGMENTS.GUT_V1_SOURCE_DATASETS}/auth-test.h5ad`,
-  SOURCE_DATASET_DUPLICATE: `${TEST_PATH_SEGMENTS.GUT_V1_SOURCE_DATASETS}/duplicate-test.h5ad`,
-  SOURCE_DATASET_ETAG: `${TEST_PATH_SEGMENTS.GUT_V1_SOURCE_DATASETS}/etag-test.h5ad`,
-  SOURCE_DATASET_TEST: `${TEST_PATH_SEGMENTS.GUT_V1_SOURCE_DATASETS}/test-file.h5ad`,
-  SOURCE_DATASET_VERSIONED: `${TEST_PATH_SEGMENTS.GUT_V1_SOURCE_DATASETS}/versioned-file.h5ad`,
-} as const;
-
-// SQL query constants
-const SQL_QUERIES = {
-  SELECT_FILE_BY_BUCKET_AND_KEY:
-    "SELECT * FROM hat.files WHERE bucket = $1 AND key = $2",
-  SELECT_FILE_BY_BUCKET_AND_KEY_ORDERED:
-    "SELECT * FROM hat.files WHERE bucket = $1 AND key = $2 ORDER BY created_at ASC",
-  SELECT_LATEST_FILE_BY_BUCKET_AND_KEY:
-    "SELECT * FROM hat.files WHERE bucket = $1 AND key = $2 AND is_latest = true",
-} as const;
-
-// SNS message constants
-const SNS_MESSAGE_DEFAULTS = {
-  SUBJECT: "Amazon S3 Notification",
-} as const;
-
-// Test data constants
-const TEST_VERSION_IDS = {
-  DEFAULT: "096fKKXTRTtl3on89fVO.nfljtsv6qko",
-} as const;
-
-const TEST_TIMESTAMP = "2024-01-01T12:00:00.000Z";
-const TEST_TIMESTAMP_ALT = "2023-01-01T00:00:00.000Z";
-const TEST_SIGNATURE = "fake-signature-for-testing";
-const TEST_SIGNATURE_VALID = "valid-signature";
-const TEST_SIGNATURE_INVALID = "INVALID-SIGNATURE-SHOULD-BE-REJECTED";
-const TEST_ERROR_MESSAGE_INVALID_SIGNATURE = "Invalid signature";
-const TEST_MODULE_SNS_VALIDATOR = "sns-validator";
-
-// S3 Event and SNS Message Factory Functions
-interface S3EventOptions {
-  bucket?: string;
-  etag: string;
-  eventName?: string;
-  eventTime?: string;
-  key: string;
-  sha256?: string; // Optional to support tests that intentionally omit SHA256
-  size: number;
-  versionId: string;
-}
-
-function createS3Event(options: S3EventOptions): S3Event {
-  const objectData: S3Object = {
-    eTag: options.etag,
-    key: options.key,
-    size: options.size,
-    versionId: options.versionId,
-  };
-
-  return {
-    Records: [
-      {
-        eventName: options.eventName || TEST_S3_EVENT_NAME,
-        eventSource: "aws:s3",
-        eventTime: options.eventTime || TEST_TIMESTAMP,
-        s3: {
-          bucket: {
-            name: options.bucket || TEST_S3_BUCKET,
-          },
-          object: objectData,
-        },
-      },
-    ],
-  };
-}
-
-interface SNSMessageOptions {
-  messageId?: string;
-  s3Event: S3Event;
-  signature?: string;
-  signingCertURL?: string;
-  subject?: string;
-  timestamp?: string;
-  topicArn?: string;
-}
-
-function createSNSMessage(options: SNSMessageOptions): SNSMessage {
-  return {
-    Message: JSON.stringify(options.s3Event),
-    MessageId: options.messageId || "test-message-id",
-    Signature: options.signature || TEST_SIGNATURE,
-    SignatureVersion: "1",
-    SigningCertURL:
-      options.signingCertURL ||
-      "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-fake.pem",
-    Subject: options.subject || SNS_MESSAGE_DEFAULTS.SUBJECT,
-    Timestamp: options.timestamp || TEST_TIMESTAMP,
-    TopicArn: options.topicArn || TEST_AWS_CONFIG.sns_topics[0],
-    Type: "Notification",
-  };
-}
 
 jest.mock(
   "../site-config/hca-atlas-tracker/local/authentication/next-auth-config"
@@ -164,74 +63,13 @@ afterEach(() => {
 
 jest.mock("sns-validator", () => {
   return jest.fn().mockImplementation(() => ({
-    validate: jest.fn((message, callback) => {
-      // Check if this is our test case for invalid signatures
-      if (message.Signature === TEST_SIGNATURE_INVALID) {
-        callback(new Error(TEST_ERROR_MESSAGE_INVALID_SIGNATURE));
-        return;
-      }
-
-      // For all other test cases, simulate successful validation
-      callback(null, message);
-    }),
+    validate: jest.fn(validateTestSnsMessage),
   }));
 });
 
 const TEST_ROUTE = "/api/sns";
 
 import snsHandler from "../pages/api/sns";
-
-// Helper function to create test atlas data
-async function createTestAtlasData(): Promise<void> {
-  // Create multiple test atlases to cover different network/version scenarios
-  const atlases = [
-    {
-      id: TEST_GUT_ATLAS_ID,
-      overview: {
-        description: "Test gut atlas for S3 notification integration tests",
-        network: "gut", // Matches S3 path 'gut/gut-v1/...'
-        shortName: "Gut", // Case-insensitive match with S3 atlas base name 'gut'
-        title: "Test Gut Atlas v1",
-        version: "1", // DB version format (S3 'v1' -> DB '1')
-      },
-    },
-    {
-      id: "550e8400-e29b-41d4-a716-446655440001",
-      overview: {
-        description: "Test retina atlas for S3 notification integration tests",
-        network: "eye", // Matches S3 path 'eye/retina-v1/...'
-        shortName: "Retina", // Case-insensitive match with S3 atlas base name 'retina'
-        title: "Test Retina Atlas v1",
-        version: "1", // DB version format (S3 'v1' -> DB '1')
-      },
-    },
-    {
-      id: "550e8400-e29b-41d4-a716-446655440002",
-      overview: {
-        description:
-          "Test gut atlas v1.1 for S3 notification integration tests",
-        network: "gut", // Same network as first gut atlas
-        shortName: "Gut", // Same shortName but different version
-        title: "Test Gut Atlas v1.1",
-        version: "1.1", // DB version format (S3 'v1-1' -> DB '1.1')
-      },
-    },
-  ];
-
-  // Insert all test atlases
-  for (const atlas of atlases) {
-    await query(
-      `INSERT INTO hat.atlases (id, overview, source_studies, status, created_at, updated_at)
-       VALUES ($1, $2, $3, $4, NOW(), NOW())`,
-      [
-        atlas.id,
-        JSON.stringify(atlas.overview),
-        JSON.stringify([]), // Empty source studies array
-        "draft", // Status field
-      ]
-    );
-  }
-}
 
 beforeEach(async () => {
   await resetDatabase();

--- a/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
+++ b/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
@@ -49,8 +49,18 @@ export const snsMessageSchema = object({
   UnsubscribeURL: string().url().optional(),
 }).required();
 
+// Dataset validator results schema
+// Validates the structure of validation results received via SNS notification
+
+export const datasetValidatorResultsSchema = object({});
+
 // Type inference from Yup schemas
+
 export type S3Object = InferType<typeof s3ObjectSchema>;
 export type S3EventRecord = InferType<typeof s3RecordSchema>;
 export type S3Event = InferType<typeof s3EventSchema>;
 export type SNSMessage = InferType<typeof snsMessageSchema>;
+
+export type DatasetValidatorResults = InferType<
+  typeof datasetValidatorResultsSchema
+>;

--- a/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
+++ b/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
@@ -1,5 +1,5 @@
 import { array, InferType, number, object, string } from "yup";
-import { FILE_VALIDATION_STATUS, INTEGRITY_STATUS } from "../common/entities";
+import { INTEGRITY_STATUS } from "../common/entities";
 
 // AWS S3 and SNS Event Validation Schemas
 // These schemas validate the structure of AWS events received via SNS notifications
@@ -76,7 +76,9 @@ export const datasetValidatorResultsSchema = object({
     .defined()
     .nullable(),
   source_sha256: string().defined().nullable(),
-  status: string().required().oneOf(Object.values(FILE_VALIDATION_STATUS)),
+  status: string()
+    .required()
+    .oneOf(["failure", "success"] as const),
   timestamp: string().required(),
 })
   .strict()

--- a/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
+++ b/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
@@ -1,4 +1,5 @@
 import { array, InferType, number, object, string } from "yup";
+import { FILE_VALIDATION_STATUS, INTEGRITY_STATUS } from "../common/entities";
 
 // AWS S3 and SNS Event Validation Schemas
 // These schemas validate the structure of AWS events received via SNS notifications
@@ -52,7 +53,34 @@ export const snsMessageSchema = object({
 // Dataset validator results schema
 // Validates the structure of validation results received via SNS notification
 
-export const datasetValidatorResultsSchema = object({});
+export const datasetValidatorResultsSchema = object({
+  batch_job_id: string().required(),
+  batch_job_name: string().defined().nullable(),
+  bucket: string().required(),
+  downloaded_sha256: string().defined().nullable(),
+  error_message: string().defined().nullable(),
+  file_id: string().required(),
+  integrity_status: string()
+    .oneOf(Object.values(INTEGRITY_STATUS))
+    .defined()
+    .nullable(),
+  key: string().required(),
+  metadata_summary: object({
+    assay: array(string().required()).required(),
+    cell_count: number().required(),
+    disease: array(string().required()).required(),
+    suspension_type: array(string().required()).required(),
+    tissue: array(string().required()).required(),
+    title: string().defined(),
+  })
+    .defined()
+    .nullable(),
+  source_sha256: string().defined().nullable(),
+  status: string().required().oneOf(Object.values(FILE_VALIDATION_STATUS)),
+  timestamp: string().required(),
+})
+  .strict()
+  .required();
 
 // Type inference from Yup schemas
 

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -660,6 +660,7 @@ export enum FILE_TYPE {
 
 export enum FILE_VALIDATION_STATUS {
   FAILURE = "failure",
+  PENDING = "pending",
   SUCCESS = "succes",
 }
 

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -404,6 +404,7 @@ export interface HCAAtlasTrackerDBFile {
   bucket: string;
   component_atlas_id: string | null;
   created_at: Date;
+  dataset_info: HCAAtlasTrackerDBFileDatasetInfo | null;
   etag: string;
   event_info: FileEventInfo;
   file_type: FILE_TYPE;
@@ -421,7 +422,17 @@ export interface HCAAtlasTrackerDBFile {
   source_study_id: string | null;
   status: FILE_STATUS;
   updated_at: Date;
+  validation_sns_message_id: string | null;
   version_id: string | null;
+}
+
+export interface HCAAtlasTrackerDBFileDatasetInfo {
+  assay: string[];
+  cellCount: number;
+  disease: string[];
+  suspensionType: string[];
+  tissue: string[];
+  title: string;
 }
 
 export interface HCAAtlasTrackerListValidationRecord
@@ -656,12 +667,6 @@ export enum FILE_TYPE {
   INGEST_MANIFEST = "ingest_manifest",
   INTEGRATED_OBJECT = "integrated_object",
   SOURCE_DATASET = "source_dataset",
-}
-
-export enum FILE_VALIDATION_STATUS {
-  FAILURE = "failure",
-  PENDING = "pending",
-  SUCCESS = "succes",
 }
 
 export enum INTEGRITY_STATUS {

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -658,6 +658,11 @@ export enum FILE_TYPE {
   SOURCE_DATASET = "source_dataset",
 }
 
+export enum FILE_VALIDATION_STATUS {
+  FAILURE = "failure",
+  SUCCESS = "succes",
+}
+
 export enum INTEGRITY_STATUS {
   ERROR = "error",
   INVALID = "invalid",

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -422,7 +422,7 @@ export interface HCAAtlasTrackerDBFile {
   source_study_id: string | null;
   status: FILE_STATUS;
   updated_at: Date;
-  validation_sns_message_id: string | null;
+  validation_info: HCAAtlasTrackerDBFileValidationInfo | null;
   version_id: string | null;
 }
 
@@ -433,6 +433,12 @@ export interface HCAAtlasTrackerDBFileDatasetInfo {
   suspensionType: string[];
   tissue: string[];
   title: string;
+}
+
+export interface HCAAtlasTrackerDBFileValidationInfo {
+  batchJobId: string;
+  snsMessageId: string;
+  snsMessageTime: string;
 }
 
 export interface HCAAtlasTrackerListValidationRecord

--- a/app/data/files.ts
+++ b/app/data/files.ts
@@ -5,6 +5,7 @@ import {
   HCAAtlasTrackerDBAtlas,
   HCAAtlasTrackerDBFile,
   HCAAtlasTrackerDBFileDatasetInfo,
+  HCAAtlasTrackerDBFileValidationInfo,
   INTEGRITY_STATUS,
   NetworkKey,
   type FileEventInfo,
@@ -327,39 +328,39 @@ export async function getLastValidationTimestamp(
  * @param params.datasetInfo - Dataset info to add to the file.
  * @param params.fileId - ID of the file to update.
  * @param params.integrityStatus - Integrity status to set on the file.
- * @param params.snsMessageId - ID of the SNS message that triggered the update, for deduplication.
  * @param params.validatedAt - Time at which the validation started.
+ * @param params.validationInfo - Metadata of the validation.
  */
 export async function addValidationResultsToFile(params: {
   client: pg.PoolClient;
   datasetInfo: HCAAtlasTrackerDBFileDatasetInfo | null;
   fileId: string;
   integrityStatus: INTEGRITY_STATUS;
-  snsMessageId: string;
   validatedAt: Date;
+  validationInfo: HCAAtlasTrackerDBFileValidationInfo;
 }): Promise<void> {
   const {
     client,
     datasetInfo,
     fileId,
     integrityStatus,
-    snsMessageId,
     validatedAt,
+    validationInfo,
   } = params;
   await client.query(
     `
       UPDATE hat.files
       SET
-        validation_sns_message_id = $1,
-        integrity_status = $2,
-        dataset_info = $3,
+        integrity_status = $1,
+        dataset_info = $2,
+        validation_info = $3,
         integrity_checked_at = $4
       WHERE id = $5
     `,
     [
-      snsMessageId,
       integrityStatus,
       JSON.stringify(datasetInfo),
+      JSON.stringify(validationInfo),
       validatedAt,
       fileId,
     ]

--- a/app/data/files.ts
+++ b/app/data/files.ts
@@ -309,21 +309,34 @@ export async function upsertFileRecord(
  * @param params.fileId - ID of the file to update.
  * @param params.integrityStatus - Integrity status to set on the file.
  * @param params.snsMessageId - ID of the SNS message that triggered the update, for deduplication.
+ * @param params.validatedAt - Time at which the validation started.
  */
 export async function addValidationResultsToFile(params: {
   datasetInfo: HCAAtlasTrackerDBFileDatasetInfo | null;
   fileId: string;
   integrityStatus: INTEGRITY_STATUS;
   snsMessageId: string;
+  validatedAt: Date;
 }): Promise<void> {
-  const { datasetInfo, fileId, integrityStatus, snsMessageId } = params;
+  const { datasetInfo, fileId, integrityStatus, snsMessageId, validatedAt } =
+    params;
   await query(
     `
       UPDATE hat.files
       -- Setting validation_sns_message_id will implicitly ensure that the same SNS message is not used multiple times
-      SET validation_sns_message_id = $1, integrity_status = $2, dataset_info = $3
-      WHERE id = $4
+      SET
+        validation_sns_message_id = $1,
+        integrity_status = $2,
+        dataset_info = $3,
+        integrity_checked_at = $4
+      WHERE id = $5
     `,
-    [snsMessageId, integrityStatus, JSON.stringify(datasetInfo), fileId]
+    [
+      snsMessageId,
+      integrityStatus,
+      JSON.stringify(datasetInfo),
+      validatedAt,
+      fileId,
+    ]
   );
 }

--- a/app/data/files.ts
+++ b/app/data/files.ts
@@ -321,7 +321,7 @@ export async function getLastValidationTimestamp(
 }
 
 /**
- * Add info from validation results to a file record, implicitly handling duplicate SNS notifications.
+ * Add info from validation results to a file record.
  * @param params - Parameters.
  * @param params.client - Postgres client to use.
  * @param params.datasetInfo - Dataset info to add to the file.
@@ -349,7 +349,6 @@ export async function addValidationResultsToFile(params: {
   await client.query(
     `
       UPDATE hat.files
-      -- Setting validation_sns_message_id will implicitly ensure that the same SNS message is not used multiple times
       SET
         validation_sns_message_id = $1,
         integrity_status = $2,

--- a/app/services/sns-dispatcher.ts
+++ b/app/services/sns-dispatcher.ts
@@ -49,5 +49,5 @@ function isS3NotificationTopic(topicArn: string): boolean {
  * @returns True if this is the validation results topic
  */
 function isValidationResultsTopic(topicArn: string): boolean {
-  return topicArn === "validation-results";
+  return topicArn.includes("validation-results");
 }

--- a/app/services/validation-results-notification.ts
+++ b/app/services/validation-results-notification.ts
@@ -1,0 +1,30 @@
+import { InvalidOperationError } from "../utils/api-handler";
+import { DatasetValidatorResults, datasetValidatorResultsSchema, SNSMessage } from "../apis/catalog/hca-atlas-tracker/aws/schemas";
+
+/**
+ * Processes an SNS notification message containing dataset validation results
+ * @param snsMessage - The authorized SNS message containing validation results
+ * @throws InvalidOperationError if the SNS message doesn't contain a valid validation results message
+ */
+export async function processValidationResultsMessage(
+  snsMessage: SNSMessage
+): Promise<void> {
+  let parsedMessage: unknown;
+  try {
+    parsedMessage = JSON.parse(snsMessage.Message);
+  } catch (parseError) {
+    throw new InvalidOperationError(
+      "Failed to parse validation results from SNS message"
+    );
+  }
+
+  const validationResults = await datasetValidatorResultsSchema.validate(
+    parsedMessage
+  );
+
+  await processValidationResults(validationResults);
+}
+
+async function processValidationResults(
+  validationResults: DatasetValidatorResults
+): Promise<void> {}

--- a/app/services/validation-results-notification.ts
+++ b/app/services/validation-results-notification.ts
@@ -43,6 +43,7 @@ export async function processValidationResultsMessage(
     integrityStatus:
       validationResults.integrity_status ?? INTEGRITY_STATUS.PENDING,
     snsMessageId: snsMessage.MessageId,
+    validatedAt: new Date(validationResults.timestamp),
   });
 }
 

--- a/migrations/1757716803455_validation-results-columns.ts
+++ b/migrations/1757716803455_validation-results-columns.ts
@@ -10,12 +10,11 @@ export function up(pgm: MigrationBuilder): void {
         notNull: false,
         type: "jsonb",
       },
-      validation_sns_message_id: {
+      validation_info: {
         comment:
-          "SNS MessageId for deduplication of duplicate validation results SNS notifications",
+          "Metadata of the batch job and SNS message used in validating the file",
         notNull: false,
-        type: "varchar(255)",
-        unique: true,
+        type: "jsonb",
       },
     }
   );

--- a/migrations/1757716803455_validation-results-columns.ts
+++ b/migrations/1757716803455_validation-results-columns.ts
@@ -1,0 +1,22 @@
+import { MigrationBuilder } from "node-pg-migrate";
+
+export function up(pgm: MigrationBuilder): void {
+  // Add additional columns required to hold dataset validator results
+  pgm.addColumns(
+    { name: "files", schema: "hat" },
+    {
+      dataset_info: {
+        comment: "Metadata from the file",
+        notNull: false,
+        type: "jsonb",
+      },
+      validation_sns_message_id: {
+        comment:
+          "SNS MessageId for deduplication of duplicate validation results SNS notifications",
+        notNull: false,
+        type: "varchar(255)",
+        unique: true,
+      },
+    }
+  );
+}

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -1464,12 +1464,12 @@ export const TEST_SOURCE_STUDIES = [...INITIAL_TEST_SOURCE_STUDIES];
 
 // SOURCE DATASETS
 
-export const SOURCE_DATASET_FOO: TestSourceDataset = {
+export const SOURCE_DATASET_FOO = {
   assay: ["assay foo"],
   cellCount: 354,
   disease: ["disease foo"],
   file: {
-    atlas: () => ATLAS_WITH_MISC_SOURCE_STUDIES,
+    atlas: (): TestAtlas => ATLAS_WITH_MISC_SOURCE_STUDIES,
     bucket: "bucket-source-dataset-foo",
     etag: "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d",
     eventTime: "2025-08-22T06:10:15.123Z",
@@ -1484,11 +1484,11 @@ export const SOURCE_DATASET_FOO: TestSourceDataset = {
   suspensionType: ["suspension type foo"],
   tissue: ["tissue foo"],
   title: "Source Dataset Foo",
-};
+} satisfies TestSourceDataset;
 
-export const SOURCE_DATASET_BAR: TestSourceDataset = {
+export const SOURCE_DATASET_BAR = {
   file: {
-    atlas: () => ATLAS_WITH_MISC_SOURCE_STUDIES,
+    atlas: (): TestAtlas => ATLAS_WITH_MISC_SOURCE_STUDIES,
     bucket: "bucket-source-dataset-bar",
     etag: "2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e",
     eventTime: "2025-08-22T06:10:32.456Z",
@@ -1501,11 +1501,11 @@ export const SOURCE_DATASET_BAR: TestSourceDataset = {
   id: "cd053619-8b50-4e2d-ba62-96fbbcad6011",
   sourceStudyId: SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
   title: "Source Dataset Bar",
-};
+} satisfies TestSourceDataset;
 
-export const SOURCE_DATASET_BAZ: TestSourceDataset = {
+export const SOURCE_DATASET_BAZ = {
   file: {
-    atlas: () => ATLAS_WITH_MISC_SOURCE_STUDIES,
+    atlas: (): TestAtlas => ATLAS_WITH_MISC_SOURCE_STUDIES,
     bucket: "bucket-source-dataset-baz",
     etag: "3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f",
     eventTime: "2025-08-22T06:10:49.789Z",
@@ -1518,14 +1518,14 @@ export const SOURCE_DATASET_BAZ: TestSourceDataset = {
   id: "3682751a-7a97-48e1-a43e-d355c1707e26",
   sourceStudyId: SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
   title: "Source Dataset Baz",
-};
+} satisfies TestSourceDataset;
 
-export const SOURCE_DATASET_FOOFOO: TestSourceDataset = {
+export const SOURCE_DATASET_FOOFOO = {
   assay: ["assay foofoo"],
   cellCount: 534,
   disease: ["disease foofoo"],
   file: {
-    atlas: () => ATLAS_WITH_MISC_SOURCE_STUDIES,
+    atlas: (): TestAtlas => ATLAS_WITH_MISC_SOURCE_STUDIES,
     bucket: "bucket-source-dataset-foofoo",
     etag: "4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f90",
     eventTime: "2025-08-22T06:11:06.012Z",
@@ -1540,11 +1540,11 @@ export const SOURCE_DATASET_FOOFOO: TestSourceDataset = {
   suspensionType: ["suspension type foofoo"],
   tissue: ["tissue foofoo"],
   title: "Source Dataset Foofoo",
-};
+} satisfies TestSourceDataset;
 
-export const SOURCE_DATASET_FOOBAR: TestSourceDataset = {
+export const SOURCE_DATASET_FOOBAR = {
   file: {
-    atlas: () => ATLAS_WITH_MISC_SOURCE_STUDIES,
+    atlas: (): TestAtlas => ATLAS_WITH_MISC_SOURCE_STUDIES,
     bucket: "bucket-source-dataset-foobar",
     etag: "5e6f7a8b9c0d1e2f3a4b5c6d7e8f9012",
     eventTime: "2025-08-22T06:11:23.345Z",
@@ -1557,11 +1557,11 @@ export const SOURCE_DATASET_FOOBAR: TestSourceDataset = {
   id: "4de3dadd-a35c-4386-be62-4536934e9179",
   sourceStudyId: SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
   title: "Source Dataset Foobar",
-};
+} satisfies TestSourceDataset;
 
-export const SOURCE_DATASET_FOOBAZ: TestSourceDataset = {
+export const SOURCE_DATASET_FOOBAZ = {
   file: {
-    atlas: () => ATLAS_WITH_MISC_SOURCE_STUDIES,
+    atlas: (): TestAtlas => ATLAS_WITH_MISC_SOURCE_STUDIES,
     bucket: "bucket-source-dataset-foobaz",
     etag: "6f7a8b9c0d1e2f3a4b5c6d7e8f901234",
     eventTime: "2025-08-22T06:11:40.678Z",
@@ -1574,16 +1574,16 @@ export const SOURCE_DATASET_FOOBAZ: TestSourceDataset = {
   id: "7ac2afd8-493d-46e5-b9d8-cadc512bb2cc",
   sourceStudyId: SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
   title: "Source Dataset Foobar",
-};
+} satisfies TestSourceDataset;
 
-export const SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE: TestSourceDataset = {
+export const SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE = {
   assay: ["foo"],
   cellCount: 123,
   cellxgeneDatasetId: CELLXGENE_ID_DATASET_WITHOUT_UPDATE,
   cellxgeneDatasetVersion: CELLXGENE_VERSION_DATASET_WITHOUT_UPDATE,
   disease: ["bar"],
   file: {
-    atlas: () => ATLAS_WITH_MISC_SOURCE_STUDIES,
+    atlas: (): TestAtlas => ATLAS_WITH_MISC_SOURCE_STUDIES,
     bucket: "bucket-source-dataset-cellxgene-without-update",
     etag: "7a8b9c0d1e2f3a4b5c6d7e8f90123456",
     eventTime: "2025-08-22T06:11:57.901Z",
@@ -1598,16 +1598,16 @@ export const SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE: TestSourceDataset = {
   suspensionType: ["foobarbaz"],
   tissue: ["baz"],
   title: "Source Dataset CELLxGENE Without Update",
-};
+} satisfies TestSourceDataset;
 
-export const SOURCE_DATASET_CELLXGENE_WITH_UPDATE: TestSourceDataset = {
+export const SOURCE_DATASET_CELLXGENE_WITH_UPDATE = {
   assay: ["foobarfoo"],
   cellCount: 4567,
   cellxgeneDatasetId: CELLXGENE_ID_DATASET_WITH_UPDATE,
   cellxgeneDatasetVersion: "cellxgene-version-dataset-with-update-a",
   disease: ["barbarfoo"],
   file: {
-    atlas: () => ATLAS_WITH_MISC_SOURCE_STUDIES,
+    atlas: (): TestAtlas => ATLAS_WITH_MISC_SOURCE_STUDIES,
     bucket: "bucket-source-dataset-cellxgene-with-update",
     etag: "8b9c0d1e2f3a4b5c6d7e8f9012345678",
     eventTime: "2025-08-22T06:12:14.234Z",
@@ -1625,11 +1625,11 @@ export const SOURCE_DATASET_CELLXGENE_WITH_UPDATE: TestSourceDataset = {
   suspensionType: ["foobazbarfoo"],
   tissue: ["bazbarfoo"],
   title: "Source Dataset CELLxGENE With Update",
-};
+} satisfies TestSourceDataset;
 
-export const SOURCE_DATASET_DRAFT_OK_FOO: TestSourceDataset = {
+export const SOURCE_DATASET_DRAFT_OK_FOO = {
   file: {
-    atlas: () => ATLAS_DRAFT,
+    atlas: (): TestAtlas => ATLAS_DRAFT,
     bucket: "bucket-source-dataset-draft-ok-foo",
     etag: "9c0d1e2f3a4b5c6d7e8f901234567890",
     eventTime: "2025-08-22T06:12:31.567Z",
@@ -1642,11 +1642,11 @@ export const SOURCE_DATASET_DRAFT_OK_FOO: TestSourceDataset = {
   id: "edf62340-8180-4206-87f2-d95e388a3a4c",
   sourceStudyId: SOURCE_STUDY_DRAFT_OK.id,
   title: "Source Dataset Draft OK Foo",
-};
+} satisfies TestSourceDataset;
 
-export const SOURCE_DATASET_DRAFT_OK_BAR: TestSourceDataset = {
+export const SOURCE_DATASET_DRAFT_OK_BAR = {
   file: {
-    atlas: () => ATLAS_DRAFT,
+    atlas: (): TestAtlas => ATLAS_DRAFT,
     bucket: "bucket-source-dataset-draft-ok-bar",
     etag: "0d1e2f3a4b5c6d7e8f90123456789012",
     eventTime: "2025-08-22T06:12:48.890Z",
@@ -1659,14 +1659,14 @@ export const SOURCE_DATASET_DRAFT_OK_BAR: TestSourceDataset = {
   id: "3b41d607-05ff-48a7-92bd-9d257a230b3d",
   sourceStudyId: SOURCE_STUDY_DRAFT_OK.id,
   title: "Source Dataset Draft OK Bar",
-};
+} satisfies TestSourceDataset;
 
-export const SOURCE_DATASET_OTHER_FOO: TestSourceDataset = {
+export const SOURCE_DATASET_OTHER_FOO = {
   assay: ["assay other foo"],
   cellCount: 23424,
   disease: ["disease other foo"],
   file: {
-    atlas: () => ATLAS_WITH_MISC_SOURCE_STUDIES,
+    atlas: (): TestAtlas => ATLAS_WITH_MISC_SOURCE_STUDIES,
     bucket: "bucket-source-dataset-other-foo",
     etag: "1e2f3a4b5c6d7e8f9012345678901234",
     eventTime: "2025-08-22T06:13:05.123Z",
@@ -1681,14 +1681,14 @@ export const SOURCE_DATASET_OTHER_FOO: TestSourceDataset = {
   suspensionType: ["suspension type other foo"],
   tissue: ["tissue other foo"],
   title: "Source Dataset Other Foo",
-};
+} satisfies TestSourceDataset;
 
-export const SOURCE_DATASET_OTHER_BAR: TestSourceDataset = {
+export const SOURCE_DATASET_OTHER_BAR = {
   assay: ["assay other bar"],
   cellCount: 23424,
   disease: ["disease other bar"],
   file: {
-    atlas: () => ATLAS_WITH_MISC_SOURCE_STUDIES,
+    atlas: (): TestAtlas => ATLAS_WITH_MISC_SOURCE_STUDIES,
     bucket: "bucket-source-dataset-other-bar",
     etag: "2f3a4b5c6d7e8f90123456789012345a",
     eventTime: "2025-08-22T06:13:22.456Z",
@@ -1703,138 +1703,133 @@ export const SOURCE_DATASET_OTHER_BAR: TestSourceDataset = {
   suspensionType: ["suspension type other bar"],
   tissue: ["tissue other bar"],
   title: "Source Dataset Other Bar",
-};
+} satisfies TestSourceDataset;
 
-export const SOURCE_DATASET_UNPUBLISHED_WITH_CELLXGENE_FOO: TestSourceDataset =
-  {
-    assay: ["assay unpublished with cellxgene foo"],
-    cellCount: 5464,
-    cellxgeneDatasetId: CELLXGENE_ID_DATASET_UNPUBLISHED_WITH_CELLXGENE_FOO,
-    cellxgeneDatasetVersion:
-      CELLXGENE_VERSION_DATASET_UNPUBLISHED_WITH_CELLXGENE_FOO,
-    disease: ["disease unpublished with cellxgene foo"],
-    file: {
-      atlas: () => ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_A,
-      bucket: "bucket-source-dataset-unpublished-with-cellxgene-foo",
-      etag: "3a4b5c6d7e8f90123456789012345678",
-      eventTime: "2025-08-22T06:13:39.789Z",
-      fileName: "source-dataset-unpublished-with-cellxgene-foo.h5ad",
-      fileType: FILE_TYPE.SOURCE_DATASET,
-      id: "a3b4c5d6-e7f8-9012-ab34-345678901234",
-      sizeBytes: "1356789",
-      versionId: null,
-    },
-    id: "1d872ee4-cfb3-4893-a275-fe0f105697c4",
-    sourceStudyId: SOURCE_STUDY_UNPUBLISHED_WITH_CELLXGENE.id,
-    suspensionType: ["suspension type unpublished with cellxgene foo"],
-    tissue: ["tissue unpublished with cellxgene foo"],
-    title: "Source Dataset Unpublished With CELLxGENE Foo",
-  };
+export const SOURCE_DATASET_UNPUBLISHED_WITH_CELLXGENE_FOO = {
+  assay: ["assay unpublished with cellxgene foo"],
+  cellCount: 5464,
+  cellxgeneDatasetId: CELLXGENE_ID_DATASET_UNPUBLISHED_WITH_CELLXGENE_FOO,
+  cellxgeneDatasetVersion:
+    CELLXGENE_VERSION_DATASET_UNPUBLISHED_WITH_CELLXGENE_FOO,
+  disease: ["disease unpublished with cellxgene foo"],
+  file: {
+    atlas: (): TestAtlas => ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_A,
+    bucket: "bucket-source-dataset-unpublished-with-cellxgene-foo",
+    etag: "3a4b5c6d7e8f90123456789012345678",
+    eventTime: "2025-08-22T06:13:39.789Z",
+    fileName: "source-dataset-unpublished-with-cellxgene-foo.h5ad",
+    fileType: FILE_TYPE.SOURCE_DATASET,
+    id: "a3b4c5d6-e7f8-9012-ab34-345678901234",
+    sizeBytes: "1356789",
+    versionId: null,
+  },
+  id: "1d872ee4-cfb3-4893-a275-fe0f105697c4",
+  sourceStudyId: SOURCE_STUDY_UNPUBLISHED_WITH_CELLXGENE.id,
+  suspensionType: ["suspension type unpublished with cellxgene foo"],
+  tissue: ["tissue unpublished with cellxgene foo"],
+  title: "Source Dataset Unpublished With CELLxGENE Foo",
+} satisfies TestSourceDataset;
 
-export const SOURCE_DATASET_UNPUBLISHED_WITH_CELLXGENE_BAR: TestSourceDataset =
-  {
-    assay: ["assay unpublished with cellxgene bar"],
-    cellCount: 3493,
-    cellxgeneDatasetId: CELLXGENE_ID_DATASET_UNPUBLISHED_WITH_CELLXGENE_BAR,
-    cellxgeneDatasetVersion:
-      CELLXGENE_VERSION_DATASET_UNPUBLISHED_WITH_CELLXGENE_BAR,
-    disease: ["disease unpublished with cellxgene bar"],
-    file: {
-      atlas: () => ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_A,
-      bucket: "bucket-source-dataset-unpublished-with-cellxgene-bar",
-      etag: "4b5c6d7e8f90123456789012345678901",
-      eventTime: "2025-08-22T06:13:56.012Z",
-      fileName: "source-dataset-unpublished-with-cellxgene-bar.h5ad",
-      fileType: FILE_TYPE.SOURCE_DATASET,
-      id: "b4c5d6e7-f8a9-0123-bc45-456789012345",
-      sizeBytes: "1467890",
-      versionId: null,
-    },
-    id: "30bd81d7-1db7-4f28-b6d3-6afa73066f99",
-    sourceStudyId: SOURCE_STUDY_UNPUBLISHED_WITH_CELLXGENE.id,
-    suspensionType: ["suspension type unpublished with cellxgene bar"],
-    tissue: ["tissue unpublished with cellxgene bar"],
-    title: "Source Dataset Unpublished With CELLxGENE Bar",
-  };
+export const SOURCE_DATASET_UNPUBLISHED_WITH_CELLXGENE_BAR = {
+  assay: ["assay unpublished with cellxgene bar"],
+  cellCount: 3493,
+  cellxgeneDatasetId: CELLXGENE_ID_DATASET_UNPUBLISHED_WITH_CELLXGENE_BAR,
+  cellxgeneDatasetVersion:
+    CELLXGENE_VERSION_DATASET_UNPUBLISHED_WITH_CELLXGENE_BAR,
+  disease: ["disease unpublished with cellxgene bar"],
+  file: {
+    atlas: (): TestAtlas => ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_A,
+    bucket: "bucket-source-dataset-unpublished-with-cellxgene-bar",
+    etag: "4b5c6d7e8f90123456789012345678901",
+    eventTime: "2025-08-22T06:13:56.012Z",
+    fileName: "source-dataset-unpublished-with-cellxgene-bar.h5ad",
+    fileType: FILE_TYPE.SOURCE_DATASET,
+    id: "b4c5d6e7-f8a9-0123-bc45-456789012345",
+    sizeBytes: "1467890",
+    versionId: null,
+  },
+  id: "30bd81d7-1db7-4f28-b6d3-6afa73066f99",
+  sourceStudyId: SOURCE_STUDY_UNPUBLISHED_WITH_CELLXGENE.id,
+  suspensionType: ["suspension type unpublished with cellxgene bar"],
+  tissue: ["tissue unpublished with cellxgene bar"],
+  title: "Source Dataset Unpublished With CELLxGENE Bar",
+} satisfies TestSourceDataset;
 
-export const SOURCE_DATASET_UNPUBLISHED_WITH_CELLXGENE_BAZ: TestSourceDataset =
-  {
-    assay: ["assay unpublished with cellxgene baz"],
-    cellCount: 64345,
-    disease: ["disease unpublished with cellxgene baz"],
-    file: {
-      atlas: () => ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_A,
-      bucket: "bucket-source-dataset-unpublished-with-cellxgene-baz",
-      etag: "5c6d7e8f90123456789012345678901a",
-      eventTime: "2025-08-22T06:14:12.345Z",
-      fileName: "source-dataset-unpublished-with-cellxgene-baz.h5ad",
-      fileType: FILE_TYPE.SOURCE_DATASET,
-      id: "c5d6e7f8-a9b0-1234-cd56-567890123456",
-      sizeBytes: "1578901",
-      versionId: null,
-    },
-    id: "4b7acc76-89f2-4839-a15c-fc79183c1ed7",
-    sourceStudyId: SOURCE_STUDY_UNPUBLISHED_WITH_CELLXGENE.id,
-    suspensionType: ["suspension type unpublished with cellxgene baz"],
-    tissue: ["tissue unpublished with cellxgene baz"],
-    title: "Source Dataset Unpublished With CELLxGENE Baz",
-  };
+export const SOURCE_DATASET_UNPUBLISHED_WITH_CELLXGENE_BAZ = {
+  assay: ["assay unpublished with cellxgene baz"],
+  cellCount: 64345,
+  disease: ["disease unpublished with cellxgene baz"],
+  file: {
+    atlas: (): TestAtlas => ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_A,
+    bucket: "bucket-source-dataset-unpublished-with-cellxgene-baz",
+    etag: "5c6d7e8f90123456789012345678901a",
+    eventTime: "2025-08-22T06:14:12.345Z",
+    fileName: "source-dataset-unpublished-with-cellxgene-baz.h5ad",
+    fileType: FILE_TYPE.SOURCE_DATASET,
+    id: "c5d6e7f8-a9b0-1234-cd56-567890123456",
+    sizeBytes: "1578901",
+    versionId: null,
+  },
+  id: "4b7acc76-89f2-4839-a15c-fc79183c1ed7",
+  sourceStudyId: SOURCE_STUDY_UNPUBLISHED_WITH_CELLXGENE.id,
+  suspensionType: ["suspension type unpublished with cellxgene baz"],
+  tissue: ["tissue unpublished with cellxgene baz"],
+  title: "Source Dataset Unpublished With CELLxGENE Baz",
+} satisfies TestSourceDataset;
 
-export const SOURCE_DATASET_PUBLISHED_WITHOUT_CELLXGENE_ID_FOO: TestSourceDataset =
-  {
-    assay: ["assay published without cellxgene id foo"],
-    cellCount: 34538,
-    cellxgeneDatasetId: CELLXGENE_ID_DATASET_PUBLISHED_WITHOUT_CELLXGENE_ID_FOO,
-    cellxgeneDatasetVersion:
-      CELLXGENE_VERSION_DATASET_PUBLISHED_WITHOUT_CELLXGENE_ID_FOO,
-    disease: ["disease published without cellxgene id foo"],
-    file: {
-      atlas: () => ATLAS_WITH_MISC_SOURCE_STUDIES,
-      bucket: "bucket-source-dataset-published-without-cellxgene-id-foo",
-      etag: "6d7e8f90123456789012345678901234",
-      eventTime: "2025-08-22T06:14:29.678Z",
-      fileName: "source-dataset-published-without-cellxgene-id-foo.h5ad",
-      fileType: FILE_TYPE.SOURCE_DATASET,
-      id: "d6e7f8a9-b0c1-2345-de67-678901234567",
-      sizeBytes: "1689012",
-      versionId: null,
-    },
-    id: "68dbf3ec-45a5-43a4-b806-97923de1df2c",
-    sourceStudyId: SOURCE_STUDY_PUBLISHED_WITHOUT_CELLXGENE_ID.id,
-    suspensionType: ["suspension type published without cellxgene id foo"],
-    tissue: ["tissue published without cellxgene id foo"],
-    title: "Source Dataset Published Without CELLxGENE ID Foo",
-  };
+export const SOURCE_DATASET_PUBLISHED_WITHOUT_CELLXGENE_ID_FOO = {
+  assay: ["assay published without cellxgene id foo"],
+  cellCount: 34538,
+  cellxgeneDatasetId: CELLXGENE_ID_DATASET_PUBLISHED_WITHOUT_CELLXGENE_ID_FOO,
+  cellxgeneDatasetVersion:
+    CELLXGENE_VERSION_DATASET_PUBLISHED_WITHOUT_CELLXGENE_ID_FOO,
+  disease: ["disease published without cellxgene id foo"],
+  file: {
+    atlas: (): TestAtlas => ATLAS_WITH_MISC_SOURCE_STUDIES,
+    bucket: "bucket-source-dataset-published-without-cellxgene-id-foo",
+    etag: "6d7e8f90123456789012345678901234",
+    eventTime: "2025-08-22T06:14:29.678Z",
+    fileName: "source-dataset-published-without-cellxgene-id-foo.h5ad",
+    fileType: FILE_TYPE.SOURCE_DATASET,
+    id: "d6e7f8a9-b0c1-2345-de67-678901234567",
+    sizeBytes: "1689012",
+    versionId: null,
+  },
+  id: "68dbf3ec-45a5-43a4-b806-97923de1df2c",
+  sourceStudyId: SOURCE_STUDY_PUBLISHED_WITHOUT_CELLXGENE_ID.id,
+  suspensionType: ["suspension type published without cellxgene id foo"],
+  tissue: ["tissue published without cellxgene id foo"],
+  title: "Source Dataset Published Without CELLxGENE ID Foo",
+} satisfies TestSourceDataset;
 
-export const SOURCE_DATASET_PUBLISHED_WITHOUT_CELLXGENE_ID_BAR: TestSourceDataset =
-  {
-    assay: ["assay published without cellxgene id bar"],
-    cellCount: 2348,
-    disease: ["disease published without cellxgene id bar"],
-    file: {
-      atlas: () => ATLAS_WITH_MISC_SOURCE_STUDIES,
-      bucket: "bucket-source-dataset-published-without-cellxgene-id-bar",
-      etag: "7e8f90123456789012345678901234ab",
-      eventTime: "2025-08-22T06:14:46.901Z",
-      fileName: "source-dataset-published-without-cellxgene-id-bar.h5ad",
-      fileType: FILE_TYPE.SOURCE_DATASET,
-      id: "e7f8a9b0-c1d2-3456-ef78-789012345678",
-      sizeBytes: "1790123",
-      versionId: null,
-    },
-    id: "2d4f2d93-7c2c-4c1f-94af-566f3d3ed8ec",
-    sourceStudyId: SOURCE_STUDY_PUBLISHED_WITHOUT_CELLXGENE_ID.id,
-    suspensionType: ["suspension type published without cellxgene id bar"],
-    tissue: ["tissue published without cellxgene id bar"],
-    title: "Source Dataset Published Without CELLxGENE ID Bar",
-  };
+export const SOURCE_DATASET_PUBLISHED_WITHOUT_CELLXGENE_ID_BAR = {
+  assay: ["assay published without cellxgene id bar"],
+  cellCount: 2348,
+  disease: ["disease published without cellxgene id bar"],
+  file: {
+    atlas: (): TestAtlas => ATLAS_WITH_MISC_SOURCE_STUDIES,
+    bucket: "bucket-source-dataset-published-without-cellxgene-id-bar",
+    etag: "7e8f90123456789012345678901234ab",
+    eventTime: "2025-08-22T06:14:46.901Z",
+    fileName: "source-dataset-published-without-cellxgene-id-bar.h5ad",
+    fileType: FILE_TYPE.SOURCE_DATASET,
+    id: "e7f8a9b0-c1d2-3456-ef78-789012345678",
+    sizeBytes: "1790123",
+    versionId: null,
+  },
+  id: "2d4f2d93-7c2c-4c1f-94af-566f3d3ed8ec",
+  sourceStudyId: SOURCE_STUDY_PUBLISHED_WITHOUT_CELLXGENE_ID.id,
+  suspensionType: ["suspension type published without cellxgene id bar"],
+  tissue: ["tissue published without cellxgene id bar"],
+  title: "Source Dataset Published Without CELLxGENE ID Bar",
+} satisfies TestSourceDataset;
 
-export const SOURCE_DATASET_ATLAS_LINKED_A_FOO: TestSourceDataset = {
+export const SOURCE_DATASET_ATLAS_LINKED_A_FOO = {
   assay: ["assay atlas linked a foo"],
   cellCount: 3982,
   disease: ["disease atlas linked a foo"],
   file: {
-    atlas: () => ATLAS_WITH_MISC_SOURCE_STUDIES,
+    atlas: (): TestAtlas => ATLAS_WITH_MISC_SOURCE_STUDIES,
     bucket: "bucket-source-dataset-atlas-linked-a-foo",
     etag: "8f90123456789012345678901234567b",
     eventTime: "2025-08-22T06:15:03.234Z",
@@ -1849,14 +1844,14 @@ export const SOURCE_DATASET_ATLAS_LINKED_A_FOO: TestSourceDataset = {
   suspensionType: ["suspension type atlas linked a foo"],
   tissue: ["tissue atlas linked a foo"],
   title: "Source Dataset Atlas Linked A Foo",
-};
+} satisfies TestSourceDataset;
 
-export const SOURCE_DATASET_ATLAS_LINKED_B_FOO: TestSourceDataset = {
+export const SOURCE_DATASET_ATLAS_LINKED_B_FOO = {
   assay: ["assay atlas linked b foo"],
   cellCount: 81283,
   disease: ["disease atlas linked b foo"],
   file: {
-    atlas: () => ATLAS_WITH_MISC_SOURCE_STUDIES,
+    atlas: (): TestAtlas => ATLAS_WITH_MISC_SOURCE_STUDIES,
     bucket: "bucket-source-dataset-atlas-linked-b-foo",
     etag: "90123456789012345678901234567890",
     eventTime: "2025-08-22T06:15:20.567Z",
@@ -1871,14 +1866,14 @@ export const SOURCE_DATASET_ATLAS_LINKED_B_FOO: TestSourceDataset = {
   suspensionType: ["suspension type atlas linked b foo"],
   tissue: ["tissue atlas linked b foo"],
   title: "Source Dataset Atlas Linked B Foo",
-};
+} satisfies TestSourceDataset;
 
-export const SOURCE_DATASET_ATLAS_LINKED_B_BAR: TestSourceDataset = {
+export const SOURCE_DATASET_ATLAS_LINKED_B_BAR = {
   assay: ["assay atlas linked b bar"],
   cellCount: 12353,
   disease: ["disease atlas linked b bar"],
   file: {
-    atlas: () => ATLAS_WITH_MISC_SOURCE_STUDIES,
+    atlas: (): TestAtlas => ATLAS_WITH_MISC_SOURCE_STUDIES,
     bucket: "bucket-source-dataset-atlas-linked-b-bar",
     etag: "01234567890123456789012345678901",
     eventTime: "2025-08-22T06:15:37.890Z",
@@ -1894,14 +1889,14 @@ export const SOURCE_DATASET_ATLAS_LINKED_B_BAR: TestSourceDataset = {
   suspensionType: ["suspension type atlas linked b bar"],
   tissue: ["tissue atlas linked b bar"],
   title: "Source Dataset Atlas Linked B Bar",
-};
+} satisfies TestSourceDataset;
 
-export const SOURCE_DATASET_ATLAS_LINKED_B_BAZ: TestSourceDataset = {
+export const SOURCE_DATASET_ATLAS_LINKED_B_BAZ = {
   assay: ["assay atlas linked b baz"],
   cellCount: 38429,
   disease: ["disease atlas linked b baz"],
   file: {
-    atlas: () => ATLAS_WITH_MISC_SOURCE_STUDIES,
+    atlas: (): TestAtlas => ATLAS_WITH_MISC_SOURCE_STUDIES,
     bucket: "bucket-source-dataset-atlas-linked-b-baz",
     etag: "12345678901234567890123456789012",
     eventTime: "2025-08-22T06:15:54.123Z",
@@ -1916,7 +1911,7 @@ export const SOURCE_DATASET_ATLAS_LINKED_B_BAZ: TestSourceDataset = {
   suspensionType: ["suspension type atlas linked b baz"],
   tissue: ["tissue atlas linked b baz"],
   title: "Source Dataset Atlas Linked B Baz",
-};
+} satisfies TestSourceDataset;
 
 // Source datasets intitialized in the database before tests
 export const INITIAL_TEST_SOURCE_DATASETS = [
@@ -2562,7 +2557,7 @@ export const COMPONENT_ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_BAR = {
 } satisfies TestComponentAtlas;
 
 // Component atlases to initialize in the database before tests
-export const INITIAL_TEST_COMPONENT_ATLASES = [
+export const INITIAL_TEST_COMPONENT_ATLASES: TestComponentAtlas[] = [
   COMPONENT_ATLAS_DRAFT_FOO,
   COMPONENT_ATLAS_DRAFT_BAR,
   COMPONENT_ATLAS_MISC_FOO,

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -40,6 +40,7 @@ import {
   expectDbSourceDatasetToMatchTest,
   expectIsDefined,
   fillTestFileDefaults,
+  getTestFileKey,
   makeTestAtlasOverview,
   makeTestSourceDatasetInfo,
   makeTestSourceStudyOverview,
@@ -206,7 +207,6 @@ async function initTestFile(
     etag,
     eventName,
     eventTime,
-    fileName,
     fileType,
     id,
     integrityCheckedAt,
@@ -220,22 +220,7 @@ async function initTestFile(
     status,
     versionId,
   } = fillTestFileDefaults(file);
-  let folderName: string;
-  switch (fileType) {
-    case FILE_TYPE.INGEST_MANIFEST:
-      folderName = "manifests";
-      break;
-    case FILE_TYPE.INTEGRATED_OBJECT:
-      folderName = "integrated-objects";
-      break;
-    case FILE_TYPE.SOURCE_DATASET:
-      folderName = "source-datasets";
-      break;
-  }
-  const key = `${atlas.network}/${atlas.shortName}-v${atlas.version.replaceAll(
-    ".",
-    "-"
-  )}/${folderName}/${fileName}`;
+  const key = getTestFileKey(file, atlas);
   const eventInfo: FileEventInfo = {
     eventName,
     eventTime,

--- a/testing/sns-testing.ts
+++ b/testing/sns-testing.ts
@@ -1,11 +1,17 @@
-import { INTEGRITY_STATUS } from "app/apis/catalog/hca-atlas-tracker/common/entities";
 import {
   DatasetValidatorResults,
   S3Event,
   S3Object,
   SNSMessage,
 } from "../app/apis/catalog/hca-atlas-tracker/aws/schemas";
+import {
+  HCAAtlasTrackerDBFileDatasetInfo,
+  HCAAtlasTrackerDBFileValidationInfo,
+  INTEGRITY_STATUS,
+} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { query } from "../app/services/database";
+import { getFileFromDatabase } from "./db-utils";
+import { expectIsDefined } from "./utils";
 
 export const TEST_S3_BUCKET = "hca-atlas-tracker-data-dev";
 export const TEST_GUT_ATLAS_ID = "550e8400-e29b-41d4-a716-446655440000";
@@ -258,4 +264,20 @@ export async function createTestAtlasData(): Promise<void> {
       ]
     );
   }
+}
+
+export async function expectDbFileValidationFieldsToMatch(
+  fileId: string,
+  validationTime: string,
+  integrityStatus: INTEGRITY_STATUS,
+  datasetInfo: HCAAtlasTrackerDBFileDatasetInfo,
+  validationInfo: HCAAtlasTrackerDBFileValidationInfo
+): Promise<void> {
+  const file = await getFileFromDatabase(fileId);
+  if (!expectIsDefined(file)) return;
+
+  expect(file.dataset_info).toEqual(datasetInfo);
+  expect(file.integrity_checked_at?.toISOString()).toEqual(validationTime);
+  expect(file.integrity_status).toEqual(integrityStatus);
+  expect(file.validation_info).toEqual(validationInfo);
 }

--- a/testing/sns-testing.ts
+++ b/testing/sns-testing.ts
@@ -112,6 +112,8 @@ export function createS3Event(options: S3EventOptions): S3Event {
 }
 
 export interface ValidationResultsOptions {
+  batchJobId?: string;
+  batchJobName?: string | null;
   downloadedSha256?: string | null;
   errorMessage?: string | null;
   fileId: string;
@@ -134,12 +136,15 @@ export interface ValidationResultsOptions {
 export function createValidationResults(
   options: ValidationResultsOptions
 ): DatasetValidatorResults {
-  const { integrityStatus = INTEGRITY_STATUS.VALID, sha256 = "test-sha256" } =
-    options;
+  const {
+    batchJobName = "test-batch-job",
+    integrityStatus = INTEGRITY_STATUS.VALID,
+    sha256 = "test-sha256",
+  } = options;
   const { downloadedSha256 = sha256, sourceSha256 = sha256 } = options;
   return {
-    batch_job_id: "test-batch-job-id",
-    batch_job_name: "test-batch-job",
+    batch_job_id: options.batchJobId ?? "test-batch-job-id",
+    batch_job_name: batchJobName,
     bucket: TEST_S3_BUCKET,
     downloaded_sha256: downloadedSha256,
     error_message: options.errorMessage ?? null,

--- a/testing/sns-testing.ts
+++ b/testing/sns-testing.ts
@@ -1,0 +1,197 @@
+import {
+  S3Event,
+  S3Object,
+  SNSMessage,
+} from "../app/apis/catalog/hca-atlas-tracker/aws/schemas";
+import { query } from "../app/services/database";
+
+export const TEST_S3_BUCKET = "hca-atlas-tracker-data-dev";
+export const TEST_GUT_ATLAS_ID = "550e8400-e29b-41d4-a716-446655440000";
+export const TEST_S3_EVENT_NAME = "s3:ObjectCreated:Put";
+export const TEST_AWS_CONFIG = {
+  s3_buckets: [TEST_S3_BUCKET],
+  sns_topics: [
+    "arn:aws:sns:us-east-1:123456789012:hca-atlas-tracker-s3-notifications",
+  ],
+};
+
+export function setUpAwsConfig(): void {
+  process.env.AWS_RESOURCE_CONFIG = JSON.stringify(TEST_AWS_CONFIG);
+}
+
+// Test file path constants
+export const TEST_PATH_SEGMENTS = {
+  GUT_V1_INTEGRATED_OBJECTS: "gut/gut-v1/integrated-objects",
+  GUT_V1_MANIFESTS: "gut/gut-v1/manifests",
+  GUT_V1_SOURCE_DATASETS: "gut/gut-v1/source-datasets",
+} as const;
+
+export const TEST_FILE_PATHS = {
+  INTEGRATED_OBJECT: `${TEST_PATH_SEGMENTS.GUT_V1_INTEGRATED_OBJECTS}/atlas.h5ad`,
+  MANIFEST: `${TEST_PATH_SEGMENTS.GUT_V1_MANIFESTS}/upload-manifest.json`,
+  SOURCE_DATASET_AUTH: `${TEST_PATH_SEGMENTS.GUT_V1_SOURCE_DATASETS}/auth-test.h5ad`,
+  SOURCE_DATASET_DUPLICATE: `${TEST_PATH_SEGMENTS.GUT_V1_SOURCE_DATASETS}/duplicate-test.h5ad`,
+  SOURCE_DATASET_ETAG: `${TEST_PATH_SEGMENTS.GUT_V1_SOURCE_DATASETS}/etag-test.h5ad`,
+  SOURCE_DATASET_TEST: `${TEST_PATH_SEGMENTS.GUT_V1_SOURCE_DATASETS}/test-file.h5ad`,
+  SOURCE_DATASET_VERSIONED: `${TEST_PATH_SEGMENTS.GUT_V1_SOURCE_DATASETS}/versioned-file.h5ad`,
+} as const;
+
+// SQL query constants
+export const SQL_QUERIES = {
+  SELECT_FILE_BY_BUCKET_AND_KEY:
+    "SELECT * FROM hat.files WHERE bucket = $1 AND key = $2",
+  SELECT_FILE_BY_BUCKET_AND_KEY_ORDERED:
+    "SELECT * FROM hat.files WHERE bucket = $1 AND key = $2 ORDER BY created_at ASC",
+  SELECT_LATEST_FILE_BY_BUCKET_AND_KEY:
+    "SELECT * FROM hat.files WHERE bucket = $1 AND key = $2 AND is_latest = true",
+} as const;
+
+// SNS message constants
+export const SNS_MESSAGE_DEFAULTS = {
+  SUBJECT: "Amazon S3 Notification",
+} as const;
+
+// Test data constants
+export const TEST_VERSION_IDS = {
+  DEFAULT: "096fKKXTRTtl3on89fVO.nfljtsv6qko",
+} as const;
+
+export const TEST_TIMESTAMP = "2024-01-01T12:00:00.000Z";
+export const TEST_TIMESTAMP_PLUS_1H = "2024-01-01T13:00:00.000Z";
+export const TEST_TIMESTAMP_ALT = "2023-01-01T00:00:00.000Z";
+export const TEST_SIGNATURE = "fake-signature-for-testing";
+export const TEST_SIGNATURE_VALID = "valid-signature";
+export const TEST_SIGNATURE_VALID_FOR_TESTING = "valid-signature-for-testing";
+export const TEST_SIGNATURE_INVALID = "INVALID-SIGNATURE-SHOULD-BE-REJECTED";
+export const TEST_ERROR_MESSAGE_INVALID_SIGNATURE = "Invalid signature";
+export const TEST_MODULE_SNS_VALIDATOR = "sns-validator";
+export const TEST_S3_EVENT_NAME_OBJECT_CREATED = "ObjectCreated:Put";
+
+// S3 Event and SNS Message Factory Functions
+export interface S3EventOptions {
+  bucket?: string;
+  etag: string;
+  eventName?: string;
+  eventTime?: string;
+  key: string;
+  sha256?: string; // Optional to support tests that intentionally omit SHA256
+  size: number;
+  versionId: string;
+}
+
+export function createS3Event(options: S3EventOptions): S3Event {
+  const objectData: S3Object = {
+    eTag: options.etag,
+    key: options.key,
+    size: options.size,
+    versionId: options.versionId,
+  };
+
+  return {
+    Records: [
+      {
+        eventName: options.eventName || TEST_S3_EVENT_NAME,
+        eventSource: "aws:s3",
+        eventTime: options.eventTime || TEST_TIMESTAMP,
+        s3: {
+          bucket: {
+            name: options.bucket || TEST_S3_BUCKET,
+          },
+          object: objectData,
+        },
+      },
+    ],
+  };
+}
+
+export interface SNSMessageOptions {
+  messageId?: string;
+  s3Event: S3Event;
+  signature?: string;
+  signingCertURL?: string;
+  subject?: string;
+  timestamp?: string;
+  topicArn?: string;
+}
+
+export function createSNSMessage(options: SNSMessageOptions): SNSMessage {
+  return {
+    Message: JSON.stringify(options.s3Event),
+    MessageId: options.messageId || "test-message-id",
+    Signature: options.signature || TEST_SIGNATURE,
+    SignatureVersion: "1",
+    SigningCertURL:
+      options.signingCertURL ||
+      "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-fake.pem",
+    Subject: options.subject || SNS_MESSAGE_DEFAULTS.SUBJECT,
+    Timestamp: options.timestamp || TEST_TIMESTAMP,
+    TopicArn: options.topicArn || TEST_AWS_CONFIG.sns_topics[0],
+    Type: "Notification",
+  };
+}
+
+export function validateTestSnsMessage(
+  message: SNSMessage,
+  callback: (e: Error | null, m?: SNSMessage) => void
+): void {
+  // Check if this is our test case for invalid signatures
+  if (message.Signature === TEST_SIGNATURE_INVALID) {
+    callback(new Error(TEST_ERROR_MESSAGE_INVALID_SIGNATURE));
+    return;
+  }
+
+  // For all other test cases, simulate successful validation
+  callback(null, message);
+}
+
+// Helper function to create test atlas data
+export async function createTestAtlasData(): Promise<void> {
+  // Create multiple test atlases to cover different network/version scenarios
+  const atlases = [
+    {
+      id: TEST_GUT_ATLAS_ID,
+      overview: {
+        description: "Test gut atlas for S3 notification integration tests",
+        network: "gut", // Matches S3 path 'gut/gut-v1/...'
+        shortName: "Gut", // Case-insensitive match with S3 atlas base name 'gut'
+        title: "Test Gut Atlas v1",
+        version: "1", // DB version format (S3 'v1' -> DB '1')
+      },
+    },
+    {
+      id: "550e8400-e29b-41d4-a716-446655440001",
+      overview: {
+        description: "Test retina atlas for S3 notification integration tests",
+        network: "eye", // Matches S3 path 'eye/retina-v1/...'
+        shortName: "Retina", // Case-insensitive match with S3 atlas base name 'retina'
+        title: "Test Retina Atlas v1",
+        version: "1", // DB version format (S3 'v1' -> DB '1')
+      },
+    },
+    {
+      id: "550e8400-e29b-41d4-a716-446655440002",
+      overview: {
+        description:
+          "Test gut atlas v1.1 for S3 notification integration tests",
+        network: "gut", // Same network as first gut atlas
+        shortName: "Gut", // Same shortName but different version
+        title: "Test Gut Atlas v1.1",
+        version: "1.1", // DB version format (S3 'v1-1' -> DB '1.1')
+      },
+    },
+  ];
+
+  // Insert all test atlases
+  for (const atlas of atlases) {
+    await query(
+      `INSERT INTO hat.atlases (id, overview, source_studies, status, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, NOW(), NOW())`,
+      [
+        atlas.id,
+        JSON.stringify(atlas.overview),
+        JSON.stringify([]), // Empty source studies array
+        "draft", // Status field
+      ]
+    );
+  }
+}

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -4,6 +4,7 @@ import { ProjectsResponse } from "../app/apis/azul/hca-dcp/common/responses";
 import {
   DOI_STATUS,
   FILE_STATUS,
+  FILE_TYPE,
   HCAAtlasTrackerAtlas,
   HCAAtlasTrackerComponentAtlas,
   HCAAtlasTrackerDBAtlas,
@@ -253,6 +254,25 @@ export function fillTestFileDefaults(
     status,
     ...restFields,
   };
+}
+
+export function getTestFileKey(file: TestFile, atlas: TestAtlas): string {
+  let folderName: string;
+  switch (file.fileType) {
+    case FILE_TYPE.INGEST_MANIFEST:
+      folderName = "manifests";
+      break;
+    case FILE_TYPE.INTEGRATED_OBJECT:
+      folderName = "integrated-objects";
+      break;
+    case FILE_TYPE.SOURCE_DATASET:
+      folderName = "source-datasets";
+      break;
+  }
+  return `${atlas.network}/${atlas.shortName}-v${atlas.version.replaceAll(
+    ".",
+    "-"
+  )}/${folderName}/${file.fileName}`;
 }
 
 export function aggregateSourceDatasetArrayField(


### PR DESCRIPTION
Closes #803

Notes:
- Updated the existing SNS tests to separate tests specific to S3 events from tests for the high-level SNS handling
- Moved some shared SNS testing code to a separate file
- Renamed the existing SNS test files to follow the convention of mirroring the API path