### PR TITLE
chore: upgrade @databiosphere/findable-ui to the latest version (#1051)

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "20.10.0"
+          node-version: "22.12.0"
       - run: |
           npm ci
           npm run check-format

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -2,7 +2,7 @@
 # docker run -p 3000:3000 tracker-node
 
 # Base stage
-FROM --platform=linux/amd64 node:20 AS base
+FROM --platform=linux/amd64 node:22 AS base
 
 # Deps stage
 FROM base AS deps
@@ -12,7 +12,7 @@ ENV ENVIRONMENT ${ENVIRONMENT}
 COPY ./package*.json ./
 RUN node --version
 RUN npm install -g n
-RUN n 20.10.0
+RUN n 22.12.0
 RUN node --version
 RUN npm ci
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Setup
 
-Use Node.js version `20.10.0`.
+Use Node.js version `22.12.0`.
 
 Run `npm install`.
 

--- a/app/content/common/constants.ts
+++ b/app/content/common/constants.ts
@@ -25,7 +25,7 @@ const MDX_SCOPE = { ROUTE };
 
 export const SERIALIZE_OPTIONS = {
   mdxOptions: {
-    development: false, // See https://github.com/hashicorp/next-mdx-remote/issues/307#issuecomment-1363415249 and https://github.com/hashicorp/next-mdx-remote/issues/307#issuecomment-1378362096.
+    development: process.env.NODE_ENV === "development",
     rehypePlugins: [],
     remarkPlugins: [],
   },

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,9 +1,7 @@
 import nextMDX from "@next/mdx";
 import withPlugins from "next-compose-plugins";
-import path from "path";
 
 const ESM_PACKAGES = [
-  "axios",
   "codsen-utils",
   "lodash-es",
   "ranges-apply",
@@ -14,8 +12,6 @@ const ESM_PACKAGES = [
   "string-left-right",
   "string-strip-html",
   "@databiosphere/findable-ui",
-  "@tanstack/react-table",
-  "@tanstack/react-virtual",
 ];
 
 const withMDX = nextMDX({
@@ -43,65 +39,5 @@ export default withPlugins(
       ];
     },
     transpilePackages: [...ESM_PACKAGES],
-    webpack: (config) => {
-      // Add the alias for the peer dependency
-      config.resolve.alias["@emotion/react"] = path.resolve(
-        process.cwd(),
-        "node_modules/@emotion/react"
-      );
-      config.resolve.alias["@emotion/styled"] = path.resolve(
-        process.cwd(),
-        "node_modules/@emotion/styled"
-      );
-      config.resolve.alias["@mui/icons-material"] = path.resolve(
-        process.cwd(),
-        "node_modules/@mui/icons-material"
-      );
-      config.resolve.alias["@mui/material"] = path.resolve(
-        process.cwd(),
-        "node_modules/@mui/material"
-      );
-      config.resolve.alias["react-dropzone"] = path.resolve(
-        process.cwd(),
-        "node_modules/react-dropzone"
-      );
-      config.resolve.alias["isomorphic-dompurify"] = path.resolve(
-        process.cwd(),
-        "node_modules/isomorphic-dompurify"
-      );
-      config.resolve.alias["match-sorter"] = path.resolve(
-        process.cwd(),
-        "node_modules/match-sorter"
-      );
-      config.resolve.alias["next"] = path.resolve(
-        process.cwd(),
-        "node_modules/next"
-      );
-      config.resolve.alias["react"] = path.resolve(
-        process.cwd(),
-        "node_modules/react"
-      );
-      config.resolve.alias["react-dom"] = path.resolve(
-        process.cwd(),
-        "node_modules/react-dom"
-      );
-      config.resolve.alias["react-gtm-module"] = path.resolve(
-        process.cwd(),
-        "node_modules/react-gtm-module"
-      );
-      config.resolve.alias["react-window"] = path.resolve(
-        process.cwd(),
-        "node_modules/react-window"
-      );
-      config.resolve.alias["uuid"] = path.resolve(
-        process.cwd(),
-        "node_modules/uuid"
-      );
-      config.resolve.alias["yup"] = path.resolve(
-        process.cwd(),
-        "node_modules/yup"
-      );
-      return config;
-    },
   }
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@aws-sdk/client-batch": "^3.896.0",
         "@aws-sdk/client-s3": "^3.896.0",
         "@aws-sdk/s3-request-presigner": "^3.896.0",
-        "@databiosphere/findable-ui": "^46.1.3",
+        "@databiosphere/findable-ui": "^47.0.2",
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@hookform/resolvers": "^3.3.4",
@@ -30,7 +30,7 @@
         "isomorphic-dompurify": "^2.22.0",
         "ky": "^1.7.2",
         "next": "^14.2.33",
-        "next-auth": "^4.24.11",
+        "next-auth": "^4.24.13",
         "next-compose-plugins": "^2.2.1",
         "raw-body": "^3.0.0",
         "react": "^18.3.1",
@@ -62,7 +62,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^16.0.1",
         "@types/mdx": "^2.0.11",
-        "@types/node": "20.10.0",
+        "@types/node": "22.12.0",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
         "@types/react-table": "^7.7.12",
@@ -94,7 +94,7 @@
         "typescript": "^5.5.4"
       },
       "engines": {
-        "node": "20.10.0"
+        "node": "22.12.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2020,11 +2020,11 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "46.1.3",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-46.1.3.tgz",
-      "integrity": "sha512-SVPxgmJq0glk3O1wCNOD+c9HwfCbLTxezAiq+pKZ39+s9G7lpBM06CQx/k20JhRgL+MRYE1CtnyYkk37m9U6lQ==",
+      "version": "47.0.2",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-47.0.2.tgz",
+      "integrity": "sha512-jotk1s0O9xLtsZ1IgpFMx9IF/BLJOTxEMaqqzde3ptM303WNDR32YYxYGNVtcT5RDsYBRd1OVt+AhRgciIJ2Vg==",
       "engines": {
-        "node": "20.10.0"
+        "node": "22.12.0"
       },
       "peerDependencies": {
         "@emotion/react": "^11.13.3",
@@ -2035,7 +2035,7 @@
         "@tanstack/match-sorter-utils": "^8.19.4",
         "@tanstack/react-table": "^8.19.2",
         "@tanstack/react-virtual": "^3.13.12",
-        "copy-to-clipboard": "3.3.1",
+        "copy-to-clipboard": "^3.3.1",
         "gray-matter": "^4.0.3",
         "isomorphic-dompurify": "^2.22.0",
         "ky": "^1.7.2",
@@ -2045,9 +2045,9 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-dropzone": "^14.2.3",
-        "react-gtm-module": "2.0.11",
+        "react-gtm-module": "^2.0.11",
         "react-idle-timer": "^5.7.2",
-        "react-window": "1.8.9",
+        "react-window": "^1.8.9",
         "rehype-raw": "^7.0.0",
         "rehype-react": "^7.2.0",
         "rehype-sanitize": "^5.0.1",
@@ -2056,7 +2056,7 @@
         "remark-rehype": "^10.1.0",
         "slugify": "^1.6.6",
         "unified": "^10.1.2",
-        "uuid": "8.3.2",
+        "uuid": "^8.3.2",
         "yup": "^1.6.1"
       }
     },
@@ -5670,12 +5670,17 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
-      "version": "20.10.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.0.tgz",
-      "integrity": "sha512-D0WfRmU9TQ8I9PFx9Yc+EBHw+vSpIub4IDvQivcp26PtPrdMGAq5SDcpXEo/epqa/DXotVpekHiLNTg3iaKXBQ==",
+      "version": "22.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.12.0.tgz",
+      "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.20.0"
       }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -22779,7 +22784,8 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/unified": {
       "version": "10.1.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/client-batch": "^3.896.0",
     "@aws-sdk/client-s3": "^3.896.0",
     "@aws-sdk/s3-request-presigner": "^3.896.0",
-    "@databiosphere/findable-ui": "^46.1.3",
+    "@databiosphere/findable-ui": "^47.0.2",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@hookform/resolvers": "^3.3.4",
@@ -41,7 +41,7 @@
     "isomorphic-dompurify": "^2.22.0",
     "ky": "^1.7.2",
     "next": "^14.2.33",
-    "next-auth": "^4.24.11",
+    "next-auth": "^4.24.13",
     "next-compose-plugins": "^2.2.1",
     "raw-body": "^3.0.0",
     "react": "^18.3.1",
@@ -73,7 +73,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^16.0.1",
     "@types/mdx": "^2.0.11",
-    "@types/node": "20.10.0",
+    "@types/node": "22.12.0",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@types/react-table": "^7.7.12",
@@ -108,6 +108,6 @@
     "glob": "^11.0.4"
   },
   "engines": {
-    "node": "20.10.0"
+    "node": "22.12.0"
   }
 }

