### PR TITLE
docs: merge small FE tickets into full-stack tickets #1041

### DIFF
--- a/docs/prd-versioning.md
+++ b/docs/prd-versioning.md
@@ -766,16 +766,18 @@ ALTER TABLE hat.source_datasets ADD COLUMN revision integer NOT NULL DEFAULT 1;
 ALTER TABLE hat.component_atlases ADD COLUMN revision integer NOT NULL DEFAULT 1;
 ```
 
-**Code:** Update version creation functions to copy `revision` from previous version.
+**Code:** Update version creation functions to copy `revision` from previous row and bump `wip_number`. Revision stays constant while draft; only bumps after publish (handled in Slice 4).
 
 **Frontend:** Display SD/IO version as `r{revision}-wip-{wip}` in UI.
 
 **Acceptance Criteria:**
 
-- [ ] Migration adds revision columns
-- [ ] Version creation copies revision from previous version
+- [ ] Migration adds revision columns (existing SD/IOs get revision=1)
+- [ ] New SD/IO version row copies `revision` from previous row and bumps `wip_number`
 - [ ] API responses include revision
 - [ ] SD/IO version displays as `r{revision}-wip-{wip}` in UI
+
+**Note:** Revision increment (when uploading after publish) handled in Slice 4.
 
 ---
 


### PR DESCRIPTION
## Summary

**Merge small tickets into full-stack tickets:**
- Slice 2: 2.1 + 2.2 → 2.1 (atlas generation/revision + display)
- Slice 3: 3.1 + 3.2 → 3.1 (SD/IO revision + display)
- Slice 5: 5.1 + 5.2 → 5.1 (create atlas version + UI)

**Detail Ticket 2.1 frontend changes:**
- Atlas list: version column uses generation/revision fields
- Add Atlas → "Add Atlas Family": remove Version input, always v1.0
- Edit Atlas: version becomes read-only
- New generation/revision creation deferred to Slice 5

**Clarify Ticket 3.1 revision/wip behavior:**
- New SD/IO version row copies `revision` from previous row and bumps `wip_number`
- Revision increment after publish handled in Slice 4

## Depends on
- #1105

## Test plan
- [ ] Review PRD changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)