### PR TITLE
feat: show (0) count on atlas tab headers when lists are empty

### DIFF
--- a/app/components/Detail/components/TrackerForm/components/Tabs/common/utils.ts
+++ b/app/components/Detail/components/TrackerForm/components/Tabs/common/utils.ts
@@ -7,6 +7,6 @@ import { ReactNode } from "react";
  * @returns tab label with count.
  */
 export function getTabLabelWithCount(label: string, count?: number): ReactNode {
-  if (!count) return label;
+  if (count == null) return label;
   return `${label} (${count})`;
 }


### PR DESCRIPTION
## Summary
- Changes `getTabLabelWithCount()` to use `count == null` instead of `!count`, so a count of `0` renders as e.g. "Source Studies (0)" instead of omitting the count entirely
- Tabs without a list (Overview, Metadata Correctness) are unaffected since they don't pass a count

Closes #1180

## Test plan
- [x] Atlas with empty source studies list shows "Source Studies (0)"
- [x] Atlas with empty metadata entry sheets shows "Metadata Entry Sheets (0)"
- [x] Atlas with empty source datasets shows "Source Datasets (0)"
- [x] Atlas with empty integrated objects shows "Integrated Objects (0)"
- [x] Non-empty lists still show correct counts e.g. "Source Studies (7)"
- [x] Overview and Metadata Correctness tabs show no count (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2452" height="1156" alt="image" src="https://github.com/user-attachments/assets/b5122fc1-8442-448a-a1e6-2787693579f9" />
