### PR TITLE
feat: add backend support for creating new atlas revisions (#1137)

### DIFF
--- a/__tests__/api-atlases-id-versions.test.ts
+++ b/__tests__/api-atlases-id-versions.test.ts
@@ -1,0 +1,213 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
+import { HCAAtlasTrackerAtlas } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "../app/common/entities";
+import { endPgPool } from "../app/services/database";
+import versionsHandler from "../pages/api/atlases/[atlasId]/versions";
+import {
+  ATLAS_PUBLISHED,
+  ATLAS_PUBLISHED_R6,
+  ATLAS_WITH_DRAFT_LATEST_R0,
+  ATLAS_WITH_DRAFT_LATEST_R1,
+  SOURCE_STUDY_PUBLISHED,
+  STAKEHOLDER_ANALOGOUS_ROLES,
+  USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
+  USER_UNREGISTERED,
+} from "../testing/constants";
+import {
+  getExistingAtlasFromDatabase,
+  getValidationsByEntityId,
+  resetDatabase,
+} from "../testing/db-utils";
+import { TestUser } from "../testing/entities";
+import {
+  assertExpectDefined,
+  delay,
+  expectApiAtlasToMatchTestWithoutRevision,
+  expectDbAtlasToMatchApi,
+  testApiRole,
+  withConsoleErrorHiding,
+} from "../testing/utils";
+
+jest.mock(
+  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+);
+jest.mock("../app/utils/crossref/crossref-api");
+jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/cellxgene");
+jest.mock("../app/utils/pg-app-connect-config");
+
+jest.mock("googleapis");
+jest.mock("next-auth");
+
+const TEST_ROUTE = "/api/atlases/[id]/versions";
+
+const ATLAS_ID_NONEXISTENT = "f643a5ff-0803-4bf1-b650-184161220bc2";
+
+beforeAll(async () => {
+  await resetDatabase();
+});
+
+afterAll(async () => {
+  endPgPool();
+});
+
+describe(TEST_ROUTE, () => {
+  it("returns error 405 for GET request", async () => {
+    expect(
+      (
+        await doVersionsRequest(
+          ATLAS_PUBLISHED.id,
+          USER_CONTENT_ADMIN,
+          false,
+          METHOD.GET,
+        )
+      )._getStatusCode(),
+    ).toEqual(405);
+  });
+
+  it("returns error 401 when requested by logged out user", async () => {
+    expect(
+      (
+        await doVersionsRequest(ATLAS_PUBLISHED.id, undefined, true)
+      )._getStatusCode(),
+    ).toEqual(401);
+  });
+
+  it("returns error 403 when requested by unregistered user", async () => {
+    expect(
+      (
+        await doVersionsRequest(ATLAS_PUBLISHED.id, USER_UNREGISTERED, true)
+      )._getStatusCode(),
+    ).toEqual(403);
+  });
+
+  it("returns error 403 when requested by disabled user", async () => {
+    expect(
+      (
+        await doVersionsRequest(ATLAS_PUBLISHED.id, USER_DISABLED_CONTENT_ADMIN)
+      )._getStatusCode(),
+    ).toEqual(403);
+  });
+
+  for (const role of STAKEHOLDER_ANALOGOUS_ROLES) {
+    testApiRole(
+      "returns error 403",
+      TEST_ROUTE,
+      versionsHandler,
+      METHOD.POST,
+      role,
+      getQueryValues(ATLAS_PUBLISHED.id),
+      undefined,
+      false,
+      (res) => {
+        expect(res._getStatusCode()).toEqual(403);
+      },
+    );
+  }
+
+  it("returns error 404 when nonexistent atlas is requested", async () => {
+    expect(
+      (
+        await doVersionsRequest(ATLAS_ID_NONEXISTENT, USER_CONTENT_ADMIN, true)
+      )._getStatusCode(),
+    ).toEqual(404);
+  });
+
+  it("returns error 400 when non-latest atlas with published latest is requested", async () => {
+    expect(
+      (
+        await doVersionsRequest(ATLAS_PUBLISHED_R6.id, USER_CONTENT_ADMIN, true)
+      )._getStatusCode(),
+    ).toEqual(400);
+  });
+
+  it("returns error 400 when non-latest atlas with draft latest is requested", async () => {
+    expect(
+      (
+        await doVersionsRequest(
+          ATLAS_WITH_DRAFT_LATEST_R0.id,
+          USER_CONTENT_ADMIN,
+          true,
+        )
+      )._getStatusCode(),
+    ).toEqual(400);
+  });
+
+  it("returns error 400 when draft atlas is requested", async () => {
+    expect(
+      (
+        await doVersionsRequest(
+          ATLAS_WITH_DRAFT_LATEST_R1.id,
+          USER_CONTENT_ADMIN,
+          true,
+        )
+      )._getStatusCode(),
+    ).toEqual(400);
+  });
+
+  it("creates new revision of published atlas, copying fields and updating linked entities as appropriate", async () => {
+    const validationsBefore = await getValidationsByEntityId(
+      SOURCE_STUDY_PUBLISHED.id,
+    );
+
+    await delay(10); // Add a delay to ensure different timestamps
+
+    const res = await doVersionsRequest(ATLAS_PUBLISHED.id, USER_CONTENT_ADMIN);
+    expect(res._getStatusCode()).toEqual(201);
+
+    const newAtlas = res._getJSONData() as HCAAtlasTrackerAtlas;
+
+    expect(newAtlas.id).not.toEqual(ATLAS_PUBLISHED.id);
+    expect(newAtlas.revision).toEqual(ATLAS_PUBLISHED.revision + 1);
+    expect(newAtlas.publishedAt).toBeNull();
+    expect(newAtlas.isLatest).toEqual(true);
+    expectApiAtlasToMatchTestWithoutRevision(newAtlas, ATLAS_PUBLISHED);
+    expectDbAtlasToMatchApi(
+      await getExistingAtlasFromDatabase(newAtlas.id),
+      newAtlas,
+      1,
+    );
+
+    const validationsAfter = await getValidationsByEntityId(
+      SOURCE_STUDY_PUBLISHED.id,
+    );
+
+    expect(validationsAfter).toHaveLength(validationsBefore.length);
+
+    for (const validationAfter of validationsAfter) {
+      const validationBefore = validationsBefore.find(
+        (v) => v.id === validationAfter.id,
+      );
+      assertExpectDefined(validationBefore);
+      expect(validationAfter.updated_at.getTime()).toBeGreaterThan(
+        validationBefore.updated_at.getTime(),
+      );
+      expect(validationAfter.atlas_ids).toContain(ATLAS_PUBLISHED.id);
+      expect(validationAfter.atlas_ids).toContain(newAtlas.id);
+    }
+  });
+});
+
+async function doVersionsRequest(
+  atlasId: string,
+  user?: TestUser,
+  hideConsoleError = false,
+  method = METHOD.POST,
+): Promise<httpMocks.MockResponse<NextApiResponse>> {
+  const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>({
+    headers: { authorization: user?.authorization },
+    method,
+    query: getQueryValues(atlasId),
+  });
+  await withConsoleErrorHiding(
+    () => versionsHandler(req, res),
+    hideConsoleError,
+  );
+  return res;
+}
+
+function getQueryValues(atlasId: string): Record<string, string> {
+  return { atlasId };
+}

--- a/__tests__/api-atlases-id-versions.test.ts
+++ b/__tests__/api-atlases-id-versions.test.ts
@@ -13,10 +13,12 @@ import {
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
+  USER_INTEGRATION_LEAD_PUBLISHED,
   USER_UNREGISTERED,
 } from "../testing/constants";
 import {
   getExistingAtlasFromDatabase,
+  getUserFromDatabaseByEmail,
   getValidationsByEntityId,
   resetDatabase,
 } from "../testing/db-utils";
@@ -187,6 +189,15 @@ describe(TEST_ROUTE, () => {
       expect(validationAfter.atlas_ids).toContain(ATLAS_PUBLISHED.id);
       expect(validationAfter.atlas_ids).toContain(newAtlas.id);
     }
+
+    const integrationLead = await getUserFromDatabaseByEmail(
+      USER_INTEGRATION_LEAD_PUBLISHED.email,
+    );
+    assertExpectDefined(integrationLead);
+    expect(integrationLead.role_associated_resource_ids).toContain(
+      ATLAS_PUBLISHED.id,
+    );
+    expect(integrationLead.role_associated_resource_ids).toContain(newAtlas.id);
   });
 });
 

