### PR TITLE
feat: rename "Publication Status" to "Study Status" and "Published At" to "Release Date"

### DIFF
--- a/app/components/Forms/components/Atlas/common/constants.ts
+++ b/app/components/Forms/components/Atlas/common/constants.ts
@@ -77,7 +77,7 @@ const STATUS: ControllerConfig<AtlasEditData, HCAAtlasTrackerAtlas> = {
 const PUBLISHED_AT: ControllerConfig<AtlasEditData, HCAAtlasTrackerAtlas> = {
   inputProps: {
     isFullWidth: true,
-    label: "Published at",
+    label: "Release Date",
     readOnly: true,
   },
   name: FIELD_NAME.PUBLISHED_AT,

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -983,7 +983,7 @@ export function getAtlasComponentAtlasesTableColumns(): ColumnDef<
     {
       accessorKey: "publishedAt",
       cell: ({ row }) => C.BasicCell(buildPublishedAt(row.original)),
-      header: "Published At",
+      header: "Release Date",
       meta: { width: { max: "1fr", min: "160px" } },
     },
     getIntegratedObjectValidationStatusColumnDef(),

--- a/app/views/AtlasSourceDatasetView/common/controllers.ts
+++ b/app/views/AtlasSourceDatasetView/common/controllers.ts
@@ -78,7 +78,7 @@ const GENE_COUNT: CommonControllerConfig = {
 const PUBLICATION_STATUS: CommonControllerConfig = {
   inputProps: {
     isFullWidth: true,
-    label: "Publication Status",
+    label: "Study Status",
     readOnly: true,
   },
   name: FIELD_NAME.PUBLICATION_STATUS,
@@ -87,7 +87,7 @@ const PUBLICATION_STATUS: CommonControllerConfig = {
 const PUBLISHED_AT: CommonControllerConfig = {
   inputProps: {
     isFullWidth: false,
-    label: "Date Published",
+    label: "Release Date",
     readOnly: true,
   },
   name: FIELD_NAME.PUBLISHED_AT,

--- a/app/views/AtlasSourceDatasetsView/components/Table/columns.ts
+++ b/app/views/AtlasSourceDatasetsView/components/Table/columns.ts
@@ -118,13 +118,13 @@ const COLUMN_FILE_EVENT_TIME = {
 const COLUMN_PUBLISHED_AT = {
   accessorKey: "publishedAt",
   cell: ({ row }) => C.BasicCell(buildPublishedAt(row.original)),
-  header: "Published At",
+  header: "Release Date",
   meta: { width: { max: "1fr", min: "160px" } },
 } as ColumnDef<AtlasSourceDataset>;
 
 const COLUMN_PUBLICATION_STATUS = {
   accessorKey: "publicationStatus",
-  header: "Publication Status",
+  header: "Study Status",
   meta: { width: { max: "0.5fr", min: "120px" } },
 } as ColumnDef<AtlasSourceDataset>;
 

--- a/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/EditPublicationStatus/common/controllers.ts
+++ b/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/EditPublicationStatus/common/controllers.ts
@@ -14,6 +14,6 @@ export const PUBLICATION_STATUS: CommonControllerConfig = {
   selectProps: {
     SelectComponent: PublicationStatus,
     displayEmpty: true,
-    label: "Publication Status",
+    label: "Study Status",
   },
 };

--- a/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/EditPublicationStatus/editPublicationStatus.tsx
+++ b/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/EditPublicationStatus/editPublicationStatus.tsx
@@ -38,7 +38,7 @@ export const EditPublicationStatus = (props: Props): JSX.Element | null => {
           );
         }}
       >
-        Edit Publication Status
+        Edit Study Status
       </MenuItem>
       <StyledDialog
         {...DIALOG_PROPS}
@@ -47,7 +47,7 @@ export const EditPublicationStatus = (props: Props): JSX.Element | null => {
         onTransitionExited={closeMenu}
       >
         <TrackerForm>
-          <DialogTitle title="Edit Publication Status" onClose={onClose} />
+          <DialogTitle title="Edit Study Status" onClose={onClose} />
           <DialogContent dividers>
             <Controllers<PublicationStatusEditData>
               controllerConfigs={[PUBLICATION_STATUS]}

--- a/app/views/ComponentAtlasView/common/controllers.ts
+++ b/app/views/ComponentAtlasView/common/controllers.ts
@@ -75,7 +75,7 @@ const GENE_COUNT: CommonControllerConfig = {
 const PUBLISHED_AT: CommonControllerConfig = {
   inputProps: {
     isFullWidth: false,
-    label: "Date Published",
+    label: "Release Date",
     readOnly: true,
   },
   name: FIELD_NAME.PUBLISHED_AT,

--- a/site-config/hca-atlas-tracker/category.ts
+++ b/site-config/hca-atlas-tracker/category.ts
@@ -76,7 +76,7 @@ export const HCA_ATLAS_TRACKER_CATEGORY_LABEL = {
   PROJECT_TITLE: "Project Title",
   PUBLICATION: "Publication",
   PUBLICATION_STRING: "Source Study",
-  PUBLISHED_AT: "Published At",
+  PUBLISHED_AT: "Release Date",
   RELATED_ENTITY_URL: "Resource",
   RESOLVED_AT: "Completed At",
   ROLE: "Role",


### PR DESCRIPTION
## Summary
- Renames "Publication Status" to "Study Status" in SD table column, SD detail page, and Edit dropdown dialog
- Renames "Published At" / "Date Published" to "Release Date" in SD table, IO table, SD detail page, IO detail page, and category config
- Display-only change; no database, enum, API, or business logic affected

Closes #1162

## Test plan
- [x] SD table column reads "Study Status" instead of "Publication Status"
- [x] SD table column reads "Release Date" instead of "Published At"
- [x] IO table column reads "Release Date" instead of "Published At"
- [x] SD detail page shows "Study Status" and "Release Date"
- [x] IO detail page shows "Release Date"
- [x] Row selection Edit dropdown shows "Edit Study Status"
- [x] Edit Study Status dialog title and field label both say "Study Status"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1789" height="850" alt="image" src="https://github.com/user-attachments/assets/e9b5fc4e-87b0-46c2-a04a-e27baceb02aa" />

<img width="1792" height="742" alt="image" src="https://github.com/user-attachments/assets/447611a6-555d-42bb-a5b0-50df661c17c0" />

<img width="1795" height="1078" alt="image" src="https://github.com/user-attachments/assets/81204aea-6d6e-461d-856a-57e0a29b497c" />

<img width="1793" height="1097" alt="image" src="https://github.com/user-attachments/assets/5650d504-15ff-433d-b483-a14b27238dc0" />

<img width="1072" height="778" alt="image" src="https://github.com/user-attachments/assets/c8077283-04fa-4566-a0df-3280558d8ddc" />

<img width="1788" height="908" alt="image" src="https://github.com/user-attachments/assets/d10513b2-45bd-4f87-961e-8cb7e12c97bc" />

