### PR TITLE
fix: move ExploreStateProvider inside ErrorBoundary to prevent crash loop

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -81,31 +81,31 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
                     >
                       <DXHeader {...header} />
                     </ThemeProvider>
-                    <ExploreStateProvider entityListType={entityListType}>
-                      <AuthorizationProvider>
-                        <Main>
-                          <ErrorBoundary
-                            fallbackRender={({
-                              error,
-                              reset,
-                            }: {
-                              error: DataExplorerError;
-                              reset: () => void;
-                            }): JSX.Element => (
-                              <Error
-                                errorMessage={error.message}
-                                requestUrlMessage={error.requestUrlMessage}
-                                rootPath={redirectRootToPath}
-                                onReset={reset}
-                              />
-                            )}
-                          >
+                    <Main>
+                      <ErrorBoundary
+                        fallbackRender={({
+                          error,
+                          reset,
+                        }: {
+                          error: DataExplorerError;
+                          reset: () => void;
+                        }): JSX.Element => (
+                          <Error
+                            errorMessage={error.message}
+                            requestUrlMessage={error.requestUrlMessage}
+                            rootPath={redirectRootToPath}
+                            onReset={reset}
+                          />
+                        )}
+                      >
+                        <ExploreStateProvider entityListType={entityListType}>
+                          <AuthorizationProvider>
                             <Component {...pageProps} />
                             <Floating {...floating} />
-                          </ErrorBoundary>
-                        </Main>
-                      </AuthorizationProvider>
-                    </ExploreStateProvider>
+                          </AuthorizationProvider>
+                        </ExploreStateProvider>
+                      </ErrorBoundary>
+                    </Main>
                     <Footer {...footer} />
                   </AppLayout>
                 </LayoutDimensionsProvider>


### PR DESCRIPTION
## Summary
- Moves `ExploreStateProvider` and `AuthorizationProvider` inside the `ErrorBoundary` in `pages/_app.tsx`
- Prevents infinite crash loop when explore state throws (e.g. invalid filter query parameter)
- Header and Footer remain outside the boundary so users can still navigate away from the error page

Closes #1217
Ref: DataBiosphere/findable-ui#888

## Test plan
- [x] App loads and renders normally
- [x] Atlas list page with filters works correctly
- [x] Invalid filter query parameter shows error page instead of crash loop
- [x] Error page header and footer remain visible and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)