### PR TITLE
fix: fix select drop down shadow (#851)

### DIFF
--- a/app/components/common/Form/components/Select/constants.ts
+++ b/app/components/common/Form/components/Select/constants.ts
@@ -1,0 +1,9 @@
+import { SelectProps } from "@mui/material";
+
+export const SELECT_PROPS: SelectProps = {
+  MenuProps: {
+    slotProps: { paper: { sx: { my: 1 }, variant: "menu" } },
+  },
+  fullWidth: true,
+  size: "small",
+};

--- a/app/components/common/Form/components/Select/select.tsx
+++ b/app/components/common/Form/components/Select/select.tsx
@@ -3,6 +3,7 @@ import { forwardRef, ReactNode } from "react";
 import { FormControl } from "../FormControl/formControl.styles";
 import { FormHelperText } from "../FormHelperText/formHelperText";
 import { FormLabel } from "../FormLabel/formLabel";
+import { SELECT_PROPS } from "./constants";
 
 export type SelectProps = MSelectProps & {
   className?: string;
@@ -36,13 +37,7 @@ export const Select = forwardRef<HTMLInputElement, SelectProps>(function Select(
       isFullWidth={isFullWidth}
     >
       {label && <FormLabel>{label}</FormLabel>}
-      <MSelect
-        fullWidth
-        inputProps={{ onBlur }}
-        ref={ref}
-        size="small"
-        {...props}
-      >
+      <MSelect {...SELECT_PROPS} inputProps={{ onBlur }} ref={ref} {...props}>
         {children}
       </MSelect>
       {helperText && (


### PR DESCRIPTION
Closes #851.

This pull request refactors the `Select` component in the form library to centralize and standardize its default props. The main improvement is the introduction of a `constants.ts` file to define shared select properties, making the codebase more maintainable and consistent.

Component standardization and maintainability:

* Created a new `constants.ts` file that defines a `SELECT_PROPS` object with default properties for the `Select` component, such as `fullWidth`, `size`, and customized `MenuProps` for consistent styling.
* Updated the `Select` component to import and use `SELECT_PROPS` instead of hardcoding these props, ensuring all instances of the component use the same defaults and making future updates easier. [[1]](diffhunk://#diff-e08383fdf3acf4697633c927b76c5a31669559a6d8657cb84d7024898632c4d1R6) [[2]](diffhunk://#diff-e08383fdf3acf4697633c927b76c5a31669559a6d8657cb84d7024898632c4d1L39-R40)

<img width="1709" height="654" alt="image" src="https://github.com/user-attachments/assets/f46708f7-c675-4b12-871b-9c9664dd7181" />
