### PR TITLE
fix: move validation summary tooltip to right with arrow

### DIFF
--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.tsx
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.tsx
@@ -43,8 +43,10 @@ export const ValidationSummary = ({
         });
         return (
           <Tooltip
+            arrow
             disableInteractive={false}
             key={key}
+            placement="right"
             title={renderTooltipTitle(key as FileValidatorName, value)}
           >
             <Stack {...INNER_STACK_PROPS}>


### PR DESCRIPTION
## Summary
- Adds `placement="right"` to validation summary tooltips so they open to the side instead of above, preventing them from covering adjacent validator links
- Adds `arrow` prop so users can see which link the tooltip points to

Closes #1222

## Test plan
- [x] Hover over validator links in Source Datasets table — tooltip appears to the right with an arrow
- [x] Hover over validator links in Integrated Objects table — same
- [x] Tooltip no longer covers adjacent validator links
- [x] Tooltip links (e.g. CAP Upload Requirements) remain clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="510" height="194" alt="image" src="https://github.com/user-attachments/assets/75fbece3-a4dc-4f94-9148-585cec69d7ae" />

<img width="1456" height="836" alt="image" src="https://github.com/user-attachments/assets/5967f0b5-7d89-41c3-8c3f-966dd61b7173" />
