### PR TITLE
feat: return validation summary from source dataset and integrated object apis (#863)

### DIFF
--- a/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
@@ -90,6 +90,7 @@ export function dbComponentAtlasFileToApiComponentAtlas(
     tissue: dbComponentAtlasFile.dataset_info?.tissue ?? [],
     title: dbComponentAtlasFile.dataset_info?.title ?? "",
     validationStatus: dbComponentAtlasFile.validation_status,
+    validationSummary: dbComponentAtlasFile.validation_summary,
   };
 }
 
@@ -176,6 +177,7 @@ export function dbSourceDatasetToApiSourceDataset(
     title: dbSourceDataset.dataset_info?.title ?? "",
     updatedAt: dbSourceDataset.updated_at.toISOString(),
     validationStatus: dbSourceDataset.validation_status,
+    validationSummary: dbSourceDataset.validation_summary,
   };
 }
 

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -64,6 +64,7 @@ export interface HCAAtlasTrackerComponentAtlas {
   tissue: string[];
   title: string;
   validationStatus: FILE_VALIDATION_STATUS;
+  validationSummary: FileValidationSummary | null;
 }
 
 export interface HCAAtlasTrackerNetworkCoordinator {
@@ -130,6 +131,7 @@ export interface HCAAtlasTrackerSourceDataset {
   title: string;
   updatedAt: string;
   validationStatus: FILE_VALIDATION_STATUS;
+  validationSummary: FileValidationSummary | null;
 }
 
 export interface HCAAtlasTrackerValidationResult {
@@ -299,6 +301,7 @@ export type HCAAtlasTrackerDBComponentAtlasFile = Pick<
   | "key"
   | "size_bytes"
   | "validation_status"
+  | "validation_summary"
 > &
   Pick<HCAAtlasTrackerDBComponentAtlas, "atlas_id">;
 
@@ -407,7 +410,11 @@ export type HCAAtlasTrackerDBSourceDatasetForAPI = WithSourceStudyInfo<
 > &
   Pick<
     HCAAtlasTrackerDBFile,
-    "key" | "size_bytes" | "dataset_info" | "validation_status"
+    | "key"
+    | "size_bytes"
+    | "dataset_info"
+    | "validation_status"
+    | "validation_summary"
   >;
 
 export interface HCAAtlasTrackerDBFile {

--- a/app/services/component-atlases.ts
+++ b/app/services/component-atlases.ts
@@ -29,7 +29,8 @@ export async function getAtlasComponentAtlases(
           f.integrity_status,
           f.key,
           f.size_bytes,
-          f.validation_status
+          f.validation_status,
+          f.validation_summary
         FROM hat.files f
         JOIN hat.component_atlases ca ON f.component_atlas_id = ca.id
         WHERE f.is_latest AND f.file_type='integrated_object' AND ca.atlas_id=$1
@@ -59,7 +60,8 @@ export async function getComponentAtlas(
         f.integrity_status,
         f.key,
         f.size_bytes,
-        f.validation_status
+        f.validation_status,
+        f.validation_summary
       FROM hat.files f
       JOIN hat.component_atlases ca ON f.component_atlas_id = ca.id
       WHERE f.id=$1 AND ca.atlas_id=$2

--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -43,7 +43,15 @@ export async function getSourceStudyDatasets(
   await confirmSourceStudyExistsOnAtlas(sourceStudyId, atlasId);
   const queryResult = await query<HCAAtlasTrackerDBSourceDatasetForAPI>(
     `
-      SELECT d.*, f.key, f.size_bytes, f.dataset_info, f.validation_status, s.doi, s.study_info
+      SELECT
+        d.*,
+        f.key,
+        f.size_bytes,
+        f.dataset_info,
+        f.validation_status,
+        f.validation_summary,
+        s.doi,
+        s.study_info
       FROM hat.source_datasets d
       JOIN hat.files f ON f.source_dataset_id = d.id
       JOIN hat.source_studies s ON d.source_study_id = s.id
@@ -64,7 +72,15 @@ export async function getAtlasDatasets(
   const sourceDatasetIds = await getAtlasSourceDatasetIds(atlasId);
   const queryResult = await query<HCAAtlasTrackerDBSourceDatasetForAPI>(
     `
-      SELECT d.*, f.key, f.size_bytes, f.dataset_info, f.validation_status, s.doi, s.study_info
+      SELECT
+        d.*,
+        f.key,
+        f.size_bytes,
+        f.dataset_info,
+        f.validation_status,
+        f.validation_summary,
+        s.doi,
+        s.study_info
       FROM hat.source_datasets d
       JOIN hat.files f ON f.source_dataset_id = d.id
       LEFT JOIN hat.source_studies s ON d.source_study_id = s.id
@@ -98,7 +114,15 @@ export async function getComponentAtlasDatasets(
   const sourceDatasetIds = componentAtlasResult.rows[0].source_datasets;
   const queryResult = await query<HCAAtlasTrackerDBSourceDatasetForAPI>(
     `
-      SELECT d.*, f.key, f.size_bytes, f.dataset_info, f.validation_status, s.doi, s.study_info
+      SELECT
+        d.*,
+        f.key,
+        f.size_bytes,
+        f.dataset_info,
+        f.validation_status,
+        f.validation_summary,
+        s.doi,
+        s.study_info
       FROM hat.source_datasets d
       JOIN hat.files f ON f.source_dataset_id = d.id
       LEFT JOIN hat.source_studies s ON d.source_study_id = s.id
@@ -131,7 +155,15 @@ export async function getSourceDataset(
   );
   const queryResult = await query<HCAAtlasTrackerDBSourceDatasetForAPI>(
     `
-      SELECT d.*, f.key, f.size_bytes, f.dataset_info, f.validation_status, s.doi, s.study_info
+      SELECT
+        d.*,
+        f.key,
+        f.size_bytes,
+        f.dataset_info,
+        f.validation_status,
+        f.validation_summary,
+        s.doi,
+        s.study_info
       FROM hat.source_datasets d
       JOIN hat.files f ON f.source_dataset_id = d.id
       JOIN hat.source_studies s ON d.source_study_id = s.id
@@ -160,7 +192,15 @@ export async function getAtlasSourceDataset(
   await confirmSourceDatasetIsLinkedToAtlas(sourceDatasetId, atlasId);
   const queryResult = await query<HCAAtlasTrackerDBSourceDatasetForAPI>(
     `
-      SELECT d.*, f.key, f.size_bytes, f.dataset_info, f.validation_status, s.doi, s.study_info
+      SELECT
+        d.*,
+        f.key,
+        f.size_bytes,
+        f.dataset_info,
+        f.validation_status,
+        f.validation_summary,
+        s.doi,
+        s.study_info
       FROM hat.source_datasets d
       JOIN hat.files f ON f.source_dataset_id = d.id
       LEFT JOIN hat.source_studies s ON d.source_study_id = s.id
@@ -201,7 +241,15 @@ export async function getComponentAtlasSourceDataset(
     );
   const queryResult = await query<HCAAtlasTrackerDBSourceDatasetForAPI>(
     `
-      SELECT d.*, f.key, f.size_bytes, f.dataset_info, f.validation_status, s.doi, s.study_info
+      SELECT
+        d.*,
+        f.key,
+        f.size_bytes,
+        f.dataset_info,
+        f.validation_status,
+        f.validation_summary,
+        s.doi,
+        s.study_info
       FROM hat.source_datasets d
       JOIN hat.files f ON f.source_dataset_id = d.id
       LEFT JOIN hat.source_studies s ON d.source_study_id = s.id

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -1500,6 +1500,12 @@ export const SOURCE_DATASET_FOO = {
     integrityCheckedAt: "2025-09-07T11:22:25.647Z",
     integrityStatus: INTEGRITY_STATUS.VALID,
     sizeBytes: "1234567",
+    validationSummary: {
+      overallValid: true,
+      validators: {
+        cap: true,
+      },
+    },
     versionId: null,
   },
   id: "6e1e281d-78cb-462a-ae29-94663c1e5713",
@@ -1918,6 +1924,12 @@ export const SOURCE_DATASET_ATLAS_LINKED_A_FOO = {
     integrityStatus: INTEGRITY_STATUS.VALID,
     sizeBytes: "1801234",
     validationStatus: FILE_VALIDATION_STATUS.COMPLETED,
+    validationSummary: {
+      overallValid: true,
+      validators: {
+        cap: true,
+      },
+    },
     versionId: null,
   },
   id: "4d08641d-be55-440b-8a19-b67c965cc2bf",
@@ -2654,6 +2666,12 @@ export const COMPONENT_ATLAS_DRAFT_BAR = {
     integrityCheckedAt: "2025-09-15T01:09:19.036Z",
     integrityStatus: INTEGRITY_STATUS.VALID,
     sizeBytes: "1987456",
+    validationSummary: {
+      overallValid: true,
+      validators: {
+        cap: true,
+      },
+    },
     versionId: null,
   },
   id: "484bc93b-836d-4efe-880a-de90eb1c4dfb",

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -235,6 +235,7 @@ async function initTestFile(
     sizeBytes,
     validationInfo,
     validationStatus,
+    validationSummary,
     versionId,
   } = fillTestFileDefaults(file);
   const key = getTestFileKey(file, atlas);
@@ -244,8 +245,8 @@ async function initTestFile(
   };
   await client.query(
     `
-      INSERT INTO hat.files (id, bucket, key, version_id, etag, size_bytes, event_info, sha256_client, sha256_server, integrity_checked_at, integrity_error, integrity_status, validation_status, is_latest, file_type, source_dataset_id, component_atlas_id, sns_message_id, dataset_info, validation_info)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
+      INSERT INTO hat.files (id, bucket, key, version_id, etag, size_bytes, event_info, sha256_client, sha256_server, integrity_checked_at, integrity_error, integrity_status, validation_status, is_latest, file_type, source_dataset_id, component_atlas_id, sns_message_id, dataset_info, validation_info, validation_summary)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
     `,
     [
       id,
@@ -268,6 +269,7 @@ async function initTestFile(
       `test-sns-message-${id}`, // Generate unique SNS message ID for test data
       JSON.stringify(datasetInfo),
       JSON.stringify(validationInfo),
+      JSON.stringify(validationSummary),
     ]
   );
 }

--- a/testing/entities.ts
+++ b/testing/entities.ts
@@ -4,6 +4,7 @@ import {
   DoiPublicationInfo,
   FILE_TYPE,
   FILE_VALIDATION_STATUS,
+  FileValidationSummary,
   GoogleSheetInfo,
   HCAAtlasTrackerDBEntrySheetValidation,
   HCAAtlasTrackerDBFileDatasetInfo,
@@ -119,6 +120,7 @@ export interface TestFile {
   sourceStudyId?: string | null;
   validationInfo?: HCAAtlasTrackerDBFileValidationInfo | null;
   validationStatus?: FILE_VALIDATION_STATUS;
+  validationSummary?: FileValidationSummary | null;
   versionId: string | null;
 }
 

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -272,6 +272,7 @@ export function fillTestFileDefaults(file: TestFile): NormalizedTestFile {
     sha256Server = null,
     sourceStudyId = null,
     validationStatus = FILE_VALIDATION_STATUS.PENDING,
+    validationSummary = null,
     ...restFields
   } = file;
   const resolvedAtlas = typeof atlas === "function" ? atlas() : atlas;
@@ -299,6 +300,7 @@ export function fillTestFileDefaults(file: TestFile): NormalizedTestFile {
     sourceStudyId,
     validationInfo,
     validationStatus,
+    validationSummary,
     ...restFields,
   };
 }
@@ -587,6 +589,9 @@ export function expectApiSourceDatasetToMatchTest(
   expect(apiSourceDataset.tissue).toEqual(testFile.datasetInfo?.tissue ?? []);
   expect(apiSourceDataset.title).toEqual(testFile.datasetInfo?.title ?? "");
   expect(apiSourceDataset.validationStatus).toEqual(testFile.validationStatus);
+  expect(apiSourceDataset.validationSummary).toEqual(
+    testFile.validationSummary
+  );
 }
 
 export function expectDbSourceDatasetToMatchTest(
@@ -645,6 +650,9 @@ export function expectApiComponentAtlasToMatchTest(
   );
   expect(apiComponentAtlas.tissue).toEqual(testFile.datasetInfo?.tissue ?? []);
   expect(apiComponentAtlas.validationStatus).toEqual(testFile.validationStatus);
+  expect(apiComponentAtlas.validationSummary).toEqual(
+    testFile.validationSummary
+  );
 
   // TODO: check for test component atlas fields once they're included
 }


### PR DESCRIPTION
Closes #863

The response differs slightly from what's specified in the ticket in that (as established in the PR adding the database column) I've used `overallValid` instead of `overall_valid`, since that's our convention in other JSON columns