--- a/__tests__/api-atlases-id.test.ts
+++ b/__tests__/api-atlases-id.test.ts
@@ -18,6 +18,8 @@ import {
   ATLAS_PUBLIC_BAZ,
   ATLAS_PUBLISHED,
   ATLAS_WITH_CAP_ID,
+  ATLAS_WITH_DRAFT_LATEST_R0,
+  ATLAS_WITH_DRAFT_LATEST_R1,
   ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A,
   ATLAS_WITH_IL,
   ATLAS_WITH_METADATA_CORRECTNESS,
@@ -346,6 +348,28 @@ describe(TEST_ROUTE, () => {
     expectApiAtlasToMatchTest(atlas, ATLAS_WITH_NON_LATEST_METADATA_ENTITIES);
     expect(atlas.componentAtlasCount).toEqual(3);
     expect(atlas.sourceDatasetCount).toEqual(2);
+  });
+
+  it("returns isLatest = true for latest-revision atlas", async () => {
+    const res = await doAtlasRequest(
+      ATLAS_WITH_DRAFT_LATEST_R1.id,
+      USER_CONTENT_ADMIN,
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const atlas = res._getJSONData() as HCAAtlasTrackerAtlas;
+    expectApiAtlasToMatchTest(atlas, ATLAS_WITH_DRAFT_LATEST_R1);
+    expect(atlas.isLatest).toEqual(true);
+  });
+
+  it("returns isLatest = false for non-latest-revision atlas", async () => {
+    const res = await doAtlasRequest(
+      ATLAS_WITH_DRAFT_LATEST_R0.id,
+      USER_CONTENT_ADMIN,
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const atlas = res._getJSONData() as HCAAtlasTrackerAtlas;
+    expectApiAtlasToMatchTest(atlas, ATLAS_WITH_DRAFT_LATEST_R0);
+    expect(atlas.isLatest).toEqual(false);
   });
 
   it("returns error 401 when public atlas is PUT requested by logged out user", async () => {

--- a/__tests__/api-atlases.test.ts
+++ b/__tests__/api-atlases.test.ts
@@ -6,6 +6,8 @@ import { endPgPool } from "../app/services/database";
 import atlasesHandler from "../pages/api/atlases";
 import {
   ATLAS_DRAFT,
+  ATLAS_WITH_DRAFT_LATEST_R0,
+  ATLAS_WITH_DRAFT_LATEST_R1,
   ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A,
   ATLAS_WITH_MISC_SOURCE_STUDIES_B,
   ATLAS_WITH_NON_LATEST_METADATA_ENTITIES,
@@ -36,30 +38,48 @@ jest.mock("next-auth");
 
 const TEST_ROUTE = "/api/atlases";
 
-const RELATED_ENTITY_INFO_TO_CHECK = [
+const EXTRA_INFO_TO_CHECK = [
   {
     atlasId: ATLAS_DRAFT.id,
     componentAtlasCount: 2,
     entrySheetValidationCount: 2,
+    isLatest: true,
     sourceDatasetCount: 7,
   },
   {
     atlasId: ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A.id,
     componentAtlasCount: 2,
     entrySheetValidationCount: 3,
+    isLatest: true,
     sourceDatasetCount: 0,
   },
   {
     atlasId: ATLAS_WITH_MISC_SOURCE_STUDIES_B.id,
     componentAtlasCount: 1,
     entrySheetValidationCount: 2,
+    isLatest: true,
     sourceDatasetCount: 1,
   },
   {
     atlasId: ATLAS_WITH_NON_LATEST_METADATA_ENTITIES.id,
     componentAtlasCount: 3,
     entrySheetValidationCount: 0,
+    isLatest: true,
     sourceDatasetCount: 2,
+  },
+  {
+    atlasId: ATLAS_WITH_DRAFT_LATEST_R0.id,
+    componentAtlasCount: 0,
+    entrySheetValidationCount: 0,
+    isLatest: false,
+    sourceDatasetCount: 0,
+  },
+  {
+    atlasId: ATLAS_WITH_DRAFT_LATEST_R1.id,
+    componentAtlasCount: 0,
+    entrySheetValidationCount: 0,
+    isLatest: true,
+    sourceDatasetCount: 0,
   },
 ];
 
@@ -110,7 +130,7 @@ describe(TEST_ROUTE, () => {
         const data = res._getJSONData() as HCAAtlasTrackerAtlas[];
         expect(res._getStatusCode()).toEqual(200);
         expectApiAtlasesToIncludeTests(data, INITIAL_TEST_ATLASES);
-        expectApiAtlasesToHaveRelatedEntities(data);
+        expectApiAtlasesToHaveExtraInfo(data);
       },
     );
   }
@@ -120,7 +140,7 @@ describe(TEST_ROUTE, () => {
     const data = res._getJSONData() as HCAAtlasTrackerAtlas[];
     expect(res._getStatusCode()).toEqual(200);
     expectApiAtlasesToIncludeTests(data, INITIAL_TEST_ATLASES);
-    expectApiAtlasesToHaveRelatedEntities(data);
+    expectApiAtlasesToHaveExtraInfo(data);
   });
 });
 
@@ -136,15 +156,16 @@ function expectApiAtlasesToIncludeTests(
   }
 }
 
-function expectApiAtlasesToHaveRelatedEntities(
+function expectApiAtlasesToHaveExtraInfo(
   apiAtlases: HCAAtlasTrackerAtlas[],
 ): void {
   for (const {
     atlasId,
     componentAtlasCount,
     entrySheetValidationCount,
+    isLatest,
     sourceDatasetCount,
-  } of RELATED_ENTITY_INFO_TO_CHECK) {
+  } of EXTRA_INFO_TO_CHECK) {
     const apiAtlas = apiAtlases.find((a) => a.id === atlasId);
     if (!expectIsDefined(apiAtlas)) continue;
     expect(apiAtlas.componentAtlasCount).toEqual(componentAtlasCount);
@@ -152,6 +173,7 @@ function expectApiAtlasesToHaveRelatedEntities(
     expect(apiAtlas.entrySheetValidationCount).toEqual(
       entrySheetValidationCount,
     );
+    expect(apiAtlas.isLatest).toEqual(isLatest);
   }
 }
 

--- a/__tests__/source-study-validation-results.test.ts
+++ b/__tests__/source-study-validation-results.test.ts
@@ -517,7 +517,7 @@ async function testValidations(
           validationExpectedProperties.differences,
         );
       expect(validationResult).toMatchObject(validationExpectedProperties);
-      expect(validationResult.atlasIds).toEqual(atlasIds);
+      expect(validationResult.atlasIds.toSorted()).toEqual(atlasIds.toSorted());
       expect(validationResult.entityId).toEqual(testStudy.id);
       expect(validationResult.entityTitle).toEqual(
         "unpublishedInfo" in testStudy

--- a/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
@@ -79,6 +79,7 @@ export function dbAtlasToApiAtlas(
     id: dbAtlas.id,
     ingestionTaskCounts: dbAtlas.overview.ingestionTaskCounts,
     integrationLead: dbAtlas.overview.integrationLead,
+    isLatest: dbAtlas.is_latest,
     metadataCorrectnessUrl: dbAtlas.overview.metadataCorrectnessUrl,
     metadataSpecificationTitle: dbAtlas.overview.metadataSpecificationTitle,
     metadataSpecificationUrl: dbAtlas.overview.metadataSpecificationUrl,

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -42,6 +42,7 @@ export interface HCAAtlasTrackerAtlas {
   id: string;
   ingestionTaskCounts: IngestionTaskCounts;
   integrationLead: IntegrationLead[];
+  isLatest: boolean;
   metadataCorrectnessUrl: string | null;
   metadataSpecificationTitle: string | null;
   metadataSpecificationUrl: string | null;
@@ -280,6 +281,7 @@ export interface HCAAtlasTrackerDBAtlas {
 export interface HCAAtlasTrackerDBAtlasForAPI extends HCAAtlasTrackerDBAtlas {
   component_atlas_count: number;
   entry_sheet_validation_count: number;
+  is_latest: boolean;
   source_dataset_count: number;
 }
 

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -50,6 +50,7 @@ export function atlasInputMapper(
     ingestionTaskCounts: apiAtlas.ingestionTaskCounts,
     integrationLeadEmail: apiAtlas.integrationLead.map(({ email }) => email),
     integrationLeadName: apiAtlas.integrationLead.map(({ name }) => name),
+    isLatest: apiAtlas.isLatest,
     metadataCorrectnessUrl: apiAtlas.metadataCorrectnessUrl,
     metadataSpecificationTitle: apiAtlas.metadataSpecificationTitle,
     metadataSpecificationUrl: apiAtlas.metadataSpecificationUrl,

--- a/app/data/atlases.ts
+++ b/app/data/atlases.ts
@@ -147,14 +147,17 @@ export async function atlasIsLatestRevision(
 ): Promise<boolean> {
   const queryResult = await query<{ is_latest: boolean }>(
     `
-      SELECT
-        a.revision = (
-          SELECT MAX(a2.revision)
-          FROM hat.atlases a2
-          WHERE a2.overview->>'shortName' = a.overview->>'shortName' AND a2.generation = a.generation
-        ) as is_latest
-      FROM hat.atlases a
-      WHERE id = $1
+      WITH atlases_with_revisions AS (
+        SELECT
+          ar.*,
+          MAX(ar.revision) OVER (
+            PARTITION BY ar.overview->>'network', ar.overview->>'shortName', ar.generation
+          ) AS max_revision
+        FROM hat.atlases ar
+      )
+      SELECT a.revision = a.max_revision as is_latest
+      FROM atlases_with_revisions a
+      WHERE a.id = $1
     `,
     [atlasId],
     client,

--- a/app/data/atlases.ts
+++ b/app/data/atlases.ts
@@ -34,6 +34,24 @@ export async function getAtlasIdBySlugNameAndVersion({
 }
 
 /**
+ * Get an atlas's source study IDs.
+ * @param atlasId - Atlas ID.
+ * @param client - Postgres client to use.
+ * @returns array of source study IDs.
+ */
+export async function getAtlasSourceStudyIds(
+  atlasId: string,
+  client: pg.PoolClient,
+): Promise<string[]> {
+  const queryResult = await client.query<
+    Pick<HCAAtlasTrackerDBAtlas, "source_studies">
+  >("SELECT source_studies FROM hat.atlases WHERE id = $1", [atlasId]);
+  if (queryResult.rows.length === 0)
+    throw new NotFoundError(`Atlas with ID ${atlasId} doesn't exist`);
+  return queryResult.rows[0].source_studies;
+}
+
+/**
  * Create a new atlas revision based on a given atlas.
  * @param atlasId - ID of the atlas to create a new revision from.
  * @param client - Postgres client to use.

--- a/app/data/atlases.ts
+++ b/app/data/atlases.ts
@@ -141,20 +141,19 @@ export async function updateSourceDatasetVersionInAtlas(
  */
 export async function atlasIsLatestRevision(
   atlasId: string,
-  client: pg.PoolClient,
+  client?: pg.PoolClient,
 ): Promise<boolean> {
   const queryResult = await query<{ is_latest: boolean }>(
     `
-      WITH atlases_with_revisions AS (
-        SELECT
-          ar.*,
-          MAX(ar.revision) OVER (
-            PARTITION BY ar.overview->>'network', ar.overview->>'shortName', ar.generation
-          ) AS max_revision
-        FROM hat.atlases ar
-      )
-      SELECT a.revision = a.max_revision as is_latest
-      FROM atlases_with_revisions a
+      SELECT
+        a.revision = (
+          SELECT MAX(a2.revision)
+          FROM hat.atlases a2
+          WHERE a2.overview->>'network' = a.overview->>'network'
+            AND a2.overview->>'shortName' = a.overview->>'shortName'
+            AND a2.generation = a.generation
+        ) as is_latest
+      FROM hat.atlases a
       WHERE a.id = $1
     `,
     [atlasId],

--- a/app/data/atlases.ts
+++ b/app/data/atlases.ts
@@ -46,9 +46,7 @@ export async function getAtlasSourceStudyIds(
   const queryResult = await client.query<
     Pick<HCAAtlasTrackerDBAtlas, "source_studies">
   >("SELECT source_studies FROM hat.atlases WHERE id = $1", [atlasId]);
-  if (queryResult.rows.length === 0)
-    throw new NotFoundError(`Atlas with ID ${atlasId} doesn't exist`);
-  return queryResult.rows[0].source_studies;
+  return getAtlasInfoFromIdBasedQuery(queryResult, atlasId).source_studies;
 }
 
 /**
@@ -72,9 +70,7 @@ export async function createAtlasRevision(
     [atlasId],
     client,
   );
-  if (queryResult.rows.length === 0)
-    throw new NotFoundError(`Atlas with ID ${atlasId} doesn't exist`);
-  return queryResult.rows[0].id;
+  return getAtlasInfoFromIdBasedQuery(queryResult, atlasId).id;
 }
 
 /**
@@ -164,9 +160,7 @@ export async function atlasIsLatestRevision(
     [atlasId],
     client,
   );
-  if (queryResult.rows.length === 0)
-    throw new NotFoundError(`Atlas with ID ${atlasId} doesn't exist`);
-  return queryResult.rows[0].is_latest;
+  return getAtlasInfoFromIdBasedQuery(queryResult, atlasId).is_latest;
 }
 
 /**
@@ -184,9 +178,7 @@ export async function getAtlasPublishedAt(
     [atlasId],
     client,
   );
-  if (queryResult.rows.length === 0)
-    throw new NotFoundError(`Atlas with ID ${atlasId} doesn't exist`);
-  return queryResult.rows[0].published_at;
+  return getAtlasInfoFromIdBasedQuery(queryResult, atlasId).published_at;
 }
 
 /**
@@ -230,6 +222,28 @@ export async function getAdvisoryLockForAtlas(
     `,
     [atlasId],
   );
-  if (queryResult.rowCount === 0)
-    throw new NotFoundError(`Atlas with ID ${atlasId} doesn't exist`);
+  if (queryResult.rowCount === 0) throw getAtlasNotFoundError(atlasId);
+}
+
+/**
+ * Get an atlas row that was queried by ID from a query result, throwing a NotFoundError if it doesn't exist.
+ * @param queryResult - Query result that should contain a single row corresponding to an atlas if successful.
+ * @param atlasId - Atlas ID that was queried, to use in the potential error message.
+ * @returns row from query result.
+ */
+export function getAtlasInfoFromIdBasedQuery<T extends pg.QueryResultRow>(
+  queryResult: pg.QueryResult<T>,
+  atlasId: string,
+): T {
+  if (queryResult.rows.length === 0) throw getAtlasNotFoundError(atlasId);
+  return queryResult.rows[0];
+}
+
+/**
+ * Create a NotFoundError indicating that the specified atlas doesn't exist.
+ * @param atlasId - Atlas ID.
+ * @returns NotFoundError.
+ */
+export function getAtlasNotFoundError(atlasId: string): NotFoundError {
+  return new NotFoundError(`Atlas with ID ${atlasId} doesn't exist`);
 }

--- a/app/data/atlases.ts
+++ b/app/data/atlases.ts
@@ -34,6 +34,30 @@ export async function getAtlasIdBySlugNameAndVersion({
 }
 
 /**
+ * Create a new atlas revision based on a given atlas.
+ * @param atlasId - ID of the atlas to create a new revision from.
+ * @param client - Postgres client to use.
+ * @returns new atlas ID.
+ */
+export async function createAtlasRevision(
+  atlasId: string,
+  client: pg.PoolClient,
+): Promise<string> {
+  const queryResult = await query<Pick<HCAAtlasTrackerDBAtlas, "id">>(
+    `
+      INSERT INTO hat.atlases (component_atlases, generation, overview, revision, source_datasets, source_studies, status, target_completion)
+      SELECT component_atlases, generation, overview, revision + 1, source_datasets, source_studies, status, target_completion
+      FROM hat.atlases
+      WHERE id = $1
+      RETURNING id
+    `,
+    [atlasId],
+    client,
+  );
+  return queryResult.rows[0].id;
+}
+
+/**
  * Replace a source study ID with another specified source study ID across all atlas source study lists.
  * @param currentSourceStudyId - Source study ID to replace.
  * @param replacementSourceStudyId - Source study ID to insert.
@@ -91,6 +115,35 @@ export async function updateSourceDatasetVersionInAtlas(
     "UPDATE hat.atlases SET source_datasets = ARRAY_REPLACE(source_datasets, $1, $2) WHERE id = $3",
     [existingVersionId, newVersionId, atlasId],
   );
+}
+
+/**
+ * Get whether an atlas is of the latest revision within its family and generation.
+ * @param atlasId - Atlas ID.
+ * @param client - Postgres client to use.
+ * @returns boolean indicating whether the atlas is of the latest revision.
+ */
+export async function atlasIsLatestRevision(
+  atlasId: string,
+  client: pg.PoolClient,
+): Promise<boolean> {
+  const queryResult = await query<{ is_latest: boolean }>(
+    `
+      SELECT
+        a.revision = (
+          SELECT MAX(a2.revision)
+          FROM hat.atlases a2
+          WHERE a2.overview->>'shortName' = a.overview->>'shortName' AND a2.generation = a.generation
+        ) as is_latest
+      FROM hat.atlases a
+      WHERE id = $1
+    `,
+    [atlasId],
+    client,
+  );
+  if (queryResult.rows.length === 0)
+    throw new Error(`Atlas with ID ${atlasId} doesn't exist`);
+  return queryResult.rows[0].is_latest;
 }
 
 /**

--- a/app/data/atlases.ts
+++ b/app/data/atlases.ts
@@ -160,7 +160,7 @@ export async function atlasIsLatestRevision(
     client,
   );
   if (queryResult.rows.length === 0)
-    throw new Error(`Atlas with ID ${atlasId} doesn't exist`);
+    throw new NotFoundError(`Atlas with ID ${atlasId} doesn't exist`);
   return queryResult.rows[0].is_latest;
 }
 

--- a/app/data/atlases.ts
+++ b/app/data/atlases.ts
@@ -207,3 +207,27 @@ export async function changeAtlasToPublished(
       `Atlas with ID ${atlasId} is already published`,
     );
 }
+
+/**
+ * Acquire (and wait for) a transaction-level advisory lock keyed by the given atlas's ID.
+ * @param atlasId - Atlas ID.
+ * @param client - Postgres client to use.
+ */
+export async function getAdvisoryLockForAtlas(
+  atlasId: string,
+  client: pg.PoolClient,
+): Promise<void> {
+  const queryResult = await client.query(
+    `
+      SELECT pg_advisory_xact_lock(
+        -- Convert second half of hexadecimal UUID to 64-bit int to use as key
+        ('x' || substr(replace(id::text, '-', ''), 17))::bit(64)::bigint
+      )
+      FROM hat.atlases
+      WHERE id = $1
+    `,
+    [atlasId],
+  );
+  if (queryResult.rowCount === 0)
+    throw new NotFoundError(`Atlas with ID ${atlasId} doesn't exist`);
+}

--- a/app/data/atlases.ts
+++ b/app/data/atlases.ts
@@ -72,6 +72,8 @@ export async function createAtlasRevision(
     [atlasId],
     client,
   );
+  if (queryResult.rows.length === 0)
+    throw new NotFoundError(`Atlas with ID ${atlasId} doesn't exist`);
   return queryResult.rows[0].id;
 }
 

--- a/app/data/users.ts
+++ b/app/data/users.ts
@@ -1,0 +1,22 @@
+import pg from "pg";
+
+/**
+ * Add a new role-associated resource ID to all users that have another given associated entity.
+ * @param newEntityId - New entity ID to add.
+ * @param existingEntityId - Existing entity ID to filter users by.
+ * @param client - Postgres client to use.
+ */
+export async function addAssociatedEntityToUsersAssociatedWith(
+  newEntityId: string,
+  existingEntityId: string,
+  client: pg.PoolClient,
+): Promise<void> {
+  await client.query(
+    `
+      UPDATE hat.users
+      SET role_associated_resource_ids = role_associated_resource_ids || $1
+      WHERE $2 = ANY(role_associated_resource_ids) AND NOT $1 = ANY(role_associated_resource_ids)
+    `,
+    [newEntityId, existingEntityId],
+  );
+}

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -105,19 +105,12 @@ export async function getAtlas(
   id: string,
   client?: pg.PoolClient,
 ): Promise<HCAAtlasTrackerDBAtlasForAPI> {
-  const queryResult = await query<HCAAtlasTrackerDBAtlasForAPI>(
+  const queryResult = await query<
+    Omit<HCAAtlasTrackerDBAtlasForAPI, "is_latest">
+  >(
     `
-      WITH atlases_with_revisions AS (
-        SELECT
-          ar.*,
-          MAX(ar.revision) OVER (
-            PARTITION BY ar.overview->>'network', ar.overview->>'shortName', ar.generation
-          ) AS max_revision
-        FROM hat.atlases ar
-      )
       SELECT
         a.*,
-        a.revision = a.max_revision as is_latest,
         (
           SELECT COUNT(c.id)::int
           FROM hat.component_atlases c
@@ -135,13 +128,16 @@ export async function getAtlas(
           FROM hat.entry_sheet_validations e
           WHERE a.source_studies ? e.source_study_id::text
         ) AS entry_sheet_validation_count
-      FROM atlases_with_revisions a
+      FROM hat.atlases a
       WHERE a.id=$1
     `,
     [id],
     client,
   );
-  return getAtlasInfoFromIdBasedQuery(queryResult, id);
+  return {
+    ...getAtlasInfoFromIdBasedQuery(queryResult, id),
+    is_latest: await atlasIsLatestRevision(id, client),
+  };
 }
 
 export async function getBaseModelAtlas(

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -36,6 +36,7 @@ import { publishUnpublishedSourceDatasetsOfAtlas } from "../data/source-datasets
 import { parseAtlasNameUrlSlug } from "../utils/atlases";
 import { doTransaction, query } from "./database";
 import { updateSourceStudyValidationsByEntityId } from "./source-studies";
+import { addAssociatedEntityToUsersAssociatedWith } from "app/data/users";
 
 interface AtlasInputDbData {
   overviewData: Omit<
@@ -297,6 +298,7 @@ export async function createAtlasRevisionIfValid(
         `The latest revision of an atlas must be published before a new revision may be created`,
       );
     const newAtlasId = await createAtlasRevision(atlasId, client);
+    await addAssociatedEntityToUsersAssociatedWith(newAtlasId, atlasId, client);
     await updateAtlasSourceStudyValidations(newAtlasId, client);
     return getAtlas(newAtlasId, client);
   });

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -281,11 +281,11 @@ export async function publishAtlas(
 }
 
 /**
- * Create a new revision based on a given atlas, throwing an error if it's not a latest published atlas.
+ * Create a new revision based on a given atlas if valid, and update linked entities.
  * @param atlasId - ID of the atlas to attempt to create a new revision from.
  * @returns new atlas.
  */
-export async function createAtlasRevisionIfValid(
+export async function createAndHandleNewAtlasRevision(
   atlasId: string,
 ): Promise<HCAAtlasTrackerDBAtlasForAPI> {
   return doTransaction(async (client) => {

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -28,6 +28,7 @@ import {
   changeAtlasToPublished,
   getAtlasIdBySlugNameAndVersion,
   createAtlasRevision,
+  getAdvisoryLockForAtlas,
   getAtlasPublishedAt,
   getAtlasSourceStudyIds,
 } from "../data/atlases";
@@ -293,6 +294,7 @@ export async function createAndHandleNewAtlasRevision(
   atlasId: string,
 ): Promise<HCAAtlasTrackerDBAtlasForAPI> {
   return doTransaction(async (client) => {
+    await getAdvisoryLockForAtlas(atlasId, client);
     if (!(await atlasIsLatestRevision(atlasId, client)))
       throw new InvalidOperationError(
         `A new atlas revision may only be created from a latest-revision atlas`,

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -56,7 +56,7 @@ export async function getAllAtlases(
         SELECT
           ar.*,
           MAX(ar.revision) OVER (
-            PARTITION BY ar.overview->>'shortName', ar.generation
+            PARTITION BY ar.overview->>'network', ar.overview->>'shortName', ar.generation
           ) AS max_revision
         FROM hat.atlases ar
       )
@@ -107,13 +107,17 @@ export async function getAtlas(
 ): Promise<HCAAtlasTrackerDBAtlasForAPI> {
   const queryResult = await query<HCAAtlasTrackerDBAtlasForAPI>(
     `
+      WITH atlases_with_revisions AS (
+        SELECT
+          ar.*,
+          MAX(ar.revision) OVER (
+            PARTITION BY ar.overview->>'network', ar.overview->>'shortName', ar.generation
+          ) AS max_revision
+        FROM hat.atlases ar
+      )
       SELECT
         a.*,
-        a.revision = (
-          SELECT MAX(a2.revision)
-          FROM hat.atlases a2
-          WHERE a2.overview->>'shortName' = a.overview->>'shortName' AND a2.generation = a.generation
-        ) as is_latest,
+        a.revision = a.max_revision as is_latest,
         (
           SELECT COUNT(c.id)::int
           FROM hat.component_atlases c
@@ -131,7 +135,7 @@ export async function getAtlas(
           FROM hat.entry_sheet_validations e
           WHERE a.source_studies ? e.source_study_id::text
         ) AS entry_sheet_validation_count
-      FROM hat.atlases a
+      FROM atlases_with_revisions a
       WHERE a.id=$1
     `,
     [id],

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -51,8 +51,17 @@ export async function getAllAtlases(
 ): Promise<HCAAtlasTrackerDBAtlasForAPI[]> {
   const queryResult = await query<HCAAtlasTrackerDBAtlasForAPI>(
     `
+      WITH atlases_with_revisions AS (
+        SELECT
+          ar.*,
+          MAX(ar.revision) OVER (
+            PARTITION BY ar.overview->>'shortName', ar.generation
+          ) AS max_revision
+        FROM hat.atlases ar
+      )
       SELECT
         a.*,
+        a.revision = a.max_revision AS is_latest,
         (
           SELECT COUNT(c.id)::int
           FROM hat.component_atlases c
@@ -70,7 +79,7 @@ export async function getAllAtlases(
           FROM hat.entry_sheet_validations e
           WHERE a.source_studies ? e.source_study_id::text
         ) AS entry_sheet_validation_count
-      FROM hat.atlases a
+      FROM atlases_with_revisions a
     `,
     undefined,
     client,
@@ -99,6 +108,11 @@ export async function getAtlas(
     `
       SELECT
         a.*,
+        a.revision = (
+          SELECT MAX(a2.revision)
+          FROM hat.atlases a2
+          WHERE a2.overview->>'shortName' = a.overview->>'shortName' AND a2.generation = a.generation
+        ) as is_latest,
         (
           SELECT COUNT(c.id)::int
           FROM hat.component_atlases c

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -34,9 +34,9 @@ import {
 import { publishUnpublishedComponentAtlasesOfAtlas } from "../data/component-atlases";
 import { publishUnpublishedSourceDatasetsOfAtlas } from "../data/source-datasets";
 import { parseAtlasNameUrlSlug } from "../utils/atlases";
+import { addAssociatedEntityToUsersAssociatedWith } from "../data/users";
 import { doTransaction, query } from "./database";
-import { updateSourceStudyValidationsByEntityId } from "./source-studies";
-import { addAssociatedEntityToUsersAssociatedWith } from "app/data/users";
+import { updateSourceStudyValidationsByEntityIds } from "./source-studies";
 
 interface AtlasInputDbData {
   overviewData: Omit<
@@ -313,9 +313,10 @@ async function updateAtlasSourceStudyValidations(
   atlasId: string,
   client: pg.PoolClient,
 ): Promise<void> {
-  for (const sourceStudyId of await getAtlasSourceStudyIds(atlasId, client)) {
-    await updateSourceStudyValidationsByEntityId(sourceStudyId, client);
-  }
+  await updateSourceStudyValidationsByEntityIds(
+    await getAtlasSourceStudyIds(atlasId, client),
+    client,
+  );
 }
 
 export async function updateTaskCounts(client?: pg.PoolClient): Promise<void> {

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -29,11 +29,13 @@ import {
   getAtlasIdBySlugNameAndVersion,
   createAtlasRevision,
   getAtlasPublishedAt,
+  getAtlasSourceStudyIds,
 } from "../data/atlases";
 import { publishUnpublishedComponentAtlasesOfAtlas } from "../data/component-atlases";
 import { publishUnpublishedSourceDatasetsOfAtlas } from "../data/source-datasets";
 import { parseAtlasNameUrlSlug } from "../utils/atlases";
 import { doTransaction, query } from "./database";
+import { updateSourceStudyValidationsByEntityId } from "./source-studies";
 
 interface AtlasInputDbData {
   overviewData: Omit<
@@ -281,8 +283,23 @@ export async function createAtlasRevisionIfValid(
         `The latest revision of an atlas must be published before a new revision may be created`,
       );
     const newAtlasId = await createAtlasRevision(atlasId, client);
+    await updateAtlasSourceStudyValidations(newAtlasId, client);
     return getAtlas(newAtlasId, client);
   });
+}
+
+/**
+ * Update validations for all source studies of a given atlas.
+ * @param atlasId - Atlas ID.
+ * @param client - Postgres client to use.
+ */
+async function updateAtlasSourceStudyValidations(
+  atlasId: string,
+  client: pg.PoolClient,
+): Promise<void> {
+  for (const sourceStudyId of await getAtlasSourceStudyIds(atlasId, client)) {
+    await updateSourceStudyValidationsByEntityId(sourceStudyId, client);
+  }
 }
 
 export async function updateTaskCounts(client?: pg.PoolClient): Promise<void> {

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -24,8 +24,10 @@ import {
 import { normalizeDoi } from "../utils/doi";
 import { getSheetTitleForApi } from "../utils/google-sheets-api";
 import {
+  atlasIsLatestRevision,
   changeAtlasToPublished,
   getAtlasIdBySlugNameAndVersion,
+  createAtlasRevision,
   getAtlasPublishedAt,
 } from "../data/atlases";
 import { publishUnpublishedComponentAtlasesOfAtlas } from "../data/component-atlases";
@@ -258,6 +260,28 @@ export async function publishAtlas(
     await publishUnpublishedSourceDatasetsOfAtlas(atlasId, publishedAt, client);
     await changeAtlasToPublished(atlasId, publishedAt, client);
     return getAtlas(atlasId, client);
+  });
+}
+
+/**
+ * Create a new revision based on a given atlas, throwing an error if it's not a latest published atlas.
+ * @param atlasId - ID of the atlas to attempt to create a new revision from.
+ * @returns new atlas.
+ */
+export async function createAtlasRevisionIfValid(
+  atlasId: string,
+): Promise<HCAAtlasTrackerDBAtlasForAPI> {
+  return doTransaction(async (client) => {
+    if (!(await atlasIsLatestRevision(atlasId, client)))
+      throw new InvalidOperationError(
+        `A new atlas revision may only be created from a latest-revision atlas`,
+      );
+    if (!(await atlasIsPublished(atlasId, client)))
+      throw new InvalidOperationError(
+        `The latest revision of an atlas must be published before a new revision may be created`,
+      );
+    const newAtlasId = await createAtlasRevision(atlasId, client);
+    return getAtlas(newAtlasId, client);
   });
 }
 

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -1,9 +1,6 @@
 import pg from "pg";
 import { ValidationError } from "yup";
-import {
-  InvalidOperationError,
-  NotFoundError,
-} from "../../app/utils/api-handler";
+import { InvalidOperationError } from "../../app/utils/api-handler";
 import { getCrossrefPublicationInfo } from "../../app/utils/crossref/crossref";
 import {
   ATLAS_STATUS,
@@ -29,6 +26,8 @@ import {
   getAtlasIdBySlugNameAndVersion,
   createAtlasRevision,
   getAdvisoryLockForAtlas,
+  getAtlasInfoFromIdBasedQuery,
+  getAtlasNotFoundError,
   getAtlasPublishedAt,
   getAtlasSourceStudyIds,
 } from "../data/atlases";
@@ -142,9 +141,7 @@ export async function getAtlas(
     [id],
     client,
   );
-  if (queryResult.rows.length === 0)
-    throw new NotFoundError(`Atlas with ID ${id} doesn't exist`);
-  return queryResult.rows[0];
+  return getAtlasInfoFromIdBasedQuery(queryResult, id);
 }
 
 export async function getBaseModelAtlas(
@@ -157,10 +154,7 @@ export async function getBaseModelAtlas(
     client,
   );
 
-  if (queryResult.rows.length === 0)
-    throw new NotFoundError(`Atlas with ID ${id} doesn't exist`);
-
-  return queryResult.rows[0];
+  return getAtlasInfoFromIdBasedQuery(queryResult, id);
 }
 
 export async function createAtlas(
@@ -196,8 +190,7 @@ export async function updateAtlas(
     "UPDATE hat.atlases SET overview=overview||$1, status=$2, target_completion=$3 WHERE id=$4 RETURNING *",
     [JSON.stringify(overviewData), status, targetCompletion, id],
   );
-  if (queryResult.rowCount === 0)
-    throw new NotFoundError(`Atlas with ID ${id} doesn't exist`);
+  if (queryResult.rowCount === 0) throw getAtlasNotFoundError(id);
   return await getAtlas(id);
 }
 
@@ -388,8 +381,7 @@ export async function atlasIsPublished(
  * @param atlasId - ID of the atlas to check for.
  */
 export async function confirmAtlasExists(atlasId: string): Promise<void> {
-  if (!(await atlasExists(atlasId)))
-    throw new NotFoundError(`Atlas with ID ${atlasId} doesn't exist`);
+  if (!(await atlasExists(atlasId))) throw getAtlasNotFoundError(atlasId);
 }
 
 /**

--- a/app/services/source-studies.ts
+++ b/app/services/source-studies.ts
@@ -898,6 +898,7 @@ export async function getSourceStudyWithAtlasProperties(
   sourceStudyId: string,
   client: pg.PoolClient,
 ): Promise<HCAAtlasTrackerDBSourceStudyWithAtlasProperties> {
+  // `getSourceStudiesWithAtlasProperties` ensures that every specified source study is returned
   const [sourceStudy] = await getSourceStudiesWithAtlasProperties(
     [sourceStudyId],
     client,

--- a/app/services/source-studies.ts
+++ b/app/services/source-studies.ts
@@ -55,6 +55,7 @@ import {
   updateSourceStudyValidations,
 } from "./validations";
 import { replaceEntrySheetValidationsSourceStudy } from "../data/entry-sheets";
+import { confirmQueryRowsContainIds } from "app/utils/database";
 
 export async function getAtlasSourceStudies(
   atlasId: string,
@@ -847,11 +848,29 @@ export async function updateSourceStudyValidationsByEntityId(
 }
 
 /**
+ * Update validations for the source study with the given ID.
+ * @param entityIds - Source study IDs.
+ * @param client - Postgres client to use.
+ */
+export async function updateSourceStudyValidationsByEntityIds(
+  entityIds: string[],
+  client: pg.PoolClient,
+): Promise<void> {
+  const sourceStudies = await getSourceStudiesWithAtlasProperties(
+    entityIds,
+    client,
+  );
+  for (const sourceStudy of sourceStudies) {
+    await updateSourceStudyValidations(sourceStudy, client);
+  }
+}
+
+/**
  * Get all source studies, with properties of their atlases added.
  * @param client - Postgres client to use.
  * @returns source studies with atlas properties.
  */
-export async function getSourceStudiesWithAtlasProperties(
+export async function getAllSourceStudiesWithAtlasProperties(
   client: pg.PoolClient,
 ): Promise<HCAAtlasTrackerDBSourceStudyWithAtlasProperties[]> {
   const queryResult =
@@ -871,14 +890,31 @@ export async function getSourceStudiesWithAtlasProperties(
 
 /**
  * Get a specified source study, with properties of its atlases added.
- * @param sourceStudyId - ID of the soruce study to get.
+ * @param sourceStudyId - ID of the source study to get.
  * @param client - Postgres client to use.
- * @returns source studies with atlas properties.
+ * @returns source study with atlas properties.
  */
 export async function getSourceStudyWithAtlasProperties(
   sourceStudyId: string,
   client: pg.PoolClient,
 ): Promise<HCAAtlasTrackerDBSourceStudyWithAtlasProperties> {
+  const [sourceStudy] = await getSourceStudiesWithAtlasProperties(
+    [sourceStudyId],
+    client,
+  );
+  return sourceStudy;
+}
+
+/**
+ * Get a specified list of source studies, with properties of their atlases added.
+ * @param sourceStudyIds - IDs of the source studies to get.
+ * @param client - Postgres client to use.
+ * @returns source studies with atlas properties.
+ */
+export async function getSourceStudiesWithAtlasProperties(
+  sourceStudyIds: string[],
+  client: pg.PoolClient,
+): Promise<HCAAtlasTrackerDBSourceStudyWithAtlasProperties[]> {
   const queryResult =
     await client.query<HCAAtlasTrackerDBSourceStudyWithAtlasProperties>(
       `
@@ -890,16 +926,14 @@ export async function getSourceStudyWithAtlasProperties(
           ARRAY_AGG(DISTINCT a.overview->>'network') AS networks
         FROM hat.source_studies s
         LEFT JOIN hat.atlases a ON a.source_studies @> to_jsonb(s.id)
-        WHERE s.id=$1
+        WHERE s.id=ANY($1)
         GROUP BY s.id
       `,
-      [sourceStudyId],
+      [sourceStudyIds],
     );
-  if (queryResult.rows.length === 0)
-    throw new NotFoundError(
-      `Source study with ID ${sourceStudyId} doesn't exist`,
-    );
-  return queryResult.rows[0];
+  const sourceStudies = queryResult.rows;
+  confirmQueryRowsContainIds(sourceStudies, sourceStudyIds, "source studies");
+  return sourceStudies;
 }
 
 /**

--- a/app/services/source-studies.ts
+++ b/app/services/source-studies.ts
@@ -848,7 +848,7 @@ export async function updateSourceStudyValidationsByEntityId(
 }
 
 /**
- * Update validations for the source study with the given ID.
+ * Update validations for the source studies with the given IDs.
  * @param entityIds - Source study IDs.
  * @param client - Postgres client to use.
  */

--- a/app/services/validations.ts
+++ b/app/services/validations.ts
@@ -43,7 +43,7 @@ import { doTransaction, getPoolClient, query } from "./database";
 import { getProjectInfoById } from "./hca-projects";
 import {
   getSourceStudiesByDois,
-  getSourceStudiesWithAtlasProperties,
+  getAllSourceStudiesWithAtlasProperties,
 } from "./source-studies";
 
 export enum VALIDATION_META_STATUS {
@@ -459,7 +459,7 @@ export async function refreshValidations(): Promise<void> {
  */
 async function revalidateAllSourceStudies(): Promise<void> {
   const client = await getPoolClient();
-  for (const study of await getSourceStudiesWithAtlasProperties(client)) {
+  for (const study of await getAllSourceStudiesWithAtlasProperties(client)) {
     try {
       await client.query("BEGIN");
       await updateSourceStudyValidations(study, client);

--- a/pages/api/atlases/[atlasId]/versions.ts
+++ b/pages/api/atlases/[atlasId]/versions.ts
@@ -1,7 +1,7 @@
 import { dbAtlasToApiAtlas } from "../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE } from "../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD } from "../../../../app/common/entities";
-import { createAtlasRevisionIfValid } from "../../../../app/services/atlases";
+import { createAndHandleNewAtlasRevision } from "../../../../app/services/atlases";
 import { handler, method, role } from "../../../../app/utils/api-handler";
 
 /**
@@ -14,6 +14,6 @@ export default handler(
     const id = req.query.atlasId as string;
     res
       .status(201)
-      .json(dbAtlasToApiAtlas(await createAtlasRevisionIfValid(id)));
+      .json(dbAtlasToApiAtlas(await createAndHandleNewAtlasRevision(id)));
   },
 );

--- a/pages/api/atlases/[atlasId]/versions.ts
+++ b/pages/api/atlases/[atlasId]/versions.ts
@@ -1,0 +1,19 @@
+import { dbAtlasToApiAtlas } from "../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
+import { ROLE } from "../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "../../../../app/common/entities";
+import { createAtlasRevisionIfValid } from "../../../../app/services/atlases";
+import { handler, method, role } from "../../../../app/utils/api-handler";
+
+/**
+ * API route for creating an atlas version.
+ */
+export default handler(
+  method(METHOD.POST),
+  role(ROLE.CONTENT_ADMIN),
+  async (req, res) => {
+    const id = req.query.atlasId as string;
+    res
+      .status(201)
+      .json(dbAtlasToApiAtlas(await createAtlasRevisionIfValid(id)));
+  },
+);

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -2927,8 +2927,12 @@ const ATLAS_ID_WITH_NON_SHARED_ENTRY_SHEET_VALIDATIONS =
   "c41f8dd8-93ee-49f6-885a-8c5107d30229";
 const ATLAS_ID_WITH_ENTRY_SHEET_VALIDATIONS_A =
   "035f5b25-7a2a-4351-9f61-5e6734f1f6dc";
+const ATLAS_ID_PUBLISHED_R6 = "88249444-e921-4bbb-a1d1-e4e0fde9f450";
+const ATLAS_ID_PUBLISHED = "6ca07821-624e-42a3-8643-2a31bb0a4831";
 const ATLAS_ID_WITH_LINKED_PUBLISH_STATUSES =
   "3b67d7c2-60d7-4907-85b6-897d15a1ca4c";
+const ATLAS_ID_WITH_DRAFT_LATEST_R0 = "c6a7245f-a112-42a2-9857-d22a5541ab64";
+const ATLAS_ID_WITH_DRAFT_LATEST_R1 = "1d4d4187-8877-4757-9ab9-f2b7c6c66cf4";
 
 // USERS
 
@@ -2983,6 +2987,12 @@ export const USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES_C = makeTestUser(
   false,
   [ATLAS_ID_WITH_MISC_SOURCE_STUDIES_C],
 );
+export const USER_INTEGRATION_LEAD_PUBLISHED = makeTestUser(
+  "test-integration-lead-published",
+  ROLE.INTEGRATION_LEAD,
+  false,
+  [ATLAS_ID_PUBLISHED_R6, ATLAS_ID_PUBLISHED],
+);
 export const USER_INTEGRATION_LEAD_WITH_LINKED_PUBLISH_STATUSES = makeTestUser(
   "test-integration-lead-with-linked-publish-statuses",
   ROLE.INTEGRATION_LEAD,
@@ -3030,6 +3040,7 @@ export const INITIAL_TEST_USERS = [
   USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
   USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES_B,
   USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES_C,
+  USER_INTEGRATION_LEAD_PUBLISHED,
   USER_INTEGRATION_LEAD_WITH_LINKED_PUBLISH_STATUSES,
   USER_INTEGRATION_LEAD_WITH_NEW_ATLAS,
   USER_CELLXGENE_ADMIN,
@@ -3056,6 +3067,8 @@ export const DEFAULT_USERS_BY_ROLE = {
 export const INTEGRATION_LEADS_BY_ATLAS_ID: Record<string, TestUser> = {
   [ATLAS_ID_DRAFT]: USER_INTEGRATION_LEAD_DRAFT,
   [ATLAS_ID_PUBLIC]: USER_INTEGRATION_LEAD_PUBLIC,
+  [ATLAS_ID_PUBLISHED]: USER_INTEGRATION_LEAD_PUBLISHED,
+  [ATLAS_ID_PUBLISHED_R6]: USER_INTEGRATION_LEAD_PUBLISHED,
   [ATLAS_ID_WITH_ENTRY_SHEET_VALIDATIONS_A]:
     USER_INTEGRATION_LEAD_WITH_ENTRY_SHEET_VALIDATIONS_A,
   [ATLAS_ID_WITH_LINKED_PUBLISH_STATUSES]:
@@ -4376,24 +4389,33 @@ export const ATLAS_WITH_NON_LATEST_METADATA_ENTITIES: TestAtlas = {
   wave: "2",
 };
 
-export const ATLAS_PUBLISHED: TestAtlas = {
+const BASE_ATLAS_PUBLISHED = {
   cellxgeneAtlasCollection: null,
   codeLinks: [],
   componentAtlases: [COMPONENT_ATLAS_PUBLISHED.versionId],
   description: "bazbar foobarbaz baz foo bar",
   generation: 2,
   highlights: "",
-  id: "6ca07821-624e-42a3-8643-2a31bb0a4831",
   integrationLead: [],
   network: "musculoskeletal",
   publications: [],
-  publishedAt: "2026-02-25T20:44:05.405Z",
-  revision: 7,
   shortName: "Test Published",
   sourceDatasets: [SOURCE_DATASET_PUBLISHED.versionId],
   sourceStudies: [SOURCE_STUDY_PUBLISHED.id],
   status: ATLAS_STATUS.OC_ENDORSED,
   wave: "2",
+} satisfies Partial<TestAtlas>;
+export const ATLAS_PUBLISHED_R6: TestAtlas = {
+  ...BASE_ATLAS_PUBLISHED,
+  id: ATLAS_ID_PUBLISHED_R6,
+  publishedAt: "2026-02-24T20:44:05.405Z",
+  revision: 6,
+};
+export const ATLAS_PUBLISHED: TestAtlas = {
+  ...BASE_ATLAS_PUBLISHED,
+  id: ATLAS_ID_PUBLISHED,
+  publishedAt: "2026-02-25T20:44:05.405Z",
+  revision: 7,
 };
 
 export const ATLAS_WITH_LINKED_PUBLISH_STATUSES: TestAtlas = {
@@ -4425,6 +4447,35 @@ export const ATLAS_WITH_LINKED_PUBLISH_STATUSES: TestAtlas = {
   wave: "1",
 };
 
+const BASE_ATLAS_WITH_DRAFT_LATEST = {
+  cellxgeneAtlasCollection: null,
+  codeLinks: [],
+  componentAtlases: [],
+  description: "foo foo bar baz bar foo barbar foo",
+  generation: 6,
+  highlights: "",
+  integrationLead: [],
+  network: "lung",
+  publications: [],
+  shortName: "test-with-draft-latest",
+  sourceDatasets: [],
+  sourceStudies: [],
+  status: ATLAS_STATUS.IN_PROGRESS,
+  wave: "3",
+} satisfies Partial<TestAtlas>;
+export const ATLAS_WITH_DRAFT_LATEST_R0: TestAtlas = {
+  ...BASE_ATLAS_WITH_DRAFT_LATEST,
+  id: ATLAS_ID_WITH_DRAFT_LATEST_R0,
+  publishedAt: "2026-03-25T21:36:09.268Z",
+  revision: 0,
+};
+export const ATLAS_WITH_DRAFT_LATEST_R1: TestAtlas = {
+  ...BASE_ATLAS_WITH_DRAFT_LATEST,
+  id: ATLAS_ID_WITH_DRAFT_LATEST_R1,
+  publishedAt: null,
+  revision: 1,
+};
+
 export const ATLAS_NONEXISTENT = {
   id: "aa992f01-39ea-4906-ac12-053552561187",
 };
@@ -4449,8 +4500,11 @@ export const INITIAL_TEST_ATLASES = [
   ATLAS_WITH_NON_SHARED_ENTRY_SHEET_VALIDATIONS,
   ATLAS_HEATMAP_TEST,
   ATLAS_WITH_NON_LATEST_METADATA_ENTITIES,
+  ATLAS_PUBLISHED_R6,
   ATLAS_PUBLISHED,
   ATLAS_WITH_LINKED_PUBLISH_STATUSES,
+  ATLAS_WITH_DRAFT_LATEST_R0,
+  ATLAS_WITH_DRAFT_LATEST_R1,
 ];
 
 export const INITIAL_TEST_ATLASES_BY_SOURCE_STUDY = INITIAL_TEST_ATLASES.reduce(

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -561,6 +561,16 @@ export async function getDbUsersByEmail(
   );
 }
 
+export async function getUserFromDatabaseByEmail(
+  email: string,
+): Promise<HCAAtlasTrackerDBUser | undefined> {
+  const queryResult = await query<HCAAtlasTrackerDBUser>(
+    "SELECT * FROM hat.users WHERE email = $1",
+    [email],
+  );
+  return queryResult.rows[0];
+}
+
 export async function getExistingAtlasFromDatabase(
   id: string,
 ): Promise<HCAAtlasTrackerDBAtlas> {

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -522,6 +522,7 @@ export function expectApiAtlasToMatchTestWithoutRevision(
   expect(apiAtlas.generation).toEqual(testAtlas.generation);
   expect(apiAtlas.wave).toEqual(testAtlas.wave);
 
+  // Check `isLatest` to the extent that is possible just based on the test atlas definition; tests can do additional checks separately as needed
   if (testAtlas.publishedAt) expect(apiAtlas.isLatest).toBeDefined();
   else expect(apiAtlas.isLatest).toEqual(true);
 }

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -494,17 +494,25 @@ export function expectApiAtlasToMatchTest(
   apiAtlas: HCAAtlasTrackerAtlas,
   testAtlas: TestAtlas,
 ): void {
+  expectApiAtlasToMatchTestWithoutRevision(apiAtlas, testAtlas);
+  expect(apiAtlas.publishedAt).toEqual(testAtlas.publishedAt ?? null);
+  expect(apiAtlas.id).toEqual(testAtlas.id);
+  expect(apiAtlas.revision).toEqual(testAtlas.revision);
+}
+
+export function expectApiAtlasToMatchTestWithoutRevision(
+  apiAtlas: HCAAtlasTrackerAtlas,
+  testAtlas: TestAtlas,
+): void {
   expect(apiAtlas.cellxgeneAtlasCollection).toEqual(
     testAtlas.cellxgeneAtlasCollection,
   );
   expect(apiAtlas.codeLinks).toEqual(testAtlas.codeLinks);
   expect(apiAtlas.description).toEqual(testAtlas.description);
   expect(apiAtlas.highlights).toEqual(testAtlas.highlights);
-  expect(apiAtlas.id).toEqual(testAtlas.id);
   expect(apiAtlas.integrationLead).toEqual(testAtlas.integrationLead);
   expect(apiAtlas.bioNetwork).toEqual(testAtlas.network);
   expect(apiAtlas.publications).toEqual(testAtlas.publications);
-  expect(apiAtlas.publishedAt).toEqual(testAtlas.publishedAt ?? null);
   expect(apiAtlas.shortName).toEqual(testAtlas.shortName);
   expect(apiAtlas.sourceStudyCount).toEqual(testAtlas.sourceStudies.length);
   expect(apiAtlas.status).toEqual(testAtlas.status);
@@ -512,7 +520,6 @@ export function expectApiAtlasToMatchTest(
     testAtlas.targetCompletion?.toISOString() ?? null,
   );
   expect(apiAtlas.generation).toEqual(testAtlas.generation);
-  expect(apiAtlas.revision).toEqual(testAtlas.revision);
   expect(apiAtlas.wave).toEqual(testAtlas.wave);
 }
 

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -521,6 +521,9 @@ export function expectApiAtlasToMatchTestWithoutRevision(
   );
   expect(apiAtlas.generation).toEqual(testAtlas.generation);
   expect(apiAtlas.wave).toEqual(testAtlas.wave);
+
+  if (testAtlas.publishedAt) expect(apiAtlas.isLatest).toBeDefined();
+  else expect(apiAtlas.isLatest).toEqual(true);
 }
 
 export function expectDbAtlasToMatchApi(


### PR DESCRIPTION
Closes #1137

Since we haven't introduced anything to help with it, determining whether an atlas is of the latest revision is done by grouping by network, short name, and generation