### PR TITLE
feat: update source dataset list to be like integrated object list for title and file name (#897)

### DIFF
--- a/app/views/AtlasSourceDatasetsView/components/Table/columns.ts
+++ b/app/views/AtlasSourceDatasetsView/components/Table/columns.ts
@@ -47,7 +47,14 @@ const COLUMN_DOWNLOAD = {
 
 const COLUMN_FILE_NAME = {
   accessorKey: "fileName",
-  cell: (ctx) => C.BasicCell({ value: ctx.getValue() as string }),
+  cell: ({ row }) =>
+    C.Link({
+      label: row.original.fileName,
+      url: getRouteURL(ROUTE.ATLAS_SOURCE_DATASET, {
+        atlasId: row.original.atlasId,
+        sourceDatasetId: row.original.id,
+      }),
+    }),
   header: "File Name",
   meta: { columnPinned: true, width: { max: "0.5fr", min: "120px" } },
 } as ColumnDef<AtlasSourceDataset>;
@@ -97,15 +104,8 @@ const COLUMN_TISSUE = {
 
 const COLUMN_TITLE = {
   accessorKey: "title",
-  cell: ({ row }) =>
-    C.Link({
-      label: row.original.title,
-      url: getRouteURL(ROUTE.ATLAS_SOURCE_DATASET, {
-        atlasId: row.original.atlasId,
-        sourceDatasetId: row.original.id,
-      }),
-    }),
-  header: "Source Dataset",
+  cell: ({ row }) => C.BasicCell({ value: row.original.title }),
+  header: "Title",
   meta: { width: { max: "1fr", min: "180px" } },
 } as ColumnDef<AtlasSourceDataset>;
 
@@ -119,10 +119,10 @@ const COLUMN_VALIDATION_STATUS = {
 export const COLUMNS: ColumnDef<AtlasSourceDataset>[] = [
   COLUMN_DEF.ROW_SELECTION as ColumnDef<AtlasSourceDataset>,
   COLUMN_DOWNLOAD,
-  COLUMN_TITLE,
-  COLUMN_SOURCE_STUDY,
   COLUMN_FILE_NAME,
+  COLUMN_TITLE,
   COLUMN_SIZE_BYTES,
+  COLUMN_SOURCE_STUDY,
   COLUMN_REPROCESSED_STATUS,
   COLUMN_VALIDATION_STATUS,
   COLUMN_ASSAY,


### PR DESCRIPTION
Closes #897.

This pull request updates the columns displayed in the `AtlasSourceDatasetsView` table to improve clarity and user navigation. The most significant changes involve swapping the "File Name" and "Title" columns' behavior and adjusting their order in the table.

**Table column behavior changes:**

* The `fileName` column now displays as a clickable link to the dataset details page, instead of plain text.
* The `title` column now displays as plain text, instead of a clickable link. The column header has also been changed from "Source Dataset" to "Title".

**Table column order changes:**

* The order of columns in the `COLUMNS` export has been updated: `COLUMN_FILE_NAME` now appears before `COLUMN_TITLE`, and `COLUMN_SOURCE_STUDY` has been moved after `COLUMN_SIZE_BYTES`.

<img width="1509" height="1004" alt="image" src="https://github.com/user-attachments/assets/7eb18115-a0b0-490a-af39-3f35e1e333b6" />
