### PR TITLE
refactor: separate source dataset retrieval queries into data layer with less duplication (#916)

### DIFF
--- a/__tests__/api-atlases-id-source-studies-id-source-datasets-create.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id-source-datasets-create.test.ts
@@ -202,8 +202,10 @@ describe(TEST_ROUTE, () => {
     );
     expect(res._getStatusCode()).toEqual(404);
     const message = res._getJSONData().message;
-    expect(message).toEqual(expect.stringContaining("Source dataset with ID"));
-    const id = /Source dataset with ID (\S+)/.exec(message)?.[1];
+    expect(message).toEqual(
+      expect.stringContaining("No source datasets exist with ID(s):")
+    );
+    const id = /ID\(s\): (\S+)/.exec(message)?.[1];
     if (expectIsDefined(id)) {
       expect(await getSourceDatasetFromDatabase(id)).toBeUndefined();
     }
@@ -219,8 +221,10 @@ describe(TEST_ROUTE, () => {
     );
     expect(res._getStatusCode()).toEqual(404);
     const message = res._getJSONData().message;
-    expect(message).toEqual(expect.stringContaining("Source dataset with ID"));
-    const id = /Source dataset with ID (\S+)/.exec(message)?.[1];
+    expect(message).toEqual(
+      expect.stringContaining("No source datasets exist with ID(s):")
+    );
+    const id = /ID\(s\): (\S+)/.exec(message)?.[1];
     if (expectIsDefined(id)) {
       expect(await getSourceDatasetFromDatabase(id)).toBeUndefined();
     }

--- a/app/data/source-datasets.ts
+++ b/app/data/source-datasets.ts
@@ -96,8 +96,8 @@ export async function getSourceDatasetsForApi(
       client
     );
 
-  const presentIds = sourceDatasets.map((d) => d.id);
-  const missingIds = sourceDatasetIds.filter((id) => !presentIds.includes(id));
+  const presentIds = new Set(sourceDatasets.map((d) => d.id));
+  const missingIds = sourceDatasetIds.filter((id) => !presentIds.has(id));
 
   if (missingIds.length)
     throw new NotFoundError(

--- a/app/data/source-datasets.ts
+++ b/app/data/source-datasets.ts
@@ -1,0 +1,168 @@
+import pg from "pg";
+import {
+  HCAAtlasTrackerDBAtlas,
+  HCAAtlasTrackerDBComponentAtlas,
+  HCAAtlasTrackerDBSourceDataset,
+  HCAAtlasTrackerDBSourceDatasetForAPI,
+  HCAAtlasTrackerDBSourceDatasetForDetailAPI,
+} from "../apis/catalog/hca-atlas-tracker/common/entities";
+import { query } from "../services/database";
+import { confirmSourceStudyExists } from "../services/source-studies";
+import { NotFoundError } from "../utils/api-handler";
+
+/**
+ * Get the IDs of source datasets linked to the given atlas.
+ * @param atlasId - Atlas ID.
+ * @param client - Postgres client to use.
+ * @returns source dataset IDs.
+ */
+export async function getAtlasSourceDatasetIds(
+  atlasId: string,
+  client?: pg.PoolClient
+): Promise<string[]> {
+  const atlasResult = await query<
+    Pick<HCAAtlasTrackerDBAtlas, "source_datasets">
+  >("SELECT source_datasets FROM hat.atlases WHERE id=$1", [atlasId], client);
+  if (atlasResult.rows.length === 0)
+    throw new NotFoundError(`Atlas with ID ${atlasId} doesn't exist`);
+  return atlasResult.rows[0].source_datasets;
+}
+
+/**
+ * Get the IDs of source datasets linked to the given source study.
+ * @param sourceStudyId - Source study ID.
+ * @returns source dataset IDs.
+ */
+export async function getSourceStudySourceDatasetIds(
+  sourceStudyId: string
+): Promise<string[]> {
+  await confirmSourceStudyExists(sourceStudyId);
+  const queryResult = await query<Pick<HCAAtlasTrackerDBSourceDataset, "id">>(
+    "SELECT id FROM hat.source_datasets WHERE source_study_id=$1",
+    [sourceStudyId]
+  );
+  return queryResult.rows.map((r) => r.id);
+}
+
+/**
+ * Get the IDs of source datasets linked to the given component atlas.
+ * @param componentAtlasId - Component atlas ID.
+ * @returns source dataset IDs.
+ */
+export async function getComponentAtlasSourceDatasetIds(
+  componentAtlasId: string
+): Promise<string[]> {
+  const componentAtlasResult = await query<
+    Pick<HCAAtlasTrackerDBComponentAtlas, "source_datasets">
+  >("SELECT source_datasets FROM hat.component_atlases WHERE id=$1", [
+    componentAtlasId,
+  ]);
+  if (componentAtlasResult.rows.length === 0)
+    throw new NotFoundError(
+      `Component atlas with ID ${componentAtlasId} doesn't exist`
+    );
+  return componentAtlasResult.rows[0].source_datasets;
+}
+
+/**
+ * Get specified source datasets joined with data used for API responses.
+ * @param sourceDatasetIds - IDs of source datasets to get.
+ * @param client - Postgres client to use.
+ * @returns source datasets with fields for APIs.
+ */
+export async function getSourceDatasetsForApi(
+  sourceDatasetIds: string[],
+  client?: pg.PoolClient
+): Promise<HCAAtlasTrackerDBSourceDatasetForAPI[]> {
+  const { rows: sourceDatasets } =
+    await query<HCAAtlasTrackerDBSourceDatasetForAPI>(
+      `
+        SELECT
+          d.*,
+          f.id as file_id,
+          f.key,
+          f.size_bytes,
+          f.dataset_info,
+          f.validation_status,
+          f.validation_summary,
+          s.doi,
+          s.study_info
+        FROM hat.source_datasets d
+        JOIN hat.files f ON f.source_dataset_id = d.id
+        LEFT JOIN hat.source_studies s ON d.source_study_id = s.id
+        WHERE d.id = ANY($1) AND f.is_latest
+      `,
+      [sourceDatasetIds],
+      client
+    );
+
+  const presentIds = sourceDatasets.map((d) => d.id);
+  const missingIds = sourceDatasetIds.filter((id) => !presentIds.includes(id));
+
+  if (missingIds.length)
+    throw new NotFoundError(
+      `No source datasets exist with ID(s): ${missingIds.join(", ")}`
+    );
+
+  return sourceDatasets;
+}
+
+/**
+ * Get specified source dataset joined with data used for detail API responses.
+ * @param sourceDatasetId - ID of source dataset to get.
+ * @param client - Postgres client to use.
+ * @returns source dataset with fields for detail API.
+ */
+export async function getSourceDatasetForDetailApi(
+  sourceDatasetId: string,
+  client?: pg.PoolClient
+): Promise<HCAAtlasTrackerDBSourceDatasetForDetailAPI> {
+  const queryResult = await query<HCAAtlasTrackerDBSourceDatasetForDetailAPI>(
+    `
+      SELECT
+        d.*,
+        f.id as file_id,
+        f.key,
+        f.size_bytes,
+        f.dataset_info,
+        f.validation_status,
+        f.validation_summary,
+        f.validation_reports,
+        s.doi,
+        s.study_info
+      FROM hat.source_datasets d
+      JOIN hat.files f ON f.source_dataset_id = d.id
+      LEFT JOIN hat.source_studies s ON d.source_study_id = s.id
+      WHERE d.id = $1 AND f.is_latest
+    `,
+    [sourceDatasetId],
+    client
+  );
+  if (queryResult.rows.length === 0)
+    throw new NotFoundError(
+      `Source dataset with ID ${sourceDatasetId} does not exist`
+    );
+  return queryResult.rows[0];
+}
+
+/**
+ * Throw an error if the given source dataset is not linked to the given source study.
+ * @param sourceDatasetId - Source dataset ID.
+ * @param sourceStudyId - Source study ID.
+ * @param client - Postgres client to use.
+ */
+export async function confirmSourceDatasetIsLinkedToStudy(
+  sourceDatasetId: string,
+  sourceStudyId: string,
+  client?: pg.PoolClient
+): Promise<void> {
+  const queryResult = await query(
+    "SELECT 1 FROM hat.source_datasets WHERE id=$1 AND source_study_id=$2",
+    [sourceDatasetId, sourceStudyId],
+    client
+  );
+  if (queryResult.rows.length === 0)
+    throw new NotFoundError(
+      `Source dataset with ID ${sourceDatasetId} is not linked to source study with ID ${sourceStudyId}`
+    );
+}

--- a/app/services/source-studies.ts
+++ b/app/services/source-studies.ts
@@ -703,6 +703,26 @@ async function confirmSourceStudyCanBeDeletedFromAtlas(
 }
 
 /**
+ * Throw an error if the given source study doesn't exist.
+ * @param sourceStudyId - Source study ID.
+ * @param client - Postgres client to use.
+ */
+export async function confirmSourceStudyExists(
+  sourceStudyId: string,
+  client?: pg.PoolClient
+): Promise<void> {
+  const queryResult = await query(
+    "SELECT 1 FROM hat.source_studies WHERE id=$1",
+    [sourceStudyId],
+    client
+  );
+  if (queryResult.rows.length === 0)
+    throw new NotFoundError(
+      `Source study with ID ${sourceStudyId} doesn't exist`
+    );
+}
+
+/**
  * Throw an error if the given source study doesn't exist on the given atlas.
  * @param sourceStudyId - Source study ID.
  * @param atlasId - Atlas ID.


### PR DESCRIPTION
Closes #916

As suggested by the title, this only covers queries that are used to retrieve source datasets -- there are some other queries still left in `services/source-datasets.ts`