### PR TITLE
feat: link validation summary in tables to validation detail pages (#899)

### DIFF
--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/entities.ts
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/entities.ts
@@ -1,5 +1,6 @@
 import { FileValidationSummary } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
 
 export interface Props {
+  validationRoute: string;
   validationSummary: FileValidationSummary | null;
 }

--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.tsx
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.tsx
@@ -1,6 +1,11 @@
 import { SuccessIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/SuccessIcon/successIcon";
+import {
+  ANCHOR_TARGET,
+  REL_ATTRIBUTE,
+} from "@databiosphere/findable-ui/lib/components/Links/common/entities";
 import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/svgIcon";
-import { Stack } from "@mui/material";
+import { Link as MLink, Stack } from "@mui/material";
+import Link from "next/link";
 import { FILE_VALIDATOR_NAME_LABEL } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/constants";
 import { FileValidatorName } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { INNER_STACK_PROPS, STACK_PROPS } from "./constants";
@@ -8,6 +13,7 @@ import { Props } from "./entities";
 import { StyledErrorIcon } from "./validationSummary.styles";
 
 export const ValidationSummary = ({
+  validationRoute,
   validationSummary,
 }: Props): JSX.Element | null => {
   if (!validationSummary) return null;
@@ -28,7 +34,14 @@ export const ValidationSummary = ({
           ) : (
             <StyledErrorIcon fontSize={SVG_ICON_PROPS.FONT_SIZE.SMALL} />
           )}
-          {FILE_VALIDATOR_NAME_LABEL[key as FileValidatorName]}
+          <MLink
+            component={Link}
+            href={validationRoute}
+            rel={REL_ATTRIBUTE.NO_OPENER}
+            target={ANCHOR_TARGET.SELF}
+          >
+            {FILE_VALIDATOR_NAME_LABEL[key as FileValidatorName]}
+          </MLink>
         </Stack>
       ))}
     </Stack>

--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/entities.ts
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/entities.ts
@@ -1,0 +1,16 @@
+import { CellContext } from "@tanstack/react-table";
+import { HCAAtlasTrackerComponentAtlas } from "../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { AtlasSourceDataset } from "../../../../../../views/AtlasSourceDatasetsView/entities";
+
+export type Props =
+  | (CellContext<
+      HCAAtlasTrackerComponentAtlas,
+      HCAAtlasTrackerComponentAtlas["validationStatus"]
+    > &
+      TValue)
+  | (CellContext<AtlasSourceDataset, AtlasSourceDataset["validationStatus"]> &
+      TValue);
+
+interface TValue {
+  validationRoute: string;
+}

--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/validationStatusCell.tsx
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/validationStatusCell.tsx
@@ -1,24 +1,23 @@
-import { CellContext } from "@tanstack/react-table";
-import {
-  FILE_VALIDATION_STATUS,
-  HCAAtlasTrackerComponentAtlas,
-} from "../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
-import { AtlasSourceDataset } from "../../../../../../views/AtlasSourceDatasetsView/entities";
+import { FILE_VALIDATION_STATUS } from "../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { ValidationStatus } from "./components/ValidationStatus/validationStatus";
 import { ValidationSummary } from "./components/ValidationSummary/validationSummary";
+import { Props } from "./entities";
 
