### PR TITLE
refactor: rename atlas "Status" label to "OC Endorsed"

### DIFF
--- a/app/components/Forms/components/Atlas/common/constants.ts
+++ b/app/components/Forms/components/Atlas/common/constants.ts
@@ -70,7 +70,7 @@ const STATUS: ControllerConfig<AtlasEditData, HCAAtlasTrackerAtlas> = {
   selectProps: {
     SelectComponent: Status,
     displayEmpty: true,
-    label: "Status",
+    label: "OC Endorsed",
   },
 };
 

--- a/site-config/hca-atlas-tracker/category.ts
+++ b/site-config/hca-atlas-tracker/category.ts
@@ -60,7 +60,7 @@ export const HCA_ATLAS_TRACKER_CATEGORY_LABEL = {
   DISEASE: "Disease",
   DOI: "DOI",
   EMAIL: "Email",
-  ENDORSEMENT_STATUS: "Status",
+  ENDORSEMENT_STATUS: "OC Endorsed",
   ENTITY_TITLE: "Title",
   ENTITY_TYPE: "Entity Type",
   FULL_NAME: "Name",


### PR DESCRIPTION
## Summary
- Renames the atlas "Status" display label to "OC Endorsed" in two locations:
  - `site-config/hca-atlas-tracker/category.ts` — propagates to atlas list filter sidebar and table column header
  - `app/components/Forms/components/Atlas/common/constants.ts` — atlas detail/edit form field label
- UI-only change; no database, API, enum, or identifier changes

Closes #1196

## Test plan
- [x] Atlases list sidebar filter reads "OC Endorsed"
- [x] Atlases list table column header reads "OC Endorsed"
- [x] Atlas detail page field label reads "OC Endorsed"
- [x] Atlas edit page field label reads "OC Endorsed"
- [x] No other "Status" labels are affected (task status, validation status, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1547" height="893" alt="image" src="https://github.com/user-attachments/assets/57a0d550-c906-47d9-83b8-c25b91ecd6ce" />

<img width="1547" height="900" alt="image" src="https://github.com/user-attachments/assets/2e2858d6-daba-4340-aeb9-44efd8f64aae" />

<img width="2313" height="550" alt="image" src="https://github.com/user-attachments/assets/dd0139ac-5c4e-46f3-872f-cb258d1902de" />

