### PR TITLE
fix: bump Validation Summary min-width to 200px

### DIFF
--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.ts
@@ -1345,7 +1345,7 @@ function getIntegratedObjectValidationStatusColumnDef(): ColumnDef<
       });
     },
     header: "Validation Summary",
-    meta: { width: { max: "1fr", min: "180px" } },
+    meta: { width: { max: "1fr", min: "200px" } },
   };
 }
 

--- a/app/views/AtlasSourceDatasetsView/components/Table/columns.ts
+++ b/app/views/AtlasSourceDatasetsView/components/Table/columns.ts
@@ -169,7 +169,7 @@ const COLUMN_VALIDATION_STATUS = {
   accessorKey: "validationStatus",
   cell: renderSourceDatasetValidationStatus,
   header: "Validation Summary",
-  meta: { width: { max: "0.5fr", min: "180px" } },
+  meta: { width: { max: "0.5fr", min: "200px" } },
 } as ColumnDef<AtlasSourceDataset>;
 
 const COLUMN_VERSION = {


### PR DESCRIPTION
## Summary
- Increases Validation Summary column min-width from 180px to 200px for both Source Datasets and Integrated Objects tables

Follow-up to #1191 which was merged at 180px before the adjustment to 200px could land.

Closes #1190

## Test plan
- [ ] Source Datasets table: Validation Summary column displays all validator icons without truncation
- [ ] Integrated Objects table: Validation Summary column displays all validator icons without truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)