### PR TITLE
feat: add editable download name to source dataset and integrated object forms (#1177)

### DIFF
--- a/__tests__/api-atlases-id-component-atlases-id.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id.test.ts
@@ -39,6 +39,7 @@ import { resetDatabase } from "../testing/db-utils";
 import { TestUser } from "../testing/entities";
 import {
   expectDetailApiComponentAtlasToMatchTest,
+  getTestEntityDownloadName,
   testApiRole,
   withConsoleErrorHiding,
 } from "../testing/utils";
@@ -54,14 +55,17 @@ jest.mock("next-auth");
 
 const MISC_FOO_EDIT_DATA = {
   capUrl: "https://celltype.info/project/982834/dataset/325453",
+  downloadName: getTestEntityDownloadName(COMPONENT_ATLAS_MISC_FOO),
 } satisfies ComponentAtlasEditData;
 
 const MISC_BAR_EDIT_DATA = {
   capUrl: "https://celltype.info/project/234782/dataset/645632",
+  downloadName: getTestEntityDownloadName(COMPONENT_ATLAS_MISC_BAR),
 } satisfies ComponentAtlasEditData;
 
 const MISC_BAZ_EDIT_DATA = {
   capUrl: "",
+  downloadName: getTestEntityDownloadName(COMPONENT_ATLAS_MISC_BAZ),
 } satisfies ComponentAtlasEditData;
 
 const TEST_ROUTE =
@@ -430,7 +434,12 @@ describe(TEST_ROUTE, () => {
   });
 
   it("returns error 400 when PATCH requested with component atlas that the atlas does not have the latest version of", async () => {
-    const editData = { capUrl: null } satisfies ComponentAtlasEditData;
+    const editData = {
+      capUrl: null,
+      downloadName: getTestEntityDownloadName(
+        COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_FOO_W2,
+      ),
+    } satisfies ComponentAtlasEditData;
     const res = await doComponentAtlasRequest(
       ATLAS_WITH_NON_LATEST_METADATA_ENTITIES.id,
       COMPONENT_ATLAS_ID_NON_LATEST_METADATA_ENTITIES_FOO,
@@ -524,6 +533,9 @@ describe(TEST_ROUTE, () => {
   it("updates component atlas when PATCH requested from atlas that is linked to its latest version", async () => {
     const editData = {
       capUrl: "https://celltype.info/project/928342/dataset/458432",
+      downloadName: getTestEntityDownloadName(
+        COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_FOO_W2,
+      ),
     } satisfies ComponentAtlasEditData;
     const res = await doComponentAtlasRequest(
       ATLAS_WITH_NON_LATEST_METADATA_ENTITIES.id,

--- a/__tests__/api-atlases-id-component-atlases-id.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id.test.ts
@@ -22,6 +22,7 @@ import {
   COMPONENT_ATLAS_MISC_BAR,
   COMPONENT_ATLAS_MISC_BAZ,
   COMPONENT_ATLAS_MISC_FOO,
+  COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAR_W2,
   COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_FOO_W2,
   COMPONENT_ATLAS_WITH_ARCHIVED_LATEST_W2,
   COMPONENT_ATLAS_WITH_MULTIPLE_FILES_W3,
@@ -535,7 +536,7 @@ describe(TEST_ROUTE, () => {
     const editData = {
       capUrl: "https://celltype.info/project/928342/dataset/458432",
       downloadName: getTestEntityDownloadName(
-        COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_FOO_W2,
+        COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAR_W2,
       ),
     } satisfies ComponentAtlasEditData;
     const res = await doComponentAtlasRequest(

--- a/__tests__/api-atlases-id-component-atlases-id.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id.test.ts
@@ -592,8 +592,8 @@ describe(TEST_ROUTE, () => {
     );
     assertExpectDefined(conceptAfter);
     // Download name wasn't changed, so concept shouldn't have been updated
-    expect(conceptAfter.updated_at.getDate()).toEqual(
-      conceptBefore.updated_at.getDate(),
+    expect(conceptAfter.updated_at.getTime()).toEqual(
+      conceptBefore.updated_at.getTime(),
     );
   });
 

--- a/__tests__/api-atlases-id-component-atlases-id.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id.test.ts
@@ -3,6 +3,7 @@ import httpMocks from "node-mocks-http";
 import { HCAAtlasTrackerDetailComponentAtlas } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { ComponentAtlasEditData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
 import { METHOD } from "../app/common/entities";
+import { FormResponseErrors } from "../app/hooks/useForm/common/entities";
 import { endPgPool } from "../app/services/database";
 import componentAtlasHandler from "../pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId]";
 import {
@@ -525,39 +526,45 @@ describe(TEST_ROUTE, () => {
   });
 
   it("returns error 400 when PATCH requested with download name containing version suffix", async () => {
-    expect(
-      (
-        await doComponentAtlasRequest(
-          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
-          COMPONENT_ATLAS_MISC_BAR.id,
-          USER_CONTENT_ADMIN,
-          METHOD.PATCH,
-          {
-            ...MISC_BAR_EDIT_DATA,
-            downloadName: "file-r1",
-          },
-          true,
-        )
-      )._getStatusCode(),
-    ).toEqual(400);
+    const res = await doComponentAtlasRequest(
+      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+      COMPONENT_ATLAS_MISC_BAR.id,
+      USER_CONTENT_ADMIN,
+      METHOD.PATCH,
+      {
+        ...MISC_BAR_EDIT_DATA,
+        downloadName: "file-r1",
+      },
+      true,
+    );
+    expect(res._getStatusCode()).toEqual(400);
+    const errorInfo = res._getJSONData() as FormResponseErrors;
+    expect(errorInfo).toMatchObject({
+      errors: {
+        downloadName: [expect.stringContaining("version suffix")],
+      },
+    });
   });
 
   it("returns error 409 when PATCH requested with download name that already exists in the atlas generation", async () => {
-    expect(
-      (
-        await doComponentAtlasRequest(
-          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
-          COMPONENT_ATLAS_MISC_BAR.id,
-          USER_CONTENT_ADMIN,
-          METHOD.PATCH,
-          {
-            ...MISC_BAR_EDIT_DATA,
-            downloadName: getTestEntityDownloadName(COMPONENT_ATLAS_MISC_FOO),
-          },
-          true,
-        )
-      )._getStatusCode(),
-    ).toEqual(409);
+    const res = await doComponentAtlasRequest(
+      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+      COMPONENT_ATLAS_MISC_BAR.id,
+      USER_CONTENT_ADMIN,
+      METHOD.PATCH,
+      {
+        ...MISC_BAR_EDIT_DATA,
+        downloadName: getTestEntityDownloadName(COMPONENT_ATLAS_MISC_FOO),
+      },
+      true,
+    );
+    expect(res._getStatusCode()).toEqual(409);
+    const errorInfo = res._getJSONData() as FormResponseErrors;
+    expect(errorInfo).toMatchObject({
+      errors: {
+        downloadName: [expect.stringContaining("already exists")],
+      },
+    });
   });
 
   it("updates component atlas when PATCH requested by user with CONTENT_ADMIN role", async () => {

--- a/__tests__/api-atlases-id-component-atlases-id.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id.test.ts
@@ -36,9 +36,11 @@ import {
   USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
   USER_UNREGISTERED,
 } from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
+import { getConceptFromDatabase, resetDatabase } from "../testing/db-utils";
 import { TestUser } from "../testing/entities";
 import {
+  assertExpectDefined,
+  delay,
   expectDetailApiComponentAtlasToMatchTest,
   getTestEntityDownloadName,
   testApiRole,
@@ -504,7 +506,48 @@ describe(TEST_ROUTE, () => {
     ).toEqual(400);
   });
 
+  it("returns error 400 when PATCH requested with download name set to empty string", async () => {
+    expect(
+      (
+        await doComponentAtlasRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          COMPONENT_ATLAS_MISC_BAR.id,
+          USER_CONTENT_ADMIN,
+          METHOD.PATCH,
+          {
+            ...MISC_BAR_EDIT_DATA,
+            downloadName: "",
+          },
+          true,
+        )
+      )._getStatusCode(),
+    ).toEqual(400);
+  });
+
+  it("returns error 409 when PATCH requested with download name that already exists in the atlas generation", async () => {
+    expect(
+      (
+        await doComponentAtlasRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          COMPONENT_ATLAS_MISC_BAR.id,
+          USER_CONTENT_ADMIN,
+          METHOD.PATCH,
+          {
+            ...MISC_BAR_EDIT_DATA,
+            downloadName: getTestEntityDownloadName(COMPONENT_ATLAS_MISC_FOO),
+          },
+          true,
+        )
+      )._getStatusCode(),
+    ).toEqual(409);
+  });
+
   it("updates component atlas when PATCH requested by user with CONTENT_ADMIN role", async () => {
+    const conceptBefore = await getConceptFromDatabase(
+      COMPONENT_ATLAS_MISC_BAR.id,
+    );
+    assertExpectDefined(conceptBefore);
+    await delay(10); // Ensure timestamps can be different
     const res = await doComponentAtlasRequest(
       ATLAS_WITH_MISC_SOURCE_STUDIES.id,
       COMPONENT_ATLAS_MISC_BAR.id,
@@ -518,6 +561,14 @@ describe(TEST_ROUTE, () => {
     expect(componentAtlas.capUrl).toEqual(MISC_BAR_EDIT_DATA.capUrl);
     expect(componentAtlas.downloadName).toEqual(
       MISC_BAR_EDIT_DATA.downloadName,
+    );
+    const conceptAfter = await getConceptFromDatabase(
+      COMPONENT_ATLAS_MISC_BAR.id,
+    );
+    assertExpectDefined(conceptAfter);
+    // Download name wasn't changed, so concept shouldn't have been updated
+    expect(conceptAfter.updated_at.getDate()).toEqual(
+      conceptBefore.updated_at.getDate(),
     );
   });
 
@@ -557,6 +608,28 @@ describe(TEST_ROUTE, () => {
       res._getJSONData() as HCAAtlasTrackerDetailComponentAtlas;
     expect(componentAtlas.capUrl).toEqual(editData.capUrl);
     expect(componentAtlas.downloadName).toEqual(editData.downloadName);
+  });
+
+  it("updates associated concept when PATCH requested with new download name", async () => {
+    const editData = {
+      capUrl: null,
+      downloadName: "new-download-name",
+    } satisfies ComponentAtlasEditData;
+    const res = await doComponentAtlasRequest(
+      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+      COMPONENT_ATLAS_MISC_FOO.id,
+      USER_CONTENT_ADMIN,
+      METHOD.PATCH,
+      editData,
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const componentAtlas =
+      res._getJSONData() as HCAAtlasTrackerDetailComponentAtlas;
+    expect(componentAtlas.capUrl).toEqual(editData.capUrl);
+    expect(componentAtlas.downloadName).toEqual(editData.downloadName);
+    const concept = await getConceptFromDatabase(COMPONENT_ATLAS_MISC_FOO.id);
+    assertExpectDefined(concept);
+    expect(concept.base_filename).toEqual(editData.downloadName + ".h5ad");
   });
 });
 

--- a/__tests__/api-atlases-id-component-atlases-id.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id.test.ts
@@ -524,6 +524,24 @@ describe(TEST_ROUTE, () => {
     ).toEqual(400);
   });
 
+  it("returns error 400 when PATCH requested with download name containing version suffix", async () => {
+    expect(
+      (
+        await doComponentAtlasRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          COMPONENT_ATLAS_MISC_BAR.id,
+          USER_CONTENT_ADMIN,
+          METHOD.PATCH,
+          {
+            ...MISC_BAR_EDIT_DATA,
+            downloadName: "file-r1",
+          },
+          true,
+        )
+      )._getStatusCode(),
+    ).toEqual(400);
+  });
+
   it("returns error 409 when PATCH requested with download name that already exists in the atlas generation", async () => {
     expect(
       (

--- a/__tests__/api-atlases-id-component-atlases-id.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id.test.ts
@@ -388,6 +388,21 @@ describe(TEST_ROUTE, () => {
     ).toEqual(403);
   });
 
+  it("returns error 403 when PATCH requested by user with INTEGRATION_LEAD role for the atlas", async () => {
+    expect(
+      (
+        await doComponentAtlasRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          COMPONENT_ATLAS_MISC_FOO.id,
+          USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
+          METHOD.PATCH,
+          MISC_FOO_EDIT_DATA,
+          false,
+        )
+      )._getStatusCode(),
+    ).toEqual(403);
+  });
+
   it("returns error 404 when PATCH requested with nonexistent component atlas", async () => {
     expect(
       (
@@ -486,20 +501,6 @@ describe(TEST_ROUTE, () => {
         )
       )._getStatusCode(),
     ).toEqual(400);
-  });
-
-  it("updates component atlas when PATCH requested by user with INTEGRATION_LEAD role for the atlas", async () => {
-    const res = await doComponentAtlasRequest(
-      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
-      COMPONENT_ATLAS_MISC_FOO.id,
-      USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
-      METHOD.PATCH,
-      MISC_FOO_EDIT_DATA,
-    );
-    expect(res._getStatusCode()).toEqual(200);
-    const componentAtlas =
-      res._getJSONData() as HCAAtlasTrackerDetailComponentAtlas;
-    expect(componentAtlas.capUrl).toEqual(MISC_FOO_EDIT_DATA.capUrl);
   });
 
   it("updates component atlas when PATCH requested by user with CONTENT_ADMIN role", async () => {

--- a/__tests__/api-atlases-id-component-atlases-id.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id.test.ts
@@ -516,6 +516,9 @@ describe(TEST_ROUTE, () => {
     const componentAtlas =
       res._getJSONData() as HCAAtlasTrackerDetailComponentAtlas;
     expect(componentAtlas.capUrl).toEqual(MISC_BAR_EDIT_DATA.capUrl);
+    expect(componentAtlas.downloadName).toEqual(
+      MISC_BAR_EDIT_DATA.downloadName,
+    );
   });
 
   it("sets CAP URL to null when PATCH requested with empty string CAP URL", async () => {
@@ -530,6 +533,9 @@ describe(TEST_ROUTE, () => {
     const componentAtlas =
       res._getJSONData() as HCAAtlasTrackerDetailComponentAtlas;
     expect(componentAtlas.capUrl).toBeNull();
+    expect(componentAtlas.downloadName).toEqual(
+      MISC_BAZ_EDIT_DATA.downloadName,
+    );
   });
 
   it("updates component atlas when PATCH requested from atlas that is linked to its latest version", async () => {
@@ -550,6 +556,7 @@ describe(TEST_ROUTE, () => {
     const componentAtlas =
       res._getJSONData() as HCAAtlasTrackerDetailComponentAtlas;
     expect(componentAtlas.capUrl).toEqual(editData.capUrl);
+    expect(componentAtlas.downloadName).toEqual(editData.downloadName);
   });
 });
 

--- a/__tests__/api-atlases-id-source-datasets-id.test.ts
+++ b/__tests__/api-atlases-id-source-datasets-id.test.ts
@@ -600,6 +600,7 @@ describe(`${TEST_ROUTE} (PATCH)`, () => {
     expect(res._getStatusCode()).toEqual(200);
     const sourceDataset = res._getJSONData() as HCAAtlasTrackerSourceDataset;
     expect(sourceDataset.capUrl).toBeNull();
+    expect(sourceDataset.downloadName).toEqual(A_FOO_EDIT_DATA.downloadName);
     expect(sourceDataset.metadataSpreadsheetTitle).toEqual("Sheet Bar");
     expect(sourceDataset.metadataSpreadsheetUrl).toEqual(
       A_FOO_EDIT_DATA.metadataSpreadsheetUrl,
@@ -623,6 +624,7 @@ describe(`${TEST_ROUTE} (PATCH)`, () => {
     expect(res._getStatusCode()).toEqual(200);
     const sourceDataset = res._getJSONData() as HCAAtlasTrackerSourceDataset;
     expect(sourceDataset.capUrl).toEqual(A_BAR_EDIT_DATA.capUrl);
+    expect(sourceDataset.downloadName).toEqual(A_BAR_EDIT_DATA.downloadName);
     expect(sourceDataset.metadataSpreadsheetTitle).toBeNull();
     expect(sourceDataset.metadataSpreadsheetUrl).toBeNull();
     await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_ATLAS_LINKED_B_FOO);
@@ -640,6 +642,7 @@ describe(`${TEST_ROUTE} (PATCH)`, () => {
     expect(res._getStatusCode()).toEqual(200);
     const sourceDataset = res._getJSONData() as HCAAtlasTrackerSourceDataset;
     expect(sourceDataset.capUrl).toBeNull();
+    expect(sourceDataset.downloadName).toEqual(WSS_FOO_EDIT_DATA.downloadName);
     expect(sourceDataset.metadataSpreadsheetTitle).toBeNull();
     expect(sourceDataset.metadataSpreadsheetUrl).toBeNull();
     await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_ATLAS_LINKED_B_FOO);

--- a/__tests__/api-atlases-id-source-datasets-id.test.ts
+++ b/__tests__/api-atlases-id-source-datasets-id.test.ts
@@ -40,10 +40,13 @@ import {
 } from "../testing/constants";
 import {
   expectSourceDatasetToBeUnchanged,
+  getConceptFromDatabase,
   resetDatabase,
 } from "../testing/db-utils";
 import { TestUser } from "../testing/entities";
 import {
+  assertExpectDefined,
+  delay,
   expectDetailApiSourceDatasetToMatchTest,
   getTestEntityDownloadName,
   testApiRole,
@@ -587,8 +590,53 @@ describe(`${TEST_ROUTE} (PATCH)`, () => {
     await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_ATLAS_LINKED_A_FOO);
   });
 
+  it("returns error 400 when PATCH requested with download name set to empty string", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_DATASET_ATLAS_LINKED_A_BAR.id,
+          USER_CONTENT_ADMIN,
+          METHOD.PATCH,
+          true,
+          {
+            ...A_BAR_EDIT_DATA,
+            downloadName: "",
+          },
+        )
+      )._getStatusCode(),
+    ).toEqual(400);
+    await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_ATLAS_LINKED_A_BAR);
+  });
+
+  it("returns error 409 when PATCH requested with download name that already exists in the atlas generation", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_DATASET_ATLAS_LINKED_A_BAR.id,
+          USER_CONTENT_ADMIN,
+          METHOD.PATCH,
+          true,
+          {
+            ...A_BAR_EDIT_DATA,
+            downloadName: getTestEntityDownloadName(
+              SOURCE_DATASET_ATLAS_LINKED_B_FOO,
+            ),
+          },
+        )
+      )._getStatusCode(),
+    ).toEqual(409);
+    await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_ATLAS_LINKED_A_BAR);
+  });
+
   it("updates and returns source dataset when PATCH requested by user with CONTENT_ADMIN role", async () => {
     const callCountBefore = getSheetTitleMock.mock.calls.length;
+    const conceptBefore = await getConceptFromDatabase(
+      SOURCE_DATASET_ATLAS_LINKED_A_FOO.id,
+    );
+    assertExpectDefined(conceptBefore);
+    await delay(10); // Ensure timestamps can be different
     const res = await doSourceDatasetRequest(
       ATLAS_WITH_MISC_SOURCE_STUDIES.id,
       SOURCE_DATASET_ATLAS_LINKED_A_FOO.id,
@@ -609,6 +657,14 @@ describe(`${TEST_ROUTE} (PATCH)`, () => {
       SOURCE_DATASET_ATLAS_LINKED_A_FOO.file.datasetInfo.title,
     );
     expect(getSheetTitleMock).toHaveBeenCalledTimes(callCountBefore + 1);
+    const conceptAfter = await getConceptFromDatabase(
+      SOURCE_DATASET_ATLAS_LINKED_A_FOO.id,
+    );
+    assertExpectDefined(conceptAfter);
+    // Download name wasn't changed, so concept shouldn't have been updated
+    expect(conceptAfter.updated_at.getDate()).toEqual(
+      conceptBefore.updated_at.getDate(),
+    );
     await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_ATLAS_LINKED_B_FOO);
   });
 
@@ -645,6 +701,34 @@ describe(`${TEST_ROUTE} (PATCH)`, () => {
     expect(sourceDataset.downloadName).toEqual(WSS_FOO_EDIT_DATA.downloadName);
     expect(sourceDataset.metadataSpreadsheetTitle).toBeNull();
     expect(sourceDataset.metadataSpreadsheetUrl).toBeNull();
+    await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_ATLAS_LINKED_B_FOO);
+  });
+
+  it("updates associated concept when PATCH requested with new download name", async () => {
+    const editData: AtlasSourceDatasetEditData = {
+      capUrl: null,
+      downloadName: "new-download-name",
+      metadataSpreadsheetUrl: null,
+    };
+    const res = await doSourceDatasetRequest(
+      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+      SOURCE_DATASET_ATLAS_LINKED_B_BAR.id,
+      USER_CONTENT_ADMIN,
+      METHOD.PATCH,
+      true,
+      editData,
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const sourceDataset = res._getJSONData() as HCAAtlasTrackerSourceDataset;
+    expect(sourceDataset.capUrl).toBeNull();
+    expect(sourceDataset.downloadName).toEqual(editData.downloadName);
+    expect(sourceDataset.metadataSpreadsheetTitle).toBeNull();
+    expect(sourceDataset.metadataSpreadsheetUrl).toBeNull();
+    const concept = await getConceptFromDatabase(
+      SOURCE_DATASET_ATLAS_LINKED_B_BAR.id,
+    );
+    assertExpectDefined(concept);
+    expect(concept.base_filename).toEqual(editData.downloadName + ".h5ad");
     await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_ATLAS_LINKED_B_FOO);
   });
 });

--- a/__tests__/api-atlases-id-source-datasets-id.test.ts
+++ b/__tests__/api-atlases-id-source-datasets-id.test.ts
@@ -418,6 +418,22 @@ describe(`${TEST_ROUTE} (PATCH)`, () => {
     await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_ATLAS_LINKED_A_FOO);
   });
 
+  it("returns error 403 when PATCH requested by user with INTEGRATION_LEAD role for the atlas", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_DATASET_ATLAS_LINKED_B_BAR.id,
+          USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
+          METHOD.PATCH,
+          false,
+          B_BAR_EDIT_DATA,
+        )
+      )._getStatusCode(),
+    ).toEqual(403);
+    await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_ATLAS_LINKED_B_BAR);
+  });
+
   it("returns error 404 when PATCH requested with nonexistent source dataset", async () => {
     expect(
       (
@@ -569,25 +585,6 @@ describe(`${TEST_ROUTE} (PATCH)`, () => {
       )._getStatusCode(),
     ).toEqual(400);
     await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_ATLAS_LINKED_A_FOO);
-  });
-
-  it("updates and returns source dataset when PATCH requested by user with INTEGRATION_LEAD role for the atlas", async () => {
-    const res = await doSourceDatasetRequest(
-      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
-      SOURCE_DATASET_ATLAS_LINKED_B_BAR.id,
-      USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
-      METHOD.PATCH,
-      true,
-      B_BAR_EDIT_DATA,
-    );
-    expect(res._getStatusCode()).toEqual(200);
-    const sourceDataset = res._getJSONData() as HCAAtlasTrackerSourceDataset;
-    expect(sourceDataset.capUrl).toBeNull();
-    expect(sourceDataset.metadataSpreadsheetUrl).toEqual(null);
-    expect(sourceDataset.title).toEqual(
-      SOURCE_DATASET_ATLAS_LINKED_B_BAR.file.datasetInfo.title,
-    );
-    await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_ATLAS_LINKED_B_FOO);
   });
 
   it("updates and returns source dataset when PATCH requested by user with CONTENT_ADMIN role", async () => {

--- a/__tests__/api-atlases-id-source-datasets-id.test.ts
+++ b/__tests__/api-atlases-id-source-datasets-id.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { AtlasSourceDatasetEditData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
 import { METHOD } from "../app/common/entities";
+import { FormResponseErrors } from "../app/hooks/useForm/common/entities";
 import { endPgPool } from "../app/services/database";
 import { getSheetTitleForApi } from "../app/utils/google-sheets-api";
 import sourceDatasetHandler from "../pages/api/atlases/[atlasId]/source-datasets/[sourceDatasetId]";
@@ -610,42 +611,48 @@ describe(`${TEST_ROUTE} (PATCH)`, () => {
   });
 
   it("returns error 400 when PATCH requested with download name containing version suffix", async () => {
-    expect(
-      (
-        await doSourceDatasetRequest(
-          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
-          SOURCE_DATASET_ATLAS_LINKED_A_BAR.id,
-          USER_CONTENT_ADMIN,
-          METHOD.PATCH,
-          true,
-          {
-            ...A_BAR_EDIT_DATA,
-            downloadName: "file-r1",
-          },
-        )
-      )._getStatusCode(),
-    ).toEqual(400);
+    const res = await doSourceDatasetRequest(
+      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+      SOURCE_DATASET_ATLAS_LINKED_A_BAR.id,
+      USER_CONTENT_ADMIN,
+      METHOD.PATCH,
+      true,
+      {
+        ...A_BAR_EDIT_DATA,
+        downloadName: "file-r1",
+      },
+    );
+    expect(res._getStatusCode()).toEqual(400);
+    const errorInfo = res._getJSONData() as FormResponseErrors;
+    expect(errorInfo).toMatchObject({
+      errors: {
+        downloadName: [expect.stringContaining("version suffix")],
+      },
+    });
     await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_ATLAS_LINKED_A_BAR);
   });
 
   it("returns error 409 when PATCH requested with download name that already exists in the atlas generation", async () => {
-    expect(
-      (
-        await doSourceDatasetRequest(
-          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
-          SOURCE_DATASET_ATLAS_LINKED_A_BAR.id,
-          USER_CONTENT_ADMIN,
-          METHOD.PATCH,
-          true,
-          {
-            ...A_BAR_EDIT_DATA,
-            downloadName: getTestEntityDownloadName(
-              SOURCE_DATASET_ATLAS_LINKED_B_FOO,
-            ),
-          },
-        )
-      )._getStatusCode(),
-    ).toEqual(409);
+    const res = await doSourceDatasetRequest(
+      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+      SOURCE_DATASET_ATLAS_LINKED_A_BAR.id,
+      USER_CONTENT_ADMIN,
+      METHOD.PATCH,
+      true,
+      {
+        ...A_BAR_EDIT_DATA,
+        downloadName: getTestEntityDownloadName(
+          SOURCE_DATASET_ATLAS_LINKED_B_FOO,
+        ),
+      },
+    );
+    expect(res._getStatusCode()).toEqual(409);
+    const errorInfo = res._getJSONData() as FormResponseErrors;
+    expect(errorInfo).toMatchObject({
+      errors: {
+        downloadName: [expect.stringContaining("already exists")],
+      },
+    });
     await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_ATLAS_LINKED_A_BAR);
   });
 

--- a/__tests__/api-atlases-id-source-datasets-id.test.ts
+++ b/__tests__/api-atlases-id-source-datasets-id.test.ts
@@ -609,6 +609,25 @@ describe(`${TEST_ROUTE} (PATCH)`, () => {
     await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_ATLAS_LINKED_A_BAR);
   });
 
+  it("returns error 400 when PATCH requested with download name containing version suffix", async () => {
+    expect(
+      (
+        await doSourceDatasetRequest(
+          ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+          SOURCE_DATASET_ATLAS_LINKED_A_BAR.id,
+          USER_CONTENT_ADMIN,
+          METHOD.PATCH,
+          true,
+          {
+            ...A_BAR_EDIT_DATA,
+            downloadName: "file-r1",
+          },
+        )
+      )._getStatusCode(),
+    ).toEqual(400);
+    await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_ATLAS_LINKED_A_BAR);
+  });
+
   it("returns error 409 when PATCH requested with download name that already exists in the atlas generation", async () => {
     expect(
       (

--- a/__tests__/api-atlases-id-source-datasets-id.test.ts
+++ b/__tests__/api-atlases-id-source-datasets-id.test.ts
@@ -688,8 +688,8 @@ describe(`${TEST_ROUTE} (PATCH)`, () => {
     );
     assertExpectDefined(conceptAfter);
     // Download name wasn't changed, so concept shouldn't have been updated
-    expect(conceptAfter.updated_at.getDate()).toEqual(
-      conceptBefore.updated_at.getDate(),
+    expect(conceptAfter.updated_at.getTime()).toEqual(
+      conceptBefore.updated_at.getTime(),
     );
     await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_ATLAS_LINKED_B_FOO);
   });

--- a/__tests__/api-atlases-id-source-datasets-id.test.ts
+++ b/__tests__/api-atlases-id-source-datasets-id.test.ts
@@ -45,6 +45,7 @@ import {
 import { TestUser } from "../testing/entities";
 import {
   expectDetailApiSourceDatasetToMatchTest,
+  getTestEntityDownloadName,
   testApiRole,
   withConsoleErrorHiding,
 } from "../testing/utils";
@@ -78,20 +79,24 @@ const SOURCE_DATASET_ID_NONEXISTENT = "52281fde-232c-4481-8b45-cc986570e7b9";
 
 const A_FOO_EDIT_DATA: AtlasSourceDatasetEditData = {
   capUrl: null,
+  downloadName: getTestEntityDownloadName(SOURCE_DATASET_ATLAS_LINKED_A_FOO),
   metadataSpreadsheetUrl: "https://docs.google.com/spreadsheets/d/sheet-bar",
 };
 
 const B_BAR_EDIT_DATA: AtlasSourceDatasetEditData = {
   capUrl: null,
+  downloadName: getTestEntityDownloadName(SOURCE_DATASET_ATLAS_LINKED_B_BAR),
   metadataSpreadsheetUrl: "",
 };
 
 const A_BAR_EDIT_DATA: AtlasSourceDatasetEditData = {
   capUrl: "https://celltype.info/project/534534/dataset/234727",
+  downloadName: getTestEntityDownloadName(SOURCE_DATASET_ATLAS_LINKED_A_BAR),
 };
 
 const WSS_FOO_EDIT_DATA: AtlasSourceDatasetEditData = {
   capUrl: "",
+  downloadName: getTestEntityDownloadName(SOURCE_DATASET_WITH_SOURCE_STUDY_FOO),
 };
 
 beforeAll(async () => {
@@ -465,6 +470,9 @@ describe(`${TEST_ROUTE} (PATCH)`, () => {
   it("returns error 400 when PATCH requested with source dataset with non-latest version linked to the atlas", async () => {
     const editData = {
       capUrl: "https://celltype.info/project/376345/dataset/745632",
+      downloadName: getTestEntityDownloadName(
+        SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_BAR_W2,
+      ),
     } satisfies AtlasSourceDatasetEditData;
     expect(
       (

--- a/__tests__/api-sns-with-s3-event.test.ts
+++ b/__tests__/api-sns-with-s3-event.test.ts
@@ -49,6 +49,7 @@ import {
 import { METHOD } from "../app/common/entities";
 import { resetConfigCache } from "../app/config/aws-resources";
 import { endPgPool, query } from "../app/services/database";
+import { parseNormalizedInfoFromS3Key } from "../app/utils/files";
 import {
   expectSourceDatasetFileToBeConsistentWith,
   getAtlasFromDatabase,
@@ -1694,6 +1695,27 @@ describe(`${TEST_ROUTE} (S3 event)`, () => {
       firstKey: "gut/gut-v1-0/source-datasets/test-file-new-rev.h5ad",
       secondKey: "gut/gut-v1-1/source-datasets/test-file-new-rev.h5ad",
     },
+    {
+      afterFirst: async (): Promise<void> => {
+        await query(
+          `
+            UPDATE hat.concepts
+            SET base_filename = 'test-file-new-name-after.h5ad'
+            WHERE base_filename = 'test-file-new-name-before.h5ad'
+          `,
+        );
+      },
+      description: "different filename matching updated concept",
+      expectedConceptFields: {
+        atlas_short_name: "gut",
+        base_filename: "test-file-new-name-before.h5ad",
+        file_type: FILE_TYPE.SOURCE_DATASET,
+        generation: 1,
+        network: "gut",
+      },
+      firstKey: "gut/gut-v1-0/source-datasets/test-file-new-name-before.h5ad",
+      secondKey: "gut/gut-v1-0/source-datasets/test-file-new-name-after.h5ad",
+    },
   ])(
     "uses the same concept for S3 key with $description",
     async ({
@@ -1828,14 +1850,16 @@ describe(`${TEST_ROUTE} (S3 event)`, () => {
         wipNumber: 2,
       });
 
-      // Verify only one concept exists for this base filename
+      // Verify exactly one concept exists among the original concept fields, the new file's name, and the concept's ID
       const allConcepts = await query<HCAAtlasTrackerDBConcept>(
-        "SELECT * FROM hat.concepts WHERE base_filename = $1 AND file_type = $2 AND network = $3 AND generation = $4",
+        "SELECT * FROM hat.concepts WHERE ((base_filename = $1 OR base_filename = $5) AND file_type = $2 AND network = $3 AND generation = $4) OR id = $6",
         [
           expectedConceptFields.base_filename,
           expectedConceptFields.file_type,
           expectedConceptFields.network,
           expectedConceptFields.generation,
+          parseNormalizedInfoFromS3Key(secondFile.key).fileBaseName,
+          firstConcept.id,
         ],
       );
       expect(allConcepts.rows).toHaveLength(1);

--- a/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
@@ -1,6 +1,6 @@
 import savedCellxgeneInfo from "../../../../../catalog/output/cellxgene-info.json";
 import { getCellxGeneCollectionInfoById } from "../../../../services/cellxgene";
-import { parseS3KeyPath } from "../../../../utils/files";
+import { parseS3KeyPath, removeFileExtension } from "../../../../utils/files";
 import {
   HCAAtlasTrackerAtlas,
   HCAAtlasTrackerAtlasSummary,
@@ -118,6 +118,7 @@ export function dbComponentAtlasFileToApiComponentAtlas(
     capUrl: dbComponentAtlas.component_info.capUrl,
     cellCount: dbComponentAtlas.dataset_info?.cellCount ?? 0,
     disease: dbComponentAtlas.dataset_info?.disease ?? [],
+    downloadName: removeFileExtension(dbComponentAtlas.base_filename),
     fileEventTime: dbComponentAtlas.event_info.eventTime,
     fileId: dbComponentAtlas.file_id,
     fileName: parseS3KeyPath(dbComponentAtlas.key).filename,
@@ -213,6 +214,7 @@ export function dbSourceDatasetToApiSourceDataset(
     createdAt: dbSourceDataset.created_at.toISOString(),
     disease: dbSourceDataset.dataset_info?.disease ?? [],
     doi: dbSourceDataset.doi,
+    downloadName: removeFileExtension(dbSourceDataset.base_filename),
     fileEventTime: dbSourceDataset.event_info.eventTime,
     fileId: dbSourceDataset.file_id,
     fileName: parseS3KeyPath(dbSourceDataset.key).filename,

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -67,6 +67,7 @@ export interface HCAAtlasTrackerComponentAtlas {
   capUrl: string | null;
   cellCount: number;
   disease: string[];
+  downloadName: string;
   fileEventTime: string;
   fileId: string;
   fileName: string;
@@ -136,6 +137,7 @@ export interface HCAAtlasTrackerSourceDataset {
   createdAt: string;
   disease: string[];
   doi: string | null;
+  downloadName: string;
   fileEventTime: string;
   fileId: string;
   fileName: string;

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -332,6 +332,7 @@ export type SourceStudyEditData =
  */
 export const componentAtlasEditSchema = object({
   capUrl: capDatasetUrlSchema,
+  downloadName: string().required(),
 }).strict();
 
 export type ComponentAtlasEditData = InferType<typeof componentAtlasEditSchema>;
@@ -341,6 +342,7 @@ export type ComponentAtlasEditData = InferType<typeof componentAtlasEditSchema>;
  */
 export const atlasSourceDatasetEditSchema = object({
   capUrl: capDatasetUrlSchema,
+  downloadName: string().required(),
   metadataSpreadsheetUrl: string()
     .matches(GOOGLE_SHEETS_URL_OR_EMPTY_STRING_REGEX)
     .nullable(),

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -332,7 +332,7 @@ export type SourceStudyEditData =
  */
 export const componentAtlasEditSchema = object({
   capUrl: capDatasetUrlSchema,
-  downloadName: string().required(),
+  downloadName: string().required("Download name is required"),
 }).strict();
 
 export type ComponentAtlasEditData = InferType<typeof componentAtlasEditSchema>;
@@ -342,7 +342,7 @@ export type ComponentAtlasEditData = InferType<typeof componentAtlasEditSchema>;
  */
 export const atlasSourceDatasetEditSchema = object({
   capUrl: capDatasetUrlSchema,
-  downloadName: string().required(),
+  downloadName: string().required("Download name is required"),
   metadataSpreadsheetUrl: string()
     .matches(GOOGLE_SHEETS_URL_OR_EMPTY_STRING_REGEX)
     .nullable(),

--- a/app/data/concepts.ts
+++ b/app/data/concepts.ts
@@ -149,3 +149,20 @@ export async function getConcept(
     throw new NotFoundError(`Concept with ID ${conceptId} does not exist`);
   return queryResult.rows[0];
 }
+
+/**
+ * Set a concept's base filename.
+ * @param conceptId - ID of the concept to update.
+ * @param baseFilename - Base filename to set.
+ * @param client - Postgres client to use.
+ */
+export async function setConceptBaseFilename(
+  conceptId: string,
+  baseFilename: string,
+  client: pg.PoolClient,
+): Promise<void> {
+  await client.query(
+    "UPDATE hat.concepts SET base_filename = $1 WHERE id = $2",
+    [baseFilename, conceptId],
+  );
+}

--- a/app/hooks/useUserHasEditAuthorization/common/constants.ts
+++ b/app/hooks/useUserHasEditAuthorization/common/constants.ts
@@ -2,9 +2,7 @@ import { ROUTE } from "../../../routes/constants";
 import { RouteValue } from "../../../routes/entities";
 
 export const ROUTES: RouteValue[] = [
-  ROUTE.ATLAS_SOURCE_DATASET,
   ROUTE.ATLAS_SOURCE_DATASETS,
-  ROUTE.COMPONENT_ATLAS,
   ROUTE.COMPONENT_ATLASES,
   ROUTE.CREATE_SOURCE_STUDY,
   ROUTE.INTEGRATED_OBJECT_SOURCE_DATASETS,

--- a/app/services/component-atlases.ts
+++ b/app/services/component-atlases.ts
@@ -10,6 +10,7 @@ import {
 import { ComponentAtlasEditData } from "../apis/catalog/hca-atlas-tracker/common/schema";
 import { getSourceDatasetVersionsForAtlas } from "../data/source-datasets";
 import { InvalidOperationError, NotFoundError } from "../utils/api-handler";
+import { updateDownloadNameIfChanged } from "./concepts";
 import { doOrContinueTransaction, doTransaction, query } from "./database";
 
 type ComponentAtlasInfoUpdateFields = Pick<
@@ -131,12 +132,14 @@ export async function getAtlasComponentAtlasVersionIds(
  * @param atlasId - ID of the atlas that the component atlas is accessed through.
  * @param componentAtlasId - ID of the component atlas to update.
  * @param inputData - Data with which to update the component atlas.
+ * @param beforeUpdateDownloadName - Function to call before an update that would change the download name.
  * @returns updated component atlas.
  */
 export async function updateComponentAtlas(
   atlasId: string,
   componentAtlasId: string,
   inputData: ComponentAtlasEditData,
+  beforeUpdateDownloadName: (() => void) | null,
 ): Promise<HCAAtlasTrackerDBComponentAtlasForDetailAPI> {
   const componentAtlasVersion = await getComponentAtlasVersionForAtlas(
     componentAtlasId,
@@ -147,6 +150,12 @@ export async function updateComponentAtlas(
     capUrl: inputData.capUrl || null,
   };
   return await doTransaction(async (client) => {
+    await updateDownloadNameIfChanged(
+      componentAtlasId,
+      inputData.downloadName,
+      beforeUpdateDownloadName,
+      client,
+    );
     await query(
       "UPDATE hat.component_atlases SET component_info = component_info || $1 WHERE version_id = $2",
       [JSON.stringify(updatedInfoFields), componentAtlasVersion],

--- a/app/services/component-atlases.ts
+++ b/app/services/component-atlases.ts
@@ -132,14 +132,12 @@ export async function getAtlasComponentAtlasVersionIds(
  * @param atlasId - ID of the atlas that the component atlas is accessed through.
  * @param componentAtlasId - ID of the component atlas to update.
  * @param inputData - Data with which to update the component atlas.
- * @param beforeUpdateDownloadName - Function to call before an update that would change the download name.
  * @returns updated component atlas.
  */
 export async function updateComponentAtlas(
   atlasId: string,
   componentAtlasId: string,
   inputData: ComponentAtlasEditData,
-  beforeUpdateDownloadName: (() => void) | null,
 ): Promise<HCAAtlasTrackerDBComponentAtlasForDetailAPI> {
   const componentAtlasVersion = await getComponentAtlasVersionForAtlas(
     componentAtlasId,
@@ -153,7 +151,6 @@ export async function updateComponentAtlas(
     await updateDownloadNameIfChanged(
       componentAtlasId,
       inputData.downloadName,
-      beforeUpdateDownloadName,
       client,
     );
     await query(

--- a/app/services/concepts.ts
+++ b/app/services/concepts.ts
@@ -1,4 +1,4 @@
-import { getFileExtension } from "app/utils/files";
+import { getFileBaseName, getFileExtension } from "app/utils/files";
 import pg from "pg";
 import {
   HCAAtlasTrackerDBAtlas,
@@ -11,7 +11,11 @@ import {
   getConceptIdByInfo,
   setConceptBaseFilename,
 } from "../data/concepts";
-import { ConflictError, NotFoundError } from "../utils/api-handler";
+import {
+  ConflictError,
+  InvalidOperationError,
+  NotFoundError,
+} from "../utils/api-handler";
 import { mapDatabaseError } from "./database";
 
 /**
@@ -104,6 +108,12 @@ export async function updateDownloadNameIfChanged(
     newDownloadName + getFileExtension(existingBaseFilename);
 
   if (newBaseFilename === existingBaseFilename) return;
+
+  if (getFileBaseName(newBaseFilename) !== newBaseFilename)
+    throw new InvalidOperationError(
+      "The specified download name appears to contain a version suffix",
+      "downloadName",
+    );
 
   await mapDatabaseError(
     () => setConceptBaseFilename(conceptId, newBaseFilename, client),

--- a/app/services/concepts.ts
+++ b/app/services/concepts.ts
@@ -1,4 +1,6 @@
+import { getFileExtension } from "app/utils/files";
 import pg from "pg";
+import { ValidationError } from "yup";
 import {
   HCAAtlasTrackerDBAtlas,
   HCAAtlasTrackerDBConcept,
@@ -8,8 +10,10 @@ import {
   getAtlasesMatchingConceptAndRevision,
   getConcept,
   getConceptIdByInfo,
+  setConceptBaseFilename,
 } from "../data/concepts";
 import { NotFoundError } from "../utils/api-handler";
+import { mapDatabaseError } from "./database";
 
 /**
  * Get an existing concept ID if it exists, or create a new concept otherwise.
@@ -80,4 +84,39 @@ async function getConceptAtlasInfoString(
 ): Promise<string> {
   const concept = await getConcept(conceptId, client);
   return `${concept.atlas_short_name} v${concept.generation} in ${concept.network} network`;
+}
+
+/**
+ * Update a concept's base filename based on a specified download name, if it's changed, and call a specified function before any actual update occurs.
+ * @param conceptId - ID of the concept to update.
+ * @param newDownloadName - New download name to derive a new base filename from.
+ * @param beforeUpdate - Optional function to call before an update that would change the value occurs.
+ * @param client - Postgres client to use.
+ */
+export async function updateDownloadNameIfChanged(
+  conceptId: string,
+  newDownloadName: string,
+  beforeUpdate: (() => void) | null,
+  client: pg.PoolClient,
+): Promise<void> {
+  const { base_filename: existingBaseFilename } = await getConcept(
+    conceptId,
+    client,
+  );
+  const newBaseFilename =
+    newDownloadName + getFileExtension(existingBaseFilename);
+  if (newBaseFilename === existingBaseFilename) return;
+
+  beforeUpdate?.();
+
+  await mapDatabaseError(
+    () => setConceptBaseFilename(conceptId, newBaseFilename, client),
+    () =>
+      new ValidationError(
+        `A file with download name ${JSON.stringify(newDownloadName)} already exists for this atlas generation`,
+        undefined,
+        "downloadName",
+      ),
+    { constraint: "idx_concepts_identity_fields" },
+  );
 }

--- a/app/services/concepts.ts
+++ b/app/services/concepts.ts
@@ -87,7 +87,7 @@ async function getConceptAtlasInfoString(
 }
 
 /**
- * Update a concept's base filename based on a specified download name, if it's changed, and call a specified function before any actual update occurs.
+ * Update a concept's base filename based on a specified download name.
  * @param conceptId - ID of the concept to update.
  * @param newDownloadName - New download name to derive a new base filename from.
  * @param client - Postgres client to use.

--- a/app/services/concepts.ts
+++ b/app/services/concepts.ts
@@ -1,6 +1,5 @@
 import { getFileExtension } from "app/utils/files";
 import pg from "pg";
-import { ValidationError } from "yup";
 import {
   HCAAtlasTrackerDBAtlas,
   HCAAtlasTrackerDBConcept,
@@ -12,7 +11,7 @@ import {
   getConceptIdByInfo,
   setConceptBaseFilename,
 } from "../data/concepts";
-import { NotFoundError } from "../utils/api-handler";
+import { ConflictError, NotFoundError } from "../utils/api-handler";
 import { mapDatabaseError } from "./database";
 
 /**
@@ -109,9 +108,8 @@ export async function updateDownloadNameIfChanged(
   await mapDatabaseError(
     () => setConceptBaseFilename(conceptId, newBaseFilename, client),
     () =>
-      new ValidationError(
+      new ConflictError(
         `A file with download name ${JSON.stringify(newDownloadName)} already exists for this atlas generation`,
-        undefined,
         "downloadName",
       ),
     { constraint: "idx_concepts_identity_fields" },

--- a/app/services/concepts.ts
+++ b/app/services/concepts.ts
@@ -90,13 +90,11 @@ async function getConceptAtlasInfoString(
  * Update a concept's base filename based on a specified download name, if it's changed, and call a specified function before any actual update occurs.
  * @param conceptId - ID of the concept to update.
  * @param newDownloadName - New download name to derive a new base filename from.
- * @param beforeUpdate - Optional function to call before an update that would change the value occurs.
  * @param client - Postgres client to use.
  */
 export async function updateDownloadNameIfChanged(
   conceptId: string,
   newDownloadName: string,
-  beforeUpdate: (() => void) | null,
   client: pg.PoolClient,
 ): Promise<void> {
   const { base_filename: existingBaseFilename } = await getConcept(
@@ -105,9 +103,8 @@ export async function updateDownloadNameIfChanged(
   );
   const newBaseFilename =
     newDownloadName + getFileExtension(existingBaseFilename);
-  if (newBaseFilename === existingBaseFilename) return;
 
-  beforeUpdate?.();
+  if (newBaseFilename === existingBaseFilename) return;
 
   await mapDatabaseError(
     () => setConceptBaseFilename(conceptId, newBaseFilename, client),

--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -180,14 +180,12 @@ function createSourceDatasetInfo(): HCAAtlasTrackerDBSourceDatasetInfo {
  * @param atlasId - ID of the atlas that the source dataset is accessed through.
  * @param sourceDatasetId - ID of the source dataset to update.
  * @param inputData - Input data to apply to the source dataset.
- * @param beforeUpdateDownloadName - Function to call before an update that would change the download name.
  * @returns update source dataset.
  */
 export async function updateAtlasSourceDataset(
   atlasId: string,
   sourceDatasetId: string,
   inputData: AtlasSourceDatasetEditData,
-  beforeUpdateDownloadName: (() => void) | null,
 ): Promise<HCAAtlasTrackerDBSourceDatasetForAPI> {
   const sourceDatasetVersion = await getSourceDatasetVersionForAtlas(
     sourceDatasetId,
@@ -206,7 +204,6 @@ export async function updateAtlasSourceDataset(
     await updateDownloadNameIfChanged(
       sourceDatasetId,
       inputData.downloadName,
-      beforeUpdateDownloadName,
       client,
     );
     await query(

--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -27,6 +27,7 @@ import {
 } from "../data/source-datasets";
 import { getSheetTitleForApi } from "../utils/google-sheets-api";
 import { getComponentAtlasVersionForAtlas } from "./component-atlases";
+import { updateDownloadNameIfChanged } from "./concepts";
 import { doTransaction, query } from "./database";
 import { confirmSourceStudyExistsOnAtlas } from "./source-studies";
 
@@ -174,10 +175,19 @@ function createSourceDatasetInfo(): HCAAtlasTrackerDBSourceDatasetInfo {
   };
 }
 
+/**
+ * Update an atlas-linked source dataset.
+ * @param atlasId - ID of the atlas that the source dataset is accessed through.
+ * @param sourceDatasetId - ID of the source dataset to update.
+ * @param inputData - Input data to apply to the source dataset.
+ * @param beforeUpdateDownloadName - Function to call before an update that would change the download name.
+ * @returns update source dataset.
+ */
 export async function updateAtlasSourceDataset(
   atlasId: string,
   sourceDatasetId: string,
   inputData: AtlasSourceDatasetEditData,
+  beforeUpdateDownloadName: (() => void) | null,
 ): Promise<HCAAtlasTrackerDBSourceDatasetForAPI> {
   const sourceDatasetVersion = await getSourceDatasetVersionForAtlas(
     sourceDatasetId,
@@ -193,6 +203,12 @@ export async function updateAtlasSourceDataset(
     metadataSpreadsheetUrl: inputData.metadataSpreadsheetUrl || null,
   };
   return await doTransaction(async (client) => {
+    await updateDownloadNameIfChanged(
+      sourceDatasetId,
+      inputData.downloadName,
+      beforeUpdateDownloadName,
+      client,
+    );
     await query(
       "UPDATE hat.source_datasets SET sd_info = sd_info || $1 WHERE version_id = $2",
       [JSON.stringify(updatedInfoFields), sourceDatasetVersion],

--- a/app/utils/api-handler.ts
+++ b/app/utils/api-handler.ts
@@ -32,30 +32,45 @@ export type Handler = (
   res: NextApiResponse,
 ) => Promise<void>;
 
-export class InvalidOperationError extends Error {
+abstract class ApiError extends Error {
+  abstract statusCode: number;
+  fieldPath: string | null;
+  constructor(message?: string, fieldPath: string | null = null) {
+    super(message);
+    this.fieldPath = fieldPath;
+  }
+}
+
+export class InvalidOperationError extends ApiError {
   name = "InvalidOperationError";
+  statusCode = 400;
 }
 
 // Represents a request conflict (e.g., ETag mismatch/version conflicts)
 // Maps to HTTP 409 Conflict
-export class ConflictError extends InvalidOperationError {
+export class ConflictError extends ApiError {
   name = "ConflictError";
+  statusCode = 409;
 }
 
-export class UnauthenticatedError extends Error {
+export class UnauthenticatedError extends ApiError {
   name = "UnauthenticatedError";
+  statusCode = 401;
 }
 
-export class ForbiddenError extends Error {
+export class ForbiddenError extends ApiError {
   name = "ForbiddenError";
+  statusCode = 403;
 }
 
-export class AccessError extends Error {
+export class AccessError extends ApiError {
   name = "AccessError";
+  statusCode = 400;
 }
 
-export class NotFoundError extends Error {
+export class NotFoundError extends ApiError {
   name = "NotFoundError";
+  statusCode = 404;
 }
 
 /**
@@ -340,43 +355,34 @@ export async function getRegisteredActiveUser(
  * @param error - Error or other thrown value.
  */
 function respondError(res: NextApiResponse, error: unknown): void {
-  if (error instanceof ConflictError)
-    res.status(409).json({ message: error.message });
-  else if (error instanceof InvalidOperationError)
-    res.status(400).json({ message: error.message });
-  else if (error instanceof S3KeyFormatError)
-    res.status(400).json({ message: error.message });
-  else if (error instanceof UnauthenticatedError)
-    res.status(401).json({ message: error.message });
-  else if (error instanceof ForbiddenError)
-    res.status(403).json({ message: error.message });
-  else if (error instanceof NotFoundError)
-    res.status(404).json({ message: error.message });
-  else if (error instanceof ValidationError) respondValidationError(res, error);
-  else if (error instanceof Error && typeof error.stack === "string")
-    res.status(500).json({ message: error.stack });
-  else res.status(500).json({ message: String(error) });
-}
-
-/**
- * Send an error response based on a Yup validation error.
- * @param res - Next API response.
- * @param error - ValidationError.
- */
-export function respondValidationError(
-  res: NextApiResponse,
-  error: ValidationError,
-): void {
-  const errorInfo: FormResponseErrors = error.path
-    ? {
-        errors: {
-          [error.path]: error.errors,
-        },
-      }
-    : {
-        message: error.message,
-      };
-  res.status(400).json(errorInfo);
+  let status = 500;
+  let errorInfo: FormResponseErrors;
+  if (error instanceof ApiError) {
+    status = error.statusCode;
+    errorInfo =
+      error.fieldPath === null
+        ? { message: error.message }
+        : { errors: { [error.fieldPath]: [error.message] } };
+  } else if (error instanceof ValidationError) {
+    status = 400;
+    errorInfo = error.path
+      ? {
+          errors: {
+            [error.path]: error.errors,
+          },
+        }
+      : {
+          message: error.message,
+        };
+  } else if (error instanceof S3KeyFormatError) {
+    status = 400;
+    errorInfo = { message: error.message };
+  } else if (error instanceof Error && typeof error.stack === "string") {
+    errorInfo = { message: error.stack };
+  } else {
+    errorInfo = { message: String(error) };
+  }
+  res.status(status).json(errorInfo);
 }
 
 export async function getProvidedUserProfile(

--- a/app/utils/files.ts
+++ b/app/utils/files.ts
@@ -21,6 +21,11 @@ export class S3KeyFormatError extends Error {
   name = "S3KeyFormatError";
 }
 
+const EXTENSION_REGEX = /\.[^.]+$/;
+const BEFORE_EXTENSION_REGEX = /(?=\.[^.]+$)/;
+const VERSION_SUFFIX_REGEX =
+  /(?:-r\d+(?:-wip-\d+)?(?:-edit-.+)?|-edit-.+)(?=\.[^.]+$)/;
+
 /**
  * Parses S3 key path into standardized components
  * @param s3Key - The S3 object key to parse
@@ -107,7 +112,7 @@ export function insertVersionInFilename(
   baseFilename: string,
   versionString: string,
 ): string {
-  return baseFilename.replace(/(?=\.[^.]+$)/, "-" + versionString);
+  return baseFilename.replace(BEFORE_EXTENSION_REGEX, "-" + versionString);
 }
 
 /**
@@ -116,10 +121,17 @@ export function insertVersionInFilename(
  * @returns filename with version and edit suffixes stripped.
  */
 export function getFileBaseName(filename: string): string {
-  return filename.replace(
-    /(?:-r\d+(?:-wip-\d+)?(?:-edit-.+)?|-edit-.+)(?=\.[^.]+$)/,
-    "",
-  );
+  return filename.replace(VERSION_SUFFIX_REGEX, "");
+}
+
+/**
+ * Get the extension, including separating dot, from a filename, returning empty string if none is found.
+ * @param filename - Filename to get extension from.
+ * @returns extension.
+ */
+export function getFileExtension(filename: string): string {
+  const match = EXTENSION_REGEX.exec(filename);
+  return match?.[0] ?? "";
 }
 
 /**

--- a/app/utils/files.ts
+++ b/app/utils/files.ts
@@ -125,6 +125,15 @@ export function getFileBaseName(filename: string): string {
 }
 
 /**
+ * Drop the extension from a filename.
+ * @param filename - Filename to remove extension from.
+ * @returns filename without extension.
+ */
+export function removeFileExtension(filename: string): string {
+  return filename.replace(EXTENSION_REGEX, "");
+}
+
+/**
  * Get the extension, including separating dot, from a filename, returning empty string if none is found.
  * @param filename - Filename to get extension from.
  * @returns extension.

--- a/app/views/AtlasSourceDatasetView/common/constants.ts
+++ b/app/views/AtlasSourceDatasetView/common/constants.ts
@@ -4,7 +4,7 @@ export const FIELD_NAME = {
   CELL_COUNT: "cellCount",
   DOWNLOAD_NAME: "downloadName",
   FILE_EVENT_TIME: "fileEventTime",
-  FILE_NAME: "baseFileName",
+  FILE_NAME: "fileName",
   GENE_COUNT: "geneCount",
   PUBLICATION_STATUS: "publicationStatus",
   PUBLISHED_AT: "publishedAt",

--- a/app/views/AtlasSourceDatasetView/common/constants.ts
+++ b/app/views/AtlasSourceDatasetView/common/constants.ts
@@ -2,6 +2,7 @@ export const FIELD_NAME = {
   CAP_INGEST_STATUS: "capIngestStatus",
   CAP_URL: "capUrl",
   CELL_COUNT: "cellCount",
+  DOWNLOAD_NAME: "downloadName",
   FILE_EVENT_TIME: "fileEventTime",
   FILE_NAME: "baseFileName",
   GENE_COUNT: "geneCount",

--- a/app/views/AtlasSourceDatasetView/common/controllers.ts
+++ b/app/views/AtlasSourceDatasetView/common/controllers.ts
@@ -48,6 +48,15 @@ const CELL_COUNT: CommonControllerConfig = {
   name: FIELD_NAME.CELL_COUNT,
 };
 
+const DOWNLOAD_NAME: CommonControllerConfig = {
+  inputProps: {
+    isFullWidth: false,
+    label: "Download Name",
+    readOnly: true,
+  },
+  name: FIELD_NAME.DOWNLOAD_NAME,
+};
+
 const FILE_EVENT_TIME: CommonControllerConfig = {
   inputProps: {
     isFullWidth: false,
@@ -95,7 +104,7 @@ const PUBLISHED_AT: CommonControllerConfig = {
 
 const SIZE_BYTES: CommonControllerConfig = {
   inputProps: {
-    isFullWidth: true,
+    isFullWidth: false,
     label: "File Size",
     readOnly: true,
   },
@@ -135,8 +144,9 @@ export const GENERAL_INFO_SOURCE_DATASET_CONTROLLERS: (
   | ChipInputControllerConfig
   | CommonControllerConfig
 )[] = [
-  FILE_NAME,
+  DOWNLOAD_NAME,
   VERSION,
+  FILE_NAME,
   SIZE_BYTES,
   TITLE,
   CELL_COUNT,

--- a/app/views/AtlasSourceDatasetView/common/controllers.ts
+++ b/app/views/AtlasSourceDatasetView/common/controllers.ts
@@ -70,7 +70,6 @@ const FILE_NAME: CommonControllerConfig = {
   inputProps: {
     isFullWidth: false,
     label: "File Name",
-    readOnly: true,
   },
   name: FIELD_NAME.FILE_NAME,
 };

--- a/app/views/AtlasSourceDatasetView/common/controllers.ts
+++ b/app/views/AtlasSourceDatasetView/common/controllers.ts
@@ -52,7 +52,6 @@ const DOWNLOAD_NAME: CommonControllerConfig = {
   inputProps: {
     isFullWidth: false,
     label: "Download Name",
-    readOnly: true,
   },
   name: FIELD_NAME.DOWNLOAD_NAME,
 };
@@ -70,6 +69,7 @@ const FILE_NAME: CommonControllerConfig = {
   inputProps: {
     isFullWidth: false,
     label: "File Name",
+    readOnly: true,
   },
   name: FIELD_NAME.FILE_NAME,
 };

--- a/app/views/AtlasSourceDatasetView/common/schema.ts
+++ b/app/views/AtlasSourceDatasetView/common/schema.ts
@@ -13,6 +13,7 @@ export const viewAtlasSourceDatasetSchema = object({
     .matches(CAP_DATASET_URL_REGEXP, "Invalid CAP URL (must be a dataset URL)")
     .nullable(),
   [FIELD_NAME.CELL_COUNT]: number(),
+  [FIELD_NAME.DOWNLOAD_NAME]: string().required("Download name is required"),
   [FIELD_NAME.FILE_EVENT_TIME]: string(),
   [FIELD_NAME.FILE_NAME]: string(),
   [FIELD_NAME.GENE_COUNT]: number().nullable(),

--- a/app/views/AtlasSourceDatasetView/hooks/useEditAtlasSourceDatasetForm.ts
+++ b/app/views/AtlasSourceDatasetView/hooks/useEditAtlasSourceDatasetForm.ts
@@ -38,7 +38,7 @@ function mapSchemaValues(
     [FIELD_NAME.CELL_COUNT]: sourceDataset.cellCount,
     [FIELD_NAME.DOWNLOAD_NAME]: sourceDataset.downloadName,
     [FIELD_NAME.FILE_EVENT_TIME]: sourceDataset.fileEventTime,
-    [FIELD_NAME.FILE_NAME]: sourceDataset.baseFileName,
+    [FIELD_NAME.FILE_NAME]: sourceDataset.fileName,
     [FIELD_NAME.GENE_COUNT]: sourceDataset.geneCount,
     [FIELD_NAME.PUBLICATION_STATUS]: sourceDataset.publicationStatus,
     [FIELD_NAME.PUBLISHED_AT]: sourceDataset.publishedAt ?? "Unpublished",

--- a/app/views/AtlasSourceDatasetView/hooks/useEditAtlasSourceDatasetForm.ts
+++ b/app/views/AtlasSourceDatasetView/hooks/useEditAtlasSourceDatasetForm.ts
@@ -30,12 +30,13 @@ export const useEditAtlasSourceDatasetForm = (
  */
 function mapSchemaValues(
   sourceDataset?: HCAAtlasTrackerSourceDataset,
-): ViewAtlasSourceDatasetData | undefined {
-  if (!sourceDataset) return;
+): ViewAtlasSourceDatasetData {
+  if (!sourceDataset) return { capUrl: null, downloadName: "" };
   return {
     [FIELD_NAME.CAP_INGEST_STATUS]: getCapIngestStatus(sourceDataset),
     [FIELD_NAME.CAP_URL]: sourceDataset.capUrl,
     [FIELD_NAME.CELL_COUNT]: sourceDataset.cellCount,
+    [FIELD_NAME.DOWNLOAD_NAME]: sourceDataset.downloadName,
     [FIELD_NAME.FILE_EVENT_TIME]: sourceDataset.fileEventTime,
     [FIELD_NAME.FILE_NAME]: sourceDataset.baseFileName,
     [FIELD_NAME.GENE_COUNT]: sourceDataset.geneCount,

--- a/app/views/AtlasSourceDatasetView/hooks/useEditAtlasSourceDatasetFormManager.ts
+++ b/app/views/AtlasSourceDatasetView/hooks/useEditAtlasSourceDatasetFormManager.ts
@@ -15,6 +15,7 @@ import { SOURCE_DATASET } from "./useFetchAtlasSourceDataset";
 
 type Payload = {
   capUrl: string | null;
+  downloadName: string;
 };
 
 export const useEditAtlasSourceDatasetFormManager = (
@@ -63,5 +64,5 @@ export const useEditAtlasSourceDatasetFormManager = (
  * @returns Payload.
  */
 function mapPayload(payload: ViewAtlasSourceDatasetData): Payload {
-  return { capUrl: payload.capUrl || null };
+  return { capUrl: payload.capUrl || null, downloadName: payload.downloadName };
 }

--- a/app/views/ComponentAtlasView/common/constants.ts
+++ b/app/views/ComponentAtlasView/common/constants.ts
@@ -2,6 +2,7 @@ export const FIELD_NAME = {
   CAP_INGEST_STATUS: "capIngestStatus",
   CAP_URL: "capUrl",
   CELL_COUNT: "cellCount",
+  DOWNLOAD_NAME: "downloadName",
   FILE_EVENT_TIME: "fileEventTime",
   FILE_NAME: "baseFileName",
   GENE_COUNT: "geneCount",

--- a/app/views/ComponentAtlasView/common/constants.ts
+++ b/app/views/ComponentAtlasView/common/constants.ts
@@ -4,7 +4,7 @@ export const FIELD_NAME = {
   CELL_COUNT: "cellCount",
   DOWNLOAD_NAME: "downloadName",
   FILE_EVENT_TIME: "fileEventTime",
-  FILE_NAME: "baseFileName",
+  FILE_NAME: "fileName",
   GENE_COUNT: "geneCount",
   PUBLISHED_AT: "publishedAt",
   SIZE_BY_BYTES: "sizeBytes",

--- a/app/views/ComponentAtlasView/common/controllers.ts
+++ b/app/views/ComponentAtlasView/common/controllers.ts
@@ -45,6 +45,15 @@ const CELL_COUNT: CommonControllerConfig = {
   name: FIELD_NAME.CELL_COUNT,
 };
 
+const DOWNLOAD_NAME: CommonControllerConfig = {
+  inputProps: {
+    isFullWidth: false,
+    label: "Download Name",
+    readOnly: true,
+  },
+  name: FIELD_NAME.DOWNLOAD_NAME,
+};
+
 const FILE_EVENT_TIME: CommonControllerConfig = {
   inputProps: {
     isFullWidth: false,
@@ -83,7 +92,7 @@ const PUBLISHED_AT: CommonControllerConfig = {
 
 const SIZE_BY_BYTES: CommonControllerConfig = {
   inputProps: {
-    isFullWidth: true,
+    isFullWidth: false,
     label: "File Size",
     readOnly: true,
   },
@@ -123,8 +132,9 @@ export const GENERAL_INFO_INTEGRATED_OBJECT_CONTROLLERS: (
   | ChipInputControllerConfig
   | CommonControllerConfig
 )[] = [
-  FILE_NAME,
+  DOWNLOAD_NAME,
   VERSION,
+  FILE_NAME,
   SIZE_BY_BYTES,
   TITLE,
   CELL_COUNT,

--- a/app/views/ComponentAtlasView/common/controllers.ts
+++ b/app/views/ComponentAtlasView/common/controllers.ts
@@ -49,7 +49,6 @@ const DOWNLOAD_NAME: CommonControllerConfig = {
   inputProps: {
     isFullWidth: false,
     label: "Download Name",
-    readOnly: true,
   },
   name: FIELD_NAME.DOWNLOAD_NAME,
 };

--- a/app/views/ComponentAtlasView/common/schema.ts
+++ b/app/views/ComponentAtlasView/common/schema.ts
@@ -12,6 +12,7 @@ export const viewIntegratedObjectSchema = object({
     .matches(CAP_DATASET_URL_REGEXP, "Invalid CAP URL (must be a dataset URL)")
     .nullable(),
   [FIELD_NAME.CELL_COUNT]: number(),
+  [FIELD_NAME.DOWNLOAD_NAME]: string().required("Download name is required"),
   [FIELD_NAME.FILE_EVENT_TIME]: string(),
   [FIELD_NAME.FILE_NAME]: string(),
   [FIELD_NAME.GENE_COUNT]: number().nullable(),

--- a/app/views/ComponentAtlasView/hooks/useEditIntegratedObjectFormManager.ts
+++ b/app/views/ComponentAtlasView/hooks/useEditIntegratedObjectFormManager.ts
@@ -15,6 +15,7 @@ import { INTEGRATED_OBJECT } from "./useFetchComponentAtlas";
 
 type Payload = {
   capUrl: string | null;
+  downloadName: string;
 };
 
 export const useEditIntegratedObjectFormManager = (
@@ -61,5 +62,5 @@ export const useEditIntegratedObjectFormManager = (
  * @returns Payload.
  */
 function mapPayload(payload: ViewIntegratedObjectData): Payload {
-  return { capUrl: payload.capUrl || null };
+  return { capUrl: payload.capUrl || null, downloadName: payload.downloadName };
 }

--- a/app/views/ComponentAtlasView/hooks/useViewComponentAtlasForm.ts
+++ b/app/views/ComponentAtlasView/hooks/useViewComponentAtlasForm.ts
@@ -30,12 +30,13 @@ export const useViewComponentAtlasForm = (
  */
 function mapSchemaValues(
   integratedObject?: HCAAtlasTrackerComponentAtlas,
-): ViewIntegratedObjectData | undefined {
-  if (!integratedObject) return;
+): ViewIntegratedObjectData {
+  if (!integratedObject) return { capUrl: null, downloadName: "" };
   return {
     [FIELD_NAME.CAP_INGEST_STATUS]: getCapIngestStatus(integratedObject),
     [FIELD_NAME.CAP_URL]: integratedObject.capUrl,
     [FIELD_NAME.CELL_COUNT]: integratedObject.cellCount,
+    [FIELD_NAME.DOWNLOAD_NAME]: integratedObject.downloadName,
     [FIELD_NAME.FILE_EVENT_TIME]: integratedObject.fileEventTime,
     [FIELD_NAME.FILE_NAME]: integratedObject.baseFileName,
     [FIELD_NAME.GENE_COUNT]: integratedObject.geneCount,

--- a/app/views/ComponentAtlasView/hooks/useViewComponentAtlasForm.ts
+++ b/app/views/ComponentAtlasView/hooks/useViewComponentAtlasForm.ts
@@ -38,7 +38,7 @@ function mapSchemaValues(
     [FIELD_NAME.CELL_COUNT]: integratedObject.cellCount,
     [FIELD_NAME.DOWNLOAD_NAME]: integratedObject.downloadName,
     [FIELD_NAME.FILE_EVENT_TIME]: integratedObject.fileEventTime,
-    [FIELD_NAME.FILE_NAME]: integratedObject.baseFileName,
+    [FIELD_NAME.FILE_NAME]: integratedObject.fileName,
     [FIELD_NAME.GENE_COUNT]: integratedObject.geneCount,
     [FIELD_NAME.PUBLISHED_AT]: integratedObject.publishedAt ?? "Unpublished",
     [FIELD_NAME.SIZE_BY_BYTES]: formatFileSize(integratedObject.sizeBytes),

--- a/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId].ts
+++ b/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId].ts
@@ -10,7 +10,6 @@ import {
 import {
   handleByMethod,
   handler,
-  integrationLeadAssociatedAtlasOnly,
   role,
 } from "../../../../../app/utils/api-handler";
 
@@ -26,22 +25,18 @@ const getHandler = handler(role(ROLE_GROUP.READ), async (req, res) => {
     );
 });
 
-const patchHandler = handler(
-  role([ROLE.CONTENT_ADMIN, ROLE.INTEGRATION_LEAD]),
-  integrationLeadAssociatedAtlasOnly,
-  async (req, res) => {
-    const atlasId = req.query.atlasId as string;
-    const componentAtlasId = req.query.componentAtlasId as string;
-    const inputData = await componentAtlasEditSchema.validate(req.body);
-    res
-      .status(200)
-      .json(
-        dbComponentAtlasFileToDetailApiComponentAtlas(
-          await updateComponentAtlas(atlasId, componentAtlasId, inputData),
-        ),
-      );
-  },
-);
+const patchHandler = handler(role(ROLE.CONTENT_ADMIN), async (req, res) => {
+  const atlasId = req.query.atlasId as string;
+  const componentAtlasId = req.query.componentAtlasId as string;
+  const inputData = await componentAtlasEditSchema.validate(req.body);
+  res
+    .status(200)
+    .json(
+      dbComponentAtlasFileToDetailApiComponentAtlas(
+        await updateComponentAtlas(atlasId, componentAtlasId, inputData),
+      ),
+    );
+});
 
 export default handleByMethod({
   [METHOD.GET]: getHandler,

--- a/pages/api/atlases/[atlasId]/source-datasets/[sourceDatasetId].ts
+++ b/pages/api/atlases/[atlasId]/source-datasets/[sourceDatasetId].ts
@@ -13,7 +13,6 @@ import {
 import {
   handleByMethod,
   handler,
-  integrationLeadAssociatedAtlasOnly,
   role,
 } from "../../../../../app/utils/api-handler";
 
@@ -27,20 +26,16 @@ const getHandler = handler(role(ROLE_GROUP.READ), async (req, res) => {
   );
 });
 
-const patchHandler = handler(
-  role([ROLE.CONTENT_ADMIN, ROLE.INTEGRATION_LEAD]),
-  integrationLeadAssociatedAtlasOnly,
-  async (req, res) => {
-    const atlasId = req.query.atlasId as string;
-    const sourceDatasetId = req.query.sourceDatasetId as string;
-    const inputData = await atlasSourceDatasetEditSchema.validate(req.body);
-    res.json(
-      dbSourceDatasetToApiSourceDataset(
-        await updateAtlasSourceDataset(atlasId, sourceDatasetId, inputData),
-      ),
-    );
-  },
-);
+const patchHandler = handler(role(ROLE.CONTENT_ADMIN), async (req, res) => {
+  const atlasId = req.query.atlasId as string;
+  const sourceDatasetId = req.query.sourceDatasetId as string;
+  const inputData = await atlasSourceDatasetEditSchema.validate(req.body);
+  res.json(
+    dbSourceDatasetToApiSourceDataset(
+      await updateAtlasSourceDataset(atlasId, sourceDatasetId, inputData),
+    ),
+  );
+});
 
 /**
  * API route for getting or editing a source dataset of an atlas.

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -41,6 +41,7 @@ import {
 import { METHOD } from "../app/common/entities";
 import { Handler } from "../app/utils/api-handler";
 import { slugifyAtlasShortName } from "../app/utils/atlases";
+import { removeFileExtension } from "../app/utils/files";
 import {
   ATLAS_DRAFT,
   DEFAULT_USERS_BY_ROLE,
@@ -354,6 +355,12 @@ export function getTestSourceStudyCitation(
       sourceStudy.unpublishedInfo.contactEmail,
     );
   }
+}
+
+export function getTestEntityDownloadName(
+  entity: TestComponentAtlas | TestSourceDataset,
+): string {
+  return removeFileExtension(getTestEntityBaseFilename(entity));
 }
 
 function getTestEntityBaseFilename(


### PR DESCRIPTION
Closes #1177

Notable differences from ticket:
- The "File Name" fields on the forms are updated to display the actual name from S3, which the ticket does not explicitly mention
- The forms and APIs are updated to be entirely content-admin-only rather than only the new field being so
- There's only a minimal format check for the name, done by checking on the backend whether it changes when passed through the suffix-stripping function
- The conflict check is taken care of by the unique constraint on the concepts table
- Filename manipulation is kept within the backend TypeScript code; the existing download name to show on the form is determined on the backend, and a new base filename is calculated via TypeScript (not SQL)
- The tests may not be quite as granular as described in the ticket