### PR TITLE
fix: bug can't create or edit a source study (#1113)

### DIFF
--- a/app/views/AddNewSourceStudyView/hooks/useAddSourceStudyFormManager.ts
+++ b/app/views/AddNewSourceStudyView/hooks/useAddSourceStudyFormManager.ts
@@ -53,13 +53,18 @@ export const useAddSourceStudyFormManager = (
 };
 
 /**
- * Filters the payload to exclude the publication status.
+ * Filters the payload to only include fields relevant to the publication status.
  * @param payload - Payload.
- * @returns filtered payload (payload without the publication status).
+ * @returns filtered payload.
  */
 function filterPayload(payload: NewSourceStudyData): NewSourceStudyData {
+  const fieldsToInclude: NewSourceStudyDataKeys[] =
+    payload.publicationStatus === PUBLICATION_STATUS.PUBLISHED_PREPRINT
+      ? PUBLISHED_PREPRINT_FIELDS
+      : NO_DOI_FIELDS;
+
   return Object.entries(payload).reduce((acc, [key, value]) => {
-    if (key !== FIELD_NAME.PUBLICATION_STATUS) {
+    if (fieldsToInclude.includes(key as NewSourceStudyDataKeys)) {
       return { ...acc, [key]: value };
     }
     return acc;

--- a/app/views/SourceStudyView/hooks/useEditSourceStudyFormManager.ts
+++ b/app/views/SourceStudyView/hooks/useEditSourceStudyFormManager.ts
@@ -54,13 +54,20 @@ export const useEditSourceStudyFormManager = (
 };
 
 /**
- * Filters the payload to exclude the publication status.
+ * Filters the payload to only include fields relevant to the publication status.
  * @param payload - Payload.
- * @returns filtered payload (payload without the publication status).
+ * @returns filtered payload.
  */
 function filterPayload(payload: SourceStudyEditData): SourceStudyEditData {
+  const fieldsToInclude =
+    payload.publicationStatus === PUBLICATION_STATUS.PUBLISHED_PREPRINT
+      ? [...PUBLISHED_PREPRINT_FIELDS]
+      : [...NO_DOI_FIELDS];
+
+  fieldsToInclude.push("capId"); // @deprecated - legacy field required by BE but not shown in UI. Remove when BE removes capId.
+
   return Object.entries(payload).reduce((acc, [key, value]) => {
-    if (key !== FIELD_NAME.PUBLICATION_STATUS) {
+    if (fieldsToInclude.includes(key as SourceStudyEditDataKeys)) {
       return { ...acc, [key]: value };
     }
     return acc;


### PR DESCRIPTION
Closes #1113.

## Summary
- Update `useAddSourceStudyFormManager` and `useEditSourceStudyFormManager` to filter payload fields based on publication status
- Only includes fields relevant to the selected publication status (published preprint vs no DOI) instead of excluding just the publication status field
- Maintains backward compatibility by including deprecated `capId` field in edit form

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This pull request updates the logic for filtering payload fields in both the add and edit source study form managers. The main improvement is that the payload is now filtered to include only the fields relevant to the current publication status, rather than just excluding the publication status field. Additionally, a legacy field (`capId`) is explicitly included for backward compatibility in the edit form manager.

**Form payload filtering improvements:**

* The `filterPayload` function in both `useAddSourceStudyFormManager` and `useEditSourceStudyFormManager` now includes only fields relevant to the selected publication status, using `PUBLISHED_PREPRINT_FIELDS` or `NO_DOI_FIELDS` as appropriate. [[1]](diffhunk://#diff-cffd61d3c162026fb3de5b2e567d5674baf8415bfea5a82f2a1dd1fdb9352b3cL56-R67) [[2]](diffhunk://#diff-eb920088562a8c1e8760796eb8de2f5ec6a4c1cbf730a6433b8ace5ebd4becacL57-R70)
* In the edit form manager, the legacy `capId` field is always included in the filtered payload to meet backend requirements, with a comment noting its eventual removal.