-export const ValidationStatusCell = <
-  T extends HCAAtlasTrackerComponentAtlas | AtlasSourceDataset,
-  TValue
->({
+export const ValidationStatusCell = ({
   row,
-}: CellContext<T, TValue>): JSX.Element | null => {
+  validationRoute,
+}: Props): JSX.Element | null => {
   const { original } = row;
   const { validationStatus, validationSummary } = original;
 
   // Render validation summary if validation status is completed.
   if (validationStatus === FILE_VALIDATION_STATUS.COMPLETED)
-    return <ValidationSummary validationSummary={validationSummary} />;
+    return (
+      <ValidationSummary
+        validationRoute={validationRoute}
+        validationSummary={validationSummary}
+      />
+    );
 
   // Render validation status otherwise.
   return <ValidationStatus validationStatus={validationStatus} />;

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -1286,7 +1286,15 @@ function getIntegratedObjectValidationStatusColumnDef(): ColumnDef<
 > {
   return {
     accessorKey: "validationStatus",
-    cell: C.ValidationStatusCell,
+    cell: (ctx): JSX.Element | null => {
+      const { atlasId, id: componentAtlasId } = ctx.row.original;
+      const validationRoute = getRouteURL(ROUTE.INTEGRATED_OBJECT_VALIDATION, {
+        atlasId,
+        componentAtlasId,
+        validatorName: "cap",
+      });
+      return C.ValidationStatusCell({ ...ctx, validationRoute });
+    },
     header: "Validation Summary",
   };
 }

--- a/app/views/AtlasSourceDatasetsView/components/Table/columns.ts
+++ b/app/views/AtlasSourceDatasetsView/components/Table/columns.ts
@@ -14,6 +14,7 @@ import { AtlasSourceDataset } from "../../entities";
 import {
   renderSourceDatasetCellCount,
   renderSourceDatasetFileDownloadCell,
+  renderSourceDatasetValidationStatus,
 } from "./viewBuilders";
 
 const COLUMN_ASSAY = {
@@ -111,7 +112,7 @@ const COLUMN_TITLE = {
 
 const COLUMN_VALIDATION_STATUS = {
   accessorKey: "validationStatus",
-  cell: C.ValidationStatusCell,
+  cell: renderSourceDatasetValidationStatus,
   header: "Validation Summary",
   meta: { width: { max: "0.5fr", min: "120px" } },
 } as ColumnDef<AtlasSourceDataset>;

--- a/app/views/AtlasSourceDatasetsView/components/Table/viewBuilders.ts
+++ b/app/views/AtlasSourceDatasetsView/components/Table/viewBuilders.ts
@@ -1,6 +1,8 @@
 import { CellContext } from "@tanstack/react-table";
 import { INTEGRITY_STATUS } from "../../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { getRouteURL } from "../../../../common/utils";
 import * as C from "../../../../components";
+import { ROUTE } from "../../../../routes/constants";
 import { AtlasSourceDataset } from "../../entities";
 
 /**
@@ -38,4 +40,21 @@ export function renderSourceDatasetFileDownloadCell(
   const sizeBytes = row.original.sizeBytes;
 
   return C.FileDownloadCell({ disabled: !canEdit, fileId, sizeBytes });
+}
+
+/**
+ * Returns the source dataset validation status cell.
+ * @param ctx - Cell context.
+ * @returns Validation status cell.
+ */
+export function renderSourceDatasetValidationStatus(
+  ctx: CellContext<AtlasSourceDataset, AtlasSourceDataset["validationStatus"]>
+): JSX.Element | null {
+  const { atlasId, id: sourceDatasetId } = ctx.row.original;
+  const validationRoute = getRouteURL(ROUTE.ATLAS_SOURCE_DATASET_VALIDATION, {
+    atlasId,
+    sourceDatasetId,
+    validatorName: "cap",
+  });
+  return C.ValidationStatusCell({ ...ctx, validationRoute });
 }


### PR DESCRIPTION
Closes #899.

This pull request refactors the validation status cell components to support dynamic routing for validation summary links and improves type safety and reusability. The main changes involve updating the props and rendering logic of the `ValidationStatusCell` and `ValidationSummary` components, and ensuring that validation summary links now use the appropriate dynamic routes for both integrated objects and source datasets.

**Component and Type Refactoring:**

- Updated the `ValidationStatusCell` and `ValidationSummary` components to accept a `validationRoute` prop, enabling dynamic linking to validation summary pages. The `Props` types were revised to include this new property and improve type safety for usage with different data models. [[1]](diffhunk://#diff-6d6bf63fab5f71c425d4378a81dc771ed0191493b89ce1d57198bccc81927bc6R4) [[2]](diffhunk://#diff-f5ad477e16b3bf34f8540577b9a7160277023015e8948e59e3d660cf3f30f9d1R1-R16) [[3]](diffhunk://#diff-06f6a7a5ef99b667bf047c14cef44272d8f65456c78ecda3c2da267ca6376372L1-R20)

**Validation Summary Link Improvements:**

- Modified the `ValidationSummary` component to render the validator name as a link using the new `validationRoute` prop, with appropriate `rel` and `target` attributes for security and behavior. [[1]](diffhunk://#diff-3557c7eb9eadddc572b60aa5b597d314806bbf1206ee661f9de786a50a827ceaR2-R16) [[2]](diffhunk://#diff-3557c7eb9eadddc572b60aa5b597d314806bbf1206ee661f9de786a50a827ceaR37-R44)

**Dynamic Route Integration:**

- Updated the integrated object and source dataset table column definitions to generate and pass the correct validation route to the cell components, ensuring that each row links to its specific validation summary page. [[1]](diffhunk://#diff-b40c9cfae34bbe2fe51e79be552b0af2ebf79552105c70236d5978760ebbe81aL1289-R1297) [[2]](diffhunk://#diff-f361f2840939c1e2a393f67480c520bc82c1e90c662fa7eb2a220193ec4da2aeR17) [[3]](diffhunk://#diff-f361f2840939c1e2a393f67480c520bc82c1e90c662fa7eb2a220193ec4da2aeL114-R115) [[4]](diffhunk://#diff-45691c74f76fe2452a871182dba5b434dee50f127528da2c4b65f2ca746986f4R3-R5) [[5]](diffhunk://#diff-45691c74f76fe2452a871182dba5b434dee50f127528da2c4b65f2ca746986f4R44-R60)

<img width="1672" height="813" alt="image" src="https://github.com/user-attachments/assets/a1603928-9c6c-433f-9146-0f739f3bf78f" />
