### PR TITLE
fix: fix fallback message for empty integration objects and other similar pages (#774)

### DIFF
--- a/app/components/Detail/components/ViewSourceDatasets/viewSourceDatasets.tsx
+++ b/app/components/Detail/components/ViewSourceDatasets/viewSourceDatasets.tsx
@@ -19,7 +19,7 @@ export const ViewSourceDatasets = ({
   sourceDatasets = [],
 }: ViewSourceDatasetsProps): JSX.Element => {
   const {
-    access: { canEdit, canView },
+    access: { canView },
   } = formManager;
   if (!canView) return <RequestAccess />;
   return (
@@ -34,7 +34,6 @@ export const ViewSourceDatasets = ({
           />
         )}
         <TablePlaceholder
-          canEdit={canEdit}
           message="No source datasets"
           rowCount={sourceDatasets.length}
         />


### PR DESCRIPTION
Closes #774.

This pull request makes a small adjustment to the `ViewSourceDatasets` component by removing the unused `canEdit` property from both the access destructuring and the `TablePlaceholder` component. No functional changes are introduced; this is a cleanup to remove unnecessary code. [[1]](diffhunk://#diff-52ef7f19f386d1d673b069b99552ec314fc0c93d39dd7cf55932b46a7cc92b33L22-R22) [[2]](diffhunk://#diff-52ef7f19f386d1d673b069b99552ec314fc0c93d39dd7cf55932b46a7cc92b33L37)