### PR TITLE
feat: start validation job when a file is added or updated (#839)

### DIFF
--- a/__tests__/api-atlases-id-component-atlases.test.ts
+++ b/__tests__/api-atlases-id-component-atlases.test.ts
@@ -17,6 +17,7 @@ import {
   COMPONENT_ATLAS_DRAFT_BAR,
   COMPONENT_ATLAS_DRAFT_FOO,
   COMPONENT_ATLAS_WITH_MULTIPLE_FILES,
+  EMPTY_COMPONENT_INFO,
   FILE_C_COMPONENT_ATLAS_WITH_MULTIPLE_FILES,
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
@@ -156,17 +157,6 @@ describe(TEST_ROUTE, () => {
     );
   });
 });
-
-const EMPTY_COMPONENT_INFO = {
-  assay: [],
-  cellCount: 0,
-  cellxgeneDatasetId: null,
-  cellxgeneDatasetVersion: null,
-  description: "",
-  disease: [],
-  suspensionType: [],
-  tissue: [],
-};
 
 describe("createComponentAtlas", () => {
   const TEST_COMPONENT_ATLAS_TITLE = "Test Component Atlas";

--- a/__tests__/api-sns-with-s3-event.test.ts
+++ b/__tests__/api-sns-with-s3-event.test.ts
@@ -49,6 +49,7 @@ jest.mock("../app/utils/crossref/crossref-api");
 jest.mock("../app/services/hca-projects");
 jest.mock("../app/services/cellxgene");
 jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("../app/services/validator-batch");
 
 jest.mock("next-auth");
 
@@ -63,6 +64,10 @@ jest.mock("sns-validator", () => {
     validate: jest.fn(validateTestSnsMessage),
   }));
 });
+
+const mockSubmitJob = jest.requireMock<
+  typeof import("../app/services/__mocks__/validator-batch")
+>("../app/services/validator-batch").submitDatasetValidationJob;
 
 const TEST_ROUTE = "/api/sns";
 
