### PR TITLE
feat: return validation reports from atlas source dataset and component atlas detail apis (#864)

### DIFF
--- a/__tests__/api-atlases-id-component-atlases-id.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id.test.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
-import { HCAAtlasTrackerComponentAtlas } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { HCAAtlasTrackerDetailComponentAtlas } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD } from "../app/common/entities";
 import { endPgPool } from "../app/services/database";
 import componentAtlasHandler from "../pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId]";
@@ -17,7 +17,7 @@ import {
 import { resetDatabase } from "../testing/db-utils";
 import { TestUser } from "../testing/entities";
 import {
-  expectApiComponentAtlasToMatchTest,
+  expectDetailApiComponentAtlasToMatchTest,
   testApiRole,
   withConsoleErrorHiding,
 } from "../testing/utils";
@@ -152,8 +152,8 @@ describe(TEST_ROUTE, () => {
       (res) => {
         expect(res._getStatusCode()).toEqual(200);
         const componentAtlas =
-          res._getJSONData() as HCAAtlasTrackerComponentAtlas;
-        expectApiComponentAtlasToMatchTest(
+          res._getJSONData() as HCAAtlasTrackerDetailComponentAtlas;
+        expectDetailApiComponentAtlasToMatchTest(
           componentAtlas,
           COMPONENT_ATLAS_DRAFT_FOO
         );
@@ -168,8 +168,9 @@ describe(TEST_ROUTE, () => {
       USER_CONTENT_ADMIN
     );
     expect(res._getStatusCode()).toEqual(200);
-    const componentAtlas = res._getJSONData() as HCAAtlasTrackerComponentAtlas;
-    expectApiComponentAtlasToMatchTest(
+    const componentAtlas =
+      res._getJSONData() as HCAAtlasTrackerDetailComponentAtlas;
+    expectDetailApiComponentAtlasToMatchTest(
       componentAtlas,
       COMPONENT_ATLAS_DRAFT_FOO
     );
@@ -188,8 +189,9 @@ describe(TEST_ROUTE, () => {
       USER_CONTENT_ADMIN
     );
     expect(res._getStatusCode()).toEqual(200);
-    const componentAtlas = res._getJSONData() as HCAAtlasTrackerComponentAtlas;
-    expectApiComponentAtlasToMatchTest(
+    const componentAtlas =
+      res._getJSONData() as HCAAtlasTrackerDetailComponentAtlas;
+    expectDetailApiComponentAtlasToMatchTest(
       componentAtlas,
       COMPONENT_ATLAS_DRAFT_BAR
     );

--- a/__tests__/api-atlases-id-source-datasets-id.test.ts
+++ b/__tests__/api-atlases-id-source-datasets-id.test.ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
 import {
   HCAAtlasTrackerDBAtlas,
+  HCAAtlasTrackerDetailSourceDataset,
   HCAAtlasTrackerSourceDataset,
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { AtlasSourceDatasetEditData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
@@ -35,8 +36,8 @@ import {
 } from "../testing/db-utils";
 import { TestAtlas, TestUser } from "../testing/entities";
 import {
-  expectApiSourceDatasetToMatchTest,
   expectAtlasDatasetsToHaveDifference,
+  expectDetailApiSourceDatasetToMatchTest,
   expectIsDefined,
   testApiRole,
   withConsoleErrorHiding,
@@ -158,8 +159,8 @@ describe(`${TEST_ROUTE} (GET)`, () => {
       (res) => {
         expect(res._getStatusCode()).toEqual(200);
         const sourceDataset =
-          res._getJSONData() as HCAAtlasTrackerSourceDataset;
-        expectApiSourceDatasetToMatchTest(
+          res._getJSONData() as HCAAtlasTrackerDetailSourceDataset;
+        expectDetailApiSourceDatasetToMatchTest(
           sourceDataset,
           SOURCE_DATASET_ATLAS_LINKED_A_FOO
         );
@@ -175,8 +176,9 @@ describe(`${TEST_ROUTE} (GET)`, () => {
       METHOD.GET
     );
     expect(res._getStatusCode()).toEqual(200);
-    const sourceDataset = res._getJSONData() as HCAAtlasTrackerSourceDataset;
-    expectApiSourceDatasetToMatchTest(
+    const sourceDataset =
+      res._getJSONData() as HCAAtlasTrackerDetailSourceDataset;
+    expectDetailApiSourceDatasetToMatchTest(
       sourceDataset,
       SOURCE_DATASET_ATLAS_LINKED_A_FOO
     );
@@ -196,8 +198,9 @@ describe(`${TEST_ROUTE} (GET)`, () => {
       METHOD.GET
     );
     expect(res._getStatusCode()).toEqual(200);
-    const sourceDataset = res._getJSONData() as HCAAtlasTrackerSourceDataset;
-    expectApiSourceDatasetToMatchTest(
+    const sourceDataset =
+      res._getJSONData() as HCAAtlasTrackerDetailSourceDataset;
+    expectDetailApiSourceDatasetToMatchTest(
       sourceDataset,
       SOURCE_DATASET_ATLAS_LINKED_A_BAR
     );
@@ -217,8 +220,9 @@ describe(`${TEST_ROUTE} (GET)`, () => {
       METHOD.GET
     );
     expect(res._getStatusCode()).toEqual(200);
-    const sourceDataset = res._getJSONData() as HCAAtlasTrackerSourceDataset;
-    expectApiSourceDatasetToMatchTest(
+    const sourceDataset =
+      res._getJSONData() as HCAAtlasTrackerDetailSourceDataset;
+    expectDetailApiSourceDatasetToMatchTest(
       sourceDataset,
       SOURCE_DATASET_WITH_MULTIPLE_FILES
     );

--- a/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
@@ -8,15 +8,19 @@ import {
   HCAAtlasTrackerDBAtlasWithComponentAtlases,
   HCAAtlasTrackerDBComment,
   HCAAtlasTrackerDBComponentAtlasFile,
+  HCAAtlasTrackerDBComponentAtlasFileForDetailAPI,
   HCAAtlasTrackerDBEntrySheetValidation,
   HCAAtlasTrackerDBEntrySheetValidationListFields,
   HCAAtlasTrackerDBSourceDataset,
   HCAAtlasTrackerDBSourceDatasetForAPI,
+  HCAAtlasTrackerDBSourceDatasetForDetailAPI,
   HCAAtlasTrackerDBSourceStudy,
   HCAAtlasTrackerDBSourceStudyWithRelatedEntities,
   HCAAtlasTrackerDBUserWithAssociatedResources,
   HCAAtlasTrackerDBValidation,
   HCAAtlasTrackerDBValidationWithAtlasProperties,
+  HCAAtlasTrackerDetailComponentAtlas,
+  HCAAtlasTrackerDetailSourceDataset,
   HCAAtlasTrackerEntrySheetValidation,
   HCAAtlasTrackerListEntrySheetValidation,
   HCAAtlasTrackerSourceDataset,
@@ -67,6 +71,15 @@ export function dbAtlasToApiAtlas(
     title: "",
     version: dbAtlas.overview.version,
     wave: dbAtlas.overview.wave,
+  };
+}
+
+export function dbComponentAtlasFileToDetailApiComponentAtlas(
+  dbComponentAtlasFile: HCAAtlasTrackerDBComponentAtlasFileForDetailAPI
+): HCAAtlasTrackerDetailComponentAtlas {
+  return {
+    ...dbComponentAtlasFileToApiComponentAtlas(dbComponentAtlasFile),
+    validationReports: dbComponentAtlasFile.validation_reports,
   };
 }
 
@@ -139,6 +152,15 @@ export function dbSourceStudyToApiSourceStudy(
       title: publication?.title ?? null,
     };
   }
+}
+
+export function dbSourceDatasetToDetailApiSourceDataset(
+  dbSourceDataset: HCAAtlasTrackerDBSourceDatasetForDetailAPI
+): HCAAtlasTrackerDetailSourceDataset {
+  return {
+    ...dbSourceDatasetToApiSourceDataset(dbSourceDataset),
+    validationReports: dbSourceDataset.validation_reports,
+  };
 }
 
 export function dbSourceDatasetToApiSourceDataset(

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -67,6 +67,11 @@ export interface HCAAtlasTrackerComponentAtlas {
   validationSummary: FileValidationSummary | null;
 }
 
+export interface HCAAtlasTrackerDetailComponentAtlas
+  extends HCAAtlasTrackerComponentAtlas {
+  validationReports: FileValidationReports | null;
+}
+
 export interface HCAAtlasTrackerNetworkCoordinator {
   coordinatorNames: string[];
   email: string;
@@ -132,6 +137,11 @@ export interface HCAAtlasTrackerSourceDataset {
   updatedAt: string;
   validationStatus: FILE_VALIDATION_STATUS;
   validationSummary: FileValidationSummary | null;
+}
+
+export interface HCAAtlasTrackerDetailSourceDataset
+  extends HCAAtlasTrackerSourceDataset {
+  validationReports: FileValidationReports | null;
 }
 
 export interface HCAAtlasTrackerValidationResult {
@@ -305,6 +315,10 @@ export type HCAAtlasTrackerDBComponentAtlasFile = Pick<
 > &
   Pick<HCAAtlasTrackerDBComponentAtlas, "atlas_id">;
 
+export type HCAAtlasTrackerDBComponentAtlasFileForDetailAPI =
+  HCAAtlasTrackerDBComponentAtlasFile &
+    Pick<HCAAtlasTrackerDBFile, "validation_reports">;
+
 export interface HCAAtlasTrackerDBPublishedSourceStudy {
   created_at: Date;
   doi: string;
@@ -416,6 +430,10 @@ export type HCAAtlasTrackerDBSourceDatasetForAPI = WithSourceStudyInfo<
     | "validation_status"
     | "validation_summary"
   >;
+
+export type HCAAtlasTrackerDBSourceDatasetForDetailAPI =
+  HCAAtlasTrackerDBSourceDatasetForAPI &
+    Pick<HCAAtlasTrackerDBFile, "validation_reports">;
 
 export interface HCAAtlasTrackerDBFile {
   bucket: string;

--- a/app/services/component-atlases.ts
+++ b/app/services/component-atlases.ts
@@ -2,6 +2,7 @@ import pg from "pg";
 import {
   HCAAtlasTrackerDBComponentAtlas,
   HCAAtlasTrackerDBComponentAtlasFile,
+  HCAAtlasTrackerDBComponentAtlasFileForDetailAPI,
   HCAAtlasTrackerDBComponentAtlasInfo,
 } from "../apis/catalog/hca-atlas-tracker/common/entities";
 import { confirmFileExistsOnAtlas } from "../data/files";
@@ -49,9 +50,9 @@ export async function getAtlasComponentAtlases(
 export async function getComponentAtlas(
   atlasId: string,
   fileId: string
-): Promise<HCAAtlasTrackerDBComponentAtlasFile> {
+): Promise<HCAAtlasTrackerDBComponentAtlasFileForDetailAPI> {
   const queryResult = await query<
-    Omit<HCAAtlasTrackerDBComponentAtlasFile, "atlas_id">
+    Omit<HCAAtlasTrackerDBComponentAtlasFileForDetailAPI, "atlas_id">
   >(
     `
       SELECT
@@ -61,7 +62,8 @@ export async function getComponentAtlas(
         f.key,
         f.size_bytes,
         f.validation_status,
-        f.validation_summary
+        f.validation_summary,
+        f.validation_reports
       FROM hat.files f
       JOIN hat.component_atlases ca ON f.component_atlas_id = ca.id
       WHERE f.id=$1 AND ca.atlas_id=$2

--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -4,6 +4,7 @@ import {
   HCAAtlasTrackerDBComponentAtlas,
   HCAAtlasTrackerDBSourceDataset,
   HCAAtlasTrackerDBSourceDatasetForAPI,
+  HCAAtlasTrackerDBSourceDatasetForDetailAPI,
   HCAAtlasTrackerDBSourceDatasetInfo,
 } from "../apis/catalog/hca-atlas-tracker/common/entities";
 import {
@@ -188,9 +189,9 @@ export async function getAtlasSourceDataset(
   atlasId: string,
   sourceDatasetId: string,
   client?: pg.PoolClient
-): Promise<HCAAtlasTrackerDBSourceDatasetForAPI> {
+): Promise<HCAAtlasTrackerDBSourceDatasetForDetailAPI> {
   await confirmSourceDatasetIsLinkedToAtlas(sourceDatasetId, atlasId);
-  const queryResult = await query<HCAAtlasTrackerDBSourceDatasetForAPI>(
+  const queryResult = await query<HCAAtlasTrackerDBSourceDatasetForDetailAPI>(
     `
       SELECT
         d.*,
@@ -199,6 +200,7 @@ export async function getAtlasSourceDataset(
         f.dataset_info,
         f.validation_status,
         f.validation_summary,
+        f.validation_reports,
         s.doi,
         s.study_info
       FROM hat.source_datasets d

--- a/app/views/AtlasSourceDatasetView/hooks/useFetchAtlasSourceDataset.ts
+++ b/app/views/AtlasSourceDatasetView/hooks/useFetchAtlasSourceDataset.ts
@@ -1,18 +1,18 @@
 import { API } from "../../../apis/catalog/hca-atlas-tracker/common/api";
-import { HCAAtlasTrackerSourceDataset } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { HCAAtlasTrackerDetailSourceDataset } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD, PathParameter } from "../../../common/entities";
 import { getRequestURL } from "../../../common/utils";
 import { useFetchData } from "../../../hooks/useFetchData";
 
 interface UseFetchAtlasSourceDataset {
-  sourceDataset?: HCAAtlasTrackerSourceDataset;
+  sourceDataset?: HCAAtlasTrackerDetailSourceDataset;
 }
 
 export const useFetchAtlasSourceDataset = (
   pathParameter: PathParameter
 ): UseFetchAtlasSourceDataset => {
   const { data: sourceDataset } = useFetchData<
-    HCAAtlasTrackerSourceDataset | undefined
+    HCAAtlasTrackerDetailSourceDataset | undefined
   >(getRequestURL(API.ATLAS_SOURCE_DATASET, pathParameter), METHOD.GET);
   return { sourceDataset };
 };

--- a/app/views/ComponentAtlasView/hooks/useFetchComponentAtlas.ts
+++ b/app/views/ComponentAtlasView/hooks/useFetchComponentAtlas.ts
@@ -1,18 +1,18 @@
 import { API } from "../../../apis/catalog/hca-atlas-tracker/common/api";
-import { HCAAtlasTrackerComponentAtlas } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { HCAAtlasTrackerDetailComponentAtlas } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD, PathParameter } from "../../../common/entities";
 import { getRequestURL } from "../../../common/utils";
 import { useFetchData } from "../../../hooks/useFetchData";
 
 interface UseFetchComponentAtlas {
-  componentAtlas?: HCAAtlasTrackerComponentAtlas;
+  componentAtlas?: HCAAtlasTrackerDetailComponentAtlas;
 }
 
 export const useFetchComponentAtlas = (
   pathParameter: PathParameter
 ): UseFetchComponentAtlas => {
   const { data: componentAtlas } = useFetchData<
-    HCAAtlasTrackerComponentAtlas | undefined
+    HCAAtlasTrackerDetailComponentAtlas | undefined
   >(getRequestURL(API.ATLAS_COMPONENT_ATLAS, pathParameter), METHOD.GET);
 
   return {

--- a/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId].ts
+++ b/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId].ts
@@ -1,4 +1,4 @@
-import { dbComponentAtlasFileToApiComponentAtlas } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
+import { dbComponentAtlasFileToDetailApiComponentAtlas } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE_GROUP } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/constants";
 import { METHOD } from "../../../../../app/common/entities";
 import { getComponentAtlas } from "../../../../../app/services/component-atlases";
@@ -13,7 +13,7 @@ export default handler(
     res
       .status(200)
       .json(
-        dbComponentAtlasFileToApiComponentAtlas(
+        dbComponentAtlasFileToDetailApiComponentAtlas(
           await getComponentAtlas(atlasId, componentAtlasId)
         )
       );

--- a/pages/api/atlases/[atlasId]/source-datasets/[sourceDatasetId].ts
+++ b/pages/api/atlases/[atlasId]/source-datasets/[sourceDatasetId].ts
@@ -2,7 +2,10 @@ import {
   addSourceDatasetToAtlas,
   removeSourceDatasetFromAtlas,
 } from "app/services/atlases";
-import { dbSourceDatasetToApiSourceDataset } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
+import {
+  dbSourceDatasetToApiSourceDataset,
+  dbSourceDatasetToDetailApiSourceDataset,
+} from "../../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE_GROUP } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/constants";
 import { ROLE } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { atlasSourceDatasetEditSchema } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/schema";
@@ -22,7 +25,7 @@ const getHandler = handler(role(ROLE_GROUP.READ), async (req, res) => {
   const atlasId = req.query.atlasId as string;
   const sourceDatasetId = req.query.sourceDatasetId as string;
   res.json(
-    dbSourceDatasetToApiSourceDataset(
+    dbSourceDatasetToDetailApiSourceDataset(
       await getAtlasSourceDataset(atlasId, sourceDatasetId)
     )
   );

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -1500,6 +1500,15 @@ export const SOURCE_DATASET_FOO = {
     integrityCheckedAt: "2025-09-07T11:22:25.647Z",
     integrityStatus: INTEGRITY_STATUS.VALID,
     sizeBytes: "1234567",
+    validationReports: {
+      cap: {
+        errors: [],
+        finishedAt: "2025-09-07T11:22:27.000Z",
+        startedAt: "2025-09-07T11:22:26.000Z",
+        valid: true,
+        warnings: [],
+      },
+    },
     validationSummary: {
       overallValid: true,
       validators: {
@@ -1923,6 +1932,15 @@ export const SOURCE_DATASET_ATLAS_LINKED_A_FOO = {
     integrityCheckedAt: "2025-09-13T07:38:02.243Z",
     integrityStatus: INTEGRITY_STATUS.VALID,
     sizeBytes: "1801234",
+    validationReports: {
+      cap: {
+        errors: [],
+        finishedAt: "2025-09-13T07:38:04.000Z",
+        startedAt: "2025-09-13T07:38:03.000Z",
+        valid: true,
+        warnings: [],
+      },
+    },
     validationStatus: FILE_VALIDATION_STATUS.COMPLETED,
     validationSummary: {
       overallValid: true,
@@ -2666,6 +2684,15 @@ export const COMPONENT_ATLAS_DRAFT_BAR = {
     integrityCheckedAt: "2025-09-15T01:09:19.036Z",
     integrityStatus: INTEGRITY_STATUS.VALID,
     sizeBytes: "1987456",
+    validationReports: {
+      cap: {
+        errors: [],
+        finishedAt: "2025-09-15T01:09:21.000Z",
+        startedAt: "2025-09-15T01:09:20.000Z",
+        valid: true,
+        warnings: [],
+      },
+    },
     validationSummary: {
       overallValid: true,
       validators: {

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -234,6 +234,7 @@ async function initTestFile(
     sha256Server,
     sizeBytes,
     validationInfo,
+    validationReports,
     validationStatus,
     validationSummary,
     versionId,
@@ -245,8 +246,8 @@ async function initTestFile(
   };
   await client.query(
     `
-      INSERT INTO hat.files (id, bucket, key, version_id, etag, size_bytes, event_info, sha256_client, sha256_server, integrity_checked_at, integrity_error, integrity_status, validation_status, is_latest, file_type, source_dataset_id, component_atlas_id, sns_message_id, dataset_info, validation_info, validation_summary)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
+      INSERT INTO hat.files (id, bucket, key, version_id, etag, size_bytes, event_info, sha256_client, sha256_server, integrity_checked_at, integrity_error, integrity_status, validation_status, is_latest, file_type, source_dataset_id, component_atlas_id, sns_message_id, dataset_info, validation_info, validation_summary, validation_reports)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
     `,
     [
       id,
@@ -270,6 +271,7 @@ async function initTestFile(
       JSON.stringify(datasetInfo),
       JSON.stringify(validationInfo),
       JSON.stringify(validationSummary),
+      JSON.stringify(validationReports),
     ]
   );
 }

--- a/testing/entities.ts
+++ b/testing/entities.ts
@@ -4,6 +4,7 @@ import {
   DoiPublicationInfo,
   FILE_TYPE,
   FILE_VALIDATION_STATUS,
+  FileValidationReports,
   FileValidationSummary,
   GoogleSheetInfo,
   HCAAtlasTrackerDBEntrySheetValidation,
@@ -119,6 +120,7 @@ export interface TestFile {
   sizeBytes: string;
   sourceStudyId?: string | null;
   validationInfo?: HCAAtlasTrackerDBFileValidationInfo | null;
+  validationReports?: FileValidationReports | null;
   validationStatus?: FILE_VALIDATION_STATUS;
   validationSummary?: FileValidationSummary | null;
   versionId: string | null;

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -17,6 +17,8 @@ import {
   HCAAtlasTrackerDBUnpublishedSourceStudyInfo,
   HCAAtlasTrackerDBUser,
   HCAAtlasTrackerDBValidation,
+  HCAAtlasTrackerDetailComponentAtlas,
+  HCAAtlasTrackerDetailSourceDataset,
   HCAAtlasTrackerSourceDataset,
   HCAAtlasTrackerSourceStudy,
   HCAAtlasTrackerUser,
@@ -271,6 +273,7 @@ export function fillTestFileDefaults(file: TestFile): NormalizedTestFile {
     sha256Client = null,
     sha256Server = null,
     sourceStudyId = null,
+    validationReports = null,
     validationStatus = FILE_VALIDATION_STATUS.PENDING,
     validationSummary = null,
     ...restFields
@@ -299,6 +302,7 @@ export function fillTestFileDefaults(file: TestFile): NormalizedTestFile {
     sha256Server,
     sourceStudyId,
     validationInfo,
+    validationReports,
     validationStatus,
     validationSummary,
     ...restFields,
@@ -559,9 +563,27 @@ export function expectApiSourceDatasetsToMatchTest(
   }
 }
 
+export function expectDetailApiSourceDatasetToMatchTest(
+  apiSourceDataset: HCAAtlasTrackerDetailSourceDataset,
+  testSourceDataset: TestSourceDataset
+): void {
+  expectApiSourceDatasetToMatchTest(
+    apiSourceDataset,
+    testSourceDataset,
+    true,
+    (testFile) => {
+      expect(apiSourceDataset.validationReports).toEqual(
+        testFile.validationReports
+      );
+    }
+  );
+}
+
 export function expectApiSourceDatasetToMatchTest(
   apiSourceDataset: HCAAtlasTrackerSourceDataset,
-  testSourceDataset: TestSourceDataset
+  testSourceDataset: TestSourceDataset,
+  expectDetail = false,
+  doAdditionalChecks?: (file: NormalizedTestFile) => void
 ): void {
   if (!expectIsDefined(testSourceDataset.file)) return;
   const testFile = getNormalizedFileForTestEntity(testSourceDataset);
@@ -592,6 +614,13 @@ export function expectApiSourceDatasetToMatchTest(
   expect(apiSourceDataset.validationSummary).toEqual(
     testFile.validationSummary
   );
+  if (expectDetail) {
+    expect(apiSourceDataset).toHaveProperty("validationReports");
+  } else {
+    expect(apiSourceDataset).not.toHaveProperty("validationReports");
+  }
+
+  doAdditionalChecks?.(testFile);
 }
 
 export function expectDbSourceDatasetToMatchTest(
@@ -626,9 +655,27 @@ export function expectDbSourceDatasetToMatchTest(
   expect(dbSourceDataset.sd_info.title).toEqual(testSourceDataset.title);
 }
 
+export function expectDetailApiComponentAtlasToMatchTest(
+  apiComponentAtlas: HCAAtlasTrackerDetailComponentAtlas,
+  testComponentAtlas: TestComponentAtlas
+): void {
+  expectApiComponentAtlasToMatchTest(
+    apiComponentAtlas,
+    testComponentAtlas,
+    true,
+    (testFile) => {
+      expect(apiComponentAtlas.validationReports).toEqual(
+        testFile.validationReports
+      );
+    }
+  );
+}
+
 export function expectApiComponentAtlasToMatchTest(
   apiComponentAtlas: HCAAtlasTrackerComponentAtlas,
-  testComponentAtlas: TestComponentAtlas
+  testComponentAtlas: TestComponentAtlas,
+  expectDetail = false,
+  doAdditionalChecks?: (file: NormalizedTestFile) => void
 ): void {
   if (!expectIsDefined(testComponentAtlas.file)) return;
   const testFile = getNormalizedFileForTestEntity(testComponentAtlas);
@@ -653,6 +700,13 @@ export function expectApiComponentAtlasToMatchTest(
   expect(apiComponentAtlas.validationSummary).toEqual(
     testFile.validationSummary
   );
+  if (expectDetail) {
+    expect(apiComponentAtlas).toHaveProperty("validationReports");
+  } else {
+    expect(apiComponentAtlas).not.toHaveProperty("validationReports");
+  }
+
+  doAdditionalChecks?.(testFile);
 
   // TODO: check for test component atlas fields once they're included
 }


### PR DESCRIPTION
Closes #864

Notes:
- This only includes the atlas-based APIs (i.e. not the obsolete(?) source dataset APIs off of source studies and component atlases)
- I updated the types on `useFetchComponentAtlas` and `useFetchAtlasSourceDataset`, but not on anything that uses them (which works fine since the new types returned from the APIs are subtypes of the old types)
- The test data generation script already creates validation reports