### PR TITLE
feat: save and display hca schema validator results from dataset validator (#944, #945)

### DIFF
--- a/__tests__/api-sns-with-validation-results.test.ts
+++ b/__tests__/api-sns-with-validation-results.test.ts
@@ -231,12 +231,20 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
         valid: false,
         warnings: [],
       },
+      hcaSchema: {
+        errors: [],
+        finished_at: "2025-09-14T10:00:02.342",
+        started_at: "2025-09-14T10:00:01.645",
+        valid: true,
+        warnings: [],
+      },
     };
     const firstExpectedValidationSummary: FileValidationSummary = {
       overallValid: false,
       validators: {
         cap: true,
         cellxgene: false,
+        hcaSchema: true,
       },
     };
     const firstValidationResults = createValidationResults({
@@ -345,12 +353,20 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
         valid: false,
         warnings: ["Warning dataset successful CxG"],
       },
+      hcaSchema: {
+        errors: [],
+        finished_at: validationTime,
+        started_at: validationTime,
+        valid: true,
+        warnings: [],
+      },
     };
     const expectedValidationSummary: FileValidationSummary = {
       overallValid: false,
       validators: {
         cap: false,
         cellxgene: false,
+        hcaSchema: true,
       },
     };
     const validationResults = createValidationResults({
@@ -421,12 +437,20 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
         valid: false,
         warnings: ["Warning IO successful CxG"],
       },
+      hcaSchema: {
+        errors: [],
+        finished_at: validationTime,
+        started_at: validationTime,
+        valid: true,
+        warnings: [],
+      },
     };
     const expectedValidationSummary: FileValidationSummary = {
       overallValid: false,
       validators: {
         cap: false,
         cellxgene: false,
+        hcaSchema: true,
       },
     };
     const validationResults = createValidationResults({

--- a/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
+++ b/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
@@ -64,6 +64,7 @@ const datasetValidatorToolReportSchema = object({
 const datasetValidatorToolReportsSchema = object({
   cap: datasetValidatorToolReportSchema.required(),
   cellxgene: datasetValidatorToolReportSchema.required(),
+  hcaSchema: datasetValidatorToolReportSchema.required(),
 });
 
 export const datasetValidatorResultsSchema = object({

--- a/app/apis/catalog/hca-atlas-tracker/common/constants.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/constants.ts
@@ -205,11 +205,12 @@ export const FILE_VALIDATION_STATUS_NAME_LABEL: Record<
   [FILE_VALIDATION_STATUS.STALE]: "Stale",
 };
 
-export const FILE_VALIDATOR_NAMES = ["cap", "cellxgene"] as const;
+export const FILE_VALIDATOR_NAMES = ["cap", "cellxgene", "hcaSchema"] as const;
 
 export const FILE_VALIDATOR_NAME_LABEL: Record<FileValidatorName, string> = {
   cap: "CAP",
   cellxgene: "CELLxGENE",
+  hcaSchema: "HCA Schema",
 };
 
 export const UNPUBLISHED = "Unpublished";

--- a/testing/sns-testing.ts
+++ b/testing/sns-testing.ts
@@ -137,6 +137,13 @@ export const SUCCESSFUL_TOOL_REPORTS: DatasetValidatorToolReports = {
     valid: true,
     warnings: [],
   },
+  hcaSchema: {
+    errors: [],
+    finished_at: TEST_TIMESTAMP,
+    started_at: TEST_TIMESTAMP,
+    valid: true,
+    warnings: [],
+  },
 };
 
 export const SUCCESSFUL_VALIDATION_SUMMARY: FileValidationSummary = {
@@ -144,6 +151,7 @@ export const SUCCESSFUL_VALIDATION_SUMMARY: FileValidationSummary = {
   validators: {
     cap: true,
     cellxgene: true,
+    hcaSchema: true,
   },
 };
 


### PR DESCRIPTION
Closes #944
Closes #945

Notes:
- This will require the updated dataset validator to be deployed first
- I've used "HCA Schema" as the label in the app