### PR TITLE
feat: add concepts table for concept-based identity #1099

### DIFF
--- a/__tests__/data-files.test.ts
+++ b/__tests__/data-files.test.ts
@@ -225,6 +225,7 @@ describe("upsertFileRecord", () => {
         atlasId: ATLAS_DRAFT.id,
         bucket: TEST_BUCKET,
         componentAtlasId: COMPONENT_ATLAS_DRAFT_FOO.id, // Valid UUID
+        conceptId: null,
         etag: TEST_ETAG,
         eventInfo: TEST_EVENT_INFO,
         fileType: FILE_TYPE.INTEGRATED_OBJECT,
@@ -264,6 +265,7 @@ describe("upsertFileRecord", () => {
         atlasId: ATLAS_DRAFT.id,
         bucket: TEST_BUCKET,
         componentAtlasId: COMPONENT_ATLAS_DRAFT_FOO.id, // Valid UUID for integrated_object
+        conceptId: null,
         etag: TEST_ETAG,
         eventInfo: TEST_EVENT_INFO,
         fileType: FILE_TYPE.INTEGRATED_OBJECT,
@@ -304,6 +306,7 @@ describe("upsertFileRecord", () => {
         atlasId: null,
         bucket: TEST_BUCKET,
         componentAtlasId: null, // Must be null for source_dataset
+        conceptId: null,
         etag: TEST_ETAG_ALT,
         eventInfo: TEST_EVENT_INFO,
         fileType: FILE_TYPE.SOURCE_DATASET,
@@ -341,6 +344,7 @@ describe("upsertFileRecord", () => {
         atlasId: ATLAS_DRAFT.id,
         bucket: TEST_BUCKET,
         componentAtlasId: COMPONENT_ATLAS_DRAFT_FOO.id, // Valid UUID for integrated_object
+        conceptId: null,
         etag: "original-etag",
         eventInfo: TEST_EVENT_INFO,
         fileType: FILE_TYPE.INTEGRATED_OBJECT,

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -427,6 +427,7 @@ export type HCAAtlasTrackerDBSourceDatasetForDetailAPI =
 
 export interface HCAAtlasTrackerDBFile {
   bucket: string;
+  concept_id: string | null;
   created_at: Date;
   dataset_info: HCAAtlasTrackerDBFileDatasetInfo | null;
   etag: string;
@@ -450,6 +451,16 @@ export interface HCAAtlasTrackerDBFile {
   validation_status: FILE_VALIDATION_STATUS;
   validation_summary: FileValidationSummary | null;
   version_id: string | null;
+}
+
+export interface HCAAtlasTrackerDBConcept {
+  atlas_short_name: string;
+  base_filename: string;
+  created_at: Date;
+  file_type: string;
+  generation: number;
+  id: string;
+  network: string;
 }
 
 export interface HCAAtlasTrackerDBFileDatasetInfo {

--- a/app/data/concepts.ts
+++ b/app/data/concepts.ts
@@ -1,0 +1,48 @@
+import pg from "pg";
+
+export interface ConceptData {
+  atlasShortName: string;
+  baseFilename: string;
+  fileType: string;
+  generation: number;
+  network: string;
+}
+
+/**
+ * Find an existing concept or create a new one based on the unique tuple.
+ * Uses INSERT ... ON CONFLICT to atomically find-or-create.
+ * @param data - Concept identifying fields.
+ * @param client - Postgres client (transaction).
+ * @returns The concept's UUID.
+ */
+export async function findOrCreateConcept(
+  data: ConceptData,
+  client: pg.PoolClient,
+): Promise<string> {
+  // Attempt insert; on conflict (concept already exists), do nothing
+  const result = await client.query<{ id: string }>(
+    `
+      WITH new_concept AS (
+        INSERT INTO hat.concepts (atlas_short_name, network, generation, base_filename, file_type)
+        VALUES ($1, $2, $3, $4, $5)
+        ON CONFLICT (atlas_short_name, network, generation, base_filename, file_type)
+        DO NOTHING
+        RETURNING id
+      )
+      SELECT id FROM new_concept
+      UNION ALL
+      SELECT id FROM hat.concepts
+      WHERE atlas_short_name = $1 AND network = $2 AND generation = $3 AND base_filename = $4 AND file_type = $5
+      LIMIT 1
+    `,
+    [
+      data.atlasShortName,
+      data.network,
+      data.generation,
+      data.baseFilename,
+      data.fileType,
+    ],
+  );
+
+  return result.rows[0].id;
+}

--- a/app/data/files.ts
+++ b/app/data/files.ts
@@ -343,6 +343,7 @@ async function getTypeFilesMissingFromAtlas(
 
 export interface FileUpsertData {
   bucket: string;
+  conceptId?: string | null;
   etag: string;
   eventInfo: string;
   fileType: string;
@@ -398,18 +399,18 @@ export async function upsertFileRecord(
   // For same ETag, this is likely a duplicate notification; handle via ON CONFLICT
 
   const result = await transaction.query<FileUpsertResult>(
-    `INSERT INTO hat.files (bucket, key, version_id, etag, size_bytes, event_info, sha256_client, integrity_status, validation_status, is_latest, file_type, sns_message_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-       
+    `INSERT INTO hat.files (bucket, key, version_id, etag, size_bytes, event_info, sha256_client, integrity_status, validation_status, is_latest, file_type, sns_message_id, concept_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+
        -- Handle conflicts on sns_message_id (proper SNS idempotency)
-       ON CONFLICT (sns_message_id) 
-       DO UPDATE SET 
+       ON CONFLICT (sns_message_id)
+       DO UPDATE SET
          etag = files.etag,  -- Keep existing ETag (no change)
          event_info = files.event_info,
          updated_at = CURRENT_TIMESTAMP
        WHERE files.etag = EXCLUDED.etag
-       
-       RETURNING 
+
+       RETURNING
          (CASE WHEN xmax = 0 THEN 'inserted' ELSE 'updated' END) as operation,
          etag,
          id`,
@@ -426,6 +427,7 @@ export async function upsertFileRecord(
       true,
       fileData.fileType,
       fileData.snsMessageId,
+      fileData.conceptId ?? null,
     ],
   );
 

--- a/app/services/component-atlases.ts
+++ b/app/services/component-atlases.ts
@@ -260,12 +260,14 @@ export async function deleteSourceDatasetsFromComponentAtlas(
  * Create a new component atlas.
  * @param atlasId - ID of the parent atlas.
  * @param fileId - Associated file ID for the new component atlas to reference.
+ * @param conceptId - Concept ID to use as the component atlas's stable `id`.
  * @param client - Optional database client for transactions.
  * @returns the created component atlas.
  */
 export async function createComponentAtlas(
   atlasId: string,
   fileId: string,
+  conceptId: string,
   client?: pg.PoolClient,
 ): Promise<HCAAtlasTrackerDBComponentAtlas> {
   const info: HCAAtlasTrackerDBComponentAtlasInfo = {
@@ -275,11 +277,11 @@ export async function createComponentAtlas(
   return doOrContinueTransaction(client, async (client) => {
     const result = await query<HCAAtlasTrackerDBComponentAtlas>(
       `
-        INSERT INTO hat.component_atlases (component_info, file_id)
-        VALUES ($1, $2)
+        INSERT INTO hat.component_atlases (component_info, file_id, id)
+        VALUES ($1, $2, $3)
         RETURNING *
       `,
-      [JSON.stringify(info), fileId],
+      [JSON.stringify(info), fileId, conceptId],
       client,
     );
 

--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -146,19 +146,21 @@ export async function getComponentAtlasSourceDataset(
 /**
  * Create a source dataset.
  * @param fileId - Associated file ID for the new source dataset to reference.
+ * @param conceptId - Concept ID to use as the source dataset's stable `id`.
  * @param client - Postgres client to reuse an existing transaction.
  * @returns version ID of the created source dataset.
  */
 export async function createSourceDataset(
   fileId: string,
+  conceptId: string,
   client: pg.PoolClient,
 ): Promise<string> {
   const info = createSourceDatasetInfo();
   const insertResult = await client.query<
     Pick<HCAAtlasTrackerDBSourceDataset, "version_id">
   >(
-    "INSERT INTO hat.source_datasets (sd_info, file_id) VALUES ($1, $2) RETURNING version_id",
-    [JSON.stringify(info), fileId],
+    "INSERT INTO hat.source_datasets (sd_info, file_id, id) VALUES ($1, $2, $3) RETURNING version_id",
+    [JSON.stringify(info), fileId, conceptId],
   );
   return insertResult.rows[0].version_id;
 }

--- a/app/utils/concepts.ts
+++ b/app/utils/concepts.ts
@@ -1,0 +1,35 @@
+/**
+ * Strip version suffix from a filename.
+ * Removes patterns like `-r1`, `-r2-wip-3` from `.h5ad` filenames.
+ * @param filename - The filename to strip the version suffix from.
+ * @returns The filename with any version suffix removed.
+ * @example
+ * stripVersionSuffix("foo-r1-wip-2.h5ad") // "foo.h5ad"
+ * stripVersionSuffix("foo-r2.h5ad") // "foo.h5ad"
+ * stripVersionSuffix("foo.h5ad") // "foo.h5ad"
+ * stripVersionSuffix("foo.csv") // "foo.csv" (unchanged, not .h5ad)
+ */
+export function stripVersionSuffix(filename: string): string {
+  return filename.replace(/-r\d+(-wip-\d+)?(?=\.h5ad$)/, "");
+}
+
+/**
+ * Extract the generation number from an S3 atlas version string.
+ * The generation is the first (major) number in the version.
+ * @param s3Version - Version string from S3 path (e.g., "1", "1-1", "2-3")
+ * @returns The generation number.
+ * @example
+ * extractGeneration("1") // 1
+ * extractGeneration("1-1") // 1
+ * extractGeneration("2-3") // 2
+ */
+export function extractGeneration(s3Version: string): number {
+  const major = s3Version.split("-")[0];
+  const generation = parseInt(major, 10);
+  if (isNaN(generation)) {
+    throw new Error(
+      `Invalid S3 version format: ${s3Version}. Cannot extract generation.`,
+    );
+  }
+  return generation;
+}

--- a/migrations/1769500000000_concepts-table.ts
+++ b/migrations/1769500000000_concepts-table.ts
@@ -1,0 +1,176 @@
+import { MigrationBuilder } from "node-pg-migrate";
+
+export function up(pgm: MigrationBuilder): void {
+  // 1. Create the concepts table
+  pgm.createTable(
+    { name: "concepts", schema: "hat" },
+    {
+      atlas_short_name: {
+        notNull: true,
+        type: "text",
+      },
+      base_filename: {
+        notNull: true,
+        type: "text",
+      },
+      created_at: {
+        default: pgm.func("NOW()"),
+        type: "timestamp",
+      },
+      file_type: {
+        notNull: true,
+        type: "text",
+      },
+      generation: {
+        notNull: true,
+        type: "integer",
+      },
+      id: {
+        default: pgm.func("gen_random_uuid()"),
+        notNull: true,
+        primaryKey: true,
+        type: "uuid",
+      },
+      network: {
+        notNull: true,
+        type: "text",
+      },
+    },
+  );
+
+  // 2. Create unique index for concept identity
+  pgm.createIndex(
+    { name: "concepts", schema: "hat" },
+    ["atlas_short_name", "network", "generation", "base_filename", "file_type"],
+    {
+      name: "idx_concepts_unique",
+      unique: true,
+    },
+  );
+
+  // 3. Add concept_id column to files table (nullable for now)
+  pgm.addColumns(
+    { name: "files", schema: "hat" },
+    {
+      concept_id: {
+        type: "uuid",
+      },
+    },
+  );
+
+  // 4. Data migration: Create concepts from existing source datasets.
+  //    Use each SD's `id` as the concept's `id` so the FK will be valid.
+  //    Extract (atlas_short_name, network, generation, base_filename) from the S3 key of the latest file.
+  pgm.sql(`
+    INSERT INTO hat.concepts (id, atlas_short_name, network, generation, base_filename, file_type)
+    SELECT DISTINCT ON (sd.id)
+      sd.id,
+      -- Extract short name: second path segment with version suffix removed
+      -- e.g., 'gut-v1' -> 'gut', 'retina-v1-1' -> 'retina'
+      regexp_replace(split_part(f.key, '/', 2), '-v\\d+(-\\d+)*$', ''),
+      -- Extract network: first path segment
+      split_part(f.key, '/', 1),
+      -- Extract generation: first number after -v in second path segment
+      (regexp_match(split_part(f.key, '/', 2), '-v(\\d+)'))[1]::integer,
+      -- Strip version suffix from filename to get base_filename
+      regexp_replace(
+        substring(f.key from '[^/]+$'),
+        '-r\\d+(-wip-\\d+)?\\.h5ad$',
+        '.h5ad'
+      ),
+      'source_dataset'
+    FROM hat.source_datasets sd
+    JOIN hat.files f ON f.id = sd.file_id
+    WHERE sd.is_latest
+  `);
+
+  // 5. Data migration: Create concepts from existing component atlases (integrated objects).
+  pgm.sql(`
+    INSERT INTO hat.concepts (id, atlas_short_name, network, generation, base_filename, file_type)
+    SELECT DISTINCT ON (ca.id)
+      ca.id,
+      regexp_replace(split_part(f.key, '/', 2), '-v\\d+(-\\d+)*$', ''),
+      split_part(f.key, '/', 1),
+      (regexp_match(split_part(f.key, '/', 2), '-v(\\d+)'))[1]::integer,
+      regexp_replace(
+        substring(f.key from '[^/]+$'),
+        '-r\\d+(-wip-\\d+)?\\.h5ad$',
+        '.h5ad'
+      ),
+      'integrated_object'
+    FROM hat.component_atlases ca
+    JOIN hat.files f ON f.id = ca.file_id
+    WHERE ca.is_latest
+  `);
+
+  // 6. Populate concept_id on files linked to source datasets
+  pgm.sql(`
+    UPDATE hat.files f
+    SET concept_id = sd.id
+    FROM hat.source_datasets sd
+    WHERE sd.file_id = f.id
+  `);
+
+  // 7. Populate concept_id on files linked to component atlases
+  pgm.sql(`
+    UPDATE hat.files f
+    SET concept_id = ca.id
+    FROM hat.component_atlases ca
+    WHERE ca.file_id = f.id
+  `);
+
+  // 8. Add FK: source_datasets.id -> concepts.id
+  pgm.addConstraint(
+    { name: "source_datasets", schema: "hat" },
+    "fk_sd_concept",
+    {
+      foreignKeys: {
+        columns: "id",
+        references: { name: "concepts", schema: "hat" },
+      },
+    },
+  );
+
+  // 9. Add FK: component_atlases.id -> concepts.id
+  pgm.addConstraint(
+    { name: "component_atlases", schema: "hat" },
+    "fk_io_concept",
+    {
+      foreignKeys: {
+        columns: "id",
+        references: { name: "concepts", schema: "hat" },
+      },
+    },
+  );
+
+  // 10. Add FK: files.concept_id -> concepts.id
+  pgm.addConstraint({ name: "files", schema: "hat" }, "fk_files_concept", {
+    foreignKeys: {
+      columns: "concept_id",
+      references: { name: "concepts", schema: "hat" },
+    },
+  });
+}
+
+export function down(pgm: MigrationBuilder): void {
+  // Drop FK: files.concept_id -> concepts.id
+  pgm.dropConstraint({ name: "files", schema: "hat" }, "fk_files_concept");
+
+  // Drop FK: component_atlases.id -> concepts.id
+  pgm.dropConstraint(
+    { name: "component_atlases", schema: "hat" },
+    "fk_io_concept",
+  );
+
+  // Drop FK: source_datasets.id -> concepts.id
+  pgm.dropConstraint(
+    { name: "source_datasets", schema: "hat" },
+    "fk_sd_concept",
+  );
+
+  // Drop concept_id column from files
+  pgm.dropColumns({ name: "files", schema: "hat" }, ["concept_id"]);
+
+  // Drop concepts table (cascade drops index)
+  pgm.dropTable({ name: "concepts", schema: "hat" });
+}

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -312,6 +312,10 @@ export function fillTestFileDefaults(file: TestFile): NormalizedTestFile {
   };
 }
 
+export function resolveTestAtlas(file: TestFile): TestAtlas {
+  return typeof file.atlas === "function" ? file.atlas() : file.atlas;
+}
+
 export function getTestFileKey(file: TestFile, atlas: TestAtlas): string {
   let folderName: string;
   switch (file.fileType) {


### PR DESCRIPTION
- Create hat.concepts table with unique composite index
- Add stripVersionSuffix() and findOrCreateConcept()
- Integrate concept lookup into S3 upload workflow
- Update createSourceDataset/createComponentAtlas for concept ID
- Add concept_id FK to files, SD.id/IO.id FK to concepts
- Data migration: backfill concepts from existing records
- Update test infrastructure for concept support

https://claude.ai/code/session_012qCHkcEvqPqriNphkXnmWH