### PR TITLE
fix: use latest file version where unspecified for source dataset and integrated object apis (#840)

### DIFF
--- a/__tests__/api-atlases-id-source-datasets-id.test.ts
+++ b/__tests__/api-atlases-id-source-datasets-id.test.ts
@@ -12,11 +12,13 @@ import sourceDatasetHandler from "../pages/api/atlases/[atlasId]/source-datasets
 import {
   ATLAS_WITH_MISC_SOURCE_STUDIES,
   ATLAS_WITH_MISC_SOURCE_STUDIES_B,
+  FILE_C_SOURCE_DATASET_WITH_MULTIPLE_FILES,
   SOURCE_DATASET_ATLAS_LINKED_A_BAR,
   SOURCE_DATASET_ATLAS_LINKED_A_FOO,
   SOURCE_DATASET_ATLAS_LINKED_B_BAR,
   SOURCE_DATASET_ATLAS_LINKED_B_BAZ,
   SOURCE_DATASET_ATLAS_LINKED_B_FOO,
+  SOURCE_DATASET_WITH_MULTIPLE_FILES,
   STAKEHOLDER_ANALOGOUS_ROLES,
   STAKEHOLDER_ANALOGOUS_ROLES_WITHOUT_INTEGRATION_LEAD,
   USER_CONTENT_ADMIN,
@@ -205,6 +207,24 @@ describe(`${TEST_ROUTE} (GET)`, () => {
     expect(sourceDataset.disease).toEqual([]);
     expect(sourceDataset.suspensionType).toEqual([]);
     expect(sourceDataset.tissue).toEqual([]);
+  });
+
+  it("returns data from latest of multiple file versions", async () => {
+    const res = await doSourceDatasetRequest(
+      ATLAS_WITH_MISC_SOURCE_STUDIES_B.id,
+      SOURCE_DATASET_WITH_MULTIPLE_FILES.id,
+      USER_CONTENT_ADMIN,
+      METHOD.GET
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const sourceDataset = res._getJSONData() as HCAAtlasTrackerSourceDataset;
+    expectApiSourceDatasetToMatchTest(
+      sourceDataset,
+      SOURCE_DATASET_WITH_MULTIPLE_FILES
+    );
+    expect(sourceDataset.sizeBytes).toEqual(
+      Number(FILE_C_SOURCE_DATASET_WITH_MULTIPLE_FILES.sizeBytes)
+    );
   });
 });
 

--- a/__tests__/api-atlases-id-source-studies-id-source-datasets-id.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id-source-datasets-id.test.ts
@@ -13,13 +13,17 @@ import sourceDatasetHandler from "../pages/api/atlases/[atlasId]/source-studies/
 import {
   ATLAS_PUBLIC,
   ATLAS_WITH_MISC_SOURCE_STUDIES,
+  ATLAS_WITH_MISC_SOURCE_STUDIES_B,
+  FILE_C_SOURCE_DATASET_WITH_MULTIPLE_FILES,
   SOURCE_DATASET_ATLAS_LINKED_B_FOO,
   SOURCE_DATASET_BAR,
   SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE,
   SOURCE_DATASET_FOO,
   SOURCE_DATASET_FOOBAR,
   SOURCE_DATASET_FOOFOO,
+  SOURCE_DATASET_WITH_MULTIPLE_FILES,
   SOURCE_STUDY_PUBLIC_WITH_JOURNAL,
+  SOURCE_STUDY_WITH_ATLAS_LINKED_DATASETS_A,
   SOURCE_STUDY_WITH_ATLAS_LINKED_DATASETS_B,
   SOURCE_STUDY_WITH_SOURCE_DATASETS,
   STAKEHOLDER_ANALOGOUS_ROLES,
@@ -206,6 +210,24 @@ describe(TEST_ROUTE, () => {
     expectApiSourceDatasetToMatchTest(
       sourceDataset,
       SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE
+    );
+  });
+
+  it("returns data from latest file version", async () => {
+    const res = await doSourceDatasetRequest(
+      ATLAS_WITH_MISC_SOURCE_STUDIES_B.id,
+      SOURCE_STUDY_WITH_ATLAS_LINKED_DATASETS_A.id,
+      SOURCE_DATASET_WITH_MULTIPLE_FILES.id,
+      USER_CONTENT_ADMIN
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const sourceDataset = res._getJSONData() as HCAAtlasTrackerSourceDataset;
+    expectApiSourceDatasetToMatchTest(
+      sourceDataset,
+      SOURCE_DATASET_WITH_MULTIPLE_FILES
+    );
+    expect(sourceDataset.sizeBytes).toEqual(
+      Number(FILE_C_SOURCE_DATASET_WITH_MULTIPLE_FILES.sizeBytes)
     );
   });
 
@@ -671,7 +693,7 @@ async function expectSourceDatasetToBeUnchanged(
   expect(sourceDatasetFromDb).toBeDefined();
   if (!sourceDatasetFromDb) return;
   expect(sourceDatasetFromDb.source_study_id).toEqual(
-    sourceDataset.sourceStudyId
+    sourceDataset.sourceStudyId ?? null
   );
   expect(sourceDatasetFromDb.sd_info.title).toEqual(sourceDataset.title);
 }

--- a/__tests__/api-atlases-id-source-studies-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id-source-datasets.test.ts
@@ -6,10 +6,20 @@ import { endPgPool } from "../app/services/database";
 import sourceDatasetsHandler from "../pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets";
 import {
   ATLAS_WITH_MISC_SOURCE_STUDIES,
+  ATLAS_WITH_MISC_SOURCE_STUDIES_B,
+  FILE_C_SOURCE_DATASET_WITH_MULTIPLE_FILES,
+  SOURCE_DATASET_ATLAS_LINKED_A_BAR,
+  SOURCE_DATASET_ATLAS_LINKED_A_FOO,
   SOURCE_DATASET_BAR,
+  SOURCE_DATASET_BAZ,
   SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE,
   SOURCE_DATASET_CELLXGENE_WITH_UPDATE,
   SOURCE_DATASET_FOO,
+  SOURCE_DATASET_FOOBAR,
+  SOURCE_DATASET_FOOBAZ,
+  SOURCE_DATASET_FOOFOO,
+  SOURCE_DATASET_WITH_MULTIPLE_FILES,
+  SOURCE_STUDY_WITH_ATLAS_LINKED_DATASETS_A,
   SOURCE_STUDY_WITH_SOURCE_DATASETS,
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
@@ -20,6 +30,7 @@ import { resetDatabase } from "../testing/db-utils";
 import { TestUser } from "../testing/entities";
 import {
   expectApiSourceDatasetsToMatchTest,
+  expectIsDefined,
   testApiRole,
   withConsoleErrorHiding,
 } from "../testing/utils";
@@ -115,10 +126,13 @@ describe(TEST_ROUTE, () => {
         expect(res._getStatusCode()).toEqual(200);
         const sourceDatasets =
           res._getJSONData() as HCAAtlasTrackerSourceDataset[];
-        expect(sourceDatasets).toHaveLength(8);
         expectApiSourceDatasetsToMatchTest(sourceDatasets, [
           SOURCE_DATASET_FOO,
           SOURCE_DATASET_BAR,
+          SOURCE_DATASET_BAZ,
+          SOURCE_DATASET_FOOFOO,
+          SOURCE_DATASET_FOOBAR,
+          SOURCE_DATASET_FOOBAZ,
           SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE,
           SOURCE_DATASET_CELLXGENE_WITH_UPDATE,
         ]);
@@ -134,13 +148,38 @@ describe(TEST_ROUTE, () => {
     );
     expect(res._getStatusCode()).toEqual(200);
     const sourceDatasets = res._getJSONData() as HCAAtlasTrackerSourceDataset[];
-    expect(sourceDatasets).toHaveLength(8);
     expectApiSourceDatasetsToMatchTest(sourceDatasets, [
       SOURCE_DATASET_FOO,
       SOURCE_DATASET_BAR,
+      SOURCE_DATASET_BAZ,
+      SOURCE_DATASET_FOOFOO,
+      SOURCE_DATASET_FOOBAR,
+      SOURCE_DATASET_FOOBAZ,
       SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE,
       SOURCE_DATASET_CELLXGENE_WITH_UPDATE,
     ]);
+  });
+
+  it("returns source datasets for latest file versions only", async () => {
+    const res = await doSourceDatasetsRequest(
+      ATLAS_WITH_MISC_SOURCE_STUDIES_B.id,
+      SOURCE_STUDY_WITH_ATLAS_LINKED_DATASETS_A.id,
+      USER_CONTENT_ADMIN
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const sourceDatasets = res._getJSONData() as HCAAtlasTrackerSourceDataset[];
+    expectApiSourceDatasetsToMatchTest(sourceDatasets, [
+      SOURCE_DATASET_ATLAS_LINKED_A_FOO,
+      SOURCE_DATASET_ATLAS_LINKED_A_BAR,
+      SOURCE_DATASET_WITH_MULTIPLE_FILES,
+    ]);
+    const datasetWithMultipleFiles = sourceDatasets.find(
+      (d) => d.id === SOURCE_DATASET_WITH_MULTIPLE_FILES.id
+    );
+    if (!expectIsDefined(datasetWithMultipleFiles)) return;
+    expect(datasetWithMultipleFiles.sizeBytes).toEqual(
+      Number(FILE_C_SOURCE_DATASET_WITH_MULTIPLE_FILES.sizeBytes)
+    );
   });
 });
 

--- a/app/services/component-atlases.ts
+++ b/app/services/component-atlases.ts
@@ -32,7 +32,7 @@ export async function getAtlasComponentAtlases(
           f.status
         FROM hat.files f
         JOIN hat.component_atlases ca ON f.component_atlas_id = ca.id
-        WHERE f.file_type='integrated_object' AND ca.atlas_id=$1
+        WHERE f.is_latest AND f.file_type='integrated_object' AND ca.atlas_id=$1
       `,
     [atlasId]
   );

--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -46,7 +46,7 @@ export async function getSourceStudyDatasets(
       FROM hat.source_datasets d
       JOIN hat.files f ON f.source_dataset_id = d.id
       JOIN hat.source_studies s ON d.source_study_id = s.id
-      WHERE s.id = $1`,
+      WHERE s.id = $1 AND f.is_latest`,
     [sourceStudyId]
   );
   return queryResult.rows;
@@ -72,7 +72,7 @@ export async function getAtlasDatasets(
       FROM hat.source_datasets d
       JOIN hat.files f ON f.source_dataset_id = d.id
       LEFT JOIN hat.source_studies s ON d.source_study_id = s.id
-      WHERE d.id = ANY($1)
+      WHERE d.id = ANY($1) AND f.is_latest
     `,
     [sourceDatasetIds]
   );
@@ -106,7 +106,7 @@ export async function getComponentAtlasDatasets(
       FROM hat.source_datasets d
       JOIN hat.files f ON f.source_dataset_id = d.id
       LEFT JOIN hat.source_studies s ON d.source_study_id = s.id
-      WHERE d.id = ANY($1)
+      WHERE d.id = ANY($1) AND f.is_latest
     `,
     [sourceDatasetIds]
   );
@@ -139,7 +139,7 @@ export async function getSourceDataset(
       FROM hat.source_datasets d
       JOIN hat.files f ON f.source_dataset_id = d.id
       JOIN hat.source_studies s ON d.source_study_id = s.id
-      WHERE d.id = $1 AND s.id = $2
+      WHERE d.id = $1 AND s.id = $2 AND f.is_latest
     `,
     [sourceDatasetId, sourceStudyId],
     client
@@ -168,7 +168,7 @@ export async function getAtlasSourceDataset(
       FROM hat.source_datasets d
       JOIN hat.files f ON f.source_dataset_id = d.id
       LEFT JOIN hat.source_studies s ON d.source_study_id = s.id
-      WHERE d.id = $1
+      WHERE d.id = $1 AND f.is_latest
     `,
     [sourceDatasetId],
     client
@@ -209,7 +209,7 @@ export async function getComponentAtlasSourceDataset(
       FROM hat.source_datasets d
       JOIN hat.files f ON f.source_dataset_id = d.id
       LEFT JOIN hat.source_studies s ON d.source_study_id = s.id
-      WHERE d.id = $1
+      WHERE d.id = $1 AND f.is_latest
     `,
     [sourceDatasetId]
   );

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -15,6 +15,7 @@ import {
   TestComment,
   TestComponentAtlas,
   TestEntrySheetValidation,
+  TestFile,
   TestPublishedSourceStudy,
   TestSourceDataset,
   TestUnpublishedSourceStudy,
@@ -2018,8 +2019,63 @@ export const SOURCE_DATASET_ATLAS_LINKED_B_BAZ = {
   ...EMPTY_LEGACY_DATASET_METADATA,
 } satisfies TestSourceDataset;
 
+const BASE_FILE_SOURCE_DATASET_WITH_MULTIPLE_FILES = {
+  atlas: (): TestAtlas => ATLAS_WITH_MISC_SOURCE_STUDIES_B,
+  bucket: "bucket-source-dataset-with-multiple-files",
+  datasetInfo: {
+    assay: ["assay with multiple files"],
+    cellCount: 6457,
+    disease: ["disease with multiple files"],
+    suspensionType: ["suspension type with multiple files"],
+    tissue: ["tissue with multiple files"],
+    title: "Source Dataset With Multiple Files",
+  },
+  fileName: "source-dataset-with-multiple-files.h5ad",
+  fileType: FILE_TYPE.SOURCE_DATASET,
+  versionId: null,
+} satisfies Partial<TestFile>;
+export const FILE_A_SOURCE_DATASET_WITH_MULTIPLE_FILES = {
+  ...BASE_FILE_SOURCE_DATASET_WITH_MULTIPLE_FILES,
+  etag: "620667d77ed3460983851d94b9ea30c5",
+  eventTime: "2025-09-16T02:22:05.004Z",
+  id: "d27b67ec-5b2f-4211-ad69-20bd5f5d3634",
+  integrityCheckedAt: "2025-09-16T02:24:14.022Z",
+  integrityStatus: INTEGRITY_STATUS.VALID,
+  isLatest: false,
+  sizeBytes: "234234",
+} satisfies TestFile;
+export const FILE_B_SOURCE_DATASET_WITH_MULTIPLE_FILES = {
+  ...BASE_FILE_SOURCE_DATASET_WITH_MULTIPLE_FILES,
+  etag: "b4a2018644c54214b0a5beb17fa41ee1",
+  eventTime: "2025-09-16T02:46:30.663Z",
+  id: "9b2e29f2-5864-4bee-ae8b-22cb8a101b24",
+  integrityCheckedAt: "2025-09-16T02:47:14.216Z",
+  integrityStatus: INTEGRITY_STATUS.VALID,
+  isLatest: false,
+  sizeBytes: "345345",
+} satisfies TestFile;
+export const FILE_C_SOURCE_DATASET_WITH_MULTIPLE_FILES = {
+  ...BASE_FILE_SOURCE_DATASET_WITH_MULTIPLE_FILES,
+  etag: "a3acab069db94cbe81eb4eeaaad04df1",
+  eventTime: "2025-09-16T02:47:35.035Z",
+  id: "c42081da-f7e3-4fdb-b8c5-c02854215659",
+  integrityCheckedAt: "2025-09-16T02:48:08.838Z",
+  integrityStatus: INTEGRITY_STATUS.VALID,
+  sizeBytes: "434534",
+} satisfies TestFile;
+export const SOURCE_DATASET_WITH_MULTIPLE_FILES = {
+  file: [
+    FILE_A_SOURCE_DATASET_WITH_MULTIPLE_FILES,
+    FILE_C_SOURCE_DATASET_WITH_MULTIPLE_FILES,
+    FILE_B_SOURCE_DATASET_WITH_MULTIPLE_FILES,
+  ],
+  id: "3a4658fa-049f-4465-9a10-9f411dbcfb7c",
+  sourceStudyId: SOURCE_STUDY_WITH_ATLAS_LINKED_DATASETS_A.id,
+  ...EMPTY_LEGACY_DATASET_METADATA,
+} satisfies TestSourceDataset;
+
 // Source datasets intitialized in the database before tests
-export const INITIAL_TEST_SOURCE_DATASETS = [
+export const INITIAL_TEST_SOURCE_DATASETS: TestSourceDataset[] = [
   SOURCE_DATASET_FOO,
   SOURCE_DATASET_BAR,
   SOURCE_DATASET_BAZ,
@@ -2042,6 +2098,7 @@ export const INITIAL_TEST_SOURCE_DATASETS = [
   SOURCE_DATASET_ATLAS_LINKED_B_FOO,
   SOURCE_DATASET_ATLAS_LINKED_B_BAR,
   SOURCE_DATASET_ATLAS_LINKED_B_BAZ,
+  SOURCE_DATASET_WITH_MULTIPLE_FILES,
 ];
 
 // ATLAS IDS
@@ -2304,6 +2361,7 @@ export const ATLAS_WITH_MISC_SOURCE_STUDIES_B: TestAtlas = {
   network: "eye",
   publications: [],
   shortName: "test-with-misc-source-studies-b",
+  sourceDatasets: [SOURCE_DATASET_WITH_MULTIPLE_FILES.id],
   sourceStudies: [SOURCE_STUDY_WITH_ATLAS_LINKED_DATASETS_A.id],
   status: ATLAS_STATUS.IN_PROGRESS,
   version: "5.3",
@@ -2713,6 +2771,61 @@ export const COMPONENT_ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_BAR = {
   title: "",
 } satisfies TestComponentAtlas;
 
+const BASE_FILE_COMPONENT_ATLAS_WITH_MULTIPLE_FILES = {
+  atlas: ATLAS_WITH_MISC_SOURCE_STUDIES_B,
+  bucket: "bucket-with-multiple-files",
+  datasetInfo: {
+    assay: ["assay with multiple files"],
+    cellCount: 43453,
+    disease: ["disease with multiple files"],
+    suspensionType: ["suspension type with multiple files"],
+    tissue: ["tissue with multiple files"],
+    title: "Component Atlas With Multiple Files",
+  },
+  fileName: "component-atlas-with-multiple-files.h5ad",
+  fileType: FILE_TYPE.INTEGRATED_OBJECT,
+  sizeBytes: "59456",
+  versionId: null,
+} satisfies Partial<TestFile>;
+export const FILE_A_COMPONENT_ATLAS_WITH_MULTIPLE_FILES = {
+  ...BASE_FILE_COMPONENT_ATLAS_WITH_MULTIPLE_FILES,
+  etag: "ba58c1a1fbea4a1086f7a0a767364cca",
+  eventTime: "2025-09-16T02:59:48.485Z",
+  id: "7e4b60ae-2d78-47ac-8e5c-83196047a7f3",
+  integrityCheckedAt: "2025-09-16T03:00:11.886Z",
+  integrityStatus: INTEGRITY_STATUS.VALID,
+  isLatest: false,
+} satisfies TestFile;
+export const FILE_B_COMPONENT_ATLAS_WITH_MULTIPLE_FILES = {
+  ...BASE_FILE_COMPONENT_ATLAS_WITH_MULTIPLE_FILES,
+  etag: "55bcb2de7f144a829bfcf3aa5712d47d",
+  eventTime: "2025-09-16T03:00:35.982Z",
+  id: "f1a1496f-4a00-43cc-881b-2b5e3360cc5d",
+  integrityCheckedAt: "2025-09-16T03:00:55.834Z",
+  integrityStatus: INTEGRITY_STATUS.VALID,
+  isLatest: false,
+} satisfies TestFile;
+export const FILE_C_COMPONENT_ATLAS_WITH_MULTIPLE_FILES = {
+  ...BASE_FILE_COMPONENT_ATLAS_WITH_MULTIPLE_FILES,
+  etag: "0e1b0a46450b475b82d095265034bfeb",
+  eventTime: "2025-09-16T03:01:23.949Z",
+  id: "69586fc2-95d3-415e-b505-9d5768feb1bb",
+  integrityCheckedAt: "2025-09-16T03:02:19.235Z",
+  integrityStatus: INTEGRITY_STATUS.VALID,
+} satisfies TestFile;
+export const COMPONENT_ATLAS_WITH_MULTIPLE_FILES = {
+  atlasId: ATLAS_WITH_MISC_SOURCE_STUDIES_B.id,
+  description: "",
+  file: [
+    FILE_A_COMPONENT_ATLAS_WITH_MULTIPLE_FILES,
+    FILE_C_COMPONENT_ATLAS_WITH_MULTIPLE_FILES,
+    FILE_B_COMPONENT_ATLAS_WITH_MULTIPLE_FILES,
+  ],
+  id: "235920d2-b08b-408a-aa1a-9a1af9a98297",
+  sourceDatasets: [],
+  title: "",
+} satisfies TestComponentAtlas;
+
 // Component atlases to initialize in the database before tests
 export const INITIAL_TEST_COMPONENT_ATLASES: TestComponentAtlas[] = [
   COMPONENT_ATLAS_DRAFT_FOO,
@@ -2721,6 +2834,7 @@ export const INITIAL_TEST_COMPONENT_ATLASES: TestComponentAtlas[] = [
   COMPONENT_ATLAS_WITH_CELLXGENE_DATASETS,
   COMPONENT_ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_FOO,
   COMPONENT_ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_BAR,
+  COMPONENT_ATLAS_WITH_MULTIPLE_FILES,
 ];
 
 // ENTRY SHEET VALIDATIONS

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -40,6 +40,7 @@ import {
   expectDbSourceDatasetToMatchTest,
   expectIsDefined,
   fillTestFileDefaults,
+  getTestEntityFilesArray,
   getTestFileKey,
   makeTestAtlasOverview,
   makeTestSourceDatasetInfo,
@@ -121,7 +122,7 @@ export async function initSourceDatasets(
     const info = makeTestSourceDatasetInfo(sourceDataset);
     await query(
       "INSERT INTO hat.source_datasets (source_study_id, sd_info, id) VALUES ($1, $2, $3)",
-      [sourceDataset.sourceStudyId, info, sourceDataset.id],
+      [sourceDataset.sourceStudyId ?? null, info, sourceDataset.id],
       client
     );
   }
@@ -187,12 +188,14 @@ async function initComponentAtlases(client: pg.PoolClient): Promise<void> {
 
 async function initFiles(client: pg.PoolClient): Promise<void> {
   for (const componentAtlas of INITIAL_TEST_COMPONENT_ATLASES) {
-    if (componentAtlas.file)
-      await initTestFile(client, componentAtlas.file, componentAtlas.id, null);
+    for (const file of getTestEntityFilesArray(componentAtlas)) {
+      await initTestFile(client, file, componentAtlas.id, null);
+    }
   }
   for (const sourceDataset of INITIAL_TEST_SOURCE_DATASETS) {
-    if (sourceDataset.file)
-      await initTestFile(client, sourceDataset.file, null, sourceDataset.id);
+    for (const file of getTestEntityFilesArray(sourceDataset)) {
+      await initTestFile(client, file, null, sourceDataset.id);
+    }
   }
 }
 

--- a/testing/entities.ts
+++ b/testing/entities.ts
@@ -52,7 +52,7 @@ export interface TestAtlas {
 export interface TestComponentAtlas {
   atlasId: string;
   description: string;
-  file?: TestFile;
+  file?: TestFile | TestFile[];
   id: string;
   sourceDatasets?: TestSourceDataset[];
   title: string;
@@ -87,11 +87,11 @@ export interface TestSourceDataset {
   cellxgeneDatasetId?: string;
   cellxgeneDatasetVersion?: string;
   disease?: string[];
-  file?: TestFile;
+  file?: TestFile | TestFile[];
   id: string;
   metadataSpreadsheetTitle?: string;
   metadataSpreadsheetUrl?: string;
-  sourceStudyId: string;
+  sourceStudyId?: string;
   suspensionType?: string[];
   tissue?: string[];
   title: string;
@@ -119,6 +119,10 @@ export interface TestFile {
   validationInfo?: HCAAtlasTrackerDBFileValidationInfo | null;
   versionId: string | null;
 }
+
+export type NormalizedTestFile = Required<TestFile> & {
+  resolvedAtlas: TestAtlas;
+};
 
 export type TestEntrySheetValidation = HCAAtlasTrackerDBEntrySheetValidation;
 


### PR DESCRIPTION
Closes #840

All queries that reference the files table for source dataset and integrated object APIs have been updated, except for the query for getting a specific integrated object, which takes a file ID and so can only ever return that specific file record