### PR TITLE
feat: updates to source dataset 'overview' general information section (#974)

### DIFF
--- a/app/views/AtlasSourceDatasetView/common/constants.ts
+++ b/app/views/AtlasSourceDatasetView/common/constants.ts
@@ -1,6 +1,11 @@
 export const FIELD_NAME = {
+  CAP_INGEST_STATUS: "capIngestStatus",
   CAP_URL: "capUrl",
+  CELL_COUNT: "cellCount",
+  FILE_EVENT_TIME: "fileEventTime",
   FILE_NAME: "fileName",
+  GENE_COUNT: "geneCount",
   SIZE_BYTES: "sizeBytes",
+  TITLE: "title",
   VALIDATION_STATUS: "validationStatus",
 } as const;

--- a/app/views/AtlasSourceDatasetView/common/controllers.ts
+++ b/app/views/AtlasSourceDatasetView/common/controllers.ts
@@ -1,52 +1,122 @@
 import { HCAAtlasTrackerSourceDataset } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { ControllerConfig } from "../../../components/common/Form/components/Controllers/common/entities";
+import { Chip } from "../../../components/Form/components/Input/inputComponent/Chip/chip";
+import {
+  buildCAPIngestStatus,
+  buildValidationStatus,
+} from "../../ComponentAtlasView/common/viewBuilders";
 import { FIELD_NAME } from "./constants";
 import { ViewAtlasSourceDatasetData } from "./entities";
+
+type ChipInputControllerConfig = ControllerConfig<
+  ViewAtlasSourceDatasetData,
+  HCAAtlasTrackerSourceDataset,
+  typeof Chip
+>;
 
 type CommonControllerConfig = ControllerConfig<
   ViewAtlasSourceDatasetData,
   HCAAtlasTrackerSourceDataset
 >;
 
+const CAP_INGEST_STATUS: ChipInputControllerConfig = {
+  inputProps: {
+    inputComponent: Chip,
+    isFullWidth: false,
+    label: "CAP Ingest Status",
+    readOnly: true,
+  },
+  name: FIELD_NAME.CAP_INGEST_STATUS,
+  viewBuilder: buildCAPIngestStatus,
+};
+
 const CAP_URL: CommonControllerConfig = {
   inputProps: {
     isFullWidth: true,
     label: "CAP URL",
-    readOnly: false,
   },
   labelLink: true,
   name: FIELD_NAME.CAP_URL,
 };
 
+const CELL_COUNT: CommonControllerConfig = {
+  inputProps: {
+    isFullWidth: false,
+    label: "Cell Count",
+    readOnly: true,
+  },
+  name: FIELD_NAME.CELL_COUNT,
+};
+
+const FILE_EVENT_TIME: CommonControllerConfig = {
+  inputProps: {
+    isFullWidth: false,
+    label: "Date Uploaded",
+    readOnly: true,
+  },
+  name: FIELD_NAME.FILE_EVENT_TIME,
+};
+
 const FILE_NAME: CommonControllerConfig = {
   inputProps: {
-    isFullWidth: true,
+    isFullWidth: false,
     label: "File Name",
     readOnly: true,
   },
   name: FIELD_NAME.FILE_NAME,
 };
 
+const GENE_COUNT: CommonControllerConfig = {
+  inputProps: {
+    isFullWidth: false,
+    label: "Gene Count",
+    readOnly: true,
+  },
+  name: FIELD_NAME.GENE_COUNT,
+};
+
 const SIZE_BYTES: CommonControllerConfig = {
   inputProps: {
-    isFullWidth: true,
+    isFullWidth: false,
     label: "File Size",
     readOnly: true,
   },
   name: FIELD_NAME.SIZE_BYTES,
 };
 
-const VALIDATION_STATUS: CommonControllerConfig = {
+const TITLE: CommonControllerConfig = {
   inputProps: {
     isFullWidth: true,
+    label: "Title",
+    readOnly: true,
+  },
+  name: FIELD_NAME.TITLE,
+};
+
+const VALIDATION_STATUS: ChipInputControllerConfig = {
+  inputProps: {
+    inputComponent: Chip,
+    isFullWidth: false,
     label: "Validation Status",
     readOnly: true,
   },
   name: FIELD_NAME.VALIDATION_STATUS,
+  viewBuilder: buildValidationStatus,
 };
 
-export const GENERAL_INFO_SOURCE_DATASET_CONTROLLERS: CommonControllerConfig[] =
-  [FILE_NAME, SIZE_BYTES, VALIDATION_STATUS];
+export const GENERAL_INFO_SOURCE_DATASET_CONTROLLERS: (
+  | ChipInputControllerConfig
+  | CommonControllerConfig
+)[] = [
+  FILE_NAME,
+  SIZE_BYTES,
+  TITLE,
+  CELL_COUNT,
+  GENE_COUNT,
+  VALIDATION_STATUS,
+  CAP_INGEST_STATUS,
+  FILE_EVENT_TIME,
+];
 
 export const CAP_SOURCE_DATASET_CONTROLLERS: CommonControllerConfig[] = [
   CAP_URL,

--- a/app/views/AtlasSourceDatasetView/common/schema.ts
+++ b/app/views/AtlasSourceDatasetView/common/schema.ts
@@ -1,13 +1,21 @@
-import { object, string } from "yup";
+import { number, object, string } from "yup";
 import { CAP_DATASET_URL_REGEXP } from "../../../apis/catalog/hca-atlas-tracker/common/schema";
+import { CAP_INGEST_STATUS } from "../../../components/Table/components/TableCell/components/CAPIngestStatusCell/entities";
 import { FIELD_NAME } from "./constants";
 
 export const viewAtlasSourceDatasetSchema = object({
+  [FIELD_NAME.CAP_INGEST_STATUS]: string().oneOf(
+    Object.values(CAP_INGEST_STATUS)
+  ),
   [FIELD_NAME.CAP_URL]: string()
     .default(null)
     .matches(CAP_DATASET_URL_REGEXP, "Invalid CAP URL (must be a dataset URL)")
     .nullable(),
+  [FIELD_NAME.CELL_COUNT]: number(),
+  [FIELD_NAME.FILE_EVENT_TIME]: string(),
   [FIELD_NAME.FILE_NAME]: string(),
+  [FIELD_NAME.GENE_COUNT]: number().nullable(),
   [FIELD_NAME.SIZE_BYTES]: string(),
+  [FIELD_NAME.TITLE]: string(),
   [FIELD_NAME.VALIDATION_STATUS]: string(),
 }).strict(true);

--- a/app/views/AtlasSourceDatasetView/common/sections.ts
+++ b/app/views/AtlasSourceDatasetView/common/sections.ts
@@ -1,4 +1,5 @@
 import { HCAAtlasTrackerSourceDataset } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { Chip } from "../../../components/Form/components/Input/inputComponent/Chip/chip";
 import { SECTION_TITLES } from "../../../components/Forms/common/constants";
 import { SectionConfig } from "../../../components/Forms/common/entities";
 import {
@@ -7,18 +8,31 @@ import {
 } from "./controllers";
 import { ViewAtlasSourceDatasetData } from "./entities";
 
-export const VIEW_ATLAS_SOURCE_DATASET_SECTION_CONFIGS: SectionConfig<
+type ChipInputSectionConfig = SectionConfig<
+  ViewAtlasSourceDatasetData,
+  HCAAtlasTrackerSourceDataset,
+  typeof Chip
+>;
+
+type CommonSectionConfig = SectionConfig<
   ViewAtlasSourceDatasetData,
   HCAAtlasTrackerSourceDataset
->[] = [
-  {
-    controllerConfigs: GENERAL_INFO_SOURCE_DATASET_CONTROLLERS,
-    sectionTitle: SECTION_TITLES.GENERAL_INFORMATION,
-    showDivider: false,
-  },
-  {
-    controllerConfigs: CAP_SOURCE_DATASET_CONTROLLERS,
-    sectionTitle: SECTION_TITLES.CAP,
-    showDivider: true,
-  },
-];
+>;
+
+export type SourceDatasetSectionConfig =
+  | ChipInputSectionConfig
+  | CommonSectionConfig;
+
+export const VIEW_ATLAS_SOURCE_DATASET_SECTION_CONFIGS: SourceDatasetSectionConfig[] =
+  [
+    {
+      controllerConfigs: GENERAL_INFO_SOURCE_DATASET_CONTROLLERS,
+      sectionTitle: SECTION_TITLES.GENERAL_INFORMATION,
+      showDivider: false,
+    },
+    {
+      controllerConfigs: CAP_SOURCE_DATASET_CONTROLLERS,
+      sectionTitle: SECTION_TITLES.CAP,
+      showDivider: true,
+    },
+  ];

--- a/app/views/AtlasSourceDatasetView/components/ViewAtlasSourceDataset/entities.ts
+++ b/app/views/AtlasSourceDatasetView/components/ViewAtlasSourceDataset/entities.ts
@@ -1,9 +1,9 @@
 import { ReactNode } from "react";
 import { HCAAtlasTrackerSourceDataset } from "../../../../apis/catalog/hca-atlas-tracker/common/entities";
-import { SectionConfig } from "../../../../components/Forms/common/entities";
 import { FormMethod } from "../../../../hooks/useForm/common/entities";
 import { FormManager as FormManagerProps } from "../../../../hooks/useFormManager/common/entities";
 import { ViewAtlasSourceDatasetData } from "../../common/entities";
+import { SourceDatasetSectionConfig } from "../../common/sections";
 
 export interface ViewAtlasSourceDatasetProps {
   accessFallback: ReactNode;
@@ -12,8 +12,5 @@ export interface ViewAtlasSourceDatasetProps {
     ViewAtlasSourceDatasetData,
     HCAAtlasTrackerSourceDataset
   >;
-  sectionConfigs: SectionConfig<
-    ViewAtlasSourceDatasetData,
-    HCAAtlasTrackerSourceDataset
-  >[];
+  sectionConfigs: SourceDatasetSectionConfig[];
 }

--- a/app/views/AtlasSourceDatasetView/components/ViewAtlasSourceDataset/viewAtlasSourceDataset.tsx
+++ b/app/views/AtlasSourceDatasetView/components/ViewAtlasSourceDataset/viewAtlasSourceDataset.tsx
@@ -1,10 +1,8 @@
 import { Fragment } from "react";
-import { HCAAtlasTrackerSourceDataset } from "../../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { FormManager } from "../../../../components/common/Form/components/FormManager/formManager";
 import { Divider } from "../../../../components/Detail/components/TrackerForm/components/Divider/divider.styles";
 import { TrackerFormSection as Section } from "../../../../components/Detail/components/TrackerForm/components/Section/components/TrackerFormSection/trackerFormSection";
 import { TrackerForm } from "../../../../components/Detail/components/TrackerForm/trackerForm";
-import { ViewAtlasSourceDatasetData } from "../../common/entities";
 import { ViewAtlasSourceDatasetProps } from "./entities";
 
 export const ViewAtlasSourceDataset = ({
@@ -20,7 +18,7 @@ export const ViewAtlasSourceDataset = ({
       {sectionConfigs.map(({ showDivider, ...sectionConfig }, i) => (
         <Fragment key={i}>
           {(i !== 0 || showDivider) && <Divider />}
-          <Section<ViewAtlasSourceDatasetData, HCAAtlasTrackerSourceDataset>
+          <Section
             formManager={formManager}
             formMethod={formMethod}
             {...sectionConfig}

--- a/app/views/AtlasSourceDatasetView/hooks/useEditAtlasSourceDatasetForm.ts
+++ b/app/views/AtlasSourceDatasetView/hooks/useEditAtlasSourceDatasetForm.ts
@@ -1,7 +1,7 @@
 import { formatFileSize } from "@databiosphere/findable-ui/lib/utils/formatFileSize";
-import { FILE_VALIDATION_STATUS_NAME_LABEL } from "../../../apis/catalog/hca-atlas-tracker/common/constants";
 import { HCAAtlasTrackerSourceDataset } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { PathParameter } from "../../../common/entities";
+import { getCapIngestStatus } from "../../../components/Table/components/TableCell/components/CAPIngestStatusCell/utils";
 import { FormMethod } from "../../../hooks/useForm/common/entities";
 import { useForm } from "../../../hooks/useForm/useForm";
 import { FIELD_NAME } from "../common/constants";
@@ -32,10 +32,14 @@ function mapSchemaValues(
 ): ViewAtlasSourceDatasetData | undefined {
   if (!sourceDataset) return;
   return {
+    [FIELD_NAME.CAP_INGEST_STATUS]: getCapIngestStatus(sourceDataset),
     [FIELD_NAME.CAP_URL]: sourceDataset.capUrl,
+    [FIELD_NAME.CELL_COUNT]: sourceDataset.cellCount,
+    [FIELD_NAME.FILE_EVENT_TIME]: sourceDataset.fileEventTime,
     [FIELD_NAME.FILE_NAME]: sourceDataset.fileName,
+    [FIELD_NAME.GENE_COUNT]: sourceDataset.geneCount,
     [FIELD_NAME.SIZE_BYTES]: formatFileSize(sourceDataset.sizeBytes),
-    [FIELD_NAME.VALIDATION_STATUS]:
-      FILE_VALIDATION_STATUS_NAME_LABEL[sourceDataset.validationStatus],
+    [FIELD_NAME.TITLE]: sourceDataset.title,
+    [FIELD_NAME.VALIDATION_STATUS]: sourceDataset.validationStatus,
   };
 }


### PR DESCRIPTION
Closes #974.

This pull request enhances the Atlas Source Dataset view by expanding the set of displayed dataset fields and improving type safety for section and controller configurations. The main changes include adding new fields to the dataset view, updating controller and section configs to support these fields and specialized input components, and ensuring consistent schema validation and data mapping.

**Dataset field additions:**
* Added new fields to the dataset view: `title`, `cellCount`, `geneCount`, `fileEventTime`, and `capIngestStatus`, allowing for richer dataset information display. [[1]](diffhunk://#diff-333cefa1c0252fe6ee79cffde0a8f4d82f6bad0563b72afa31a900f423c62285R2-R9) [[2]](diffhunk://#diff-38ed6b7439715823339062bc4703ed80bb3355d78a7dd5fb94844f6e044a5dedL1-R19) [[3]](diffhunk://#diff-5a53681460ddd1b192ff117dd4109c61f6b794c75c46d0048d4f463236033724R35-R43)

**Controller and section configuration improvements:**
* Updated `GENERAL_INFO_SOURCE_DATASET_CONTROLLERS` to include new fields and introduced specialized controller configs for chip-based status fields (`capIngestStatus`, `validationStatus`).
* Refactored section configuration types to support both chip and common input components, improving type safety and extensibility. [[1]](diffhunk://#diff-c6466c206a6bd122ec9fff3919ffd8476b259ed779afdb3edb76a7703968fc11R2) [[2]](diffhunk://#diff-c6466c206a6bd122ec9fff3919ffd8476b259ed779afdb3edb76a7703968fc11L10-R27) [[3]](diffhunk://#diff-4f77fd714f6cdb59b0939cb0c81c4978bcff848e995104d2f0d949e50d7d82b6L3-R6) [[4]](diffhunk://#diff-4f77fd714f6cdb59b0939cb0c81c4978bcff848e995104d2f0d949e50d7d82b6L15-R15)

**Schema and data mapping updates:**
* Extended the validation schema to handle the new fields and their types, including enum validation for `capIngestStatus`.
* Updated the data mapping function to populate all new fields from the source dataset, using utility functions for formatting and status extraction.

**Component integration:**
* Modified the `ViewAtlasSourceDataset` component and its props to use the new section config types, ensuring correct rendering of all new fields and input components. [[1]](diffhunk://#diff-041849f6c8d9d86586d3f11daaa3d1702f8c7fbded60e78b9c81d58f7485bd86L2-L7) [[2]](diffhunk://#diff-041849f6c8d9d86586d3f11daaa3d1702f8c7fbded60e78b9c81d58f7485bd86L23-R21) [[3]](diffhunk://#diff-4f77fd714f6cdb59b0939cb0c81c4978bcff848e995104d2f0d949e50d7d82b6L3-R6) [[4]](diffhunk://#diff-4f77fd714f6cdb59b0939cb0c81c4978bcff848e995104d2f0d949e50d7d82b6L15-R15)

<img width="1458" height="1286" alt="image" src="https://github.com/user-attachments/assets/a9dc3f12-5a22-4d05-87c1-018b8950c2a5" />
