### PR TITLE
feat: rename CAP to "CAP Upload" and add validator hover descriptions (#1197)

### DIFF
--- a/app/apis/catalog/hca-atlas-tracker/common/constants.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/constants.ts
@@ -213,7 +213,7 @@ export const FILE_VALIDATOR_NAMES = [
 ] as const;
 
 export const FILE_VALIDATOR_NAME_LABEL: Record<FileValidatorName, string> = {
-  cap: "CAP",
+  cap: "CAP Upload",
   cellxgene: "CELLxGENE",
   hcaCellAnnotation: "HCA Cell Annotation",
   hcaSchema: "HCA Tier-1",

--- a/app/apis/catalog/hca-atlas-tracker/common/validatorDescriptions.tsx
+++ b/app/apis/catalog/hca-atlas-tracker/common/validatorDescriptions.tsx
@@ -1,0 +1,41 @@
+import {
+  ANCHOR_TARGET,
+  REL_ATTRIBUTE,
+} from "@databiosphere/findable-ui/lib/components/Links/common/entities";
+import { Link } from "@mui/material";
+import { ReactNode } from "react";
+import { FileValidatorName } from "./entities";
+
+export const FILE_VALIDATOR_DESCRIPTIONS: Record<FileValidatorName, ReactNode> =
+  {
+    cap: "Validates the dataset/object has sufficient metadata to be uploaded to CAP for annotation.",
+    cellxgene: "",
+    hcaCellAnnotation: (
+      <>
+        Validates the dataset/object conforms to the HCA{" "}
+        <Link
+          color="inherit"
+          href="https://data.humancellatlas.org/metadata/cell-annotation"
+          rel={REL_ATTRIBUTE.NO_OPENER_NO_REFERRER}
+          target={ANCHOR_TARGET.BLANK}
+        >
+          Cell Annotation Metadata Schema
+        </Link>
+        .
+      </>
+    ),
+    hcaSchema: (
+      <>
+        Validates the dataset/object conforms to the HCA{" "}
+        <Link
+          color="inherit"
+          href="https://data.humancellatlas.org/metadata/tier-1"
+          rel={REL_ATTRIBUTE.NO_OPENER_NO_REFERRER}
+          target={ANCHOR_TARGET.BLANK}
+        >
+          Tier-1 Metadata Schema
+        </Link>
+        .
+      </>
+    ),
+  };

--- a/app/components/Entity/components/EntityView/components/ValidationReport/components/Tabs/tabs.tsx
+++ b/app/components/Entity/components/EntityView/components/ValidationReport/components/Tabs/tabs.tsx
@@ -1,12 +1,13 @@
 import { ErrorIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/ErrorIcon/errorIcon";
 import { SuccessIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/SuccessIcon/successIcon";
+import { STACK_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/stack";
 import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/svgIcon";
-import { TAB_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/tab";
-import { Tab } from "@mui/material";
+import { Stack, Tab, Tooltip } from "@mui/material";
 import Router from "next/router";
 import { JSX, SyntheticEvent, useCallback } from "react";
 import { FILE_VALIDATOR_NAME_LABEL } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/constants";
 import { FileValidatorName } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { FILE_VALIDATOR_DESCRIPTIONS } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/validatorDescriptions";
 import { getRouteURL } from "../../../../../../../../common/utils";
 import { Props } from "./entities";
 import { StyledTabs } from "./tabs.styles";
@@ -19,11 +20,11 @@ export const Tabs = ({
   validatorNames,
 }: Props): JSX.Element | null => {
   const onChange = useCallback(
-    (_: SyntheticEvent, validatorName: FileValidatorName) => {
+    (_: SyntheticEvent, name: FileValidatorName) => {
       Router.push(
         getRouteURL(validationRoute, {
           ...pathParameter,
-          validatorName,
+          validatorName: name,
         }),
       );
     },
@@ -34,25 +35,35 @@ export const Tabs = ({
 
   return (
     <StyledTabs value={validatorName} onChange={onChange}>
-      {validatorNames.map((validatorName) => (
+      {validatorNames.map((name) => (
         <Tab
-          key={validatorName}
-          icon={
-            validationReports[validatorName]?.valid ? (
-              <SuccessIcon
-                color={SVG_ICON_PROPS.COLOR.SUCCESS}
-                fontSize={SVG_ICON_PROPS.FONT_SIZE.SMALL}
-              />
-            ) : (
-              <ErrorIcon
-                color={SVG_ICON_PROPS.COLOR.ERROR}
-                fontSize={SVG_ICON_PROPS.FONT_SIZE.SMALL}
-              />
-            )
+          key={name}
+          label={
+            <Tooltip
+              disableInteractive={false}
+              title={FILE_VALIDATOR_DESCRIPTIONS[name]}
+            >
+              <Stack
+                direction={STACK_PROPS.DIRECTION.ROW}
+                spacing={2}
+                useFlexGap
+              >
+                {validationReports[name]?.valid ? (
+                  <SuccessIcon
+                    color={SVG_ICON_PROPS.COLOR.SUCCESS}
+                    fontSize={SVG_ICON_PROPS.FONT_SIZE.SMALL}
+                  />
+                ) : (
+                  <ErrorIcon
+                    color={SVG_ICON_PROPS.COLOR.ERROR}
+                    fontSize={SVG_ICON_PROPS.FONT_SIZE.SMALL}
+                  />
+                )}
+                {FILE_VALIDATOR_NAME_LABEL[name]}
+              </Stack>
+            </Tooltip>
           }
-          iconPosition={TAB_PROPS.ICON_POSITION.START}
-          label={FILE_VALIDATOR_NAME_LABEL[validatorName]}
-          value={validatorName}
+          value={name}
         />
       ))}
     </StyledTabs>

--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.tsx
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.tsx
@@ -4,11 +4,12 @@ import {
   REL_ATTRIBUTE,
 } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
 import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/svgIcon";
-import { Link as MLink, Stack } from "@mui/material";
+import { Link as MLink, Stack, Tooltip } from "@mui/material";
 import Link from "next/link";
 import { JSX } from "react";
 import { FILE_VALIDATOR_NAME_LABEL } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/constants";
 import { FileValidatorName } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { FILE_VALIDATOR_DESCRIPTIONS } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/validatorDescriptions";
 import { getRouteURL } from "../../../../../../../../common/utils";
 import { INNER_STACK_PROPS, STACK_PROPS } from "./constants";
 import { Props } from "./entities";
@@ -39,25 +40,32 @@ export const ValidationSummary = ({
           validatorName: key as FileValidatorName,
         });
         return (
-          <Stack key={key} {...INNER_STACK_PROPS}>
-            {value.valid ? (
-              <SuccessIcon
-                color={SVG_ICON_PROPS.COLOR.SUCCESS}
-                fontSize={SVG_ICON_PROPS.FONT_SIZE.SMALL}
-              />
-            ) : (
-              <StyledErrorIcon fontSize={SVG_ICON_PROPS.FONT_SIZE.SMALL} />
-            )}
-            <MLink
-              as={url}
-              component={Link}
-              href={{ pathname: url, query: { from: "list" } }}
-              rel={REL_ATTRIBUTE.NO_OPENER}
-              target={ANCHOR_TARGET.SELF}
-            >
-              {FILE_VALIDATOR_NAME_LABEL[key as FileValidatorName]}
-            </MLink>
-          </Stack>
+          <Tooltip
+            disableInteractive={false}
+            key={key}
+            title={FILE_VALIDATOR_DESCRIPTIONS[key as FileValidatorName]}
+          >
+            <Stack {...INNER_STACK_PROPS}>
+              {value ? (
+                <SuccessIcon
+                  color={SVG_ICON_PROPS.COLOR.SUCCESS}
+                  fontSize={SVG_ICON_PROPS.FONT_SIZE.SMALL}
+                />
+              ) : (
+                <StyledErrorIcon fontSize={SVG_ICON_PROPS.FONT_SIZE.SMALL} />
+              )}
+
+              <MLink
+                as={url}
+                component={Link}
+                href={{ pathname: url, query: { from: "list" } }}
+                rel={REL_ATTRIBUTE.NO_OPENER}
+                target={ANCHOR_TARGET.SELF}
+              >
+                {FILE_VALIDATOR_NAME_LABEL[key as FileValidatorName]}
+              </MLink>
+            </Stack>
+          </Tooltip>
         );
       })}
     </Stack>

--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.tsx
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.tsx
@@ -46,7 +46,7 @@ export const ValidationSummary = ({
             title={FILE_VALIDATOR_DESCRIPTIONS[key as FileValidatorName]}
           >
             <Stack {...INNER_STACK_PROPS}>
-              {value ? (
+              {value.valid ? (
                 <SuccessIcon
                   color={SVG_ICON_PROPS.COLOR.SUCCESS}
                   fontSize={SVG_ICON_PROPS.FONT_SIZE.SMALL}

--- a/app/views/AtlasSourceDatasetsView/components/Table/columns.tsx
+++ b/app/views/AtlasSourceDatasetsView/components/Table/columns.tsx
@@ -86,6 +86,7 @@ const COLUMN_FILE_NAME = {
       }),
     }),
   header: "File Name",
+  id: "fileName",
   meta: { columnPinned: true, width: { max: "0.5fr", min: "120px" } },
 } as ColumnDef<AtlasSourceDataset>;
 


### PR DESCRIPTION
## Summary
- Renames "CAP" validator label to "CAP Upload" in `FILE_VALIDATOR_NAME_LABEL`
- Adds hover tooltip descriptions to validator links in both list summary cells and detail page tabs
- HCA Tier-1 and HCA Cell Annotation tooltips include clickable external documentation links (open in new tab with `noopener noreferrer`)
- Tooltips use `disableInteractive={false}` so embedded links are clickable
- Moves tab icon inside the `label` prop so tooltip covers both icon and text
- Fixes missing `fileName` column id on source datasets table

Closes #1197

## Known limitation
Tab keyboard focus is a pre-existing issue unrelated to this PR — tabs do not receive keyboard focus on `main` either. As a result, tooltip descriptions on detail-page validator tabs are hover-only. The list summary tooltips are keyboard-accessible since the validator links (`<a>`) are natively focusable. MUI Tooltip adds `aria-describedby` automatically when visible.

## Test plan
- [x] List-cell validator links show "CAP Upload" on SD and IO tables
- [x] Detail-page validator tab shows "CAP Upload"
- [x] Hovering "CAP Upload" shows: "Validates the dataset/object has sufficient metadata to be uploaded to CAP for annotation."
- [x] Hovering "HCA Tier-1" shows description with clickable "Tier-1 Metadata Schema" link to https://data.humancellatlas.org/metadata/tier-1
- [x] Hovering "HCA Cell Annotation" shows description with clickable "Cell Annotation Metadata Schema" link to https://data.humancellatlas.org/metadata/cell-annotation
- [x] Tooltip links open in new tab
- [x] No console warning about missing `fileName` column

🤖 Generated with [Claude Code](https://claude.com/claude-code)