### PR TITLE
feat: remove default grouping on atlas list page (#1091)

### DIFF
--- a/site-config/hca-atlas-tracker/local/index/atlas/tableOptions.ts
+++ b/site-config/hca-atlas-tracker/local/index/atlas/tableOptions.ts
@@ -20,16 +20,7 @@ export const TABLE_OPTIONS: ListConfig<HCAAtlasTrackerListAtlas>["tableOptions"]
         [HCA_ATLAS_TRACKER_CATEGORY_KEY.WAVE]: false,
       },
       expanded: true,
-      grouping: [HCA_ATLAS_TRACKER_CATEGORY_KEY.TARGET_COMPLETION_DATE],
       sorting: [
-        {
-          desc: SORT_DIRECTION.ASCENDING,
-          id: HCA_ATLAS_TRACKER_CATEGORY_KEY.TARGET_COMPLETION_DATE,
-        },
-        {
-          desc: SORT_DIRECTION.DESCENDING,
-          id: HCA_ATLAS_TRACKER_CATEGORY_KEY.PUBLICATION_STATUS,
-        },
         {
           desc: SORT_DIRECTION.ASCENDING,
           id: HCA_ATLAS_TRACKER_CATEGORY_KEY.NAME,


### PR DESCRIPTION
Closes #1091.

This pull request makes a small change to the table options configuration for the HCA Atlas Tracker. The change removes grouping and sorting by `TARGET_COMPLETION_DATE` and `PUBLICATION_STATUS`, leaving only sorting by `NAME`.

- Removed grouping by `TARGET_COMPLETION_DATE` and sorting by `TARGET_COMPLETION_DATE` and `PUBLICATION_STATUS` from the `TABLE_OPTIONS` in `atlas/tableOptions.ts`.

<img width="2323" height="1075" alt="image" src="https://github.com/user-attachments/assets/c9fbec76-f637-4013-8de2-9ff084c8b664" />
