### PR TITLE
feat: add link to CAP Upload hover text

### DIFF
--- a/app/apis/catalog/hca-atlas-tracker/common/validatorDescriptions.tsx
+++ b/app/apis/catalog/hca-atlas-tracker/common/validatorDescriptions.tsx
@@ -8,7 +8,21 @@ import { FileValidatorName } from "./entities";
 
 export const FILE_VALIDATOR_DESCRIPTIONS: Record<FileValidatorName, ReactNode> =
   {
-    cap: "Validates the dataset/object has sufficient metadata to be uploaded to CAP for annotation.",
+    cap: (
+      <>
+        Validates the dataset/object has sufficient metadata to be uploaded to
+        CAP for annotation. See{" "}
+        <Link
+          color="inherit"
+          href="https://celltype.info/docs/anndata-requirements-for-upload"
+          rel={REL_ATTRIBUTE.NO_OPENER_NO_REFERRER}
+          target={ANCHOR_TARGET.BLANK}
+        >
+          CAP Upload Requirements
+        </Link>
+        .
+      </>
+    ),
     cellxgene: "",
     hcaCellAnnotation: (
       <>


### PR DESCRIPTION
## Summary
- Adds a "CAP Upload Requirements" link to the CAP Upload validator tooltip description
- Links to https://celltype.info/docs/anndata-requirements-for-upload
- Opens in new tab with `noopener noreferrer`

Closes #1213

## Test plan
- [ ] Hover over CAP Upload in validation summary — tooltip shows description with clickable "CAP Upload Requirements" link
- [ ] Link opens https://celltype.info/docs/anndata-requirements-for-upload in a new tab
- [ ] Tooltip remains open while moving to click the link

🤖 Generated with [Claude Code](https://claude.com/claude-code)