### PR TITLE
feat: persist and expose hcaCellAnnotation validator report (#1185)

### DIFF
--- a/__tests__/api-sns-with-validation-results.test.ts
+++ b/__tests__/api-sns-with-validation-results.test.ts
@@ -159,7 +159,11 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
     expect(fileAfter).toEqual(fileBefore);
   });
 
-  it.each([{ tool: "cap" as const }, { tool: "cellxgene" as const }])(
+  it.each([
+    { tool: "cap" as const },
+    { tool: "cellxgene" as const },
+    { tool: "hcaCellAnnotation" as const },
+  ])(
     "returns error 400 when $tool is missing from tool reports",
     async ({ tool }) => {
       const fileBefore = await getFileFromDatabase(FILE_SOURCE_DATASET_FOO.id);
@@ -232,6 +236,13 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
         valid: false,
         warnings: [],
       },
+      hcaCellAnnotation: {
+        errors: [],
+        finished_at: "2025-09-14T10:00:02.342",
+        started_at: "2025-09-14T10:00:01.645",
+        valid: true,
+        warnings: [],
+      },
       hcaSchema: {
         errors: [],
         finished_at: "2025-09-14T10:00:02.342",
@@ -245,6 +256,7 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
       validators: {
         cap: true,
         cellxgene: false,
+        hcaCellAnnotation: true,
         hcaSchema: true,
       },
     };
@@ -356,6 +368,13 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
         valid: false,
         warnings: ["Warning dataset successful CxG"],
       },
+      hcaCellAnnotation: {
+        errors: [],
+        finished_at: validationTime,
+        started_at: validationTime,
+        valid: true,
+        warnings: [],
+      },
       hcaSchema: {
         errors: [],
         finished_at: validationTime,
@@ -369,6 +388,7 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
       validators: {
         cap: false,
         cellxgene: false,
+        hcaCellAnnotation: true,
         hcaSchema: true,
       },
     };
@@ -441,6 +461,13 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
         valid: false,
         warnings: ["Warning IO successful CxG"],
       },
+      hcaCellAnnotation: {
+        errors: [],
+        finished_at: validationTime,
+        started_at: validationTime,
+        valid: true,
+        warnings: [],
+      },
       hcaSchema: {
         errors: [],
         finished_at: validationTime,
@@ -454,6 +481,7 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
       validators: {
         cap: false,
         cellxgene: false,
+        hcaCellAnnotation: true,
         hcaSchema: true,
       },
     };

--- a/__tests__/api-sns-with-validation-results.test.ts
+++ b/__tests__/api-sns-with-validation-results.test.ts
@@ -163,6 +163,7 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
     { tool: "cap" as const },
     { tool: "cellxgene" as const },
     { tool: "hcaCellAnnotation" as const },
