### PR TITLE
chore: upgrade findable-ui from 50.7.0 to 51.0.0 (#1183)

### DIFF
--- a/app/hooks/useFetchData.ts
+++ b/app/hooks/useFetchData.ts
@@ -1,4 +1,4 @@
-import { useAuth } from "@databiosphere/findable-ui/lib/providers/authentication/auth/hook";
+import { useAuth } from "@databiosphere/findable-ui/lib/auth/hooks/useAuth";
 import { useCallback, useEffect, useReducer, useState } from "react";
 import { METHOD } from "../common/entities";
 import { fetchResource, isFetchStatusOk } from "../common/utils";

--- a/app/hooks/useFormManager/useFormManager.ts
+++ b/app/hooks/useFormManager/useFormManager.ts
@@ -1,4 +1,4 @@
-import { useAuth } from "@databiosphere/findable-ui/lib/providers/authentication/auth/hook";
+import { useAuth } from "@databiosphere/findable-ui/lib/auth/hooks/useAuth";
 import Router from "next/router";
 import { useCallback, useEffect, useState } from "react";
 import { FieldValues } from "react-hook-form";

--- a/app/providers/authorization.tsx
+++ b/app/providers/authorization.tsx
@@ -1,5 +1,5 @@
+import { useAuth } from "@databiosphere/findable-ui/lib/auth/hooks/useAuth";
 import { Main as DXMain } from "@databiosphere/findable-ui/lib/components/Layout/components/Main/main";
-import { useAuth } from "@databiosphere/findable-ui/lib/providers/authentication/auth/hook";
 import { createContext, JSX, ReactNode, useEffect } from "react";
 import {
   HCAAtlasTrackerActiveUser,

--- a/app/services/heatmaps.ts
+++ b/app/services/heatmaps.ts
@@ -56,7 +56,7 @@ function getClassHeatmap(
       return {
         name: ddAttribute.name,
         organSpecific: false,
-        required: ddAttribute.required,
+        required: Boolean(ddAttribute.required),
         title: ddAttribute.title,
       };
     }),

--- a/app/views/CellxGeneInProgressView/cellxgeneInProgressView.tsx
+++ b/app/views/CellxGeneInProgressView/cellxgeneInProgressView.tsx
@@ -1,4 +1,4 @@
-import { useAuth } from "@databiosphere/findable-ui/lib/providers/authentication/auth/hook";
+import { useAuth } from "@databiosphere/findable-ui/lib/auth/hooks/useAuth";
 import { ContentView } from "@databiosphere/findable-ui/lib/views/ContentView/contentView";
 import { JSX } from "react";
 import { AccessPrompt } from "../../components/common/Form/components/FormManager/components/AccessPrompt/accessPrompt";

--- a/app/views/FilesAdminView/filesAdminView.tsx
+++ b/app/views/FilesAdminView/filesAdminView.tsx
@@ -1,4 +1,4 @@
-import { useAuth } from "@databiosphere/findable-ui/lib/providers/authentication/auth/hook";
+import { useAuth } from "@databiosphere/findable-ui/lib/auth/hooks/useAuth";
 import { ContentView } from "@databiosphere/findable-ui/lib/views/ContentView/contentView";
 import { JSX } from "react";
 import { AccessPrompt } from "../../components/common/Form/components/FormManager/components/AccessPrompt/accessPrompt";

--- a/app/views/IntegrationLeadsFromAtlasesView/integrationLeadsFromAtlasesView.tsx
+++ b/app/views/IntegrationLeadsFromAtlasesView/integrationLeadsFromAtlasesView.tsx
@@ -1,4 +1,4 @@
-import { useAuth } from "@databiosphere/findable-ui/lib/providers/authentication/auth/hook";
+import { useAuth } from "@databiosphere/findable-ui/lib/auth/hooks/useAuth";
 import { ContentView } from "@databiosphere/findable-ui/lib/views/ContentView/contentView";
 import { JSX } from "react";
 import { AccessPrompt } from "../../components/common/Form/components/FormManager/components/AccessPrompt/accessPrompt";

--- a/app/views/RefreshView/refreshView.tsx
+++ b/app/views/RefreshView/refreshView.tsx
@@ -1,4 +1,4 @@
-import { useAuth } from "@databiosphere/findable-ui/lib/providers/authentication/auth/hook";
+import { useAuth } from "@databiosphere/findable-ui/lib/auth/hooks/useAuth";
 import { ContentView } from "@databiosphere/findable-ui/lib/views/ContentView/contentView";
 import { JSX } from "react";
 import { AccessPrompt } from "../../components/common/Form/components/FormManager/components/AccessPrompt/accessPrompt";

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@aws-sdk/client-batch": "^3.896.0",
         "@aws-sdk/client-s3": "^3.896.0",
         "@aws-sdk/s3-request-presigner": "^3.896.0",
-        "@databiosphere/findable-ui": "^50.7.0",
+        "@databiosphere/findable-ui": "^51.0.0",
         "@emotion/react": "^11",
         "@emotion/styled": "^11",
         "@hookform/resolvers": "^3.3.4",
@@ -2075,9 +2075,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "50.7.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-50.7.0.tgz",
-      "integrity": "sha512-4ISwTcj2Tdbj5vgHt8mb1bkBcP6LDqP1zaEbl/R5nh0u8BNnine9/fbXS7wT4MaiYbCNclMKucZ1qowcH+KlSQ==",
+      "version": "51.0.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-51.0.0.tgz",
+      "integrity": "sha512-Vti9a1VkgcOFuPqgFLOIApwz+DFY4+sjuAnJX8iL7/TA3EfjVzVsYg6rWja7u5M3wo4oapoUvDFim6Irx7gO0g==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.12.0"
@@ -2114,6 +2114,11 @@
         "unified": "^11.0.5",
         "uuid": "^13.0.0",
         "yup": "^1.7.1"
+      },
+      "peerDependenciesMeta": {
+        "next-auth": {
+          "optional": true
+        }
       }
     },
     "node_modules/@digitak/esrun": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/client-batch": "^3.896.0",
     "@aws-sdk/client-s3": "^3.896.0",
     "@aws-sdk/s3-request-presigner": "^3.896.0",
