### PR TITLE
feat: update and add apis to support interactions with file archiving (#921)

### DIFF
--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -59,14 +59,17 @@ export async function getSourceStudyDatasets(
 /**
  * Get all source datasets linked to the given atlas.
  * @param atlasId - Atlas ID.
+ * @param isArchivedValue - Value of `is_archived` to limit source datasets to. (Default false)
  * @returns database-model source datasets.
  */
 export async function getAtlasDatasets(
-  atlasId: string
+  atlasId: string,
+  isArchivedValue = false
 ): Promise<HCAAtlasTrackerDBSourceDatasetForAPI[]> {
   return await getSourceDatasetsForApi(
     await getAtlasSourceDatasetIds(atlasId),
-    true
+    true,
+    isArchivedValue
   );
 }
 
@@ -117,6 +120,7 @@ export async function getSourceDataset(
   const [sourceDataset] = await getSourceDatasetsForApi(
     [sourceDatasetId],
     false,
+    false,
     client
   );
   return sourceDataset;
@@ -126,16 +130,22 @@ export async function getSourceDataset(
  * Get a source dataset linked to an atlas.
  * @param atlasId - Atlas ID.
  * @param sourceDatasetId - Source dataset ID.
+ * @param isArchivedValue - Value of `is_archived` to limit source datasets to. (Default false)
  * @param client - Postgres client to use.
  * @returns database-model source dataset.
  */
 export async function getAtlasSourceDataset(
   atlasId: string,
   sourceDatasetId: string,
+  isArchivedValue = false,
   client?: pg.PoolClient
 ): Promise<HCAAtlasTrackerDBSourceDatasetForDetailAPI> {
   await confirmSourceDatasetIsLinkedToAtlas(sourceDatasetId, atlasId, client);
-  return await getSourceDatasetForDetailApi(sourceDatasetId, client);
+  return await getSourceDatasetForDetailApi(
+    sourceDatasetId,
+    isArchivedValue,
+    client
+  );
 }
 
 /**
@@ -317,7 +327,7 @@ export async function updateAtlasSourceDataset(
       [JSON.stringify(updatedInfoFields), sourceDatasetId],
       client
     );
-    return await getAtlasSourceDataset(atlasId, sourceDatasetId, client);
+    return await getAtlasSourceDataset(atlasId, sourceDatasetId, false, client);
   });
 }
 

--- a/pages/api/atlases/[atlasId]/component-atlases.ts
+++ b/pages/api/atlases/[atlasId]/component-atlases.ts
@@ -2,7 +2,12 @@ import { dbComponentAtlasFileToApiComponentAtlas } from "../../../../app/apis/ca
 import { ROLE_GROUP } from "../../../../app/apis/catalog/hca-atlas-tracker/common/constants";
 import { METHOD } from "../../../../app/common/entities";
 import { getAtlasComponentAtlases } from "../../../../app/services/component-atlases";
-import { handler, method, role } from "../../../../app/utils/api-handler";
+import {
+  handleOptionalParam,
+  handler,
+  method,
+  role,
+} from "../../../../app/utils/api-handler";
 
 /**
  * API route for getting an atlas's component atlases.
@@ -12,10 +17,18 @@ export default handler(
   role(ROLE_GROUP.READ),
   async (req, res) => {
     const atlasId = req.query.atlasId as string;
+    const { param: archived, responseSent } = handleOptionalParam(
+      req,
+      res,
+      "archived",
+      /^(?:true|false)$/
+    );
+    if (responseSent) return;
+    const isArchivedValue = archived === "true";
     res
       .status(200)
       .json(
-        (await getAtlasComponentAtlases(atlasId)).map(
+        (await getAtlasComponentAtlases(atlasId, isArchivedValue)).map(
           dbComponentAtlasFileToApiComponentAtlas
         )
       );

--- a/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId].ts
+++ b/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId].ts
@@ -2,7 +2,12 @@ import { dbComponentAtlasFileToDetailApiComponentAtlas } from "../../../../../ap
 import { ROLE_GROUP } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/constants";
 import { METHOD } from "../../../../../app/common/entities";
 import { getComponentAtlas } from "../../../../../app/services/component-atlases";
-import { handler, method, role } from "../../../../../app/utils/api-handler";
+import {
+  handleOptionalParam,
+  handler,
+  method,
+  role,
+} from "../../../../../app/utils/api-handler";
 
 export default handler(
   method(METHOD.GET),
@@ -10,11 +15,19 @@ export default handler(
   async (req, res) => {
     const atlasId = req.query.atlasId as string;
     const componentAtlasId = req.query.componentAtlasId as string;
+    const { param: archived, responseSent } = handleOptionalParam(
+      req,
+      res,
+      "archived",
+      /^(?:true|false)$/
+    );
+    if (responseSent) return;
+    const isArchivedValue = archived === "true";
     res
       .status(200)
       .json(
         dbComponentAtlasFileToDetailApiComponentAtlas(
-          await getComponentAtlas(atlasId, componentAtlasId)
+          await getComponentAtlas(atlasId, componentAtlasId, isArchivedValue)
         )
       );
   }

--- a/pages/api/atlases/[atlasId]/source-datasets.ts
+++ b/pages/api/atlases/[atlasId]/source-datasets.ts
@@ -2,17 +2,32 @@ import { dbSourceDatasetToApiSourceDataset } from "../../../../app/apis/catalog/
 import { ROLE_GROUP } from "../../../../app/apis/catalog/hca-atlas-tracker/common/constants";
 import { METHOD } from "../../../../app/common/entities";
 import { getAtlasDatasets } from "../../../../app/services/source-datasets";
-import { handler, method, role } from "../../../../app/utils/api-handler";
+import {
+  handleOptionalParam,
+  handler,
+  method,
+  role,
+} from "../../../../app/utils/api-handler";
 
 export default handler(
   method(METHOD.GET),
   role(ROLE_GROUP.READ),
   async (req, res) => {
     const atlasId = req.query.atlasId as string;
+    const { param: archived, responseSent } = handleOptionalParam(
+      req,
+      res,
+      "archived",
+      /^(?:true|false)$/
+    );
+    if (responseSent) return;
+    const isArchivedValue = archived === "true";
     res
       .status(200)
       .json(
-        (await getAtlasDatasets(atlasId)).map(dbSourceDatasetToApiSourceDataset)
+        (await getAtlasDatasets(atlasId, isArchivedValue)).map(
+          dbSourceDatasetToApiSourceDataset
+        )
       );
   }
 );

--- a/pages/api/atlases/[atlasId]/source-datasets/[sourceDatasetId].ts
+++ b/pages/api/atlases/[atlasId]/source-datasets/[sourceDatasetId].ts
@@ -16,6 +16,7 @@ import {
 } from "../../../../../app/services/source-datasets";
 import {
   handleByMethod,
+  handleOptionalParam,
   handler,
   integrationLeadAssociatedAtlasOnly,
   role,
@@ -24,9 +25,17 @@ import {
 const getHandler = handler(role(ROLE_GROUP.READ), async (req, res) => {
   const atlasId = req.query.atlasId as string;
   const sourceDatasetId = req.query.sourceDatasetId as string;
+  const { param: archived, responseSent } = handleOptionalParam(
+    req,
+    res,
+    "archived",
+    /^(?:true|false)$/
+  );
+  if (responseSent) return;
+  const isArchivedValue = archived === "true";
   res.json(
     dbSourceDatasetToDetailApiSourceDataset(
-      await getAtlasSourceDataset(atlasId, sourceDatasetId)
+      await getAtlasSourceDataset(atlasId, sourceDatasetId, isArchivedValue)
     )
   );
 });


### PR DESCRIPTION
- Updated APIs to accept a boolean `archived` query parameter (e.g. `?archived=true`) to choose between returning archived and non-archived entities:
  - `/api/atlases/[atlasId]/component-atlases`
  - `/api/atlases/[atlasId]/component-atlases/[componentAtlasId]`
  - `/api/atlases/[atlasId]/source-datasets`
  - `/api/atlases/[atlasId]/source-datasets/[sourceDatasetId]`