--- a/site-config/hca-atlas-tracker/local/config.ts
+++ b/site-config/hca-atlas-tracker/local/config.ts
@@ -114,51 +114,51 @@ export function makeConfig(
       typography: {
         [TYPOGRAPHY_PROPS.VARIANT.BODY_LARGE_500]: {
           fontFamily: FONT_FAMILY_DIN,
-          fontSize: 18,
+          fontSize: "18px",
           fontWeight: 400,
         },
         [TYPOGRAPHY_PROPS.VARIANT.HEADING]: {
           fontFamily: FONT_FAMILY_DIN,
-          fontSize: 22,
+          fontSize: "22px",
           fontWeight: 400,
           letterSpacing: "normal",
           // eslint-disable-next-line sort-keys -- disabling key order for readability
           [MEDIA_TABLET_UP]: {
-            fontSize: 26,
+            fontSize: "26px",
             letterSpacing: "normal",
           },
         },
         [TYPOGRAPHY_PROPS.VARIANT.HEADING_LARGE]: {
           fontFamily: FONT_FAMILY_DIN,
-          fontSize: 26,
+          fontSize: "26px",
           fontWeight: 400,
           letterSpacing: "normal",
           lineHeight: "34px",
           // eslint-disable-next-line sort-keys -- disabling key order for readability
           [MEDIA_TABLET_UP]: {
-            fontSize: 32,
+            fontSize: "32px",
             letterSpacing: "normal",
           },
         },
         [TYPOGRAPHY_PROPS.VARIANT.HEADING_SMALL]: {
           fontFamily: FONT_FAMILY_DIN,
-          fontSize: 20,
+          fontSize: "20px",
           fontWeight: 400,
           letterSpacing: "normal",
           // eslint-disable-next-line sort-keys -- disabling key order for readability
           [MEDIA_TABLET_UP]: {
-            fontSize: 22,
+            fontSize: "22px",
             letterSpacing: "normal",
           },
         },
         [TYPOGRAPHY_PROPS.VARIANT.HEADING_XLARGE]: {
           fontFamily: FONT_FAMILY_DIN,
-          fontSize: 32,
+          fontSize: "32px",
           fontWeight: 400,
           letterSpacing: "normal",
           // eslint-disable-next-line sort-keys -- disabling key order for readability
           [MEDIA_TABLET_UP]: {
-            fontSize: 42,
+            fontSize: "42px",
             letterSpacing: "-0.4px",
           },
         },


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1051.

This pull request upgrades the project from Node.js 20.10.0 to Node.js 22.12.0 and updates related dependencies, configuration files, and documentation accordingly. It also makes some build configuration cleanups and minor code improvements.

**Node.js and Dependency Upgrades:**
* Upgraded Node.js version from 20.10.0 to 22.12.0 across the codebase, including `Dockerfile.node`, `.github/workflows/run-checks.yml`, `package.json` (engines and `@types/node`), and updated the documentation in `README.md` to reflect the new required version. [[1]](diffhunk://#diff-3b26ff55e8c24cd3fad4fb21c4ca6ccd77bb271c3160b6af4c7bae842359cae8L5-R5) [[2]](diffhunk://#diff-3b26ff55e8c24cd3fad4fb21c4ca6ccd77bb271c3160b6af4c7bae842359cae8L15-R15) [[3]](diffhunk://#diff-73feefd4d39943a0964a8a41565afb9780c1028252516ac839a32fb5c5dbbd32L11-R11) [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L76-R76) [[5]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L111-R111) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R7)
* Updated dependencies in `package.json`: upgraded `@databiosphere/findable-ui` and `next-auth` to newer versions. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L25-R25) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L44-R44)

**Build and Configuration Cleanups:**
* Removed unnecessary Webpack aliases and some ESM packages from the Next.js configuration in `next.config.mjs`, simplifying the build process. [[1]](diffhunk://#diff-18c049b08c4a0f5ab451c598aeb2c4848bb9d7877b51ca3e5effb94a225814d2L3-L6) [[2]](diffhunk://#diff-18c049b08c4a0f5ab451c598aeb2c4848bb9d7877b51ca3e5effb94a225814d2L17-L18) [[3]](diffhunk://#diff-18c049b08c4a0f5ab451c598aeb2c4848bb9d7877b51ca3e5effb94a225814d2L46-L105)
* Changed the MDX serialization option to enable development mode only when `NODE_ENV` is set to development, improving local development experience.

**Minor Code Improvements:**
* Standardized all font size values to use pixel units as strings (e.g., `"18px"`) in the typography configuration in `site-config/hca-atlas-tracker/local/config.ts` for consistency and CSS compatibility.