-    "@databiosphere/findable-ui": "^50.7.0",
+    "@databiosphere/findable-ui": "^51.0.0",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "@hookform/resolvers": "^3.3.4",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,10 +8,10 @@ import { Floating } from "@databiosphere/findable-ui/lib/components/Layout/compo
 import { Footer } from "@databiosphere/findable-ui/lib/components/Layout/components/Footer/footer";
 import { Header as DXHeader } from "@databiosphere/findable-ui/lib/components/Layout/components/Header/header";
 import { Main as DXMain } from "@databiosphere/findable-ui/lib/components/Layout/components/Main/main";
+import { NextAuthAuthenticationProvider } from "@databiosphere/findable-ui/lib/nextauth/provider";
 import { ConfigProvider as DXConfigProvider } from "@databiosphere/findable-ui/lib/providers/config";
 import { ExploreStateProvider } from "@databiosphere/findable-ui/lib/providers/exploreState";
 import { LayoutDimensionsProvider } from "@databiosphere/findable-ui/lib/providers/layoutDimensions/provider";
-import { NextAuthAuthenticationProvider } from "@databiosphere/findable-ui/lib/providers/nextAuthAuthentication/provider";
 import { ServicesProvider } from "@databiosphere/findable-ui/lib/providers/services/provider";
 import { SystemStatusProvider } from "@databiosphere/findable-ui/lib/providers/systemStatus";
 import { createAppTheme } from "@databiosphere/findable-ui/lib/theme/theme";

--- a/site-config/common/authentication.ts
+++ b/site-config/common/authentication.ts
@@ -1,5 +1,5 @@
 import { OAuthProvider } from "@databiosphere/findable-ui/lib/config/entities";
-import { GoogleProfile } from "@databiosphere/findable-ui/lib/providers/googleSignInAuthentication/profile/types";
+import { GoogleProfile } from "@databiosphere/findable-ui/lib/google/types";
 
 export const OAUTH_GOOGLE_SIGN_IN: Pick<
   OAuthProvider<GoogleProfile>,


### PR DESCRIPTION
## Summary
- Upgrades `@databiosphere/findable-ui` from v50.7.0 to v51.0.0
- Migrates auth import paths to new tree-shakeable subpath exports:
  - `lib/providers/nextAuthAuthentication/provider` → `lib/nextauth/provider`
  - `lib/providers/authentication/auth/hook` → `lib/auth/hooks/useAuth`
  - `lib/providers/googleSignInAuthentication/profile/types` → `lib/google/types`
- Coerces `RequirementLevel` (now `boolean | string`) to `boolean` in heatmap field mapping
- `next-auth` is now an optional peer dependency of findable-ui

Closes #1183

## Test plan
- [x] `npm run build:local` passes
- [x] `npm run lint` passes
- [x] `npm run check-format` passes
- [x] `npm test` — all 1024 tests pass
- [x] Smoke test login/logout flow
- [x] Verify auth-protected pages still enforce access control

🤖 Generated with [Claude Code](https://claude.com/claude-code)