### PR TITLE
feat: log additional information when saving results from dataset validator (#936)

### DIFF
--- a/__tests__/api-sns-with-validation-results.test.ts
+++ b/__tests__/api-sns-with-validation-results.test.ts
@@ -296,7 +296,9 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
     const res = await doSnsRequest(secondSnsMessage, true);
     expect(res.statusCode).toBe(409);
     expect(res._getJSONData()).toEqual({
-      message: `Newer validation results already exist for file with ID ${FILE_SOURCE_DATASET_BAR.id}`,
+      message: expect.stringContaining(
+        `Newer validation results already exist for file with ID ${FILE_SOURCE_DATASET_BAR.id}`
+      ),
     });
 
     // Verify the file still has the first validation results (not overwritten)


### PR DESCRIPTION
Closes #936

Added some info to error messages, and added a message after validation results are saved (indicating validation time, file ID, S3 URI, and validation status)

Not sure if we also might need a message before saving results or some kind of big try/catch -- as it is we'll presumably get error messages if anything throws in the saving part, but they might lack context