### PR TITLE
feat: show cellxgene validation status in the source dataset and integrated object lists (#911)

### DIFF
--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/entities.ts
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/entities.ts
@@ -1,6 +1,8 @@
 import { FileValidationSummary } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { PathParameter } from "../../../../../../../../common/entities";
+import { RouteValue } from "../../../../../../../../routes/entities";
 
-export interface Props {
-  validationRoute: string;
+export interface Props extends PathParameter {
+  validationRoute: RouteValue;
   validationSummary: FileValidationSummary | null;
 }

--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.tsx
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.tsx
@@ -8,11 +8,15 @@ import { Link as MLink, Stack } from "@mui/material";
 import Link from "next/link";
 import { FILE_VALIDATOR_NAME_LABEL } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/constants";
 import { FileValidatorName } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { getRouteURL } from "../../../../../../../../common/utils";
 import { INNER_STACK_PROPS, STACK_PROPS } from "./constants";
 import { Props } from "./entities";
 import { StyledErrorIcon } from "./validationSummary.styles";
 
 export const ValidationSummary = ({
+  atlasId,
+  componentAtlasId,
+  sourceDatasetId,
   validationRoute,
   validationSummary,
 }: Props): JSX.Element | null => {
@@ -36,7 +40,12 @@ export const ValidationSummary = ({
           )}
           <MLink
             component={Link}
-            href={validationRoute}
+            href={getRouteURL(validationRoute, {
+              atlasId,
+              componentAtlasId,
+              sourceDatasetId,
+              validatorName: key as FileValidatorName,
+            })}
             rel={REL_ATTRIBUTE.NO_OPENER}
             target={ANCHOR_TARGET.SELF}
           >

--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/entities.ts
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/entities.ts
@@ -1,5 +1,7 @@
 import { CellContext } from "@tanstack/react-table";
 import { HCAAtlasTrackerComponentAtlas } from "../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { PathParameter } from "../../../../../../common/entities";
+import { RouteValue } from "../../../../../../routes/entities";
 import { AtlasSourceDataset } from "../../../../../../views/AtlasSourceDatasetsView/entities";
 
 export type Props =
@@ -11,6 +13,6 @@ export type Props =
   | (CellContext<AtlasSourceDataset, AtlasSourceDataset["validationStatus"]> &
       TValue);
 
-interface TValue {
-  validationRoute: string;
+interface TValue extends PathParameter {
+  validationRoute: RouteValue;
 }

--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/validationStatusCell.tsx
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/validationStatusCell.tsx
@@ -4,16 +4,21 @@ import { ValidationSummary } from "./components/ValidationSummary/validationSumm
 import { Props } from "./entities";
 
 export const ValidationStatusCell = ({
+  componentAtlasId,
   row,
+  sourceDatasetId,
   validationRoute,
 }: Props): JSX.Element | null => {
   const { original } = row;
-  const { validationStatus, validationSummary } = original;
+  const { atlasId, validationStatus, validationSummary } = original;
 
   // Render validation summary if validation status is completed.
   if (validationStatus === FILE_VALIDATION_STATUS.COMPLETED)
     return (
       <ValidationSummary
+        atlasId={atlasId}
+        componentAtlasId={componentAtlasId}
+        sourceDatasetId={sourceDatasetId}
         validationRoute={validationRoute}
         validationSummary={validationSummary}
       />

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -1289,13 +1289,11 @@ function getIntegratedObjectValidationStatusColumnDef(): ColumnDef<
   return {
     accessorKey: "validationStatus",
     cell: (ctx): JSX.Element | null => {
-      const { atlasId, id: componentAtlasId } = ctx.row.original;
-      const validationRoute = getRouteURL(ROUTE.INTEGRATED_OBJECT_VALIDATION, {
-        atlasId,
-        componentAtlasId,
-        validatorName: "cap",
+      return C.ValidationStatusCell({
+        ...ctx,
+        componentAtlasId: ctx.row.original.id,
+        validationRoute: ROUTE.INTEGRATED_OBJECT_VALIDATION,
       });
-      return C.ValidationStatusCell({ ...ctx, validationRoute });
     },
     header: "Validation Summary",
   };

--- a/app/views/AtlasSourceDatasetsView/components/Table/viewBuilders.ts
+++ b/app/views/AtlasSourceDatasetsView/components/Table/viewBuilders.ts
@@ -1,6 +1,5 @@
 import { CellContext } from "@tanstack/react-table";
 import { INTEGRITY_STATUS } from "../../../../apis/catalog/hca-atlas-tracker/common/entities";
-import { getRouteURL } from "../../../../common/utils";
 import * as C from "../../../../components";
 import { ROUTE } from "../../../../routes/constants";
 import { AtlasSourceDataset } from "../../entities";
@@ -54,11 +53,11 @@ export function renderSourceDatasetFileDownloadCell(
 export function renderSourceDatasetValidationStatus(
   ctx: CellContext<AtlasSourceDataset, AtlasSourceDataset["validationStatus"]>
 ): JSX.Element | null {
-  const { atlasId, id: sourceDatasetId } = ctx.row.original;
-  const validationRoute = getRouteURL(ROUTE.ATLAS_SOURCE_DATASET_VALIDATION, {
-    atlasId,
+  const { row } = ctx;
+  const { id: sourceDatasetId } = row.original;
+  return C.ValidationStatusCell({
+    ...ctx,
     sourceDatasetId,
-    validatorName: "cap",
+    validationRoute: ROUTE.ATLAS_SOURCE_DATASET_VALIDATION,
   });
-  return C.ValidationStatusCell({ ...ctx, validationRoute });
 }


### PR DESCRIPTION
Closes #911.

This pull request refactors how validation routes and their parameters are handled in validation status cells and summaries. The main improvement is the shift from passing pre-constructed route strings to passing route identifiers and parameters separately, allowing for more consistent and maintainable URL generation throughout the codebase.

### Route handling and parameterization

* Updated `ValidationStatusCell` and `ValidationSummary` components to accept route identifiers (`RouteValue`) and route parameters (`PathParameter`) instead of pre-built route strings, improving type safety and flexibility. [[1]](diffhunk://#diff-6d6bf63fab5f71c425d4378a81dc771ed0191493b89ce1d57198bccc81927bc6R2-R6) [[2]](diffhunk://#diff-f5ad477e16b3bf34f8540577b9a7160277023015e8948e59e3d660cf3f30f9d1L14-R17)
* Refactored usage of route construction in cell rendering functions to delegate parameterized route generation to the relevant components, using the new props structure. [[1]](diffhunk://#diff-b40c9cfae34bbe2fe51e79be552b0af2ebf79552105c70236d5978760ebbe81aL1292-L1298) [[2]](diffhunk://#diff-45691c74f76fe2452a871182dba5b434dee50f127528da2c4b65f2ca746986f4L57-L63)

### Component props and usage

* Modified props in `ValidationStatusCell` and `ValidationSummary` to explicitly pass required parameters (`atlasId`, `componentAtlasId`, `sourceDatasetId`) for route generation, ensuring correct links in validation summary cells. [[1]](diffhunk://#diff-06f6a7a5ef99b667bf047c14cef44272d8f65456c78ecda3c2da267ca6376372R7-R21) [[2]](diffhunk://#diff-3557c7eb9eadddc572b60aa5b597d314806bbf1206ee661f9de786a50a827ceaR11-R19)

### Link generation

* Updated link rendering in `ValidationSummary` to use the `getRouteURL` utility with the new parameterized props, ensuring dynamic and accurate URL creation for validator links.