### PR TITLE
fix: validation summary back arrow returns to originating list

### DIFF
--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.tsx
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.tsx
@@ -31,31 +31,35 @@ export const ValidationSummary = ({
 
   return (
     <Stack {...STACK_PROPS}>
-      {validators.map(([key, value]) => (
-        <Stack key={key} {...INNER_STACK_PROPS}>
-          {value ? (
-            <SuccessIcon
-              color={SVG_ICON_PROPS.COLOR.SUCCESS}
-              fontSize={SVG_ICON_PROPS.FONT_SIZE.SMALL}
-            />
-          ) : (
-            <StyledErrorIcon fontSize={SVG_ICON_PROPS.FONT_SIZE.SMALL} />
-          )}
-          <MLink
-            component={Link}
-            href={getRouteURL(validationRoute, {
-              atlasId,
-              componentAtlasId,
-              sourceDatasetId,
-              validatorName: key as FileValidatorName,
-            })}
-            rel={REL_ATTRIBUTE.NO_OPENER}
-            target={ANCHOR_TARGET.SELF}
-          >
-            {FILE_VALIDATOR_NAME_LABEL[key as FileValidatorName]}
-          </MLink>
-        </Stack>
-      ))}
+      {validators.map(([key, value]) => {
+        const url = getRouteURL(validationRoute, {
+          atlasId,
+          componentAtlasId,
+          sourceDatasetId,
+          validatorName: key as FileValidatorName,
+        });
+        return (
+          <Stack key={key} {...INNER_STACK_PROPS}>
+            {value ? (
+              <SuccessIcon
+                color={SVG_ICON_PROPS.COLOR.SUCCESS}
+                fontSize={SVG_ICON_PROPS.FONT_SIZE.SMALL}
+              />
+            ) : (
+              <StyledErrorIcon fontSize={SVG_ICON_PROPS.FONT_SIZE.SMALL} />
+            )}
+            <MLink
+              as={url}
+              component={Link}
+              href={{ pathname: url, query: { from: "list" } }}
+              rel={REL_ATTRIBUTE.NO_OPENER}
+              target={ANCHOR_TARGET.SELF}
+            >
+              {FILE_VALIDATOR_NAME_LABEL[key as FileValidatorName]}
+            </MLink>
+          </Stack>
+        );
+      })}
     </Stack>
   );
 };

--- a/app/views/AtlasSourceDatasetValidationView/atlasSourceDatasetValidationView.tsx
+++ b/app/views/AtlasSourceDatasetValidationView/atlasSourceDatasetValidationView.tsx
@@ -1,6 +1,6 @@
 import { ConditionalComponent } from "@databiosphere/findable-ui/lib/components/ComponentCreator/components/ConditionalComponent/conditionalComponent";
 import { useRouter } from "next/router";
-import { Fragment, JSX } from "react";
+import { Fragment, JSX, useRef } from "react";
 import { PathParameter } from "../../common/entities";
 import { getRouteURL } from "../../common/utils";
 import { AccessPrompt } from "../../components/common/Form/components/FormManager/components/AccessPrompt/accessPrompt";
@@ -26,6 +26,7 @@ export const AtlasSourceDatasetValidationView = ({
   pathParameter,
 }: Props): JSX.Element => {
   const { query } = useRouter();
+  const fromList = useRef(query.from === "list");
   const { atlas } = useFetchAtlas(pathParameter);
   const { sourceDataset } = useFetchAtlasSourceDataset(pathParameter);
   const formManager = useFormManager();
@@ -33,10 +34,9 @@ export const AtlasSourceDatasetValidationView = ({
     access: { canView },
     isLoading,
   } = formManager;
-  const backPath =
-    query.from === "list"
-      ? getRouteURL(ROUTE.ATLAS_SOURCE_DATASETS, pathParameter)
-      : getRouteURL(ROUTE.ATLAS_SOURCE_DATASET, pathParameter);
+  const backPath = fromList.current
+    ? getRouteURL(ROUTE.ATLAS_SOURCE_DATASETS, pathParameter)
+    : getRouteURL(ROUTE.ATLAS_SOURCE_DATASET, pathParameter);
   if (isLoading) return <Fragment />;
   return (
     <EntityProvider data={{ sourceDataset }} pathParameter={pathParameter}>

--- a/app/views/AtlasSourceDatasetValidationView/atlasSourceDatasetValidationView.tsx
+++ b/app/views/AtlasSourceDatasetValidationView/atlasSourceDatasetValidationView.tsx
@@ -38,7 +38,7 @@ export const AtlasSourceDatasetValidationView = ({
         isIn={shouldRenderView(canView, Boolean(atlas && sourceDataset))}
       >
         <DetailView
-          backPath={getRouteURL(ROUTE.ATLAS_SOURCE_DATASET, pathParameter)}
+          backPath={getRouteURL(ROUTE.ATLAS_SOURCE_DATASETS, pathParameter)}
           breadcrumbs={
             <Breadcrumbs breadcrumbs={getBreadcrumbs(pathParameter, atlas)} />
           }

--- a/app/views/AtlasSourceDatasetValidationView/atlasSourceDatasetValidationView.tsx
+++ b/app/views/AtlasSourceDatasetValidationView/atlasSourceDatasetValidationView.tsx
@@ -1,4 +1,5 @@
 import { ConditionalComponent } from "@databiosphere/findable-ui/lib/components/ComponentCreator/components/ConditionalComponent/conditionalComponent";
+import { useRouter } from "next/router";
 import { Fragment, JSX } from "react";
 import { PathParameter } from "../../common/entities";
 import { getRouteURL } from "../../common/utils";
@@ -24,6 +25,7 @@ interface Props {
 export const AtlasSourceDatasetValidationView = ({
   pathParameter,
 }: Props): JSX.Element => {
+  const { query } = useRouter();
   const { atlas } = useFetchAtlas(pathParameter);
   const { sourceDataset } = useFetchAtlasSourceDataset(pathParameter);
   const formManager = useFormManager();
@@ -31,6 +33,10 @@ export const AtlasSourceDatasetValidationView = ({
     access: { canView },
     isLoading,
   } = formManager;
+  const backPath =
+    query.from === "list"
+      ? getRouteURL(ROUTE.ATLAS_SOURCE_DATASETS, pathParameter)
+      : getRouteURL(ROUTE.ATLAS_SOURCE_DATASET, pathParameter);
   if (isLoading) return <Fragment />;
   return (
     <EntityProvider data={{ sourceDataset }} pathParameter={pathParameter}>
@@ -38,7 +44,7 @@ export const AtlasSourceDatasetValidationView = ({
         isIn={shouldRenderView(canView, Boolean(atlas && sourceDataset))}
       >
         <DetailView
-          backPath={getRouteURL(ROUTE.ATLAS_SOURCE_DATASETS, pathParameter)}
+          backPath={backPath}
           breadcrumbs={
             <Breadcrumbs breadcrumbs={getBreadcrumbs(pathParameter, atlas)} />
           }

--- a/app/views/IntegratedObjectValidationView/integratedObjectValidationView.tsx
+++ b/app/views/IntegratedObjectValidationView/integratedObjectValidationView.tsx
@@ -38,7 +38,7 @@ export const IntegratedObjectValidationView = ({
         isIn={shouldRenderView(canView, Boolean(atlas && componentAtlas))}
       >
         <DetailView
-          backPath={getRouteURL(ROUTE.COMPONENT_ATLAS, pathParameter)}
+          backPath={getRouteURL(ROUTE.COMPONENT_ATLASES, pathParameter)}
           breadcrumbs={
             <Breadcrumbs breadcrumbs={getBreadcrumbs(pathParameter, atlas)} />
           }

--- a/app/views/IntegratedObjectValidationView/integratedObjectValidationView.tsx
+++ b/app/views/IntegratedObjectValidationView/integratedObjectValidationView.tsx
@@ -1,6 +1,6 @@
 import { ConditionalComponent } from "@databiosphere/findable-ui/lib/components/ComponentCreator/components/ConditionalComponent/conditionalComponent";
 import { useRouter } from "next/router";
-import { Fragment, JSX } from "react";
+import { Fragment, JSX, useRef } from "react";
 import { PathParameter } from "../../common/entities";
 import { getRouteURL } from "../../common/utils";
 import { AccessPrompt } from "../../components/common/Form/components/FormManager/components/AccessPrompt/accessPrompt";
@@ -26,6 +26,7 @@ export const IntegratedObjectValidationView = ({
   pathParameter,
 }: Props): JSX.Element => {
   const { query } = useRouter();
+  const fromList = useRef(query.from === "list");
   const { atlas } = useFetchAtlas(pathParameter);
   const { componentAtlas } = useFetchComponentAtlas(pathParameter);
   const formManager = useFormManager();
@@ -33,10 +34,9 @@ export const IntegratedObjectValidationView = ({
     access: { canView },
     isLoading,
   } = formManager;
-  const backPath =
-    query.from === "list"
-      ? getRouteURL(ROUTE.COMPONENT_ATLASES, pathParameter)
-      : getRouteURL(ROUTE.COMPONENT_ATLAS, pathParameter);
+  const backPath = fromList.current
+    ? getRouteURL(ROUTE.COMPONENT_ATLASES, pathParameter)
+    : getRouteURL(ROUTE.COMPONENT_ATLAS, pathParameter);
   if (isLoading) return <Fragment />;
   return (
     <EntityProvider data={{ componentAtlas }} pathParameter={pathParameter}>

--- a/app/views/IntegratedObjectValidationView/integratedObjectValidationView.tsx
+++ b/app/views/IntegratedObjectValidationView/integratedObjectValidationView.tsx
@@ -1,4 +1,5 @@
 import { ConditionalComponent } from "@databiosphere/findable-ui/lib/components/ComponentCreator/components/ConditionalComponent/conditionalComponent";
+import { useRouter } from "next/router";
 import { Fragment, JSX } from "react";
 import { PathParameter } from "../../common/entities";
 import { getRouteURL } from "../../common/utils";
@@ -24,6 +25,7 @@ interface Props {
 export const IntegratedObjectValidationView = ({
   pathParameter,
 }: Props): JSX.Element => {
+  const { query } = useRouter();
   const { atlas } = useFetchAtlas(pathParameter);
   const { componentAtlas } = useFetchComponentAtlas(pathParameter);
   const formManager = useFormManager();
@@ -31,6 +33,10 @@ export const IntegratedObjectValidationView = ({
     access: { canView },
     isLoading,
   } = formManager;
+  const backPath =
+    query.from === "list"
+      ? getRouteURL(ROUTE.COMPONENT_ATLASES, pathParameter)
+      : getRouteURL(ROUTE.COMPONENT_ATLAS, pathParameter);
   if (isLoading) return <Fragment />;
   return (
     <EntityProvider data={{ componentAtlas }} pathParameter={pathParameter}>
@@ -38,7 +44,7 @@ export const IntegratedObjectValidationView = ({
         isIn={shouldRenderView(canView, Boolean(atlas && componentAtlas))}
       >
         <DetailView
-          backPath={getRouteURL(ROUTE.COMPONENT_ATLASES, pathParameter)}
+          backPath={backPath}
           breadcrumbs={
             <Breadcrumbs breadcrumbs={getBreadcrumbs(pathParameter, atlas)} />
           }


### PR DESCRIPTION
## Summary
- Back arrow on validation summary views now returns to the originating list tab (Source Datasets or Integrated Objects) when navigated from the list
- Uses Next.js Link `href`/`as` pattern to pass hidden `{ from: "list" }` query state — URL bar stays clean
- Falls back to file detail page when navigated directly or via deep link (no `from` in query)

Closes #1198

## Test plan
- [x] From Source Datasets tab → file validation → back arrow returns to Source Datasets tab
- [x] From Integrated Objects tab → IO validation → back arrow returns to Integrated Objects tab
- [x] Deep-link to validation URL → back arrow returns to file detail page
- [x] Browser back button behavior unchanged
- [x] URL bar shows clean path (no `?from=list` visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)