### PR TITLE
fix: use `baseFileName` for integrated object source datasets file name accessor key (#1131)

### DIFF
--- a/app/views/IntegratedObjectSourceDatasetsView/components/Table/columns.ts
+++ b/app/views/IntegratedObjectSourceDatasetsView/components/Table/columns.ts
@@ -42,7 +42,7 @@ const COLUMN_DISEASE: ColumnDef<IntegratedObjectSourceDataset> = {
 };
 
 const COLUMN_FILE_NAME: ColumnDef<IntegratedObjectSourceDataset> = {
-  accessorKey: "fileName",
+  accessorKey: "baseFileName",
   cell: renderFileName,
   header: "File Name",
   meta: { columnPinned: true, width: { max: "2fr", min: "220px" } },


### PR DESCRIPTION
Closes #1131