### PR TITLE
refactor: update modules imported by service layer to enable service use in scripts (#1229)

### DIFF
--- a/__tests__/data-files.test.ts
+++ b/__tests__/data-files.test.ts
@@ -10,7 +10,7 @@ import {
   upsertFileRecord,
 } from "../app/data/files";
 import { doTransaction, endPgPool, query } from "../app/services/database";
-import { NotFoundError } from "../app/utils/api-handler";
+import { NotFoundError } from "../app/utils/api-errors";
 import {
   ATLAS_DRAFT,
   ATLAS_WITH_MISC_SOURCE_STUDIES,

--- a/app/apis/catalog/hca-atlas-tracker/aws/errors.ts
+++ b/app/apis/catalog/hca-atlas-tracker/aws/errors.ts
@@ -5,7 +5,7 @@ import {
   ConflictError,
   ForbiddenError,
   UnauthenticatedError,
-} from "../../../../utils/api-handler";
+} from "../../../../utils/api-errors";
 
 /**
  * Error thrown when S3 object ETag doesn't match expected value

--- a/app/data/atlases.ts
+++ b/app/data/atlases.ts
@@ -1,7 +1,7 @@
 import pg from "pg";
 import { HCAAtlasTrackerDBAtlas } from "../apis/catalog/hca-atlas-tracker/common/entities";
 import { query } from "../services/database";
-import { InvalidOperationError, NotFoundError } from "../utils/api-handler";
+import { InvalidOperationError, NotFoundError } from "../utils/api-errors";
 import { AtlasSlugNameAndVersion } from "../utils/atlases";
 
 export const CONSTRAINT_ATLAS_SLUG_VERSION_UNIQUE =

--- a/app/data/component-atlases.ts
+++ b/app/data/component-atlases.ts
@@ -1,7 +1,7 @@
 import pg from "pg";
 import { HCAAtlasTrackerDBComponentAtlas } from "../apis/catalog/hca-atlas-tracker/common/entities";
 import { query } from "../services/database";
-import { NotFoundError } from "../utils/api-handler";
+import { NotFoundError } from "../utils/api-errors";
 
 /**
  * Create a new latest component atlas version based on the given existing version.

--- a/app/data/concepts.ts
+++ b/app/data/concepts.ts
@@ -1,4 +1,4 @@
-import { NotFoundError } from "app/utils/api-handler";
+import { NotFoundError } from "app/utils/api-errors";
 import pg from "pg";
 import {
   HCAAtlasTrackerDBAtlas,

--- a/app/data/files.ts
+++ b/app/data/files.ts
@@ -15,7 +15,7 @@ import {
 import { getPublishedFromPublishedAt } from "../apis/catalog/hca-atlas-tracker/common/utils";
 import { getAtlasComponentAtlasVersionIds } from "../services/component-atlases";
 import { query } from "../services/database";
-import { InvalidOperationError, NotFoundError } from "../utils/api-handler";
+import { InvalidOperationError, NotFoundError } from "../utils/api-errors";
 import { confirmQueryRowsContainIds } from "../utils/database";
 import { getAtlasSourceDatasetVersionIds } from "./source-datasets";
 

--- a/app/data/source-datasets.ts
+++ b/app/data/source-datasets.ts
@@ -11,7 +11,7 @@ import {
 import { confirmAtlasExists } from "../services/atlases";
 import { doTransaction, query } from "../services/database";
 import { confirmSourceStudyExists } from "../services/source-studies";
-import { InvalidOperationError, NotFoundError } from "../utils/api-handler";
+import { InvalidOperationError, NotFoundError } from "../utils/api-errors";
 import { confirmQueryRowsContainVersionIds } from "../utils/database";
 
 const PLURAL_ENTITY_NAME = "source datasets";

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -1,6 +1,6 @@
 import pg from "pg";
 import { ValidationError } from "yup";
-import { InvalidOperationError } from "../../app/utils/api-handler";
+import { InvalidOperationError } from "../../app/utils/api-errors";
 import { getCrossrefPublicationInfo } from "../../app/utils/crossref/crossref";
 import {
   ATLAS_STATUS,

--- a/app/services/cellxgene.ts
+++ b/app/services/cellxgene.ts
@@ -32,7 +32,6 @@ const KY_OPTIONS: KyOptions = {
 };
 
 const refreshService = makeRefreshService({
-  autoStart: process.env.NODE_ENV !== "test",
   getRefreshParams: () => undefined,
   async getRefreshedData() {
     const time = Date.now();
@@ -63,6 +62,8 @@ export const forceCellxGeneRefresh = refreshService.forceRefresh;
 export const getCellxGeneStatus = refreshService.getStatus;
 
 export const isCellxGeneRefreshing = refreshService.isRefreshing;
+
+export const refreshCellxGeneIfNeeded = refreshService.refreshIfNeeded;
 
 /**
  * Find the first of a list of DOIs that matches a CELLxGENE collection, and return the collection's ID, starting a refresh of the DOI-to-collection mappings if needed.

--- a/app/services/comments.ts
+++ b/app/services/comments.ts
@@ -11,7 +11,7 @@ import {
   ForbiddenError,
   InvalidOperationError,
   NotFoundError,
-} from "../../app/utils/api-handler";
+} from "../../app/utils/api-errors";
 import { query } from "./database";
 
 /**

--- a/app/services/common/refresh-service.ts
+++ b/app/services/common/refresh-service.ts
@@ -157,7 +157,17 @@ export function makeRefreshService<TData, TRefreshParams>(
   };
 }
 
-async function startRefreshIfNeeded<TData, TRefreshParams>(
+function startRefreshIfNeeded<TData, TRefreshParams>(
+  params: RefreshServiceParams<TData, TRefreshParams>,
+  info: RefreshInfo<TData, TRefreshParams>,
+  force?: boolean,
+): void {
+  doRefreshIfNeeded(params, info, force).catch((e) => {
+    console.error("Error in refresh service:", e);
+  });
+}
+
+async function doRefreshIfNeeded<TData, TRefreshParams>(
   params: RefreshServiceParams<TData, TRefreshParams>,
   info: RefreshInfo<TData, TRefreshParams>,
   force = false,

--- a/app/services/common/refresh-service.ts
+++ b/app/services/common/refresh-service.ts
@@ -12,11 +12,6 @@ export interface RefreshInfo<TData, TRefreshParams = undefined> {
 }
 
 export interface RefreshServiceParams<TData, TRefreshParams> {
-  /**
-   * Whether to automatically start a refresh if there is no stored info at initialization time.
-   * Defaults to true. Set to false (e.g., in tests) to prevent background refresh on import.
-   */
-  autoStart?: boolean;
   getRefreshedData: (
     refreshParams: TRefreshParams,
     prevData?: TData,
@@ -40,6 +35,7 @@ export interface RefreshService<TData> {
   getData: () => RefreshDataResult<TData>;
   getStatus: () => RefreshStatus;
   isRefreshing: () => boolean;
+  refreshIfNeeded: () => void;
 }
 
 /**
@@ -118,16 +114,13 @@ export class RefreshDataResult<T> {
 export function makeRefreshService<TData, TRefreshParams>(
   params: RefreshServiceParams<TData, TRefreshParams>,
 ): RefreshService<TData> {
-  const { autoStart, getStoredInfo, notReadyMessage, setStoredInfo } = params;
+  const { getStoredInfo, notReadyMessage, setStoredInfo } = params;
   const initStoredInfo = getStoredInfo();
   let info: RefreshInfo<TData, TRefreshParams>;
   if (initStoredInfo) {
     info = initStoredInfo;
   } else {
     setStoredInfo((info = {}));
-    if (autoStart !== false) {
-      startRefreshIfNeeded(params, info, true);
-    }
   }
 
   return {
@@ -157,6 +150,9 @@ export function makeRefreshService<TData, TRefreshParams>(
     },
     isRefreshing(): boolean {
       return Boolean(info.refreshing);
+    },
+    refreshIfNeeded(): void {
+      startRefreshIfNeeded(params, info);
     },
   };
 }

--- a/app/services/component-atlases.ts
+++ b/app/services/component-atlases.ts
@@ -9,7 +9,7 @@ import {
 } from "../apis/catalog/hca-atlas-tracker/common/entities";
 import { ComponentAtlasEditData } from "../apis/catalog/hca-atlas-tracker/common/schema";
 import { getSourceDatasetVersionsForAtlas } from "../data/source-datasets";
-import { InvalidOperationError, NotFoundError } from "../utils/api-handler";
+import { InvalidOperationError, NotFoundError } from "../utils/api-errors";
 import { updateDownloadNameIfChanged } from "./concepts";
 import { doOrContinueTransaction, doTransaction, query } from "./database";
 

--- a/app/services/concepts.ts
+++ b/app/services/concepts.ts
@@ -15,7 +15,7 @@ import {
   ConflictError,
   InvalidOperationError,
   NotFoundError,
-} from "../utils/api-handler";
+} from "../utils/api-errors";
 import { mapDatabaseError } from "./database";
 
 /**

--- a/app/services/entry-sheets.ts
+++ b/app/services/entry-sheets.ts
@@ -7,7 +7,7 @@ import {
   NetworkKey,
   WithSourceStudyInfo,
 } from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { NotFoundError } from "../utils/api-handler";
+import { NotFoundError } from "../utils/api-errors";
 import { validateEntrySheet } from "../utils/hca-validation-tools/hca-validation-tools";
 import { getBaseModelAtlas } from "./atlases";
 import { doTransaction, query } from "./database";

--- a/app/services/files.ts
+++ b/app/services/files.ts
@@ -1,5 +1,5 @@
 import { VALID_FILE_TYPES_FOR_VALIDATION } from "app/apis/catalog/hca-atlas-tracker/common/constants";
-import { InvalidOperationError } from "app/utils/api-handler";
+import { InvalidOperationError } from "app/utils/api-errors";
 import { getDbEntityFileVersion } from "../apis/catalog/hca-atlas-tracker/common/backend-utils";
 import {
   FILE_TYPE,

--- a/app/services/hca-projects.ts
+++ b/app/services/hca-projects.ts
@@ -32,7 +32,6 @@ const KY_OPTIONS: KyOptions = {
 };
 
 const refreshService = makeRefreshService({
-  autoStart: process.env.NODE_ENV !== "test",
   async getRefreshParams(
     data?: ProjectsData,
     prevRefreshParams?: ProjectsRefreshParams,
@@ -87,6 +86,8 @@ export const forceProjectsRefresh = refreshService.forceRefresh;
 export const getProjectsStatus = refreshService.getStatus;
 
 export const areProjectsRefreshing = refreshService.isRefreshing;
+
+export const refreshProjectsIfNeeded = refreshService.refreshIfNeeded;
 
 /**
  * Find the first of a list of DOIs that matches an HCA project, and return the project's ID, starting a refresh of the DOI-to-project mappings if needed.

--- a/app/services/s3-notification.ts
+++ b/app/services/s3-notification.ts
@@ -41,7 +41,7 @@ import {
   getAtlasMatchingConceptAndRevision,
   getOrCreateConceptId,
 } from "../services/concepts";
-import { InvalidOperationError } from "../utils/api-handler";
+import { InvalidOperationError } from "../utils/api-errors";
 import { parseNormalizedInfoFromS3Key, parseS3KeyPath } from "../utils/files";
 import { createComponentAtlas } from "./component-atlases";
 import { doTransaction } from "./database";

--- a/app/services/sns-subscription.ts
+++ b/app/services/sns-subscription.ts
@@ -1,6 +1,6 @@
 import { SNSMessage } from "../apis/catalog/hca-atlas-tracker/aws/schemas";
 import { validateSNSTopicAuthorization } from "../config/aws-resources";
-import { InvalidOperationError } from "../utils/api-handler";
+import { InvalidOperationError } from "../utils/api-errors";
 import { httpGet } from "../utils/http";
 
 /**

--- a/app/services/source-studies.ts
+++ b/app/services/source-studies.ts
@@ -32,7 +32,7 @@ import {
   unlinkAllSourceDatasetsFromSourceStudy,
 } from "../data/source-datasets";
 import { setSourceStudyMetadataSpreadsheets } from "../data/source-studies";
-import { AccessError, NotFoundError } from "../utils/api-handler";
+import { AccessError, NotFoundError } from "../utils/api-errors";
 import { getCrossrefPublicationInfo } from "../utils/crossref/crossref";
 import { normalizeDoi } from "../utils/doi";
 import { getSpreadsheetIdFromUrl } from "../utils/google-sheets";

--- a/app/services/users.ts
+++ b/app/services/users.ts
@@ -7,7 +7,7 @@ import {
   HCAAtlasTrackerDBUserWithAssociatedResources,
   ROLE,
 } from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { NotFoundError } from "../utils/api-handler";
+import { NotFoundError } from "../utils/api-errors";
 import { getAllAtlases } from "./atlases";
 import { doTransaction, query } from "./database";
 

--- a/app/services/validation-results-notification.ts
+++ b/app/services/validation-results-notification.ts
@@ -16,7 +16,7 @@ import {
   addValidationResultsToFile,
   getLastValidationTimestamp,
 } from "../data/files";
-import { ConflictError, InvalidOperationError } from "../utils/api-handler";
+import { ConflictError, InvalidOperationError } from "../utils/api-errors";
 import { doTransaction } from "./database";
 
 /**

--- a/app/services/validations.ts
+++ b/app/services/validations.ts
@@ -35,7 +35,7 @@ import {
   ValidationDBEntityOfType,
   ValidationDifference,
 } from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { ForbiddenError, NotFoundError } from "../utils/api-handler";
+import { ForbiddenError, NotFoundError } from "../utils/api-errors";
 import { ProjectInfo } from "../utils/hca-projects";
 import { updateTaskCounts } from "./atlases";
 import { createCommentThread, deleteCommentThread } from "./comments";

--- a/app/utils/api-errors.ts
+++ b/app/utils/api-errors.ts
@@ -1,0 +1,40 @@
+export abstract class ApiError extends Error {
+  abstract statusCode: number;
+  fieldPath: string | null;
+  constructor(message?: string, fieldPath: string | null = null) {
+    super(message);
+    this.fieldPath = fieldPath;
+  }
+}
+
+export class InvalidOperationError extends ApiError {
+  name = "InvalidOperationError";
+  statusCode = 400;
+}
+
+// Represents a request conflict (e.g., ETag mismatch/version conflicts)
+// Maps to HTTP 409 Conflict
+export class ConflictError extends ApiError {
+  name = "ConflictError";
+  statusCode = 409;
+}
+
+export class UnauthenticatedError extends ApiError {
+  name = "UnauthenticatedError";
+  statusCode = 401;
+}
+
+export class ForbiddenError extends ApiError {
+  name = "ForbiddenError";
+  statusCode = 403;
+}
+
+export class AccessError extends ApiError {
+  name = "AccessError";
+  statusCode = 400;
+}
+
+export class NotFoundError extends ApiError {
+  name = "NotFoundError";
+  statusCode = 404;
+}

--- a/app/utils/api-handler.ts
+++ b/app/utils/api-handler.ts
@@ -13,6 +13,12 @@ import {
   getAtlasIdByUrlParameter,
 } from "../services/atlases";
 import { query } from "../services/database";
+import {
+  ApiError,
+  ForbiddenError,
+  NotFoundError,
+  UnauthenticatedError,
+} from "./api-errors";
 import { S3KeyFormatError } from "./files";
 
 interface UserProfile {
@@ -31,47 +37,6 @@ export type Handler = (
   req: NextApiRequest,
   res: NextApiResponse,
 ) => Promise<void>;
-
-abstract class ApiError extends Error {
-  abstract statusCode: number;
-  fieldPath: string | null;
-  constructor(message?: string, fieldPath: string | null = null) {
-    super(message);
-    this.fieldPath = fieldPath;
-  }
-}
-
-export class InvalidOperationError extends ApiError {
-  name = "InvalidOperationError";
-  statusCode = 400;
-}
-
-// Represents a request conflict (e.g., ETag mismatch/version conflicts)
-// Maps to HTTP 409 Conflict
-export class ConflictError extends ApiError {
-  name = "ConflictError";
-  statusCode = 409;
-}
-
-export class UnauthenticatedError extends ApiError {
-  name = "UnauthenticatedError";
-  statusCode = 401;
-}
-
-export class ForbiddenError extends ApiError {
-  name = "ForbiddenError";
-  statusCode = 403;
-}
-
-export class AccessError extends ApiError {
-  name = "AccessError";
-  statusCode = 400;
-}
-
-export class NotFoundError extends ApiError {
-  name = "NotFoundError";
-  statusCode = 404;
-}
 
 /**
  * Creates an API handler function that calls the provided middleware functions in order for as long as each one calls `next` function passed to it.

--- a/app/utils/database.ts
+++ b/app/utils/database.ts
@@ -1,4 +1,4 @@
-import { NotFoundError } from "./api-handler";
+import { NotFoundError } from "./api-errors";
 
 /**
  * Throw an error if the given query rows do not include all expected version IDs.

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -4,9 +4,13 @@
 export async function register(): Promise<void> {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     // Initialize HCA projects
-    await import("./app/services/hca-projects");
+    const { refreshProjectsIfNeeded } =
+      await import("./app/services/hca-projects");
+    refreshProjectsIfNeeded();
 
     // Initialize CELLxGENE collections
-    await import("./app/services/cellxgene");
+    const { refreshCellxGeneIfNeeded } =
+      await import("./app/services/cellxgene");
+    refreshCellxGeneIfNeeded();
   }
 }

--- a/pages/api/me.ts
+++ b/pages/api/me.ts
@@ -4,12 +4,12 @@ import {
 } from "../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD } from "../../app/common/entities";
 import { createUser, updateLastLogin } from "../../app/services/users";
+import { UnauthenticatedError } from "../../app/utils/api-errors";
 import {
   getActiveUser,
   getProvidedUserProfile,
   handler,
   method,
-  UnauthenticatedError,
 } from "../../app/utils/api-handler";
 
 export default handler(method(METHOD.PUT), async (req, res) => {

--- a/pages/api/sns.ts
+++ b/pages/api/sns.ts
@@ -9,11 +9,8 @@ import {
 import { METHOD } from "../../app/common/entities";
 import { dispatchSNSNotification } from "../../app/services/sns-dispatcher";
 import { handleSNSSubscription } from "../../app/services/sns-subscription";
-import {
-  handler,
-  InvalidOperationError,
-  method,
-} from "../../app/utils/api-handler";
+import { InvalidOperationError } from "../../app/utils/api-errors";
+import { handler, method } from "../../app/utils/api-handler";
 
 /**
  * Validates the incoming SNS request and extracts the message

--- a/pages/api/users.ts
+++ b/pages/api/users.ts
@@ -3,12 +3,8 @@ import { ROLE_GROUP } from "../../app/apis/catalog/hca-atlas-tracker/common/cons
 import { HCAAtlasTrackerDBUserWithAssociatedResources } from "../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD } from "../../app/common/entities";
 import { getAllUsers, getUserByEmail } from "../../app/services/users";
-import {
-  handler,
-  method,
-  NotFoundError,
-  role,
-} from "../../app/utils/api-handler";
+import { NotFoundError } from "../../app/utils/api-errors";
+import { handler, method, role } from "../../app/utils/api-handler";
 
 /**
  * API route for list of users. Optional `email` query paramter filters by email.


### PR DESCRIPTION
Closes #1229

- Moved API errors out of `api-handler.ts`, so that they can be imported without causing auth code to be imported
- Updated refresh services to not auto-start, instead having an explicit initial refresh that's triggered by the instrumentation module (which was already importing the refresh services for an implicit initial refresh)