### PR TITLE
fix: revert providers outside ErrorBoundary and upgrade findable-ui to v51.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@aws-sdk/client-batch": "^3.896.0",
         "@aws-sdk/client-s3": "^3.896.0",
         "@aws-sdk/s3-request-presigner": "^3.896.0",
-        "@databiosphere/findable-ui": "^51.0.0",
+        "@databiosphere/findable-ui": "^51.1.0",
         "@emotion/react": "^11",
         "@emotion/styled": "^11",
         "@hookform/resolvers": "^3.3.4",
@@ -2075,9 +2075,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "51.0.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-51.0.0.tgz",
-      "integrity": "sha512-Vti9a1VkgcOFuPqgFLOIApwz+DFY4+sjuAnJX8iL7/TA3EfjVzVsYg6rWja7u5M3wo4oapoUvDFim6Irx7gO0g==",
+      "version": "51.1.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-51.1.0.tgz",
+      "integrity": "sha512-aWy0zOOGim5xoJvWes1v/mqKSobBUlGmfZt4uIMp5f+oNKEFlAA27CSJ01SsbhWQKgpPdZT3f+kXxfYG0FDk+A==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.12.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/client-batch": "^3.896.0",
     "@aws-sdk/client-s3": "^3.896.0",
     "@aws-sdk/s3-request-presigner": "^3.896.0",
-    "@databiosphere/findable-ui": "^51.0.0",
+    "@databiosphere/findable-ui": "^51.1.0",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
     "@hookform/resolvers": "^3.3.4",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -81,31 +81,31 @@ function MyApp({ Component, pageProps }: AppPropsWithComponent): JSX.Element {
                     >
                       <DXHeader {...header} />
                     </ThemeProvider>
-                    <Main>
-                      <ErrorBoundary
-                        fallbackRender={({
-                          error,
-                          reset,
-                        }: {
-                          error: DataExplorerError;
-                          reset: () => void;
-                        }): JSX.Element => (
-                          <Error
-                            errorMessage={error.message}
-                            requestUrlMessage={error.requestUrlMessage}
-                            rootPath={redirectRootToPath}
-                            onReset={reset}
-                          />
-                        )}
-                      >
-                        <ExploreStateProvider entityListType={entityListType}>
-                          <AuthorizationProvider>
+                    <ExploreStateProvider entityListType={entityListType}>
+                      <AuthorizationProvider>
+                        <Main>
+                          <ErrorBoundary
+                            fallbackRender={({
+                              error,
+                              reset,
+                            }: {
+                              error: DataExplorerError;
+                              reset: () => void;
+                            }): JSX.Element => (
+                              <Error
+                                errorMessage={error.message}
+                                requestUrlMessage={error.requestUrlMessage}
+                                rootPath={redirectRootToPath}
+                                onReset={reset}
+                              />
+                            )}
+                          >
                             <Component {...pageProps} />
                             <Floating {...floating} />
-                          </AuthorizationProvider>
-                        </ExploreStateProvider>
-                      </ErrorBoundary>
-                    </Main>
+                          </ErrorBoundary>
+                        </Main>
+                      </AuthorizationProvider>
+                    </ExploreStateProvider>
                     <Footer {...footer} />
                   </AppLayout>
                 </LayoutDimensionsProvider>


### PR DESCRIPTION
## Summary

Reverts `ExploreStateProvider` and `AuthorizationProvider` to their original position outside the `ErrorBoundary` and upgrades findable-ui to v51.1.0, which fixes the infinite crash loop at the library level.

### Why revert

PR #1218 moved `ExploreStateProvider` and `AuthorizationProvider` inside the `ErrorBoundary` to catch reducer crashes. This fixed the crash loop but caused **state loss** when navigating between pages.

### Why this works without the provider move

findable-ui v51.1.0 ([PR #899](https://github.com/DataBiosphere/findable-ui/pull/899)) fixes the root cause:

- **`parseFilterParam`** — safely validates filter URL params without throwing (prevents reducer crash above ErrorBoundary)
- **`useValidateFilterParam`** hook — runs inside ExploreView (inside ErrorBoundary), validates the URL filter param directly, throws `DataExplorerError` for invalid filters so the error page renders
- **`ErrorBoundary`** — fixes `this.render` → `this.reset` typo
- **`useAsync.run()`** — clears stale error on new request

Closes #1224

## Reference

- Umbrella: DataBiosphere/findable-ui#900
- Findable-ui fix: https://github.com/DataBiosphere/findable-ui/pull/899
- Provider move being reverted: #1218

## Test plan
- [x] Unit tests pass (1044/1044)
- [x] Lint passes
- [x] Prettier passes
- [x] TypeScript compiles
- [x] Manual: malformed JSON filter → error page, no loop
- [x] Manual: wrong shape filter → error page, no loop
- [x] Manual: valid filters work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)