### PR TITLE
feat: update metadata entity creation functions for consistency and simplicity (#1233)

### DIFF
--- a/__tests__/component-atlases.test.ts
+++ b/__tests__/component-atlases.test.ts
@@ -1,10 +1,11 @@
 import { FILE_TYPE } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { createComponentAtlas } from "../app/services/component-atlases";
-import { endPgPool, query } from "../app/services/database";
+import { doTransaction, endPgPool, query } from "../app/services/database";
 import { ATLAS_DRAFT, EMPTY_COMPONENT_INFO } from "../testing/constants";
 import {
   createTestFile,
   getAtlasFromDatabase,
+  getComponentAtlasVersionsFromDatabase,
   resetDatabase,
 } from "../testing/db-utils";
 import { expectIsDefined } from "../testing/utils";
@@ -53,17 +54,23 @@ describe("createComponentAtlas", () => {
       sizeBytes: 2342,
     });
     await expect(
-      (async (): Promise<void> => {
-        await createComponentAtlas(
+      doTransaction(async (client) =>
+        createComponentAtlas(
           ATLAS_ID_NONEXISTENT,
           FILE_ID_NONEXISTENT_ATLAS,
           CONCEPT_ID_NONEXISTENT_ATLAS,
-        );
-      })(),
+          client,
+        ),
+      ),
     ).rejects.toThrow();
   });
 
   it("creates component atlas with empty values in component info", async () => {
+    const versionsBefore = await getComponentAtlasVersionsFromDatabase(
+      CONCEPT_ID_SUCCESSFUL,
+    );
+    expect(versionsBefore).toHaveLength(0);
+
     await createTestFile(FILE_ID_SUCCESSFUL, {
       bucket: "bucket-successful",
       conceptId: CONCEPT_ID_SUCCESSFUL,
@@ -73,20 +80,30 @@ describe("createComponentAtlas", () => {
       sizeBytes: 64342,
     });
 
-    const result = await createComponentAtlas(
-      ATLAS_DRAFT.id,
-      FILE_ID_SUCCESSFUL,
-      CONCEPT_ID_SUCCESSFUL,
+    await doTransaction((client) =>
+      createComponentAtlas(
+        ATLAS_DRAFT.id,
+        FILE_ID_SUCCESSFUL,
+        CONCEPT_ID_SUCCESSFUL,
+        client,
+      ),
     );
 
-    expect(result).toBeDefined();
-    expect(result.component_info).toEqual(EMPTY_COMPONENT_INFO);
-    expect(result.id).toBeDefined();
-    expect(result.created_at).toBeDefined();
-    expect(result.updated_at).toBeDefined();
+    const versionsAfter = await getComponentAtlasVersionsFromDatabase(
+      CONCEPT_ID_SUCCESSFUL,
+    );
+    expect(versionsAfter).toHaveLength(1);
+
+    const componentAtlas = versionsAfter[0];
+
+    expect(componentAtlas).toBeDefined();
+    expect(componentAtlas.component_info).toEqual(EMPTY_COMPONENT_INFO);
+    expect(componentAtlas.id).toBeDefined();
+    expect(componentAtlas.created_at).toBeDefined();
+    expect(componentAtlas.updated_at).toBeDefined();
 
     const atlas = await getAtlasFromDatabase(ATLAS_DRAFT.id);
     if (!expectIsDefined(atlas)) return;
-    expect(atlas.component_atlases).toContain(result.version_id);
+    expect(atlas.component_atlases).toContain(componentAtlas.version_id);
   });
 });

--- a/app/services/component-atlases.ts
+++ b/app/services/component-atlases.ts
@@ -272,7 +272,6 @@ export async function deleteSourceDatasetsFromComponentAtlas(
  * @param fileId - Associated file ID for the new component atlas to reference.
  * @param conceptId - Associated concept ID for the new component atlas to reference.
  * @param client - Database client for transaction.
- * @returns the created component atlas.
  */
 export async function createComponentAtlas(
   atlasId: string,

--- a/app/services/component-atlases.ts
+++ b/app/services/component-atlases.ts
@@ -11,7 +11,7 @@ import { ComponentAtlasEditData } from "../apis/catalog/hca-atlas-tracker/common
 import { getSourceDatasetVersionsForAtlas } from "../data/source-datasets";
 import { InvalidOperationError, NotFoundError } from "../utils/api-errors";
 import { updateDownloadNameIfChanged } from "./concepts";
-import { doOrContinueTransaction, doTransaction, query } from "./database";
+import { doTransaction, query } from "./database";
 
 type ComponentAtlasInfoUpdateFields = Pick<
   HCAAtlasTrackerDBComponentAtlasInfo,
@@ -271,43 +271,39 @@ export async function deleteSourceDatasetsFromComponentAtlas(
  * @param atlasId - ID of the parent atlas.
  * @param fileId - Associated file ID for the new component atlas to reference.
  * @param conceptId - Associated concept ID for the new component atlas to reference.
- * @param client - Optional database client for transactions.
+ * @param client - Database client for transaction.
  * @returns the created component atlas.
  */
 export async function createComponentAtlas(
   atlasId: string,
   fileId: string,
   conceptId: string,
-  client?: pg.PoolClient,
-): Promise<HCAAtlasTrackerDBComponentAtlas> {
+  client: pg.PoolClient,
+): Promise<void> {
   const info: HCAAtlasTrackerDBComponentAtlasInfo = {
     capUrl: null,
   };
 
-  return doOrContinueTransaction(client, async (client) => {
-    const result = await query<HCAAtlasTrackerDBComponentAtlas>(
-      `
-        INSERT INTO hat.component_atlases (component_info, file_id, id)
-        VALUES ($1, $2, $3)
-        RETURNING *
-      `,
-      [JSON.stringify(info), fileId, conceptId],
-      client,
-    );
+  const result = await client.query<
+    Pick<HCAAtlasTrackerDBComponentAtlas, "version_id">
+  >(
+    `
+      INSERT INTO hat.component_atlases (component_info, file_id, id)
+      VALUES ($1, $2, $3)
+      RETURNING *
+    `,
+    [JSON.stringify(info), fileId, conceptId],
+  );
 
-    const componentAtlas = result.rows[0];
+  const componentAtlasVersion = result.rows[0].version_id;
 
-    const atlasResult = await query(
-      "UPDATE hat.atlases SET component_atlases = component_atlases || $1::uuid WHERE id = $2",
-      [componentAtlas.version_id, atlasId],
-      client,
-    );
+  const atlasResult = await client.query(
+    "UPDATE hat.atlases SET component_atlases = component_atlases || $1::uuid WHERE id = $2",
+    [componentAtlasVersion, atlasId],
+  );
 
-    if (atlasResult.rowCount === 0)
-      throw new NotFoundError(`Atlas with ID ${atlasId} doesn't exist`);
-
-    return componentAtlas;
-  });
+  if (atlasResult.rowCount === 0)
+    throw new NotFoundError(`Atlas with ID ${atlasId} doesn't exist`);
 }
 
 /**

--- a/app/services/component-atlases.ts
+++ b/app/services/component-atlases.ts
@@ -289,7 +289,7 @@ export async function createComponentAtlas(
     `
       INSERT INTO hat.component_atlases (component_info, file_id, id)
       VALUES ($1, $2, $3)
-      RETURNING *
+      RETURNING version_id
     `,
     [JSON.stringify(info), fileId, conceptId],
   );

--- a/app/services/s3-notification.ts
+++ b/app/services/s3-notification.ts
@@ -119,25 +119,6 @@ type FileCreationHandler = (
   transaction: PoolClient,
 ) => Promise<void>;
 
-async function createIntegratedObject(
-  atlasId: string,
-  fileId: string,
-  conceptId: string,
-  transaction: PoolClient,
-): Promise<void> {
-  await createComponentAtlas(atlasId, fileId, conceptId, transaction);
-}
-
-async function createSourceDatasetFromS3(
-  atlasId: string,
-  fileId: string,
-  conceptId: string,
-  transaction: PoolClient,
-): Promise<void> {
-  // Create source dataset using canonical service within the existing transaction
-  await createSourceDataset(atlasId, fileId, conceptId, transaction);
-}
-
 // File update handler functions
 type FileUpdateHandler = (
   fileId: string,
@@ -200,8 +181,8 @@ async function updateSourceDatasetFromS3(
 // Dispatch maps
 const FILE_CREATION_HANDLERS: Partial<Record<FILE_TYPE, FileCreationHandler>> =
   {
-    [FILE_TYPE.INTEGRATED_OBJECT]: createIntegratedObject,
-    [FILE_TYPE.SOURCE_DATASET]: createSourceDatasetFromS3,
+    [FILE_TYPE.INTEGRATED_OBJECT]: createComponentAtlas,
+    [FILE_TYPE.SOURCE_DATASET]: createSourceDataset,
     // INGEST_MANIFEST files don't need special handling - they just get file records
   };
 const FILE_UPDATE_HANDLERS: Partial<Record<FILE_TYPE, FileUpdateHandler>> = {

--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -25,7 +25,7 @@ import {
   setSourceDatasetsPublicationStatus,
   setSourceDatasetsSourceStudy,
 } from "../data/source-datasets";
-import { InvalidOperationError, NotFoundError } from "../utils/api-errors";
+import { NotFoundError } from "../utils/api-errors";
 import { getSheetTitleForApi } from "../utils/google-sheets-api";
 import { getComponentAtlasVersionForAtlas } from "./component-atlases";
 import { updateDownloadNameIfChanged } from "./concepts";
@@ -168,18 +168,6 @@ export async function createSourceDataset(
   );
 
   const sourceDatasetVersion = insertResult.rows[0].version_id;
-
-  // Link source dataset to atlas's source_datasets array if not already linked
-  const alreadyLinkedResult = await client.query(
-    "SELECT EXISTS(SELECT 1 FROM hat.atlases a WHERE a.id = $1 AND $2 = ANY(a.source_datasets))",
-    [atlasId, sourceDatasetVersion],
-  );
-
-  if (alreadyLinkedResult.rows[0]?.exists) {
-    throw new InvalidOperationError(
-      `Source dataset version ${sourceDatasetVersion} is unexpectedly already linked to atlas ${atlasId} during create flow`,
-    );
-  }
 
   const atlasResult = await client.query(
     "UPDATE hat.atlases SET source_datasets = source_datasets || $2::uuid WHERE id = $1",

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -592,12 +592,12 @@ export async function getAtlasFromDatabase(
 }
 
 export async function getComponentAtlasVersionsFromDatabase(
-  id: string,
+  componentAtlasId: string,
 ): Promise<HCAAtlasTrackerDBComponentAtlas[]> {
   return (
     await query<HCAAtlasTrackerDBComponentAtlas>(
       "SELECT * FROM hat.component_atlases WHERE id = $1",
-      [id],
+      [componentAtlasId],
     )
   ).rows;
 }

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -591,6 +591,17 @@ export async function getAtlasFromDatabase(
   ).rows[0];
 }
 
+export async function getComponentAtlasVersionsFromDatabase(
+  id: string,
+): Promise<HCAAtlasTrackerDBComponentAtlas[]> {
+  return (
+    await query<HCAAtlasTrackerDBComponentAtlas>(
+      "SELECT * FROM hat.component_atlases WHERE id = $1",
+      [id],
+    )
+  ).rows;
+}
+
 export async function getExistingComponentAtlasFromDatabase(
   versionId: string,
 ): Promise<HCAAtlasTrackerDBComponentAtlas> {


### PR DESCRIPTION
Closes #1233

- Updated `createComponentAtlas`:
  - Made `client` parameter required
  - Removed return value
- Removed already-linked check from `createSourceDataset`, since it doesn't appear especially necessary in context
- Updated file creation handler mapping to directly use `createComponentAtlas` and `createSourceDataset` rather than having an intermediate function definition for each