### PR TITLE
docs: use concept ID as SD/IO ID for stable identity #1041

### DIFF
--- a/docs/prd-versioning.md
+++ b/docs/prd-versioning.md
@@ -592,15 +592,15 @@ ALTER TABLE hat.files ADD COLUMN concept_id UUID REFERENCES hat.concepts(id);
 
 **Migration:**
 
-1. Create concepts from existing SD/IO records using (short_name, network, generation, base_filename, file_type)
-2. Update SD/IO `id` to match concept `id` (requires updating FK references in atlases arrays)
+1. Create concepts using existing SD/IO `id` as concept `id` (no need to update SD/IO ids or atlas arrays)
+2. Populate concept fields (short_name, network, generation, base_filename, file_type) from SD/IO records
 3. Populate `file.concept_id` based on linked SD/IO
 4. Generation is derived from S3 key (e.g., `gut/gut_v1_0/...` → generation 1)
 
 **Acceptance Criteria:**
 
 - [ ] Concepts table created with proper indexes
-- [ ] Existing SD/IO ids updated to reference concepts
+- [ ] Concepts created with ids matching existing SD/IO ids
 - [ ] Existing files have concept_id populated
 - [ ] Uniqueness enforced on (atlas_short_name, network, generation, base_filename, file_type)
 - [ ] All version rows for same SD/IO share the same `id` (concept ID)


### PR DESCRIPTION
## Summary

- Concept ID becomes the stable identity across all SD/IO versions
- All version rows for same SD/IO share the same `id` (= concept ID)
- `version_id` remains unique per row (identifies specific version)

**Stacked on:** #1093

## Key Changes

| Field | Meaning |
|-------|---------|
| `source_datasets.id` | = concept ID (stable across all versions) |
| `source_datasets.version_id` | Unique per row (identifies specific version) |

## Tickets Updated

- **1.1**: Added FK constraints, migration steps for updating existing SD/IO ids
- **1.2**: SD/IO version rows created with `id` = concept id
- **1.3**: Merge updates source SD/IO rows to use target's id

🤖 Generated with [Claude Code](https://claude.ai/code)