### PR TITLE
feat: add metadata link to header navigation (#1155)

### DIFF
--- a/site-config/hca-atlas-tracker/local/config.ts
+++ b/site-config/hca-atlas-tracker/local/config.ts
@@ -66,6 +66,11 @@ export function makeConfig(
             },
             { label: "Reports", url: ROUTE.REPORTS },
             { label: "Team", url: ROUTE.USERS },
+            {
+              label: "Metadata",
+              target: ANCHOR_TARGET.BLANK,
+              url: "https://data.humancellatlas.org/metadata/tier-1",
+            },
           ],
           [
             {

--- a/site-config/hca-atlas-tracker/local/config.ts
+++ b/site-config/hca-atlas-tracker/local/config.ts
@@ -69,7 +69,7 @@ export function makeConfig(
             {
               label: "Metadata",
               target: ANCHOR_TARGET.BLANK,
-              url: "https://data.humancellatlas.org/metadata/tier-1",
+              url: `${portalUrl}/metadata/tier-1`,
             },
           ],
           [


### PR DESCRIPTION
## Summary
- Adds a "Metadata" link to the header navigation that opens the HCA metadata tier-1 page in a new tab

## Test plan
- [x] Verify the "Metadata" link appears in the header navigation
- [x] Verify clicking it opens https://data.humancellatlas.org/metadata/tier-1 in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2314" height="1215" alt="image" src="https://github.com/user-attachments/assets/8616d508-57fe-47d9-a329-173e7b80af00" />

Closes #1155.
