### PR TITLE
feat: call hca validator 'hca' instead of hca schema in the list and detail tab (#947)

### DIFF
--- a/app/apis/catalog/hca-atlas-tracker/common/constants.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/constants.ts
@@ -210,7 +210,7 @@ export const FILE_VALIDATOR_NAMES = ["cap", "cellxgene", "hcaSchema"] as const;
 export const FILE_VALIDATOR_NAME_LABEL: Record<FileValidatorName, string> = {
   cap: "CAP",
   cellxgene: "CELLxGENE",
-  hcaSchema: "HCA Schema",
+  hcaSchema: "HCA",
 };
 
 export const UNPUBLISHED = "Unpublished";


### PR DESCRIPTION
Closes #947.

This pull request contains a minor update to the file validator name labels in the `app/apis/catalog/hca-atlas-tracker/common/constants.ts` file. The label for `hcaSchema` was shortened from "HCA Schema" to "HCA".