### PR TITLE
fix: allow content admins to edit DOI on existing source studies (#1121)

### DIFF
--- a/app/components/Detail/components/TrackerForm/components/Section/components/SourceStudy/components/View/components/GeneralInfo/generalInfo.tsx
+++ b/app/components/Detail/components/TrackerForm/components/Section/components/SourceStudy/components/View/components/GeneralInfo/generalInfo.tsx
@@ -49,7 +49,6 @@ export const GeneralInfo = ({
   } = formMethod;
   const watchedFields = watch([FIELD_NAME.DOI, FIELD_NAME.PUBLICATION_STATUS]);
   const [doi, publicationStatus] = watchedFields;
-  const defaultDoi = formMethod.formState.defaultValues?.[FIELD_NAME.DOI];
   const hasDoi = Boolean(doi);
 
   // Callback to handle tab change; clears errors, sets publication status, and updates form value.
@@ -103,7 +102,7 @@ export const GeneralInfo = ({
                         )}
                       </Fragment>
                     }
-                    readOnly={Boolean(defaultDoi) || isReadOnly}
+                    readOnly={isReadOnly}
                   />
                 )}
               />


### PR DESCRIPTION
Closes #1121.

This pull request makes a minor change to the `GeneralInfo` component by updating the logic for the `readOnly` property on the DOI input field. Now, the field is set to read-only only if the form is in a read-only state, rather than also checking for a default DOI value.

* The `readOnly` property on the DOI input is now determined solely by the `isReadOnly` flag, removing the previous check for a default DOI value. [[1]](diffhunk://#diff-b14843e04fb7a5ca7fd02483b00c704cc9e505e9114436b7626e3ec13c1a053eL52) [[2]](diffhunk://#diff-b14843e04fb7a5ca7fd02483b00c704cc9e505e9114436b7626e3ec13c1a053eL106-R105)

<img width="1441" height="900" alt="image" src="https://github.com/user-attachments/assets/d8b165e8-d8cf-442c-be51-8006b3ceb35f" />
