### PR TITLE
feat: increase the session inactivity timeout to 1 hour (#472)

### DIFF
--- a/site-config/hca-atlas-tracker/local/announcements/announcementsConfig.ts
+++ b/site-config/hca-atlas-tracker/local/announcements/announcementsConfig.ts
@@ -7,5 +7,9 @@ import * as C from "../../../../app/components";
 export const announcementsConfig: ComponentsConfig = [
   {
     component: C.SessionTimeout,
+    props: {
+      content:
+        "For security reasons, you have been logged out after one hour of inactivity.",
+    },
   } as ComponentConfig<typeof C.SessionTimeout>,
 ];

--- a/site-config/hca-atlas-tracker/local/authentication/constants.ts
+++ b/site-config/hca-atlas-tracker/local/authentication/constants.ts
@@ -1,3 +1,3 @@
-export const SESSION_TIMEOUT = 15 * 60 * 1000; // 15 minutes
+export const SESSION_TIMEOUT = 60 * 60 * 1000; // 1 hour
 export const SESSION_MAX_AGE = 5 * 60 * 1000; // 5 minutes
 export const SESSION_REFETCH_INTERVAL = 4 * 60 * 1000; // 4 minutes


### PR DESCRIPTION
Closes #472.
Closes https://github.com/clevercanary/hca-atlas-tracker/issues/759.

This pull request updates the session timeout configuration for the HCA Atlas Tracker site, extending the user session duration and providing improved messaging for session expiration.

Session timeout changes:

* Increased the session timeout from 15 minutes to 1 hour by updating the `SESSION_TIMEOUT` constant in `site-config/hca-atlas-tracker/local/authentication/constants.ts`.

User messaging improvements:

* Added a custom message to the `SessionTimeout` component to inform users they have been logged out after one hour of inactivity in `site-config/hca-atlas-tracker/local/announcements/announcementsConfig.ts`.

<img width="1575" height="1228" alt="image" src="https://github.com/user-attachments/assets/ce4f1107-7d7d-494f-8e0b-97be0535e9ea" />
