### PR TITLE
feat: rename "Title" field to "Dataset Title" and "Integrated Object Title"

### DIFF
--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -1101,7 +1101,7 @@ function getComponentAtlasSourceDatasetsSelectionTitleColumnDef(): ColumnDef<HCA
       C.BasicCell({
         value: row.original.title,
       }),
-    header: "Title",
+    header: "Dataset Title",
   };
 }
 
@@ -1197,7 +1197,7 @@ function getComponentAtlasSourceDatasetCountColumnDef(): ColumnDef<AtlasIntegrat
 function getComponentAtlasTitleColumnDef(): ColumnDef<AtlasIntegratedObject> {
   return {
     accessorKey: "title",
-    header: "Title",
+    header: "Integrated Object Title",
     meta: { width: { max: "1fr", min: "136px" } },
   };
 }
@@ -1406,7 +1406,7 @@ function getSourceDatasetTitleColumnDef(): ColumnDef<HCAAtlasTrackerSourceDatase
       C.BasicCell({
         value: row.original.title,
       }),
-    header: "Title",
+    header: "Dataset Title",
     meta: { columnPinned: true },
   };
 }

--- a/app/views/AtlasSourceDatasetView/common/controllers.ts
+++ b/app/views/AtlasSourceDatasetView/common/controllers.ts
@@ -105,7 +105,7 @@ const SIZE_BYTES: CommonControllerConfig = {
 const TITLE: CommonControllerConfig = {
   inputProps: {
     isFullWidth: true,
-    label: "Title",
+    label: "Dataset Title",
     readOnly: true,
   },
   name: FIELD_NAME.TITLE,

--- a/app/views/AtlasSourceDatasetsView/components/Table/columns.ts
+++ b/app/views/AtlasSourceDatasetsView/components/Table/columns.ts
@@ -161,7 +161,7 @@ const COLUMN_TISSUE = {
 const COLUMN_TITLE = {
   accessorKey: "title",
   cell: ({ row }) => C.BasicCell({ value: row.original.title }),
-  header: "Title",
+  header: "Dataset Title",
   meta: { width: { max: "1fr", min: "180px" } },
 } as ColumnDef<AtlasSourceDataset>;
 

--- a/app/views/ComponentAtlasView/common/controllers.ts
+++ b/app/views/ComponentAtlasView/common/controllers.ts
@@ -93,7 +93,7 @@ const SIZE_BY_BYTES: CommonControllerConfig = {
 const TITLE: CommonControllerConfig = {
   inputProps: {
     isFullWidth: true,
-    label: "Title",
+    label: "Integrated Object Title",
     readOnly: true,
   },
   name: FIELD_NAME.TITLE,


### PR DESCRIPTION
## Summary
- Renames "Title" label to "Dataset Title" on source dataset detail page, atlas source datasets table, source study source datasets table, and integrated object source-dataset selection table
- Renames "Title" label to "Integrated Object Title" on integrated object detail page and atlas integrated objects table
- Display-only change; no data, API, or schema changes

Closes #1173

## Test plan
- [x] Source dataset detail page General Information section shows "Dataset Title"
- [x] Atlas source datasets table column reads "Dataset Title"
- [x] Source study source datasets table column reads "Dataset Title"
- [x] Integrated object source-dataset selection dialog title column reads "Dataset Title"
- [x] Integrated object detail page shows "Integrated Object Title"
- [x] Atlas integrated objects table column reads "Integrated Object Title"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1439" height="1281" alt="image" src="https://github.com/user-attachments/assets/fc838dfb-dcd2-4ef3-9622-4c33eceb1fec" />

<img width="1442" height="1254" alt="image" src="https://github.com/user-attachments/assets/2902b946-4fe5-405e-826f-8acd849da69c" />

<img width="1440" height="1271" alt="image" src="https://github.com/user-attachments/assets/bf37e2f7-a6c3-43b0-9474-ff1044768b5a" />

<img width="1439" height="1229" alt="image" src="https://github.com/user-attachments/assets/864336d8-3234-4309-a6c3-788955885285" />

<img width="1438" height="1100" alt="image" src="https://github.com/user-attachments/assets/ae8af227-0e23-4147-a54a-31aefc84ca1c" />

<img width="1436" height="1222" alt="image" src="https://github.com/user-attachments/assets/0fb523fb-b19d-4d21-99e5-c01dd405a166" />