+    { tool: "hcaSchema" as const },
   ])(
     "returns error 400 when $tool is missing from tool reports",
     async ({ tool }) => {

--- a/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
+++ b/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
@@ -64,6 +64,7 @@ const datasetValidatorToolReportSchema = object({
 const datasetValidatorToolReportsSchema = object({
   cap: datasetValidatorToolReportSchema.required(),
   cellxgene: datasetValidatorToolReportSchema.required(),
+  hcaCellAnnotation: datasetValidatorToolReportSchema.required(),
   hcaSchema: datasetValidatorToolReportSchema.required(),
 });
 

--- a/app/apis/catalog/hca-atlas-tracker/common/constants.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/constants.ts
@@ -208,8 +208,8 @@ export const FILE_VALIDATION_STATUS_NAME_LABEL: Record<
 export const FILE_VALIDATOR_NAMES = [
   "cap",
   "cellxgene",
-  "hcaCellAnnotation",
   "hcaSchema",
+  "hcaCellAnnotation",
 ] as const;
 
 export const FILE_VALIDATOR_NAME_LABEL: Record<FileValidatorName, string> = {

--- a/app/apis/catalog/hca-atlas-tracker/common/constants.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/constants.ts
@@ -205,11 +205,17 @@ export const FILE_VALIDATION_STATUS_NAME_LABEL: Record<
   [FILE_VALIDATION_STATUS.STALE]: "Stale",
 };
 
-export const FILE_VALIDATOR_NAMES = ["cap", "cellxgene", "hcaSchema"] as const;
+export const FILE_VALIDATOR_NAMES = [
+  "cap",
+  "cellxgene",
+  "hcaCellAnnotation",
+  "hcaSchema",
+] as const;
 
 export const FILE_VALIDATOR_NAME_LABEL: Record<FileValidatorName, string> = {
   cap: "CAP",
   cellxgene: "CELLxGENE",
+  hcaCellAnnotation: "HCA Cell Annotation",
   hcaSchema: "HCA Tier-1",
 };
 

--- a/app/apis/catalog/hca-atlas-tracker/common/constants.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/constants.ts
@@ -219,6 +219,9 @@ export const FILE_VALIDATOR_NAME_LABEL: Record<FileValidatorName, string> = {
   hcaSchema: "HCA Tier-1",
 };
 
+export const FILE_VALIDATOR_NAMES_HIDDEN_WHEN_REPROCESSED: FileValidatorName[] =
+  ["cap", "hcaCellAnnotation"];
+
 export const UNPUBLISHED = "Unpublished";
 
 export const VALID_FILE_TYPES_FOR_VALIDATION = [

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -1,8 +1,14 @@
 import { GREATEST_UNIX_TIME } from "../../../../utils/date-fns";
-import { NETWORK_KEYS, UNPUBLISHED, WAVES } from "./constants";
+import {
+  FILE_VALIDATOR_NAMES_HIDDEN_WHEN_REPROCESSED,
+  NETWORK_KEYS,
+  UNPUBLISHED,
+  WAVES,
+} from "./constants";
 import {
   DOI_STATUS,
   DoiPublicationInfo,
+  FileValidatorName,
   HCAAtlasTrackerAtlas,
   HCAAtlasTrackerComponentAtlas,
   HCAAtlasTrackerListAtlas,
@@ -13,6 +19,7 @@ import {
   HCAAtlasTrackerValidationRecord,
   NetworkKey,
   PublicationInfo,
+  REPROCESSED_STATUS,
   TASK_STATUS,
   TIER_ONE_METADATA_STATUS,
   VALIDATION_ID,
@@ -320,5 +327,22 @@ export function taskInputMapper(
 export function isUuid(s: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
     s,
+  );
+}
+
+/**
+ * Whether a validator tab/summary entry should be rendered in the UI.
+ * @param validatorName - Validator.
+ * @param reprocessedStatus - Source dataset reprocessed status, when applicable; integrated objects and non-source-dataset contexts should leave it undefined.
+ * @returns True when the validator should appear in UI listings.
+ */
+export function shouldShowValidator(
+  validatorName: FileValidatorName,
+  reprocessedStatus?: REPROCESSED_STATUS,
+): boolean {
+  if (validatorName === "cellxgene") return false;
+  return !(
+    reprocessedStatus === REPROCESSED_STATUS.REPROCESSED &&
+    FILE_VALIDATOR_NAMES_HIDDEN_WHEN_REPROCESSED.includes(validatorName)
   );
 }

--- a/app/components/Entity/components/EntityView/components/ValidationReport/components/Tabs/entities.ts
+++ b/app/components/Entity/components/EntityView/components/ValidationReport/components/Tabs/entities.ts
@@ -10,4 +10,5 @@ export interface Props {
   validationReports?: FileValidationReports | null;
   validationRoute: RouteValue;
   validatorName?: FileValidatorName;
+  validatorNames: FileValidatorName[];
 }

--- a/app/components/Entity/components/EntityView/components/ValidationReport/components/Tabs/tabs.tsx
+++ b/app/components/Entity/components/EntityView/components/ValidationReport/components/Tabs/tabs.tsx
@@ -4,25 +4,20 @@ import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui
 import { TAB_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/tab";
 import { Tab } from "@mui/material";
 import Router from "next/router";
-import { JSX, SyntheticEvent, useCallback, useMemo } from "react";
+import { JSX, SyntheticEvent, useCallback } from "react";
 import { FILE_VALIDATOR_NAME_LABEL } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/constants";
 import { FileValidatorName } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { getRouteURL } from "../../../../../../../../common/utils";
 import { Props } from "./entities";
 import { StyledTabs } from "./tabs.styles";
-import { getValidatorNames } from "./utils";
 
 export const Tabs = ({
   pathParameter,
   validationReports,
   validationRoute,
   validatorName,
+  validatorNames,
 }: Props): JSX.Element | null => {
-  const validatorNames = useMemo(
-    () => getValidatorNames(validationReports),
-    [validationReports],
-  );
-
   const onChange = useCallback(
     (_: SyntheticEvent, validatorName: FileValidatorName) => {
       Router.push(

--- a/app/components/Entity/components/EntityView/components/ValidationReport/components/Tabs/utils.ts
+++ b/app/components/Entity/components/EntityView/components/ValidationReport/components/Tabs/utils.ts
@@ -1,26 +1,21 @@
 import {
   FileValidationReports,
   FileValidatorName,
+  REPROCESSED_STATUS,
 } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { shouldShowValidator } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/utils";
 
 /**
- * Returns the names of the validators that are not cellxgene.
+ * Returns the names of the validators that should be shown as tabs.
  * @param validationReports - The validation reports to get the validator names from.
- * @returns The names of the validators that are not cellxgene.
+ * @param reprocessedStatus - Source dataset reprocessed status, when applicable; used to hide validators that don't apply to reprocessed datasets.
+ * @returns The validator names to render as tabs.
  */
 export function getValidatorNames(
   validationReports?: FileValidationReports | null,
+  reprocessedStatus?: REPROCESSED_STATUS,
 ): FileValidatorName[] {
   return (Object.keys(validationReports ?? {}) as FileValidatorName[]).filter(
-    filterValidatorName,
+    (name) => shouldShowValidator(name, reprocessedStatus),
   );
-}
-
-/**
- * Returns true if the validator name is not cellxgene.
- * @param validatorName - The validator name to check.
- * @returns True if the validator name is not cellxgene.
- */
-function filterValidatorName(validatorName: FileValidatorName): boolean {
-  return validatorName !== "cellxgene";
 }

--- a/app/components/Entity/components/EntityView/components/ValidationReport/components/Tabs/utils.ts
+++ b/app/components/Entity/components/EntityView/components/ValidationReport/components/Tabs/utils.ts
@@ -1,3 +1,4 @@
+import { FILE_VALIDATOR_NAMES } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/constants";
 import {
   FileValidationReports,
   FileValidatorName,
@@ -6,8 +7,9 @@ import {
 import { shouldShowValidator } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/utils";
 
 /**
- * Returns the names of the validators that should be shown as tabs.
- * @param validationReports - The validation reports to get the validator names from.
+ * Returns the validator names to render as tabs, in canonical FILE_VALIDATOR_NAMES order.
+ * Postgres stores validation reports as jsonb, which does not preserve object key order, so the display order is driven off the constant rather than off the incoming object.
+ * @param validationReports - Validation reports for the file.
  * @param reprocessedStatus - Source dataset reprocessed status, when applicable; used to hide validators that don't apply to reprocessed datasets.
  * @returns The validator names to render as tabs.
  */
@@ -15,7 +17,10 @@ export function getValidatorNames(
   validationReports?: FileValidationReports | null,
   reprocessedStatus?: REPROCESSED_STATUS,
 ): FileValidatorName[] {
-  return (Object.keys(validationReports ?? {}) as FileValidatorName[]).filter(
-    (name) => shouldShowValidator(name, reprocessedStatus),
+  if (!validationReports) return [];
+  return FILE_VALIDATOR_NAMES.filter(
+    (name) =>
+      validationReports[name] !== undefined &&
+      shouldShowValidator(name, reprocessedStatus),
   );
 }

--- a/app/components/Entity/components/EntityView/components/ValidationReport/entities.ts
+++ b/app/components/Entity/components/EntityView/components/ValidationReport/entities.ts
@@ -2,12 +2,14 @@ import {
   FILE_VALIDATION_STATUS,
   FileValidationReports,
   FileValidatorName,
+  REPROCESSED_STATUS,
 } from "../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { PathParameter } from "../../../../../../common/entities";
 import { RouteValue } from "../../../../../../routes/entities";
 
 export interface Props {
   pathParameter: PathParameter;
+  reprocessedStatus?: REPROCESSED_STATUS;
   validationReports?: FileValidationReports | null;
   validationRoute: RouteValue;
   validationStatus?: FILE_VALIDATION_STATUS;

--- a/app/components/Entity/components/EntityView/components/ValidationReport/validationReport.tsx
+++ b/app/components/Entity/components/EntityView/components/ValidationReport/validationReport.tsx
@@ -1,17 +1,43 @@
 import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/components/FluidPaper/fluidPaper";
-import { JSX } from "react";
+import Router from "next/router";
+import { JSX, useEffect, useMemo } from "react";
+import { getRouteURL } from "../../../../../../common/utils";
 import { ReportContent } from "./components/ReportContent/reportContent";
 import { Tabs } from "./components/Tabs/tabs";
+import { getValidatorNames } from "./components/Tabs/utils";
 import { Props } from "./entities";
 
 export const ValidationReport = ({
   pathParameter,
+  reprocessedStatus,
   validationReports,
   validationRoute,
   validationStatus,
   validatorName,
 }: Props): JSX.Element | null => {
+  const validatorNames = useMemo(
+    () => getValidatorNames(validationReports, reprocessedStatus),
+    [validationReports, reprocessedStatus],
+  );
+
+  const isValidatorHidden = Boolean(
+    validatorName && !validatorNames.includes(validatorName),
+  );
+
+  useEffect(() => {
+    if (!isValidatorHidden) return;
+    const [fallback] = validatorNames;
+    if (!fallback) return;
+    Router.replace(
+      getRouteURL(validationRoute, {
+        ...pathParameter,
+        validatorName: fallback,
+      }),
+    );
+  }, [isValidatorHidden, pathParameter, validationRoute, validatorNames]);
+
   if (!validationStatus) return null; // `validationStatus` is a required field; an undefined value implies the data is not yet available.
+  if (isValidatorHidden) return null; // Redirecting to a visible validator; avoid rendering hidden-validator content.
   return (
     <FluidPaper>
       <Tabs
@@ -19,6 +45,7 @@ export const ValidationReport = ({
         validationReports={validationReports}
         validationRoute={validationRoute}
         validatorName={validatorName}
+        validatorNames={validatorNames}
       />
       <ReportContent
         validationReports={validationReports}

--- a/app/components/Entity/components/EntityView/components/ValidationReport/validationReport.tsx
+++ b/app/components/Entity/components/EntityView/components/ValidationReport/validationReport.tsx
@@ -20,24 +20,33 @@ export const ValidationReport = ({
     [validationReports, reprocessedStatus],
   );
 
+  const hasValidatorVisibilityData =
+    validationReports != null && validatorNames.length > 0;
   const isValidatorHidden = Boolean(
-    validatorName && !validatorNames.includes(validatorName),
+    hasValidatorVisibilityData &&
+    validatorName &&
+    !validatorNames.includes(validatorName),
   );
+  const [fallbackValidatorName] = validatorNames;
 
   useEffect(() => {
     if (!isValidatorHidden) return;
-    const [fallback] = validatorNames;
-    if (!fallback) return;
+    if (!fallbackValidatorName) return;
     Router.replace(
       getRouteURL(validationRoute, {
         ...pathParameter,
-        validatorName: fallback,
+        validatorName: fallbackValidatorName,
       }),
     );
-  }, [isValidatorHidden, pathParameter, validationRoute, validatorNames]);
+  }, [
+    fallbackValidatorName,
+    isValidatorHidden,
+    pathParameter,
+    validationRoute,
+  ]);
 
   if (!validationStatus) return null; // `validationStatus` is a required field; an undefined value implies the data is not yet available.
-  if (isValidatorHidden) return null; // Redirecting to a visible validator; avoid rendering hidden-validator content.
+  if (isValidatorHidden && fallbackValidatorName) return null; // Redirecting to a visible validator; avoid rendering hidden-validator content.
   return (
     <FluidPaper>
       <Tabs

--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/entities.ts
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/entities.ts
@@ -1,8 +1,12 @@
-import { FileValidationSummary } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
+import {
+  FileValidationSummary,
+  REPROCESSED_STATUS,
+} from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { PathParameter } from "../../../../../../../../common/entities";
 import { RouteValue } from "../../../../../../../../routes/entities";
 
 export interface Props extends PathParameter {
+  reprocessedStatus?: REPROCESSED_STATUS;
   validationRoute: RouteValue;
   validationSummary: FileValidationSummary | null;
 }

--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/utils.ts
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/utils.ts
@@ -1,3 +1,4 @@
+import { FILE_VALIDATOR_NAMES } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/constants";
 import {
   FileValidationSummary,
   FileValidatorName,
@@ -6,7 +7,8 @@ import {
 import { shouldShowValidator } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/utils";
 
 /**
- * Returns the validators to render in the validation summary.
+ * Returns the validators to render in the validation summary, in canonical FILE_VALIDATOR_NAMES order.
+ * Postgres stores the validators map as jsonb, which does not preserve object key order, so the display order is driven off the constant rather than off the incoming object.
  * @param validationSummary - Validation summary.
  * @param reprocessedStatus - Source dataset reprocessed status, when applicable; used to hide validators that don't apply to reprocessed datasets.
  * @returns Filtered validator entries.
@@ -15,10 +17,12 @@ export function getValidators(
   validationSummary: FileValidationSummary,
   reprocessedStatus?: REPROCESSED_STATUS,
 ): [FileValidatorName, boolean][] {
-  return (
-    Object.entries(validationSummary.validators) as [
-      FileValidatorName,
-      boolean,
-    ][]
-  ).filter(([name]) => shouldShowValidator(name, reprocessedStatus));
+  const entries: [FileValidatorName, boolean][] = [];
+  for (const name of FILE_VALIDATOR_NAMES) {
+    const value = validationSummary.validators[name];
+    if (value === undefined) continue;
+    if (!shouldShowValidator(name, reprocessedStatus)) continue;
+    entries.push([name, value]);
+  }
+  return entries;
 }

--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/utils.ts
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/utils.ts
@@ -1,29 +1,24 @@
 import {
   FileValidationSummary,
   FileValidatorName,
+  REPROCESSED_STATUS,
 } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { shouldShowValidator } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/utils";
 
 /**
- * Returns the validation summary validators.
+ * Returns the validators to render in the validation summary.
  * @param validationSummary - Validation summary.
- * @returns Validation summary validators.
+ * @param reprocessedStatus - Source dataset reprocessed status, when applicable; used to hide validators that don't apply to reprocessed datasets.
+ * @returns Filtered validator entries.
  */
 export function getValidators(
   validationSummary: FileValidationSummary,
+  reprocessedStatus?: REPROCESSED_STATUS,
 ): [FileValidatorName, boolean][] {
   return (
     Object.entries(validationSummary.validators) as [
       FileValidatorName,
       boolean,
     ][]
-  ).filter(filterValidator);
-}
-
-/**
- * Returns true if the validator is not cellxgene.
- * @param validator - Validator.
- * @returns True if the validator is not cellxgene.
- */
-function filterValidator(validator: [FileValidatorName, boolean]): boolean {
-  return validator[0] !== "cellxgene";
+  ).filter(([name]) => shouldShowValidator(name, reprocessedStatus));
 }

--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.tsx
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.tsx
@@ -18,13 +18,14 @@ import { StyledErrorIcon } from "./validationSummary.styles";
 export const ValidationSummary = ({
   atlasId,
   componentAtlasId,
+  reprocessedStatus,
   sourceDatasetId,
   validationRoute,
   validationSummary,
 }: Props): JSX.Element | null => {
   if (!validationSummary) return null;
 
-  const validators = getValidators(validationSummary);
+  const validators = getValidators(validationSummary, reprocessedStatus);
 
   if (validators.length === 0) return null;
 

--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/validationStatusCell.tsx
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/validationStatusCell.tsx
@@ -12,6 +12,8 @@ export const ValidationStatusCell = ({
 }: Props): JSX.Element | null => {
   const { original } = row;
   const { atlasId, validationStatus, validationSummary } = original;
+  const reprocessedStatus =
+    "reprocessedStatus" in original ? original.reprocessedStatus : undefined;
 
   // Render validation summary if validation status is completed.
   if (validationStatus === FILE_VALIDATION_STATUS.COMPLETED)
@@ -19,6 +21,7 @@ export const ValidationStatusCell = ({
       <ValidationSummary
         atlasId={atlasId}
         componentAtlasId={componentAtlasId}
+        reprocessedStatus={reprocessedStatus}
         sourceDatasetId={sourceDatasetId}
         validationRoute={validationRoute}
         validationSummary={validationSummary}

--- a/app/views/AtlasSourceDatasetValidationView/components/Report/report.tsx
+++ b/app/views/AtlasSourceDatasetValidationView/components/Report/report.tsx
@@ -8,13 +8,15 @@ export const Report = (): JSX.Element | null => {
   const { data, pathParameter } = useEntity();
   const { sourceDataset } = data as EntityData;
   const { validatorName } = pathParameter || {};
-  const { validationReports, validationStatus } = sourceDataset || {};
+  const { reprocessedStatus, validationReports, validationStatus } =
+    sourceDataset || {};
 
   if (!pathParameter) return null;
 
   return (
     <ValidationReport
       pathParameter={pathParameter}
+      reprocessedStatus={reprocessedStatus}
       validationReports={validationReports}
       validationRoute={ROUTE.ATLAS_SOURCE_DATASET_VALIDATION}
       validationStatus={validationStatus}

--- a/testing/sns-testing.ts
+++ b/testing/sns-testing.ts
@@ -153,6 +153,13 @@ export const SUCCESSFUL_TOOL_REPORTS: DatasetValidatorToolReports = {
     valid: true,
     warnings: [],
   },
+  hcaCellAnnotation: {
+    errors: [],
+    finished_at: TEST_TIMESTAMP,
+    started_at: TEST_TIMESTAMP,
+    valid: true,
+    warnings: [],
+  },
   hcaSchema: {
     errors: [],
     finished_at: TEST_TIMESTAMP,
@@ -167,6 +174,7 @@ export const SUCCESSFUL_VALIDATION_SUMMARY: FileValidationSummary = {
   validators: {
     cap: true,
     cellxgene: true,
+    hcaCellAnnotation: true,
     hcaSchema: true,
   },
 };


### PR DESCRIPTION
## Summary

**1. Persist and expose `hcaCellAnnotation` validator report**

- Adds `hcaCellAnnotation` as a fourth entry to `FILE_VALIDATOR_NAMES` so the new report from dataset-validator PR [#366](https://github.com/clevercanary/hca-validation-tools/pull/366) is persisted to `validation_reports`, rolled into `overallValid`, surfaced by the file-details API, and rendered as a fourth UI tab.
- Adds display label `"HCA Cell Annotation"` to `FILE_VALIDATOR_NAME_LABEL`.
- Adds `hcaCellAnnotation` as a required key in the SNS Yup schema (`datasetValidatorToolReportsSchema`) so incoming messages retain the key through validation.
- Updates shared test fixtures (`SUCCESSFUL_TOOL_REPORTS`, `SUCCESSFUL_VALIDATION_SUMMARY`) and extends SNS tests accordingly.

No DB migration required — `validation_reports` is a single JSONB column.

**2. Hide CAP and HCA Cell Annotation for reprocessed source datasets (added mid-PR)**

CAP and HCA Cell Annotation validator results are only meaningful for source datasets carrying the original CAP annotation pipeline output. For source datasets with `reprocessed_status = "Reprocessed"`, these two validators are now hidden:

- Detail-view tab bar (`ValidationReport` / `Tabs`) — tab is not rendered.
- List-cell summary (`ValidationSummary`) — pass/fail icon + link is not rendered.
- Default redirect fallback: when the URL lands on a now-hidden validator (e.g. `/source-datasets/[id]/validations` 308-redirects to `/cap`), `ValidationReport` replaces the route with the first visible validator and suppresses the hidden-validator render in the interim to avoid a content flicker.

Filter is source-dataset-only — integrated objects and non-source-dataset contexts leave `reprocessedStatus` undefined and see no filtering change. `cellxgene` continues to be filtered everywhere (pre-existing behavior, now centralized in `shouldShowValidator`).

## Merge ordering

**Hold until hca-validation-tools #366 is deployed.** The Yup schema marks `hcaCellAnnotation` as `.required()`, so merging first would cause every in-flight SNS message lacking the key to fail validation (400 → SNS retries → DLQ). Deploy the validator first, then merge.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run check-format` clean
- [x] `npm test` — 1026/1026 passing, including assertion that a missing `hcaCellAnnotation` or `hcaSchema` key returns 400
- [ ] After hca-validation-tools deploy: confirm round-trip of the new report from a real SNS message into `validation_reports` JSONB and out through the file-details API
- [ ] Confirm `overallValid` is false when only `hcaCellAnnotation.valid` is false
- [ ] Confirm UI renders a fourth tab labeled "HCA Cell Annotation" on a file whose payload includes the new key
- [ ] Confirm CAP and HCA Cell Annotation tabs + summary entries are hidden on a reprocessed source dataset
- [ ] Confirm pending / in-progress source-dataset validation pages still render the status text (non-completed state)
- [ ] Confirm integrated-object validation pages are unchanged (no filtering)

Closes #1185