### PR TITLE
fix: link sd: confusing selection ux (#1200)

### DIFF
--- a/app/components/Detail/components/TrackerForm/components/Section/section.styles.ts
+++ b/app/components/Detail/components/TrackerForm/components/Section/section.styles.ts
@@ -1,6 +1,5 @@
 import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/components/FluidPaper/fluidPaper";
 import { sectionPadding } from "@databiosphere/findable-ui/lib/components/common/Section/section.styles";
-import { Table as CommonTable } from "@databiosphere/findable-ui/lib/components/Detail/components/Table/table";
 import { FONT } from "@databiosphere/findable-ui/lib/styles/common/constants/font";
 import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
 import {
@@ -97,15 +96,3 @@ export const SectionCard = styled(FluidPaper, {
       grid-auto-flow: ${gridAutoFlow};
     `}
 `;
-
-export const SectionTable = styled(CommonTable)`
-  .MuiTable-root {
-    .MuiTableBody-root {
-      .MuiTableRow-root[id^="sub-row"] {
-        .MuiTableCell-root:first-of-type {
-          padding-left: 46px;
-        }
-      }
-    }
-  }
-` as typeof CommonTable;

--- a/app/components/Table/components/TableCell/components/GroupedRowSelectionCell/groupedRowSelectionCell.styles.ts
+++ b/app/components/Table/components/TableCell/components/GroupedRowSelectionCell/groupedRowSelectionCell.styles.ts
@@ -1,0 +1,9 @@
+import { FONT } from "@databiosphere/findable-ui/lib/styles/common/constants/font";
+import styled from "@emotion/styled";
+import { FormControlLabel } from "@mui/material";
+
+export const StyledFormControlLabel = styled(FormControlLabel)`
+  .MuiFormControlLabel-label {
+    font: ${FONT.BODY_500};
+  }
+`;

--- a/app/components/Table/components/TableCell/components/GroupedRowSelectionCell/groupedRowSelectionCell.tsx
+++ b/app/components/Table/components/TableCell/components/GroupedRowSelectionCell/groupedRowSelectionCell.tsx
@@ -1,12 +1,10 @@
 import { CheckedIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/CheckedIcon/checkedIcon";
 import { IndeterminateIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/IndeterminateIcon/indeterminateIcon";
 import { UncheckedIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/UncheckedIcon/uncheckedIcon";
-import {
-  FormControlLabel as DXFormControlLabel,
-  Checkbox as MCheckbox,
-} from "@mui/material";
+import { Checkbox as MCheckbox } from "@mui/material";
 import { Row, RowData, RowSelectionState, Table } from "@tanstack/react-table";
 import { ChangeEvent, JSX, ReactNode, useCallback } from "react";
+import { StyledFormControlLabel } from "./groupedRowSelectionCell.styles";
 
 export interface GroupedRowSelectionCellProps<T extends RowData> {
   label?: ReactNode;
@@ -37,7 +35,7 @@ export const GroupedRowSelectionCell = <T extends RowData>({
   );
 
   return (
-    <DXFormControlLabel
+    <StyledFormControlLabel
       control={
         <MCheckbox
           checked={getIsAllSubRowsSelected()}

--- a/app/components/Table/components/TableCell/components/RowSelectionCell/rowSelectionCell.styles.ts
+++ b/app/components/Table/components/TableCell/components/RowSelectionCell/rowSelectionCell.styles.ts
@@ -1,0 +1,6 @@
+import styled from "@emotion/styled";
+import { FormControlLabel } from "@mui/material";
+
+export const StyledFormControlLabel = styled(FormControlLabel)`
+  padding-left: 30px;
+`;

--- a/app/components/Table/components/TableCell/components/RowSelectionCell/rowSelectionCell.tsx
+++ b/app/components/Table/components/TableCell/components/RowSelectionCell/rowSelectionCell.tsx
@@ -1,11 +1,9 @@
 import { CheckedIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/CheckedIcon/checkedIcon";
 import { UncheckedIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/UncheckedIcon/uncheckedIcon";
-import {
-  FormControlLabel as DXFormControlLabel,
-  Checkbox as MCheckbox,
-} from "@mui/material";
+import { Checkbox as MCheckbox } from "@mui/material";
 import { Row, RowData } from "@tanstack/react-table";
 import { JSX, ReactNode } from "react";
+import { StyledFormControlLabel } from "./rowSelectionCell.styles";
 
 export interface RowSelectionCellProps<T extends RowData> {
   label?: ReactNode;
@@ -18,7 +16,7 @@ export const RowSelectionCell = <T extends RowData>({
 }: RowSelectionCellProps<T>): JSX.Element => {
   const { getCanSelect, getIsSelected, getToggleSelectedHandler } = row;
   return (
-    <DXFormControlLabel
+    <StyledFormControlLabel
       control={
         <MCheckbox
           checked={getIsSelected()}

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.tsx
@@ -1078,7 +1078,7 @@ function getComponentAtlasSourceDatasetsSelectionPublicationStringColumnDef(): C
       table,
     }: CellContext<HCAAtlasTrackerSourceDataset, unknown>) =>
       C.GroupedRowSelectionCell({
-        label: row.original.publicationString,
+        label: row.original.publicationString || "Unpublished",
         row,
         table,
       }),

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.tsx
@@ -1078,7 +1078,7 @@ function getComponentAtlasSourceDatasetsSelectionPublicationStringColumnDef(): C
       table,
     }: CellContext<HCAAtlasTrackerSourceDataset, unknown>) =>
       C.GroupedRowSelectionCell({
-        label: row.original.publicationString || "Unpublished",
+        label: row.original.publicationString || UNPUBLISHED,
         row,
         table,
       }),

--- a/app/views/IntegratedObjectSourceDatasetsView/components/ViewComponentAtlasSourceDatasetsSelection/components/ComponentAtlasSourceDatasetsSelection/components/FormContent/components/Table/table.tsx
+++ b/app/views/IntegratedObjectSourceDatasetsView/components/ViewComponentAtlasSourceDatasetsSelection/components/ComponentAtlasSourceDatasetsSelection/components/FormContent/components/Table/table.tsx
@@ -1,6 +1,6 @@
+import { Table as CommonTable } from "@databiosphere/findable-ui/lib/components/Detail/components/Table/table";
 import { JSX } from "react";
 import { HCAAtlasTrackerSourceDataset } from "../../../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
-import { SectionTable } from "../../../../../../../../../../components/Detail/components/TrackerForm/components/Section/section.styles";
 import { FormMethod } from "../../../../../../../../../../hooks/useForm/common/entities";
 import { getComponentAtlasSourceDatasetsSelectionTableColumns } from "../../../../../../../../../../viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders";
 import { ComponentAtlasSourceDatasetsEditData } from "../../../../../../common/entities";
@@ -23,7 +23,7 @@ export const Table = ({
     useComponentAtlasSourceDatasetsSelectionTableOptions(formMethod);
   useComponentAtlasSourceDatasetsSelectionFormState(formMethod, tableOptions);
   return (
-    <SectionTable
+    <CommonTable
       columns={getComponentAtlasSourceDatasetsSelectionTableColumns()}
       gridTemplateColumns="minmax(260px, 1fr) minmax(200px, 0.5fr) repeat(4, minmax(120px, 0.4fr)) minmax(100px, 0.4fr)"
       items={atlasSourceDatasets || []}


### PR DESCRIPTION
Closes #1200.

This pull request refactors how selection cells and tables are styled and used in the application, focusing on improving code maintainability and consistency in the UI. The main changes include replacing custom-styled table components with shared ones, introducing styled wrappers for `FormControlLabel` in selection cells, and improving the display of unpublished datasets.

**Table and cell styling refactor:**

* Removed the custom `SectionTable` styled component in favor of using the shared `CommonTable` component directly, simplifying table usage and reducing redundant code. (`app/components/Detail/components/TrackerForm/components/Section/section.styles.ts`, `app/views/IntegratedObjectSourceDatasetsView/components/ViewComponentAtlasSourceDatasetsSelection/components/ComponentAtlasSourceDatasetsSelection/components/FormContent/components/Table/table.tsx`) [[1]](diffhunk://#diff-722d28237449506fc1453f996b7ae5fd097ca328a7d2f2d0b7f1b58a51193b4dL3) [[2]](diffhunk://#diff-722d28237449506fc1453f996b7ae5fd097ca328a7d2f2d0b7f1b58a51193b4dL100-L111) [[3]](diffhunk://#diff-54e1d7a45c6b5c5737bceef2c57ea781816d9a0f6bf9b9254ab61bcd03c432a9R1-L3) [[4]](diffhunk://#diff-54e1d7a45c6b5c5737bceef2c57ea781816d9a0f6bf9b9254ab61bcd03c432a9L26-R26)
* Replaced direct usage of `FormControlLabel` in both `GroupedRowSelectionCell` and `RowSelectionCell` with new styled components (`StyledFormControlLabel`). This allows for consistent styling (e.g., font and padding) for selection controls in tables. (`app/components/Table/components/TableCell/components/GroupedRowSelectionCell/groupedRowSelectionCell.styles.ts`, `app/components/Table/components/TableCell/components/GroupedRowSelectionCell/groupedRowSelectionCell.tsx`, `app/components/Table/components/TableCell/components/RowSelectionCell/rowSelectionCell.styles.ts`, `app/components/Table/components/TableCell/components/RowSelectionCell/rowSelectionCell.tsx`) [[1]](diffhunk://#diff-3592ece96d21502d7a4d8a2c006a8d0c348f2442521966c168d108d2a7048961R1-R9) [[2]](diffhunk://#diff-8fa9b6fc56bad037fd93b7f14e7ba86c0ac6ded5642328d016614d239f484f5eL4-R7) [[3]](diffhunk://#diff-8fa9b6fc56bad037fd93b7f14e7ba86c0ac6ded5642328d016614d239f484f5eL40-R38) [[4]](diffhunk://#diff-6f0737d390d973723920888d2fdc9bae395a823e72bebbfcc6109c3a063933d7R1-R6) [[5]](diffhunk://#diff-6c4058e22035cf4faff100b17c218ece454f98082f7fd79d6f0b50f84b97c4faL3-R6) [[6]](diffhunk://#diff-6c4058e22035cf4faff100b17c218ece454f98082f7fd79d6f0b50f84b97c4faL21-R19)

**User experience improvement:**

* Updated the table cell rendering logic to display `"Unpublished"` when a dataset's `publicationString` is missing, improving clarity for users viewing unpublished datasets. (`app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.tsx`)