### PR TITLE
feat: increase min-width of Validation Summary columns

### DIFF
--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -1345,7 +1345,7 @@ function getIntegratedObjectValidationStatusColumnDef(): ColumnDef<
       });
     },
     header: "Validation Summary",
-    meta: { width: { max: "1fr", min: "136px" } },
+    meta: { width: { max: "1fr", min: "180px" } },
   };
 }
 

--- a/app/views/AtlasSourceDatasetsView/components/Table/columns.ts
+++ b/app/views/AtlasSourceDatasetsView/components/Table/columns.ts
@@ -169,7 +169,7 @@ const COLUMN_VALIDATION_STATUS = {
   accessorKey: "validationStatus",
   cell: renderSourceDatasetValidationStatus,
   header: "Validation Summary",
-  meta: { width: { max: "0.5fr", min: "120px" } },
+  meta: { width: { max: "0.5fr", min: "180px" } },
 } as ColumnDef<AtlasSourceDataset>;
 
 const COLUMN_VERSION = {


### PR DESCRIPTION
## Summary
- Increases the min-width of Validation Summary columns from 120px/136px to 180px to accommodate 4 validator icons without truncation

Closes #1190

## Test plan
- [x] Source Datasets table: Validation Summary column displays all validator icons without truncation
- [x] Integrated Objects table: Validation Summary column displays all validator icons without truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)