### PR TITLE
feat: format "Uploaded At" column as human-readable date + time

### DIFF
--- a/__tests__/format-iso-to-utc-date-time.test.ts
+++ b/__tests__/format-iso-to-utc-date-time.test.ts
@@ -28,4 +28,11 @@ describe("formatISOToUTCDateTime", () => {
   it("returns null for invalid date string", () => {
     expect(formatISOToUTCDateTime("not-a-date")).toBeNull();
   });
+
+  it("normalizes a non-UTC ISO offset to UTC", () => {
+    expect(formatISOToUTCDateTime("2026-04-08T20:47:25+02:00")).toEqual([
+      "2026-04-08",
+      "18:47:25 (UTC)",
+    ]);
+  });
 });

--- a/__tests__/format-iso-to-utc-date-time.test.ts
+++ b/__tests__/format-iso-to-utc-date-time.test.ts
@@ -1,0 +1,31 @@
+import { formatISOToUTCDateTime } from "../app/utils/date-fns";
+
+describe("formatISOToUTCDateTime", () => {
+  it("formats a valid ISO string into date and time parts", () => {
+    expect(formatISOToUTCDateTime("2026-04-08T20:47:25.073Z")).toEqual([
+      "2026-04-08",
+      "20:47:25 (UTC)",
+    ]);
+  });
+
+  it("drops millisecond precision", () => {
+    const result = formatISOToUTCDateTime("2026-01-15T09:03:45.999Z");
+    expect(result).toEqual(["2026-01-15", "09:03:45 (UTC)"]);
+  });
+
+  it("returns null for null input", () => {
+    expect(formatISOToUTCDateTime(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(formatISOToUTCDateTime(undefined)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(formatISOToUTCDateTime("")).toBeNull();
+  });
+
+  it("returns null for invalid date string", () => {
+    expect(formatISOToUTCDateTime("not-a-date")).toBeNull();
+  });
+});

--- a/app/utils/date-fns.ts
+++ b/app/utils/date-fns.ts
@@ -45,8 +45,9 @@ export function formatISOToUTCDateTime(
   if (!isoString) return null;
   const date = new Date(isoString);
   if (isNaN(date.getTime())) return null;
-  const datePart = isoString.slice(0, 10);
-  const timePart = isoString.slice(11, 19);
+  const utcISOString = date.toISOString();
+  const datePart = utcISOString.slice(0, 10);
+  const timePart = utcISOString.slice(11, 19);
   return [datePart, `${timePart} (UTC)`];
 }
 

--- a/app/utils/date-fns.ts
+++ b/app/utils/date-fns.ts
@@ -35,6 +35,22 @@ export function formatDateToQuarterYear(dateStr: string | null): string {
 }
 
 /**
+ * Formats an ISO date string as a UTC date and time.
+ * @param isoString - ISO date string.
+ * @returns tuple of [date, time] formatted as ["YYYY-MM-DD", "HH:MM:SS (UTC)"], or null if invalid.
+ */
+export function formatISOToUTCDateTime(
+  isoString: string | null | undefined,
+): [string, string] | null {
+  if (!isoString) return null;
+  const date = new Date(isoString);
+  if (isNaN(date.getTime())) return null;
+  const datePart = isoString.slice(0, 10);
+  const timePart = isoString.slice(11, 19);
+  return [datePart, `${timePart} (UTC)`];
+}
+
+/**
  * Returns the date for the given year and month.
  * @param year - Year.
  * @param month - Month.
@@ -54,6 +70,18 @@ function getFormattedMonth(month: number): string {
   const date = new Date(0, month - 1);
   // Format the date to get the month as a two-digit string
   return format(date, "MM");
+}
+
+/**
+ * Returns the last moment of the given quarter.
+ * @param quarter - Quarter.
+ * @param year - Year.
+ * @returns last moment of the quarter.
+ */
+function getLastMomentOfQuarter(quarter: number, year: number): Date {
+  const month = quartersToMonths(quarter);
+  const date = getDate(year, month);
+  return endOfQuarter(date);
 }
 
 /**
@@ -78,16 +106,4 @@ export function getPastAndNextTwoYearsQuartersByDate(
     }
   }
   return quartersByDate;
-}
-
-/**
- * Returns the last moment of the given quarter.
- * @param quarter - Quarter.
- * @param year - Year.
- * @returns last moment of the quarter.
- */
-function getLastMomentOfQuarter(quarter: number, year: number): Date {
-  const month = quartersToMonths(quarter);
-  const date = getDate(year, month);
-  return endOfQuarter(date);
 }

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.tsx
@@ -15,7 +15,7 @@ import {
   RowData,
   Table,
 } from "@tanstack/react-table";
-import { BaseSyntheticEvent, ComponentProps, JSX } from "react";
+import { BaseSyntheticEvent, ComponentProps, type JSX } from "react";
 import { HCA_ATLAS_TRACKER_CATEGORY_LABEL } from "../../../../../site-config/hca-atlas-tracker/category";
 import {
   NETWORKS,
@@ -50,7 +50,10 @@ import * as C from "../../../../components";
 import { CAPIngestStatusCell } from "../../../../components/Table/components/TableCell/components/CAPIngestStatusCell/capIngestStatusCell";
 import { ICON_STATUS } from "../../../../components/Table/components/TableCell/components/IconStatusBadge/iconStatusBadge";
 import { ROUTE } from "../../../../routes/constants";
-import { formatDateToQuarterYear } from "../../../../utils/date-fns";
+import {
+  formatDateToQuarterYear,
+  formatISOToUTCDateTime,
+} from "../../../../utils/date-fns";
 import { buildSheetsUrl } from "../../../../utils/google-sheets";
 import { AtlasIntegratedObject } from "../../../../views/ComponentAtlasesView/entities";
 import { EXTRA_PROPS } from "./constants";
@@ -976,7 +979,17 @@ export function getAtlasComponentAtlasesTableColumns(): ColumnDef<
     getIntegratedObjectFileSizeColumnDef(),
     {
       accessorKey: "fileEventTime",
-      cell: ({ row }) => row.original.fileEventTime,
+      cell: ({ row }): JSX.Element | null => {
+        const parts = formatISOToUTCDateTime(row.original.fileEventTime);
+        if (!parts) return null;
+        const [date, time] = parts;
+        return (
+          <div>
+            <div>{date}</div>
+            <div>{time}</div>
+          </div>
+        );
+      },
       header: "Uploaded At",
       meta: { width: { max: "1fr", min: "160px" } },
     },

--- a/app/views/AtlasSourceDatasetsView/components/Table/columns.tsx
+++ b/app/views/AtlasSourceDatasetsView/components/Table/columns.tsx
@@ -7,6 +7,7 @@ import { getRouteURL } from "../../../../common/utils";
 import * as C from "../../../../components";
 import { CAPIngestStatusCell } from "../../../../components/Table/components/TableCell/components/CAPIngestStatusCell/capIngestStatusCell";
 import { ROUTE } from "../../../../routes/constants";
+import { formatISOToUTCDateTime } from "../../../../utils/date-fns";
 import {
   buildAssay,
   buildDisease,
@@ -110,7 +111,17 @@ const COLUMN_SIZE_BYTES = {
 
 const COLUMN_FILE_EVENT_TIME = {
   accessorKey: "fileEventTime",
-  cell: ({ row }) => row.original.fileEventTime,
+  cell: ({ row }) => {
+    const parts = formatISOToUTCDateTime(row.original.fileEventTime);
+    if (!parts) return null;
+    const [date, time] = parts;
+    return (
+      <div>
+        <div>{date}</div>
+        <div>{time}</div>
+      </div>
+    );
+  },
   header: "Uploaded At",
   meta: { width: { max: "1fr", min: "160px" } },
 } as ColumnDef<AtlasSourceDataset>;


### PR DESCRIPTION
## Summary
- Formats the "Uploaded At" column as two lines: `YYYY-MM-DD` and `HH:MM:SS (UTC)` instead of the raw ISO string
- Applies to both Source Datasets and Integrated Objects tables
- Adds `formatISOToUTCDateTime` utility to `app/utils/date-fns.ts` with unit tests
- Renames `columns.ts` → `columns.tsx` and `viewModelBuilders.ts` → `viewModelBuilders.tsx` for JSX support
- Sorting continues to work on the underlying ISO string via `accessorKey: "fileEventTime"`
- Null/undefined timestamps render as empty cells

Closes #1199

## Test plan
- [x] Source Datasets "Uploaded At" column shows date on first line, time with (UTC) on second line
- [x] Integrated Objects "Uploaded At" column shows same format
- [x] No mid-token line wrapping at narrow column widths
- [x] Column sorting (asc/desc) orders chronologically
- [] Empty timestamps render as blank cells
- [x] Unit tests pass for `formatISOToUTCDateTime`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1544" height="891" alt="image" src="https://github.com/user-attachments/assets/f7571551-6358-4f55-a109-dcb6a01d2738" />

<img width="1546" height="936" alt="image" src="https://github.com/user-attachments/assets/d1e5f0c3-2545-4fca-8ed1-a527c2c5405c" />
