### PR TITLE
feat: rename "HCA" to "HCA Tier-1" in validation summary column

### DIFF
--- a/app/apis/catalog/hca-atlas-tracker/common/constants.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/constants.ts
@@ -210,7 +210,7 @@ export const FILE_VALIDATOR_NAMES = ["cap", "cellxgene", "hcaSchema"] as const;
 export const FILE_VALIDATOR_NAME_LABEL: Record<FileValidatorName, string> = {
   cap: "CAP",
   cellxgene: "CELLxGENE",
-  hcaSchema: "HCA",
+  hcaSchema: "HCA Tier-1",
 };
 
 export const UNPUBLISHED = "Unpublished";


### PR DESCRIPTION
## Summary
- Renames the "HCA" validator display label to "HCA Tier-1" in the validation summary column on source dataset and integrated object tables
- Display-only change; no database, enum, API, or business logic affected

Closes #1164

## Test plan
- [ ] Verify validation summary column shows "HCA Tier-1" instead of "HCA" on Source Datasets table
- [ ] Verify validation summary column shows "HCA Tier-1" instead of "HCA" on Integrated Objects table

🤖 Generated with [Claude Code](https://claude.com/claude-code)