### PR TITLE
feat: updates for oral and craniofacial network (add new network) (#1026)

### DIFF
--- a/app/apis/catalog/hca-atlas-tracker/common/constants.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/constants.ts
@@ -28,6 +28,7 @@ export const NETWORK_KEYS = [
   "musculoskeletal",
   "nervous-system",
   "oral",
+  "oral-and-craniofacial",
   "organoid",
   "pancreas",
   "reproduction",
@@ -92,6 +93,10 @@ export const NETWORKS: Network[] = [
     name: "Oral and Craniofacial Networks",
   },
   {
+    key: "oral-and-craniofacial",
+    name: "Oral and Craniofacial Network",
+  },
+  {
     key: "organoid",
     name: "Organoid Network",
   },
@@ -124,6 +129,7 @@ export const NETWORK_ICONS: { [key in NetworkKey]: string } = {
   musculoskeletal: "/hca-bio-networks/icons/musculoskeletal.png",
   "nervous-system": "/hca-bio-networks/icons/nervous-system.png",
   oral: "/hca-bio-networks/icons/oral-and-craniofacial.png",
+  "oral-and-craniofacial": "/hca-bio-networks/icons/oral-and-craniofacial.png",
   organoid: "/hca-bio-networks/icons/organoid.png",
   pancreas: "/hca-bio-networks/icons/pancreas.png",
   reproduction: "/hca-bio-networks/icons/reproduction.png",


### PR DESCRIPTION
Closes #1026.

This pull request adds support for a new network type, "oral-and-craniofacial", to the HCA Atlas Tracker catalog. The changes ensure this new network is included in the relevant constants for keys, display names, and icons.

**Network additions:**

* Added `"oral-and-craniofacial"` to the `NETWORK_KEYS` array to recognize it as a valid network key.
* Added an entry for `"oral-and-craniofacial"` to the `NETWORKS` array with its display name.

**Icon support:**

* Added an icon mapping for `"oral-and-craniofacial"` to the `NETWORK_ICONS` object, ensuring the network displays the correct icon.