### PR TITLE
feat: add file name to file download dialog (#901)

### DIFF
--- a/app/components/Entity/components/common/Table/components/TableCell/components/FileDownloadCell/components/Dialog/dialog.tsx
+++ b/app/components/Entity/components/common/Table/components/TableCell/components/FileDownloadCell/components/Dialog/dialog.tsx
@@ -1,7 +1,8 @@
+import { LABEL } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
 import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/components/common/Button/constants";
 import { DialogTitle } from "@databiosphere/findable-ui/lib/components/common/Dialog/components/DialogTitle/dialogTitle";
 import { formatFileSize } from "@databiosphere/findable-ui/lib/utils/formatFileSize";
-import { Button, DialogActions, DialogContent } from "@mui/material";
+import { Button, DialogActions, DialogContent, Stack } from "@mui/material";
 import { useFetchDataState } from "../../../../../../../../../../../hooks/useFetchDataState";
 import { FetchDataActionKind } from "../../../../../../../../../../../providers/fetchDataState/fetchDataState";
 import { useRequestPreSignedURL } from "../../hooks/UseRequestPreSignedURL/hook";
@@ -13,6 +14,7 @@ import { Props } from "./entities";
 
 export const Dialog = ({
   fileId,
+  fileName = LABEL.UNSPECIFIED,
   onClose,
   open,
   sizeBytes = 0,
@@ -34,8 +36,11 @@ export const Dialog = ({
       <DialogTitle onClose={onClose} title="Download from HCA Atlas Tracker" />
       <DialogContent dividers>
         <Section title="Data Format">.h5ad</Section>
-        <Section title="Download details">
-          FileSize: {formatFileSize(sizeBytes)}
+        <Section title="Download Details">
+          <Stack spacing={1} useFlexGap>
+            <span>FileName: {fileName}</span>
+            <span>FileSize: {formatFileSize(sizeBytes)}</span>
+          </Stack>
         </Section>
         <CodeSection url={url} />
       </DialogContent>

--- a/app/components/Entity/components/common/Table/components/TableCell/components/FileDownloadCell/components/Dialog/entities.ts
+++ b/app/components/Entity/components/common/Table/components/TableCell/components/FileDownloadCell/components/Dialog/entities.ts
@@ -6,5 +6,6 @@ export interface Props
   extends Omit<DialogProps, "onClose">,
     Omit<DialogTitleProps, "title"> {
   fileId?: FileId;
+  fileName?: string;
   sizeBytes?: number;
 }

--- a/app/components/Entity/components/common/Table/components/TableCell/components/FileDownloadCell/entities.ts
+++ b/app/components/Entity/components/common/Table/components/TableCell/components/FileDownloadCell/entities.ts
@@ -3,5 +3,6 @@ import { FileId } from "../../../../../../../../../apis/catalog/hca-atlas-tracke
 
 export interface Props extends IconButtonProps {
   fileId?: FileId;
+  fileName?: string;
   sizeBytes?: number;
 }

--- a/app/components/Entity/components/common/Table/components/TableCell/components/FileDownloadCell/fileDownloadCell.tsx
+++ b/app/components/Entity/components/common/Table/components/TableCell/components/FileDownloadCell/fileDownloadCell.tsx
@@ -10,6 +10,7 @@ import { Props } from "./entities";
 export const FileDownloadCell = ({
   disabled,
   fileId,
+  fileName,
   sizeBytes,
   ...props
 }: Props): JSX.Element => {
@@ -27,6 +28,7 @@ export const FileDownloadCell = ({
       <FetchDataStateProvider initialState={{ shouldFetch: false }}>
         <Dialog
           fileId={fileId}
+          fileName={fileName}
           onClose={onClose}
           open={open}
           sizeBytes={sizeBytes}

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -1234,10 +1234,12 @@ function getIntegratedObjectFileDownloadColumnDef<
         options: { meta },
       } = table;
       const { canEdit = false } = meta as { canEdit: boolean };
+      const { fileId, fileName, sizeBytes } = row.original;
       return C.FileDownloadCell({
         disabled: !canEdit,
-        fileId: row.original.fileId,
-        sizeBytes: row.original.sizeBytes,
+        fileId,
+        fileName,
+        sizeBytes,
       });
     },
     enableSorting: false,

--- a/app/views/AtlasSourceDatasetsView/components/Table/viewBuilders.ts
+++ b/app/views/AtlasSourceDatasetsView/components/Table/viewBuilders.ts
@@ -35,11 +35,15 @@ export function renderSourceDatasetFileDownloadCell(
   const { meta } = options;
   const { canEdit = false } = meta as { canEdit: boolean };
 
-  // Grab the fileId and sizeBytes from the row.
-  const fileId = row.original.fileId;
-  const sizeBytes = row.original.sizeBytes;
+  // Grab the fileId, fileName and sizeBytes from the row.
+  const { fileId, fileName, sizeBytes } = row.original;
 
-  return C.FileDownloadCell({ disabled: !canEdit, fileId, sizeBytes });
+  return C.FileDownloadCell({
+    disabled: !canEdit,
+    fileId,
+    fileName,
+    sizeBytes,
+  });
 }
 
 /**


### PR DESCRIPTION
Closes #901.

This pull request enhances the file download dialog in the table component by displaying the file name alongside the file size, and ensures that the file name is consistently passed through all relevant components and view model builders. The changes improve the clarity of download details for users and standardize the component interfaces to support the new property.

**User Interface Improvements:**

* The download dialog now displays both the file name and file size, improving the detail shown to users in the download details section. (`dialog.tsx` [app/components/Entity/components/common/Table/components/TableCell/components/FileDownloadCell/components/Dialog/dialog.tsxL37-R43](diffhunk://#diff-db2b041cff048742cb79ca95dc4616ef64a6cb0e4d254115ff4e974effd9fda8L37-R43))

**Component Interface Updates:**

* Added an optional `fileName` property to the `Dialog` and `FileDownloadCell` component props interfaces to support passing and displaying the file name. (`entities.ts` [[1]](diffhunk://#diff-b6ff5091824a137b29e02aee67c10b719012bb049fa0cbb4c557f327e30669c8R9) [[2]](diffhunk://#diff-00591778272b3abc7f4173620cd549a0d0dd5c943826a6798e20dd95af11ab1eR6)
* Updated the `Dialog` and `FileDownloadCell` components to accept and utilize the new `fileName` prop. (`dialog.tsx` [[1]](diffhunk://#diff-db2b041cff048742cb79ca95dc4616ef64a6cb0e4d254115ff4e974effd9fda8R17) [[2]](diffhunk://#diff-2924f1f28187fa0292093a3792c35cac1649eda57f347fe0e713c4ae17c49271R13) [[3]](diffhunk://#diff-2924f1f28187fa0292093a3792c35cac1649eda57f347fe0e713c4ae17c49271R31)

**View Model and Builder Updates:**

* Modified view model builder and table rendering functions to extract and pass the `fileName` property from row data to the `FileDownloadCell` component, ensuring the file name is available wherever files are listed for download. (`viewModelBuilders.ts` [[1]](diffhunk://#diff-b40c9cfae34bbe2fe51e79be552b0af2ebf79552105c70236d5978760ebbe81aR1237-R1242) `viewBuilders.ts` [[2]](diffhunk://#diff-45691c74f76fe2452a871182dba5b434dee50f127528da2c4b65f2ca746986f4L38-R46)

<img width="1669" height="1250" alt="image" src="https://github.com/user-attachments/assets/565c3513-9dc9-4fd4-a361-ea779e6a0262" />
