### PR TITLE
refactor: move usefetchcomponentatlassourcedatasets to integrated object source datasets (#1000)

### DIFF
--- a/app/components/Detail/components/ViewComponentAtlasSourceDatasetsSelection/hooks/useComponentAtlasSourceDatasetsSelectionFormManager.ts
+++ b/app/components/Detail/components/ViewComponentAtlasSourceDatasetsSelection/hooks/useComponentAtlasSourceDatasetsSelectionFormManager.ts
@@ -9,7 +9,7 @@ import { FormMethod } from "../../../../../hooks/useForm/common/entities";
 import { FormManager } from "../../../../../hooks/useFormManager/common/entities";
 import { useFormManager } from "../../../../../hooks/useFormManager/useFormManager";
 import { fetchData } from "../../../../../providers/fetchDataState/actions/fetchData/dispatch";
-import { INTEGRATED_OBJECT_SOURCE_DATASETS } from "../../../../../views/ComponentAtlasView/hooks/useFetchComponentAtlasSourceDatasets";
+import { INTEGRATED_OBJECT_SOURCE_DATASETS } from "../../../../../views/IntegratedObjectSourceDatasetsView/hooks/useFetchIntegratedObjectSourceDatasets";
 import { FIELD_NAME } from "../common/constants";
 import { ComponentAtlasSourceDatasetsEditData } from "../common/entities";
 

--- a/app/views/ComponentAtlasView/hooks/useUnlinkComponentAtlasSourceDatasets.ts
+++ b/app/views/ComponentAtlasView/hooks/useUnlinkComponentAtlasSourceDatasets.ts
@@ -4,8 +4,8 @@ import { getRequestURL } from "../../../common/utils";
 import { useDeleteData } from "../../../hooks/useDeleteData";
 import { useFetchDataState } from "../../../hooks/useFetchDataState";
 import { fetchData } from "../../../providers/fetchDataState/actions/fetchData/dispatch";
+import { INTEGRATED_OBJECT_SOURCE_DATASETS } from "../../IntegratedObjectSourceDatasetsView/hooks/useFetchIntegratedObjectSourceDatasets";
 import { ComponentAtlasDeleteSourceDatasetsData } from "../common/entities";
-import { INTEGRATED_OBJECT_SOURCE_DATASETS } from "./useFetchComponentAtlasSourceDatasets";
 
 export interface UseUnlinkComponentAtlasSourceDatasets {
   onUnlink: (payload?: ComponentAtlasDeleteSourceDatasetsData) => Promise<void>;

--- a/app/views/IntegratedObjectSourceDatasetsView/components/Table/table.tsx
+++ b/app/views/IntegratedObjectSourceDatasetsView/components/Table/table.tsx
@@ -7,14 +7,14 @@ export const Table = (): JSX.Element => {
   const {
     atlasSourceDatasets = [],
     componentAtlas,
-    componentAtlasSourceDatasets = [],
+    integratedObjectSourceDatasets = [],
   } = data;
 
   return (
     <LinkedSourceDatasets
       atlasSourceDatasets={atlasSourceDatasets}
       componentAtlasIsArchived={componentAtlas?.isArchived ?? false}
-      componentAtlasSourceDatasets={componentAtlasSourceDatasets}
+      componentAtlasSourceDatasets={integratedObjectSourceDatasets}
       formManager={formManager}
       pathParameter={pathParameter}
     />

--- a/app/views/IntegratedObjectSourceDatasetsView/entities.ts
+++ b/app/views/IntegratedObjectSourceDatasetsView/entities.ts
@@ -16,5 +16,5 @@ export interface EntityData {
   atlas?: HCAAtlasTrackerAtlas;
   atlasSourceDatasets?: HCAAtlasTrackerSourceDataset[];
   componentAtlas?: HCAAtlasTrackerDetailComponentAtlas;
-  componentAtlasSourceDatasets?: HCAAtlasTrackerSourceDataset[];
+  integratedObjectSourceDatasets?: HCAAtlasTrackerSourceDataset[];
 }

--- a/app/views/IntegratedObjectSourceDatasetsView/hooks/useFetchIntegratedObjectSourceDatasets.ts
+++ b/app/views/IntegratedObjectSourceDatasetsView/hooks/useFetchIntegratedObjectSourceDatasets.ts
@@ -9,19 +9,19 @@ import { useResetFetchStatus } from "../../../hooks/useResetFetchStatus";
 export const INTEGRATED_OBJECT_SOURCE_DATASETS =
   "integratedObjectSourceDatasets";
 
-interface UseFetchComponentAtlasSourceDatasets {
-  componentAtlasSourceDatasets?: HCAAtlasTrackerSourceDataset[];
+interface UseFetchIntegratedObjectSourceDatasets {
+  integratedObjectSourceDatasets?: HCAAtlasTrackerSourceDataset[];
 }
 
-export const useFetchComponentAtlasSourceDatasets = (
+export const useFetchIntegratedObjectSourceDatasets = (
   pathParameter: PathParameter
-): UseFetchComponentAtlasSourceDatasets => {
+): UseFetchIntegratedObjectSourceDatasets => {
   const {
     fetchDataState: { shouldFetchByKey },
   } = useFetchDataState();
   const shouldFetch = shouldFetchByKey[INTEGRATED_OBJECT_SOURCE_DATASETS];
 
-  const { data: componentAtlasSourceDatasets, progress } = useFetchData<
+  const { data: integratedObjectSourceDatasets, progress } = useFetchData<
     HCAAtlasTrackerSourceDataset[] | undefined
   >(
     getRequestURL(API.ATLAS_COMPONENT_ATLAS_SOURCE_DATASETS, pathParameter),
@@ -31,5 +31,5 @@ export const useFetchComponentAtlasSourceDatasets = (
 
   useResetFetchStatus(progress, [INTEGRATED_OBJECT_SOURCE_DATASETS]);
 
-  return { componentAtlasSourceDatasets };
+  return { integratedObjectSourceDatasets };
 };

--- a/app/views/IntegratedObjectSourceDatasetsView/integratedObjectSourceDatasetsView.tsx
+++ b/app/views/IntegratedObjectSourceDatasetsView/integratedObjectSourceDatasetsView.tsx
@@ -14,9 +14,9 @@ import { EntityProvider } from "../../providers/entity/provider";
 import { getTabs } from "../ComponentAtlasView/common/utils";
 import { useFetchAssociatedAtlasSourceDatasets } from "../ComponentAtlasView/hooks/useFetchAssociatedAtlasSourceDatasets";
 import { useFetchComponentAtlas } from "../ComponentAtlasView/hooks/useFetchComponentAtlas";
-import { useFetchComponentAtlasSourceDatasets } from "../ComponentAtlasView/hooks/useFetchComponentAtlasSourceDatasets";
 import { VIEW_INTEGRATED_OBJECT_SOURCE_DATASETS_SECTION_CONFIGS } from "./common/config";
 import { getBreadcrumbs } from "./common/utils";
+import { useFetchIntegratedObjectSourceDatasets } from "./hooks/useFetchIntegratedObjectSourceDatasets";
 
 interface Props {
   pathParameter: PathParameter;
@@ -29,8 +29,8 @@ export const IntegratedObjectSourceDatasetsView = ({
   const { atlasSourceDatasets } =
     useFetchAssociatedAtlasSourceDatasets(pathParameter);
   const { componentAtlas } = useFetchComponentAtlas(pathParameter);
-  const { componentAtlasSourceDatasets } =
-    useFetchComponentAtlasSourceDatasets(pathParameter);
+  const { integratedObjectSourceDatasets } =
+    useFetchIntegratedObjectSourceDatasets(pathParameter);
   const formManager = useFormManager();
   const {
     access: { canView },
@@ -43,7 +43,7 @@ export const IntegratedObjectSourceDatasetsView = ({
         atlas,
         atlasSourceDatasets,
         componentAtlas,
-        componentAtlasSourceDatasets,
+        integratedObjectSourceDatasets,
       }}
       formManager={formManager}
       pathParameter={pathParameter}


### PR DESCRIPTION
Closes #1000.

This pull request refactors the handling of integrated object source datasets to improve clarity and consistency across the codebase. The main change is the renaming of variables, interfaces, and hooks from `componentAtlasSourceDatasets` to `integratedObjectSourceDatasets`, along with moving related logic to the more appropriately named `IntegratedObjectSourceDatasetsView`. This update helps distinguish integrated object source datasets from component atlas source datasets and ensures all references are consistent.

**Refactoring and renaming for clarity and consistency:**

* Renamed the hook `useFetchComponentAtlasSourceDatasets` to `useFetchIntegratedObjectSourceDatasets` and moved it from `ComponentAtlasView` to `IntegratedObjectSourceDatasetsView`, updating all related imports and usages. [[1]](diffhunk://#diff-8df024c93c1ce662a0eef61f2d48d1f46c674109d1f7d9d8136d095fc878387cL12-R24) [[2]](diffhunk://#diff-41a21f071d1aaace6ca1f4ef99558e221f4b7854ba4edb57a86c89a3d911d47aL17-R19)
* Updated the interface property in `EntityData` from `componentAtlasSourceDatasets` to `integratedObjectSourceDatasets` to reflect the new naming convention.
* Changed all variable and prop names in the view and table components from `componentAtlasSourceDatasets` to `integratedObjectSourceDatasets`, ensuring consistent data handling and display. [[1]](diffhunk://#diff-e3a4fbdb1352a9363da3bf8789cd9a823718380c1e0261b1c91b3ce3b3e73f0aL10-R17) [[2]](diffhunk://#diff-41a21f071d1aaace6ca1f4ef99558e221f4b7854ba4edb57a86c89a3d911d47aL32-R33) [[3]](diffhunk://#diff-41a21f071d1aaace6ca1f4ef99558e221f4b7854ba4edb57a86c89a3d911d47aL46-R46)
* Updated the fetch hook's return value and internal variable names to use `integratedObjectSourceDatasets` instead of `componentAtlasSourceDatasets`.
* Fixed imports in hooks and components to reference the new location and name for integrated object source datasets logic. [[1]](diffhunk://#diff-1f06f8fcc8c5d3432e3ffecce7a4bd67919a2c17474b21c675da23eef05fd815L12-R12) [[2]](diffhunk://#diff-40eb971181da6bea7cf1a5fe14090a38d06df57622d449b290a2f3aad8ef2a0eR7-L8)

These changes collectively make the codebase easier to understand and maintain by clearly separating integrated object source datasets from component atlas source datasets.