### PR TITLE
feat: save cellxgene results in validation results and summary (#906)

### DIFF
--- a/__tests__/api-sns-with-validation-results.test.ts
+++ b/__tests__/api-sns-with-validation-results.test.ts
@@ -159,7 +159,7 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
     expect(fileAfter).toEqual(fileBefore);
   });
 
-  it.each([{ tool: "cap" as const }])(
+  it.each([{ tool: "cap" as const }, { tool: "cellxgene" as const }])(
     "returns error 400 when $tool is missing from tool reports",
     async ({ tool }) => {
       const fileBefore = await getFileFromDatabase(FILE_SOURCE_DATASET_FOO.id);
@@ -224,11 +224,19 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
         valid: true,
         warnings: [],
       },
+      cellxgene: {
+        errors: ["Error OOO first CxG"],
+        finished_at: "2025-09-14T10:00:04.342",
+        started_at: "2025-09-14T10:00:03.645",
+        valid: false,
+        warnings: [],
+      },
     };
     const firstExpectedValidationSummary: FileValidationSummary = {
-      overallValid: true,
+      overallValid: false,
       validators: {
         cap: true,
+        cellxgene: false,
       },
     };
     const firstValidationResults = createValidationResults({
@@ -322,17 +330,25 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
     };
     const toolReports: DatasetValidatorToolReports = {
       cap: {
-        errors: ["Error dataset successful"],
+        errors: ["Error dataset successful CAP"],
         finished_at: validationTime,
         started_at: validationTime,
         valid: false,
         warnings: [],
+      },
+      cellxgene: {
+        errors: ["Error dataset successful CxG"],
+        finished_at: validationTime,
+        started_at: validationTime,
+        valid: false,
+        warnings: ["Warning dataset successful CxG"],
       },
     };
     const expectedValidationSummary: FileValidationSummary = {
       overallValid: false,
       validators: {
         cap: false,
+        cellxgene: false,
       },
     };
     const validationResults = createValidationResults({
@@ -390,17 +406,25 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
     };
     const toolReports: DatasetValidatorToolReports = {
       cap: {
-        errors: ["Error IO successful"],
+        errors: ["Error IO successful CAP"],
         finished_at: validationTime,
         started_at: validationTime,
         valid: false,
         warnings: [],
+      },
+      cellxgene: {
+        errors: ["Error IO successful CxG"],
+        finished_at: validationTime,
+        started_at: validationTime,
+        valid: false,
+        warnings: ["Warning IO successful CxG"],
       },
     };
     const expectedValidationSummary: FileValidationSummary = {
       overallValid: false,
       validators: {
         cap: false,
+        cellxgene: false,
       },
     };
     const validationResults = createValidationResults({

--- a/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
+++ b/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
@@ -63,6 +63,7 @@ const datasetValidatorToolReportSchema = object({
 
 const datasetValidatorToolReportsSchema = object({
   cap: datasetValidatorToolReportSchema.required(),
+  cellxgene: datasetValidatorToolReportSchema.required(),
 });
 
 export const datasetValidatorResultsSchema = object({

--- a/app/apis/catalog/hca-atlas-tracker/common/constants.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/constants.ts
@@ -205,10 +205,11 @@ export const FILE_VALIDATION_STATUS_NAME_LABEL: Record<
   [FILE_VALIDATION_STATUS.STALE]: "Stale",
 };
 
-export const FILE_VALIDATOR_NAMES = ["cap"] as const;
+export const FILE_VALIDATOR_NAMES = ["cap", "cellxgene"] as const;
 
 export const FILE_VALIDATOR_NAME_LABEL: Record<FileValidatorName, string> = {
   cap: "CAP",
+  cellxgene: "CELLxGENE",
 };
 
 export const UNPUBLISHED = "Unpublished";

--- a/testing/sns-testing.ts
+++ b/testing/sns-testing.ts
@@ -130,12 +130,20 @@ export const SUCCESSFUL_TOOL_REPORTS: DatasetValidatorToolReports = {
     valid: true,
     warnings: [],
   },
+  cellxgene: {
+    errors: [],
+    finished_at: TEST_TIMESTAMP,
+    started_at: TEST_TIMESTAMP,
+    valid: true,
+    warnings: [],
+  },
 };
 
 export const SUCCESSFUL_VALIDATION_SUMMARY: FileValidationSummary = {
   overallValid: true,
   validators: {
     cap: true,
+    cellxgene: true,
   },
 };
 


### PR DESCRIPTION
Closes #906

Saving the results to the database implicitly means that they show up in the APIs, since they're in the same JSONB columns as the CAP results

Also, it looks like the UI is already set up to to display all validators -- the only issue I noticed while briefly looking at it in the app was that in the "Validation Summary" column in the entity lists, both links go to the CAP report