### PR TITLE
feat: rename cap column on integrated objects and source datasets to cap url (#1010)

### DIFF
--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -943,7 +943,7 @@ export function getAtlasComponentAtlasesTableColumns(): ColumnDef<
           capUrl: row.original.capUrl,
         }),
       enableSorting: false,
-      header: "CAP",
+      header: "CAP URL",
       meta: { width: { max: "1fr", min: "160px" } },
     },
     getComponentAtlasSourceDatasetCountColumnDef(),

--- a/app/views/AtlasSourceDatasetsView/components/Table/columns.ts
+++ b/app/views/AtlasSourceDatasetsView/components/Table/columns.ts
@@ -25,7 +25,7 @@ const COLUMN_CAP_URL = {
   accessorKey: "capUrl",
   cell: renderCAPUrl,
   enableSorting: false,
-  header: "CAP",
+  header: "CAP URL",
   id: "capUrl",
   meta: { width: { max: "0.5fr", min: "160px" } },
 } as ColumnDef<AtlasSourceDataset>;


### PR DESCRIPTION
Closes #1010.

This pull request updates the column header label for the CAP URL field in two tables to improve clarity and consistency in the user interface.

Table column header updates:

* Renamed the column header from "CAP" to "CAP URL" in the `getAtlasComponentAtlasesTableColumns` function in `viewModelBuilders.ts` to more accurately reflect the content of the column.
* Renamed the column header from "CAP" to "CAP URL" in the `COLUMN_CAP_URL` definition in `columns.ts` for atlas source datasets.