@@ -1267,5 +1272,255 @@ describe(`${TEST_ROUTE} (S3 event)`, () => {
     expect(JSON.parse(res._getData())).toEqual({
       message: "Expected exactly 1 S3 record, but received 2 records",
     });
+  });
+
+  it("starts a validation job after saving a new source dataset file and after saving an updated source dataset file", async () => {
+    mockSubmitJob.mockClear();
+
+    // First upload (creates source dataset and file record)
+    const firstEvent = createS3Event({
+      etag: "sd-v1-etag-11111111111111111111111111111111",
+      eventTime: TEST_TIMESTAMP, // older
+      key: TEST_FILE_PATHS.SOURCE_DATASET_VERSIONED,
+      size: 12345,
+      versionId: "sd-version-1",
+    });
+
+    const firstMessage = createSNSMessage({
+      messageId: "sd-update-test-v1",
+      s3Event: firstEvent,
+      signature: TEST_SIGNATURE_VALID,
+      timestamp: TEST_TIMESTAMP,
+    });
+
+    {
+      const { req, res } = httpMocks.createMocks<
+        NextApiRequest,
+        NextApiResponse
+      >({
+        body: firstMessage,
+        method: METHOD.POST,
+      });
+      await withConsoleMessageHiding(async () => {
+        await snsHandler(req, res);
+      });
+      expect(res.statusCode).toBe(200);
+    }
+
+    // Check that the dataset validator was called
+    expect(mockSubmitJob).toHaveBeenCalledTimes(1);
+    expect(mockSubmitJob).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        s3Key: TEST_FILE_PATHS.SOURCE_DATASET_VERSIONED,
+      })
+    );
+
+    // Second upload (update) with newer eventTime
+    const secondEvent = createS3Event({
+      etag: "sd-v2-etag-22222222222222222222222222222222",
+      eventTime: TEST_TIMESTAMP_PLUS_1H, // newer
+      key: TEST_FILE_PATHS.SOURCE_DATASET_VERSIONED,
+      size: 23456,
+      versionId: "sd-version-2",
+    });
+
+    const secondMessage = createSNSMessage({
+      messageId: "sd-update-test-v2",
+      s3Event: secondEvent,
+      signature: TEST_SIGNATURE_VALID,
+      timestamp: TEST_TIMESTAMP_PLUS_1H,
+    });
+
+    {
+      const { req, res } = httpMocks.createMocks<
+        NextApiRequest,
+        NextApiResponse
+      >({
+        body: secondMessage,
+        method: METHOD.POST,
+      });
+      await withConsoleMessageHiding(async () => {
+        await snsHandler(req, res);
+      });
+      expect(res.statusCode).toBe(200);
+    }
+
+    // Check that the dataset validator was called again
+    expect(mockSubmitJob).toHaveBeenCalledTimes(2);
+    expect(mockSubmitJob).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        s3Key: TEST_FILE_PATHS.SOURCE_DATASET_VERSIONED,
+      })
+    );
+  });
+
+  it("starts a validation job after saving a new integrated object file and after saving an updated integrated object file", async () => {
+    mockSubmitJob.mockClear();
+
+    // First upload (creates source dataset and file record)
+    const firstEvent = createS3Event({
+      etag: "io-v1-etag-11111111111111111111111111111111",
+      eventTime: TEST_TIMESTAMP, // older
+      key: TEST_FILE_PATHS.INTEGRATED_OBJECT,
+      size: 12345,
+      versionId: "io-version-1",
+    });
+
+    const firstMessage = createSNSMessage({
+      messageId: "io-update-test-v1",
+      s3Event: firstEvent,
+      signature: TEST_SIGNATURE_VALID,
+      timestamp: TEST_TIMESTAMP,
+    });
+
+    {
+      const { req, res } = httpMocks.createMocks<
+        NextApiRequest,
+        NextApiResponse
+      >({
+        body: firstMessage,
+        method: METHOD.POST,
+      });
+      await withConsoleMessageHiding(async () => {
+        await snsHandler(req, res);
+      });
+      expect(res.statusCode).toBe(200);
+    }
+
+    // Check that the dataset validator was called
+    expect(mockSubmitJob).toHaveBeenCalledTimes(1);
+    expect(mockSubmitJob).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        s3Key: TEST_FILE_PATHS.INTEGRATED_OBJECT,
+      })
+    );
+
+    // Second upload (update) with newer eventTime
+    const secondEvent = createS3Event({
+      etag: "io-v2-etag-22222222222222222222222222222222",
+      eventTime: TEST_TIMESTAMP_PLUS_1H, // newer
+      key: TEST_FILE_PATHS.INTEGRATED_OBJECT,
+      size: 23456,
+      versionId: "io-version-2",
+    });
+
+    const secondMessage = createSNSMessage({
+      messageId: "io-update-test-v2",
+      s3Event: secondEvent,
+      signature: TEST_SIGNATURE_VALID,
+      timestamp: TEST_TIMESTAMP_PLUS_1H,
+    });
+
+    {
+      const { req, res } = httpMocks.createMocks<
+        NextApiRequest,
+        NextApiResponse
+      >({
+        body: secondMessage,
+        method: METHOD.POST,
+      });
+      await withConsoleMessageHiding(async () => {
+        await snsHandler(req, res);
+      });
+      expect(res.statusCode).toBe(200);
+    }
+
+    // Check that the dataset validator was called again
+    expect(mockSubmitJob).toHaveBeenCalledTimes(2);
+    expect(mockSubmitJob).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        s3Key: TEST_FILE_PATHS.INTEGRATED_OBJECT,
+      })
+    );
+  });
+
+  it("does not start a validation job after saving a manifest file", async () => {
+    mockSubmitJob.mockClear();
+
+    const s3Event = createS3Event({
+      etag: "c9876543210fedcba9876543210fedcba",
+      key: TEST_FILE_PATHS.MANIFEST,
+      size: 2048,
+      versionId: "manifest-version-789",
+    });
+
+    const snsMessage = createSNSMessage({
+      messageId: "manifest-test-message",
+      s3Event,
+      signature: TEST_SIGNATURE,
+      subject: SNS_MESSAGE_DEFAULTS.SUBJECT,
+      timestamp: TEST_TIMESTAMP,
+    });
+
+    const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>(
+      {
+        body: snsMessage,
+        method: METHOD.POST,
+      }
+    );
+
+    await withConsoleMessageHiding(async () => {
+      await snsHandler(req, res);
+    });
+
+    expect(res.statusCode).toBe(200);
+
+    // Check that the dataset validator was not called
+    expect(mockSubmitJob).not.toHaveBeenCalled();
+  });
+
+  it("does not call the dataset validator for a duplicate message", async () => {
+    mockSubmitJob.mockClear();
+
+    const s3Event = createS3Event({
+      etag: "e1234567890abcdef1234567890abcdef",
+      key: TEST_FILE_PATHS.SOURCE_DATASET_DUPLICATE,
+      size: 2048000,
+      versionId: "abc123def456ghi789jkl012mno345pqr",
+    });
+
+    const snsMessage = createSNSMessage({
+      messageId: "duplicate-test-message",
+      s3Event,
+    });
+
+    const { req: req1, res: res1 } = httpMocks.createMocks<
+      NextApiRequest,
+      NextApiResponse
+    >({
+      body: snsMessage,
+      method: METHOD.POST,
+    });
+
+    // First request
+    await withConsoleMessageHiding(async () => {
+      await snsHandler(req1, res1);
+    });
+    expect(res1.statusCode).toBe(200);
+
+    // Check that the dataset validator was called for the initial request
+    expect(mockSubmitJob).toHaveBeenCalledTimes(1);
+    expect(mockSubmitJob).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        s3Key: TEST_FILE_PATHS.SOURCE_DATASET_DUPLICATE,
+      })
+    );
+
+    const { req: req2, res: res2 } = httpMocks.createMocks<
+      NextApiRequest,
+      NextApiResponse
+    >({
+      body: snsMessage,
+      method: METHOD.POST,
+    });
+
+    // Second request with same data
+    await withConsoleMessageHiding(async () => {
+      await snsHandler(req2, res2);
+    });
+    expect(res2.statusCode).toBe(200);
+
+    // Check that the dataset validator has still only been called once
+    expect(mockSubmitJob).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/apis/catalog/hca-atlas-tracker/common/constants.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/constants.ts
@@ -1,4 +1,5 @@
 import {
+  FILE_TYPE,
   Network,
   NetworkKey,
   ROLE,
@@ -191,3 +192,8 @@ export const CASE_INSENSITIVE_ARRAY_VALIDATION_VARIABLES = new Set([
 ]);
 
 export const UNPUBLISHED = "Unpublished";
+
+export const VALID_FILE_TYPES_FOR_VALIDATION = [
+  FILE_TYPE.INTEGRATED_OBJECT,
+  FILE_TYPE.SOURCE_DATASET,
+];

--- a/app/services/__mocks__/validator-batch.ts
+++ b/app/services/__mocks__/validator-batch.ts
@@ -1,0 +1,11 @@
+import {
+  SubmitDatasetValidationJobParams,
+  SubmitDatasetValidationJobResult,
+} from "../validator-batch";
+
+export const submitDatasetValidationJob = jest.fn<
+  SubmitDatasetValidationJobResult,
+  [SubmitDatasetValidationJobParams]
+>(() => ({
+  jobId: "test-job-id",
+}));

--- a/app/services/s3-notification.ts
+++ b/app/services/s3-notification.ts
@@ -33,6 +33,7 @@ import {
 } from "./component-atlases";
 import { doTransaction } from "./database";
 import { createSourceDataset, resetSourceDatasetInfo } from "./source-datasets";
+import { submitDatasetValidationJob } from "./validator-batch";
 
 /**
  * Processes an SNS notification message containing S3 events
@@ -475,6 +476,16 @@ export async function saveFileRecord(
 
     // CASE 2 & 3: Success - log the operation type for monitoring
     logFileOperation(result.operation, bucket, object, isNewFile);
+
+    // Start validation job
+    const { jobId } = await submitDatasetValidationJob({
+      fileId: result.id,
+      s3Key: object.key,
+    });
+
+    console.log(
+      `Started Batch job ${jobId} to validate ${object.key} (file ${result.id})`
+    );
   });
 }
 

--- a/app/services/s3-notification.ts
+++ b/app/services/s3-notification.ts
@@ -477,15 +477,20 @@ export async function saveFileRecord(
     // CASE 2 & 3: Success - log the operation type for monitoring
     logFileOperation(result.operation, bucket, object, isNewFile);
 
-    // Start validation job
-    const { jobId } = await submitDatasetValidationJob({
-      fileId: result.id,
-      s3Key: object.key,
-    });
+    // Start validation job if the file is of an appropriate type
+    if (
+      fileType === FILE_TYPE.INTEGRATED_OBJECT ||
+      fileType === FILE_TYPE.SOURCE_DATASET
+    ) {
+      const { jobId } = await submitDatasetValidationJob({
+        fileId: result.id,
+        s3Key: object.key,
+      });
 
-    console.log(
-      `Started Batch job ${jobId} to validate ${object.key} (file ${result.id})`
-    );
+      console.log(
+        `Started Batch job ${jobId} to validate ${object.key} (file ${result.id})`
+      );
+    }
   });
 }
 

--- a/app/services/s3-notification.ts
+++ b/app/services/s3-notification.ts
@@ -477,9 +477,10 @@ export async function saveFileRecord(
     // CASE 2 & 3: Success - log the operation type for monitoring
     logFileOperation(result.operation, bucket, object, isNewFile);
 
-    // Start validation job if a new record of the appropriate type was created
+    // Start validation job if a new latest record of the appropriate type was created
     if (
       result.operation === "inserted" &&
+      isLatestForInsert &&
       (fileType === FILE_TYPE.INTEGRATED_OBJECT ||
         fileType === FILE_TYPE.SOURCE_DATASET)
     ) {

--- a/app/services/s3-notification.ts
+++ b/app/services/s3-notification.ts
@@ -477,10 +477,11 @@ export async function saveFileRecord(
     // CASE 2 & 3: Success - log the operation type for monitoring
     logFileOperation(result.operation, bucket, object, isNewFile);
 
-    // Start validation job if the file is of an appropriate type
+    // Start validation job if a new record of the appropriate type was created
     if (
-      fileType === FILE_TYPE.INTEGRATED_OBJECT ||
-      fileType === FILE_TYPE.SOURCE_DATASET
+      result.operation === "inserted" &&
+      (fileType === FILE_TYPE.INTEGRATED_OBJECT ||
+        fileType === FILE_TYPE.SOURCE_DATASET)
     ) {
       const { jobId } = await submitDatasetValidationJob({
         fileId: result.id,

--- a/app/services/s3-notification.ts
+++ b/app/services/s3-notification.ts
@@ -6,6 +6,7 @@ import {
   S3Object,
   SNSMessage,
 } from "../apis/catalog/hca-atlas-tracker/aws/schemas";
+import { VALID_FILE_TYPES_FOR_VALIDATION } from "../apis/catalog/hca-atlas-tracker/common/constants";
 import {
   FILE_STATUS,
   FILE_TYPE,
@@ -481,8 +482,7 @@ export async function saveFileRecord(
     if (
       result.operation === "inserted" &&
       isLatestForInsert &&
-      (fileType === FILE_TYPE.INTEGRATED_OBJECT ||
-        fileType === FILE_TYPE.SOURCE_DATASET)
+      VALID_FILE_TYPES_FOR_VALIDATION.includes(fileType)
     ) {
       const { jobId } = await submitDatasetValidationJob({
         fileId: result.id,

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -2591,6 +2591,17 @@ export const INITIAL_TEST_ATLASES_BY_SOURCE_STUDY = INITIAL_TEST_ATLASES.reduce(
 
 // COMPONENT ATLASES
 
+export const EMPTY_COMPONENT_INFO = {
+  assay: [],
+  cellCount: 0,
+  cellxgeneDatasetId: null,
+  cellxgeneDatasetVersion: null,
+  description: "",
+  disease: [],
+  suspensionType: [],
+  tissue: [],
+};
+
 export const COMPONENT_ATLAS_DRAFT_FOO = {
   atlasId: ATLAS_DRAFT.id,
   description: "bar baz baz foo baz foo bar",

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -573,6 +573,12 @@ export async function getStudySourceDatasets(
   ).rows;
 }
 
+export async function getAllFileIdsFromDatabase(): Promise<string[]> {
+  return (
+    await query<Pick<HCAAtlasTrackerDBFile, "id">>("SELECT id FROM hat.files")
+  ).rows.map(({ id }) => id);
+}
+
 export async function getFileFromDatabase(
   id: string
 ): Promise<HCAAtlasTrackerDBFile | undefined> {


### PR DESCRIPTION
Closes #839

Notes:
- Validation is skipped when a file record is updated rather that being inserted (which I believe can only happen if there's a duplicate SNS message)
- Validation is also skipped when an older message arrives after a newer one. I'm not sure how useful this is though -- my thought was that since the validator just validates the latest version, we wouldn't want to save its results to a record for an older version, but what I've done here doesn't address the core issue, and we could still theoretically end up with a situation where the messages arrive in order but after multiple changes have already been made, in which case the validator *would* get called for an outdated version of the file