### PR TITLE
fix: validation summary link crashes with createElement error

### DIFF
--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.styles.ts
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.styles.ts
@@ -1,6 +1,15 @@
 import { ErrorIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/ErrorIcon/errorIcon";
 import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
-import { styled } from "@mui/material";
+import { Stack, styled } from "@mui/material";
+
+export const StyledStack = styled(Stack)`
+  a {
+    text-decoration: underline;
+    text-decoration-color: currentColor;
+    text-decoration-skip-ink: none;
+    text-underline-position: from-font;
+  }
+`;
 
 export const StyledErrorIcon = styled(ErrorIcon)`
   color: ${PALETTE.ALERT_MAIN};

--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.tsx
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.tsx
@@ -4,7 +4,7 @@ import {
   REL_ATTRIBUTE,
 } from "@databiosphere/findable-ui/lib/components/Links/common/entities";
 import { SVG_ICON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/svgIcon";
-import { Link as MLink, Stack, Tooltip } from "@mui/material";
+import { Stack, Tooltip } from "@mui/material";
 import Link from "next/link";
 import { JSX } from "react";
 import { FILE_VALIDATOR_NAME_LABEL } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/constants";
@@ -14,7 +14,7 @@ import { getRouteURL } from "../../../../../../../../common/utils";
 import { INNER_STACK_PROPS, STACK_PROPS } from "./constants";
 import { Props } from "./entities";
 import { getValidators } from "./utils";
-import { StyledErrorIcon } from "./validationSummary.styles";
+import { StyledErrorIcon, StyledStack } from "./validationSummary.styles";
 
 export const ValidationSummary = ({
   atlasId,
@@ -31,7 +31,7 @@ export const ValidationSummary = ({
   if (validators.length === 0) return null;
 
   return (
-    <Stack {...STACK_PROPS}>
+    <StyledStack {...STACK_PROPS}>
       {validators.map(([key, value]) => {
         const url = getRouteURL(validationRoute, {
           atlasId,
@@ -55,19 +55,18 @@ export const ValidationSummary = ({
                 <StyledErrorIcon fontSize={SVG_ICON_PROPS.FONT_SIZE.SMALL} />
               )}
 
-              <MLink
+              <Link
                 as={url}
-                component={Link}
                 href={{ pathname: url, query: { from: "list" } }}
                 rel={REL_ATTRIBUTE.NO_OPENER}
                 target={ANCHOR_TARGET.SELF}
               >
                 {FILE_VALIDATOR_NAME_LABEL[key as FileValidatorName]}
-              </MLink>
+              </Link>
             </Stack>
           </Tooltip>
         );
       })}
-    </Stack>
+    </StyledStack>
   );
 };


### PR DESCRIPTION
## Summary
- Fixes crash when clicking validator links in the Validation Summary column on Source Datasets and Integrated Objects tables
- Root cause: MUI `Link` interprets the `as` prop as a polymorphic component override, passing the URL path to `createElement` as a tag name
- Fix: Replace `MLink` (MUI) with Next.js `Link` which correctly handles `as` for URL masking
- Link styling moved to `StyledStack` targeting `a` elements

Closes #1211

## Test plan
- [ ] Click a validator link (e.g. CAP Upload) in Source Datasets table — navigates to validation view without crash
- [ ] Click a validator link in Integrated Objects table — same
- [ ] Back arrow on validation view returns to list (hidden `from` query state still works)
- [ ] Link styling (underline, color) matches previous appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)