### PR TITLE
feat: split "Updates Required" CAP ingest status into distinct statuses

### DIFF
--- a/__tests__/cap-ingest-status.utils.test.ts
+++ b/__tests__/cap-ingest-status.utils.test.ts
@@ -18,14 +18,14 @@ describe("getCapIngestStatus", () => {
     expect(status).toBe(CAP_INGEST_STATUS.NOT_REQUIRED);
   });
 
-  it("returns UPDATES_REQUIRED for unspecified reprocessed status", () => {
+  it("returns INFO_REQUIRED for unspecified reprocessed status", () => {
     const status = getCapIngestStatus(
       createSourceDataset({
         reprocessedStatus: REPROCESSED_STATUS.UNSPECIFIED,
       }),
     );
 
-    expect(status).toBe(CAP_INGEST_STATUS.UPDATES_REQUIRED);
+    expect(status).toBe(CAP_INGEST_STATUS.INFO_REQUIRED);
   });
 
   it("returns NEEDS_VALIDATION when validation is completed without summary", () => {
@@ -53,7 +53,7 @@ describe("getCapIngestStatus", () => {
     expect(status).toBe(CAP_INGEST_STATUS.CAP_READY);
   });
 
-  it("returns UPDATES_REQUIRED when validation completed with errors", () => {
+  it("returns CAP_VALIDATION_FAILED when validation completed with errors", () => {
     const status = getCapIngestStatus(
       createComponentAtlas({
         validationStatus: FILE_VALIDATION_STATUS.COMPLETED,
@@ -64,7 +64,7 @@ describe("getCapIngestStatus", () => {
       }),
     );
 
-    expect(status).toBe(CAP_INGEST_STATUS.UPDATES_REQUIRED);
+    expect(status).toBe(CAP_INGEST_STATUS.CAP_VALIDATION_FAILED);
   });
 
   it("returns NEEDS_VALIDATION when validation is not completed", () => {

--- a/app/components/Table/components/TableCell/components/CAPIngestStatusCell/capIngestStatusCell.tsx
+++ b/app/components/Table/components/TableCell/components/CAPIngestStatusCell/capIngestStatusCell.tsx
@@ -1,8 +1,18 @@
 import { ChipCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/ChipCell/chipCell";
+import { Tooltip } from "@mui/material";
 import { JSX } from "react";
+import { CAP_INGEST_STATUS_TOOLTIP } from "./constants";
 import { Props } from "./entities";
 import { buildCAPIngestStatus } from "./utils";
 
 export const CAPIngestStatusCell = ({ row }: Props): JSX.Element | null => {
-  return <ChipCell {...buildCAPIngestStatus({ row })} />;
+  const status = row.original.capIngestStatus;
+  const tooltip = CAP_INGEST_STATUS_TOOLTIP[status];
+  return (
+    <Tooltip title={tooltip}>
+      <span>
+        <ChipCell {...buildCAPIngestStatus({ row })} />
+      </span>
+    </Tooltip>
+  );
 };

--- a/app/components/Table/components/TableCell/components/CAPIngestStatusCell/capIngestStatusCell.tsx
+++ b/app/components/Table/components/TableCell/components/CAPIngestStatusCell/capIngestStatusCell.tsx
@@ -8,11 +8,7 @@ import { buildCAPIngestStatus } from "./utils";
 export const CAPIngestStatusCell = ({ row }: Props): JSX.Element | null => {
   const status = row.original.capIngestStatus;
   const tooltip = CAP_INGEST_STATUS_TOOLTIP[status];
-  return (
-    <Tooltip title={tooltip}>
-      <span>
-        <ChipCell {...buildCAPIngestStatus({ row })} />
-      </span>
-    </Tooltip>
-  );
+  const chipCell = <ChipCell {...buildCAPIngestStatus({ row })} />;
+  if (!tooltip) return chipCell;
+  return <Tooltip title={tooltip}>{chipCell}</Tooltip>;
 };

--- a/app/components/Table/components/TableCell/components/CAPIngestStatusCell/capIngestStatusCell.tsx
+++ b/app/components/Table/components/TableCell/components/CAPIngestStatusCell/capIngestStatusCell.tsx
@@ -8,7 +8,11 @@ import { buildCAPIngestStatus } from "./utils";
 export const CAPIngestStatusCell = ({ row }: Props): JSX.Element | null => {
   const status = row.original.capIngestStatus;
   const tooltip = CAP_INGEST_STATUS_TOOLTIP[status];
-  const chipCell = <ChipCell {...buildCAPIngestStatus({ row })} />;
-  if (!tooltip) return chipCell;
-  return <Tooltip title={tooltip}>{chipCell}</Tooltip>;
+  return (
+    <Tooltip title={tooltip}>
+      <span>
+        <ChipCell {...buildCAPIngestStatus({ row })} />
+      </span>
+    </Tooltip>
+  );
 };

--- a/app/components/Table/components/TableCell/components/CAPIngestStatusCell/constants.ts
+++ b/app/components/Table/components/TableCell/components/CAPIngestStatusCell/constants.ts
@@ -7,14 +7,22 @@ export const CAP_INGEST_STATUS_COLOR: Record<
   ChipProps["color"]
 > = {
   CAP_READY: CHIP_PROPS.COLOR.SUCCESS,
+  CAP_VALIDATION_FAILED: CHIP_PROPS.COLOR.ERROR,
+  INFO_REQUIRED: CHIP_PROPS.COLOR.WARNING,
   NEEDS_VALIDATION: CHIP_PROPS.COLOR.WARNING,
   NOT_REQUIRED: CHIP_PROPS.COLOR.DEFAULT,
-  UPDATES_REQUIRED: CHIP_PROPS.COLOR.ERROR,
 };
 
 export const CAP_INGEST_STATUS_LABEL: Record<CAP_INGEST_STATUS, string> = {
   CAP_READY: "CAP Ready",
+  CAP_VALIDATION_FAILED: "CAP Validation Failed",
+  INFO_REQUIRED: "Info Required",
   NEEDS_VALIDATION: "Needs Validation",
   NOT_REQUIRED: "Not Required",
-  UPDATES_REQUIRED: "Updates Required",
+};
+
+export const CAP_INGEST_STATUS_TOOLTIP: Partial<
+  Record<CAP_INGEST_STATUS, string>
+> = {
+  INFO_REQUIRED: "Set the Reprocessed Status to continue",
 };

--- a/app/components/Table/components/TableCell/components/CAPIngestStatusCell/entities.ts
+++ b/app/components/Table/components/TableCell/components/CAPIngestStatusCell/entities.ts
@@ -4,9 +4,10 @@ import { AtlasIntegratedObject } from "../../../../../../views/ComponentAtlasesV
 
 export enum CAP_INGEST_STATUS {
   CAP_READY = "CAP_READY",
+  CAP_VALIDATION_FAILED = "CAP_VALIDATION_FAILED",
+  INFO_REQUIRED = "INFO_REQUIRED",
   NEEDS_VALIDATION = "NEEDS_VALIDATION",
   NOT_REQUIRED = "NOT_REQUIRED",
-  UPDATES_REQUIRED = "UPDATES_REQUIRED",
 }
 
 export type Props =

--- a/app/components/Table/components/TableCell/components/CAPIngestStatusCell/utils.ts
+++ b/app/components/Table/components/TableCell/components/CAPIngestStatusCell/utils.ts
@@ -50,8 +50,8 @@ export function getCapIngestStatus(
       return CAP_INGEST_STATUS.NOT_REQUIRED;
     }
     if (original.reprocessedStatus === REPROCESSED_STATUS.UNSPECIFIED) {
-      // Status is "UPDATES_REQUIRED" for unspecified source datasets.
-      return CAP_INGEST_STATUS.UPDATES_REQUIRED;
+      // Status is "INFO_REQUIRED" for unspecified source datasets.
+      return CAP_INGEST_STATUS.INFO_REQUIRED;
     }
   }
 
@@ -65,8 +65,8 @@ export function getCapIngestStatus(
     if (validationSummary.validators.cap) {
       return CAP_INGEST_STATUS.CAP_READY;
     }
-    // Status is "UPDATES_REQUIRED" with completed validation with errors.
-    return CAP_INGEST_STATUS.UPDATES_REQUIRED;
+    // Status is "CAP_VALIDATION_FAILED" with completed validation with errors.
+    return CAP_INGEST_STATUS.CAP_VALIDATION_FAILED;
   }
 
   return CAP_INGEST_STATUS.NEEDS_VALIDATION;


### PR DESCRIPTION
## Summary
- Replaces the ambiguous "Updates Required" CAP ingest status with two distinct statuses:
  - **CAP Validation Failed** (red) — shown when CAP validation completes with errors
  - **Info Required** (orange/warning) — shown when reprocessed status is "Unspecified", with tooltip "Set the Reprocessed Status to continue"
- Removes the `UPDATES_REQUIRED` enum value, adds `CAP_VALIDATION_FAILED` and `INFO_REQUIRED`
- Wraps `CAPIngestStatusCell` with MUI `Tooltip` for statuses that have tooltip text
- Updates tests to match new status values

Depends on #1162 (merged as #1176)
Closes #1161

## Test plan
- [x] Source dataset with unspecified reprocessed status shows "Info Required" (orange) with tooltip
- [ ] Source dataset / integrated object with failed CAP validation shows "CAP Validation Failed" (red), no tooltip
- [x] Other statuses (CAP Ready, Needs Validation, Not Required) unchanged
- [x] Detail page CAP Ingest Status chip shows correct labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1874" height="1144" alt="image" src="https://github.com/user-attachments/assets/f1b9379f-8b67-440f-bce1-1891e17e3f29" />

<img width="2370" height="1089" alt="image" src="https://github.com/user-attachments/assets/7a14bdb0-8ecd-4a6e-9cda-c5dbb64a2c60" />
