### PR TITLE
feat: pass VALIDATION_RESULTS_BUCKET to validator container at SubmitJob (#1254)

### DIFF
--- a/__tests__/validator-batch.test.ts
+++ b/__tests__/validator-batch.test.ts
@@ -3,6 +3,7 @@ import {
   SubmitJobCommand,
   SubmitJobCommandInput,
 } from "@aws-sdk/client-batch";
+import { resetConfigCache } from "app/config/aws-resources";
 import { submitDatasetValidationJob } from "app/services/validator-batch";
 import { mockClient } from "aws-sdk-client-mock";
 import {
@@ -26,6 +27,9 @@ describe("submitDatasetValidationJob", () => {
     delete process.env.AWS_VALIDATION_RESULTS_BUCKET;
     delete process.env.VALIDATOR_LOG_LEVEL;
     delete process.env.AWS_RESOURCE_CONFIG;
+    // Force re-parse of AWS_RESOURCE_CONFIG in each test (cache is otherwise
+    // populated by the first test that uses it and persists across tests).
+    resetConfigCache();
   });
 
   it("submits a Batch job with required env overrides", async () => {
@@ -106,27 +110,93 @@ describe("submitDatasetValidationJob", () => {
     ).rejects.toThrow(/AWS_BATCH_VALIDATOR_JOB_QUEUE/);
   });
 
-  it("throws when AWS_VALIDATION_RESULTS_BUCKET is missing", async () => {
-    // All other required vars set, but the new validation-results bucket is not
+  it("submits without VALIDATION_RESULTS_BUCKET when env var is unset", async () => {
+    // AWS_VALIDATION_RESULTS_BUCKET is optional: missing → submit succeeds
+    // without the container env var, validator falls back to inline-only SNS.
+    const SNS_TOPIC_ARN =
+      "arn:aws:sns:us-east-1:123456789012:dev-hca-atlas-tracker-validation-results";
     process.env.AWS_BATCH_VALIDATOR_JOB_QUEUE =
       "dev-hca-atlas-tracker-validator-batch";
     process.env.AWS_BATCH_VALIDATOR_JOB_DEFINITION =
       "dev-hca-atlas-tracker-validator-batch";
-    process.env.AWS_BATCH_VALIDATOR_SNS_TOPIC_ARN =
-      "arn:aws:sns:us-east-1:123456789012:dev-hca-atlas-tracker-validation-results";
+    process.env.AWS_BATCH_VALIDATOR_SNS_TOPIC_ARN = SNS_TOPIC_ARN;
     process.env.AWS_DATA_BUCKET = TEST_S3_BUCKET;
     process.env.AWS_RESOURCE_CONFIG = JSON.stringify({
       s3_buckets: [TEST_S3_BUCKET],
-      sns_topics: [process.env.AWS_BATCH_VALIDATOR_SNS_TOPIC_ARN],
+      sns_topics: [SNS_TOPIC_ARN],
     });
 
+    batchMock.on(SubmitJobCommand).resolves({ jobId: "job-no-bucket" });
     const client = new BatchClient();
 
-    await expect(
-      submitDatasetValidationJob(
+    const { jobId } = await submitDatasetValidationJob(
+      { fileId: "id", s3Key: "a/b.h5ad" },
+      { batchClient: client },
+    );
+
+    expect(jobId).toBe("job-no-bucket");
+    const calls = batchMock.commandCalls(SubmitJobCommand);
+    expect(calls.length).toBe(1);
+    const input = calls[0].args[0].input as SubmitJobCommandInput;
+    const env = (input.containerOverrides?.environment ?? []) as Array<{
+      name: string;
+      value?: string;
+    }>;
+    expect(
+      env.find((e) => e.name === "VALIDATION_RESULTS_BUCKET"),
+    ).toBeUndefined();
+  });
+
+  it("submits without VALIDATION_RESULTS_BUCKET when env var is set but not in the allowlist", async () => {
+    // Misconfig: env var is set, but the bucket is not in
+    // AWS_RESOURCE_CONFIG.s3_buckets. Logs and submits without the container
+    // env var rather than failing the whole submit.
+    const SNS_TOPIC_ARN =
+      "arn:aws:sns:us-east-1:123456789012:dev-hca-atlas-tracker-validation-results";
+    process.env.AWS_BATCH_VALIDATOR_JOB_QUEUE =
+      "dev-hca-atlas-tracker-validator-batch";
+    process.env.AWS_BATCH_VALIDATOR_JOB_DEFINITION =
+      "dev-hca-atlas-tracker-validator-batch";
+    process.env.AWS_BATCH_VALIDATOR_SNS_TOPIC_ARN = SNS_TOPIC_ARN;
+    process.env.AWS_DATA_BUCKET = TEST_S3_BUCKET;
+    process.env.AWS_VALIDATION_RESULTS_BUCKET = TEST_VALIDATION_RESULTS_BUCKET;
+    process.env.AWS_RESOURCE_CONFIG = JSON.stringify({
+      // Validation-results bucket deliberately absent.
+      s3_buckets: [TEST_S3_BUCKET],
+      sns_topics: [SNS_TOPIC_ARN],
+    });
+
+    batchMock.on(SubmitJobCommand).resolves({ jobId: "job-bad-allowlist" });
+    const client = new BatchClient();
+
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      const { jobId } = await submitDatasetValidationJob(
         { fileId: "id", s3Key: "a/b.h5ad" },
         { batchClient: client },
-      ),
-    ).rejects.toThrow(/AWS_VALIDATION_RESULTS_BUCKET/);
+      );
+
+      expect(jobId).toBe("job-bad-allowlist");
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Submitting validator job without VALIDATION_RESULTS_BUCKET",
+        ),
+        expect.anything(),
+      );
+      const calls = batchMock.commandCalls(SubmitJobCommand);
+      expect(calls.length).toBe(1);
+      const input = calls[0].args[0].input as SubmitJobCommandInput;
+      const env = (input.containerOverrides?.environment ?? []) as Array<{
+        name: string;
+        value?: string;
+      }>;
+      expect(
+        env.find((e) => e.name === "VALIDATION_RESULTS_BUCKET"),
+      ).toBeUndefined();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 });

--- a/__tests__/validator-batch.test.ts
+++ b/__tests__/validator-batch.test.ts
@@ -20,6 +20,7 @@ describe("submitDatasetValidationJob", () => {
     delete process.env.AWS_BATCH_VALIDATOR_JOB_DEFINITION;
     delete process.env.AWS_BATCH_VALIDATOR_SNS_TOPIC_ARN;
     delete process.env.AWS_DATA_BUCKET;
+    delete process.env.AWS_VALIDATION_RESULTS_BUCKET;
     delete process.env.VALIDATOR_LOG_LEVEL;
     delete process.env.AWS_RESOURCE_CONFIG;
   });
@@ -30,16 +31,18 @@ describe("submitDatasetValidationJob", () => {
     const JOB_DEFINITION = "dev-hca-atlas-tracker-validator-batch";
     const SNS_TOPIC_ARN =
       "arn:aws:sns:us-east-1:123456789012:dev-hca-atlas-tracker-validation-results";
+    const VALIDATION_RESULTS_BUCKET = "test-validation-results-bucket";
 
     process.env.AWS_BATCH_VALIDATOR_JOB_QUEUE = JOB_QUEUE;
     process.env.AWS_BATCH_VALIDATOR_JOB_DEFINITION = JOB_DEFINITION;
     process.env.AWS_BATCH_VALIDATOR_SNS_TOPIC_ARN = SNS_TOPIC_ARN;
     process.env.AWS_DATA_BUCKET = TEST_S3_BUCKET;
+    process.env.AWS_VALIDATION_RESULTS_BUCKET = VALIDATION_RESULTS_BUCKET;
     process.env.VALIDATOR_LOG_LEVEL = "INFO";
 
     // Allowlist config for resources
     process.env.AWS_RESOURCE_CONFIG = JSON.stringify({
-      s3_buckets: [TEST_S3_BUCKET],
+      s3_buckets: [TEST_S3_BUCKET, VALIDATION_RESULTS_BUCKET],
       sns_topics: [SNS_TOPIC_ARN],
     });
 
@@ -75,6 +78,10 @@ describe("submitDatasetValidationJob", () => {
         { name: "S3_BUCKET", value: TEST_S3_BUCKET },
         { name: "S3_KEY", value: s3Key },
         { name: "FILE_ID", value: fileId },
+        {
+          name: "VALIDATION_RESULTS_BUCKET",
+          value: VALIDATION_RESULTS_BUCKET,
+        },
         { name: "SNS_TOPIC_ARN", value: SNS_TOPIC_ARN },
         { name: "LOG_LEVEL", value: "INFO" },
       ]),
@@ -95,5 +102,29 @@ describe("submitDatasetValidationJob", () => {
         { batchClient: client },
       ),
     ).rejects.toThrow(/AWS_BATCH_VALIDATOR_JOB_QUEUE/);
+  });
+
+  it("throws when AWS_VALIDATION_RESULTS_BUCKET is missing", async () => {
+    // All other required vars set, but the new validation-results bucket is not
+    process.env.AWS_BATCH_VALIDATOR_JOB_QUEUE =
+      "dev-hca-atlas-tracker-validator-batch";
+    process.env.AWS_BATCH_VALIDATOR_JOB_DEFINITION =
+      "dev-hca-atlas-tracker-validator-batch";
+    process.env.AWS_BATCH_VALIDATOR_SNS_TOPIC_ARN =
+      "arn:aws:sns:us-east-1:123456789012:dev-hca-atlas-tracker-validation-results";
+    process.env.AWS_DATA_BUCKET = TEST_S3_BUCKET;
+    process.env.AWS_RESOURCE_CONFIG = JSON.stringify({
+      s3_buckets: [TEST_S3_BUCKET],
+      sns_topics: [process.env.AWS_BATCH_VALIDATOR_SNS_TOPIC_ARN],
+    });
+
+    const client = new BatchClient();
+
+    await expect(
+      submitDatasetValidationJob(
+        { fileId: "id", s3Key: "a/b.h5ad" },
+        { batchClient: client },
+      ),
+    ).rejects.toThrow(/AWS_VALIDATION_RESULTS_BUCKET/);
   });
 });

--- a/__tests__/validator-batch.test.ts
+++ b/__tests__/validator-batch.test.ts
@@ -5,7 +5,10 @@ import {
 } from "@aws-sdk/client-batch";
 import { submitDatasetValidationJob } from "app/services/validator-batch";
 import { mockClient } from "aws-sdk-client-mock";
-import { TEST_S3_BUCKET } from "testing/constants";
+import {
+  TEST_S3_BUCKET,
+  TEST_VALIDATION_RESULTS_BUCKET,
+} from "testing/constants";
 
 // Project-wide mocks for DB connection etc.
 jest.mock("../app/utils/pg-app-connect-config");
@@ -31,18 +34,17 @@ describe("submitDatasetValidationJob", () => {
     const JOB_DEFINITION = "dev-hca-atlas-tracker-validator-batch";
     const SNS_TOPIC_ARN =
       "arn:aws:sns:us-east-1:123456789012:dev-hca-atlas-tracker-validation-results";
-    const VALIDATION_RESULTS_BUCKET = "test-validation-results-bucket";
 
     process.env.AWS_BATCH_VALIDATOR_JOB_QUEUE = JOB_QUEUE;
     process.env.AWS_BATCH_VALIDATOR_JOB_DEFINITION = JOB_DEFINITION;
     process.env.AWS_BATCH_VALIDATOR_SNS_TOPIC_ARN = SNS_TOPIC_ARN;
     process.env.AWS_DATA_BUCKET = TEST_S3_BUCKET;
-    process.env.AWS_VALIDATION_RESULTS_BUCKET = VALIDATION_RESULTS_BUCKET;
+    process.env.AWS_VALIDATION_RESULTS_BUCKET = TEST_VALIDATION_RESULTS_BUCKET;
     process.env.VALIDATOR_LOG_LEVEL = "INFO";
 
     // Allowlist config for resources
     process.env.AWS_RESOURCE_CONFIG = JSON.stringify({
-      s3_buckets: [TEST_S3_BUCKET, VALIDATION_RESULTS_BUCKET],
+      s3_buckets: [TEST_S3_BUCKET, TEST_VALIDATION_RESULTS_BUCKET],
       sns_topics: [SNS_TOPIC_ARN],
     });
 
@@ -80,7 +82,7 @@ describe("submitDatasetValidationJob", () => {
         { name: "FILE_ID", value: fileId },
         {
           name: "VALIDATION_RESULTS_BUCKET",
-          value: VALIDATION_RESULTS_BUCKET,
+          value: TEST_VALIDATION_RESULTS_BUCKET,
         },
         { name: "SNS_TOPIC_ARN", value: SNS_TOPIC_ARN },
         { name: "LOG_LEVEL", value: "INFO" },

--- a/app/services/validator-batch.ts
+++ b/app/services/validator-batch.ts
@@ -36,7 +36,8 @@ function optionalEnv(name: string): string | undefined {
  * - AWS_BATCH_VALIDATOR_JOB_QUEUE (required)
  * - AWS_BATCH_VALIDATOR_JOB_DEFINITION (required)
  * - AWS_BATCH_VALIDATOR_SNS_TOPIC_ARN (required – forwarded to container as SNS_TOPIC_ARN)
- * - AWS_DATA_BUCKET (required)
+ * - AWS_DATA_BUCKET (required – forwarded to container as S3_BUCKET)
+ * - AWS_VALIDATION_RESULTS_BUCKET (required – forwarded to container as VALIDATION_RESULTS_BUCKET; the validator writes claim-check payloads here)
  * - VALIDATOR_LOG_LEVEL (optional – forwarded to container as LOG_LEVEL)
  *
  * @param params - Parameters describing the validation request.
@@ -54,11 +55,13 @@ export async function submitDatasetValidationJob(
   const jobQueue = requiredEnv("AWS_BATCH_VALIDATOR_JOB_QUEUE");
   const jobDefinition = requiredEnv("AWS_BATCH_VALIDATOR_JOB_DEFINITION");
   const bucket = requiredEnv("AWS_DATA_BUCKET");
+  const validationResultsBucket = requiredEnv("AWS_VALIDATION_RESULTS_BUCKET");
   const snsTopicArn = requiredEnv("AWS_BATCH_VALIDATOR_SNS_TOPIC_ARN");
   const validatorLogLevel = optionalEnv("VALIDATOR_LOG_LEVEL");
 
   // Ensure allowlist validation (uses AWS_RESOURCE_CONFIG)
   validateS3BucketAuthorization(bucket);
+  validateS3BucketAuthorization(validationResultsBucket);
   validateSNSTopicAuthorization(snsTopicArn);
 
   const jobName = params.jobName ?? `dataset-validator-${params.fileId}`;
@@ -68,6 +71,7 @@ export async function submitDatasetValidationJob(
     { name: "S3_KEY", value: params.s3Key },
     { name: "FILE_ID", value: params.fileId },
     { name: "BATCH_JOB_NAME", value: jobName },
+    { name: "VALIDATION_RESULTS_BUCKET", value: validationResultsBucket },
   ];
 
   environment.push({ name: "SNS_TOPIC_ARN", value: snsTopicArn });

--- a/app/services/validator-batch.ts
+++ b/app/services/validator-batch.ts
@@ -30,6 +30,29 @@ function optionalEnv(name: string): string | undefined {
 }
 
 /**
+ * Returns the claim-check bucket if `AWS_VALIDATION_RESULTS_BUCKET` is set
+ * and present in the `AWS_RESOURCE_CONFIG.s3_buckets` allowlist. Otherwise
+ * logs and returns undefined so the caller submits without the
+ * `VALIDATION_RESULTS_BUCKET` container env var, letting the validator and
+ * tracker both fall back to inline SNS data.
+ * @returns The validated bucket name, or undefined when unset / unauthorized.
+ */
+function getValidatedClaimCheckBucket(): string | undefined {
+  const bucket = optionalEnv("AWS_VALIDATION_RESULTS_BUCKET");
+  if (!bucket) return undefined;
+  try {
+    validateS3BucketAuthorization(bucket);
+    return bucket;
+  } catch (e) {
+    console.error(
+      `Submitting validator job without VALIDATION_RESULTS_BUCKET — env-derived bucket is misconfigured:`,
+      e,
+    );
+    return undefined;
+  }
+}
+
+/**
  * Submit an AWS Batch job to run the dataset-validator against a specific S3 object.
  *
  * Environment variables read by this function:
@@ -37,7 +60,12 @@ function optionalEnv(name: string): string | undefined {
  * - AWS_BATCH_VALIDATOR_JOB_DEFINITION (required)
  * - AWS_BATCH_VALIDATOR_SNS_TOPIC_ARN (required – forwarded to container as SNS_TOPIC_ARN)
  * - AWS_DATA_BUCKET (required – forwarded to container as S3_BUCKET)
- * - AWS_VALIDATION_RESULTS_BUCKET (required – forwarded to container as VALIDATION_RESULTS_BUCKET; the validator writes claim-check payloads here)
+ * - AWS_VALIDATION_RESULTS_BUCKET (optional – forwarded to container as
+ *   VALIDATION_RESULTS_BUCKET when set; the validator writes claim-check
+ *   payloads here. Optional so a missing/misconfigured env var degrades
+ *   gracefully — the validator falls back to inline-only SNS output, and
+ *   the tracker's claim-check loader (validation-results-notification.ts)
+ *   falls back to inline data correspondingly.)
  * - VALIDATOR_LOG_LEVEL (optional – forwarded to container as LOG_LEVEL)
  *
  * @param params - Parameters describing the validation request.
@@ -55,14 +83,17 @@ export async function submitDatasetValidationJob(
   const jobQueue = requiredEnv("AWS_BATCH_VALIDATOR_JOB_QUEUE");
   const jobDefinition = requiredEnv("AWS_BATCH_VALIDATOR_JOB_DEFINITION");
   const bucket = requiredEnv("AWS_DATA_BUCKET");
-  const validationResultsBucket = requiredEnv("AWS_VALIDATION_RESULTS_BUCKET");
   const snsTopicArn = requiredEnv("AWS_BATCH_VALIDATOR_SNS_TOPIC_ARN");
   const validatorLogLevel = optionalEnv("VALIDATOR_LOG_LEVEL");
 
   // Ensure allowlist validation (uses AWS_RESOURCE_CONFIG)
   validateS3BucketAuthorization(bucket);
-  validateS3BucketAuthorization(validationResultsBucket);
   validateSNSTopicAuthorization(snsTopicArn);
+
+  // Optional: only forward when set and authorized. Missing or
+  // misconfigured → log and submit without it; the validator and tracker
+  // both fall back to inline SNS without claim-check.
+  const validationResultsBucket = getValidatedClaimCheckBucket();
 
   const jobName = params.jobName ?? `dataset-validator-${params.fileId}`;
 
@@ -71,8 +102,14 @@ export async function submitDatasetValidationJob(
     { name: "S3_KEY", value: params.s3Key },
     { name: "FILE_ID", value: params.fileId },
     { name: "BATCH_JOB_NAME", value: jobName },
-    { name: "VALIDATION_RESULTS_BUCKET", value: validationResultsBucket },
   ];
+
+  if (validationResultsBucket) {
+    environment.push({
+      name: "VALIDATION_RESULTS_BUCKET",
+      value: validationResultsBucket,
+    });
+  }
 
   environment.push({ name: "SNS_TOPIC_ARN", value: snsTopicArn });
   if (validatorLogLevel)

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -29,6 +29,8 @@ import { makeTestProjectsResponse, makeTestUser } from "./utils";
 
 export const TEST_S3_BUCKET = "test-bucket";
 
+export const TEST_VALIDATION_RESULTS_BUCKET = "test-validation-results-bucket";
+
 export const STAKEHOLDER_ANALOGOUS_ROLES = [
   ROLE.STAKEHOLDER,
   ROLE.INTEGRATION_LEAD,


### PR DESCRIPTION
## Summary

Closes #1254. Wires the tracker's `SubmitJob` call to forward the new validation-results bucket name to the validator container — with graceful fallback when the env var is unset or misconfigured.

The infrastructure side is fully in place: tf-config #25/#27 created the bucket, #28/#31 granted the validator task role `s3:PutObject` on `validation-metadata/*`, #29/#45 wired `AWS_VALIDATION_RESULTS_BUCKET` + IAM onto the tracker's App Runner service and added the bucket to `AWS_RESOURCE_CONFIG.s3_buckets`. This PR closes the last gap on the validator-submit path: passing the bucket name through to the container so the validator code (`hca-validation-tools#386`) can write claim-check payloads.

## Design decision: optional, with graceful fallback

`AWS_VALIDATION_RESULTS_BUCKET` is treated as **optional**, not required. When the env var is unset, or set but not in `AWS_RESOURCE_CONFIG.s3_buckets`, the function logs and submits the validator job **without** the `VALIDATION_RESULTS_BUCKET` container env var. The validator then runs in inline-only mode (no claim-check write attempted) and the tracker's fetch side (#1255 / PR #1261) falls back to inline SNS data correspondingly.

This is a deliberate departure from the original ticket draft (which mirrored `AWS_DATA_BUCKET`'s fail-fast pattern). The full claim-check chain (this PR + #1261 + `hca-validation-tools#386`) is now resilient to misconfiguration at every layer. Trade-off: deployment misconfig is harder to notice quickly — mitigated by a distinctive log line at every misconfig site that can be alerted on by future monitoring.

The ticket body was updated to reflect this design change.

## Changes

### `app/services/validator-batch.ts`

- New helper `getValidatedClaimCheckBucket()` returns the bucket only if env var is set AND it passes the allowlist gate. Otherwise logs and returns `undefined`.
- In `submitDatasetValidationJob`: `VALIDATION_RESULTS_BUCKET` is only pushed onto `containerOverrides.environment` when the helper returns a value.
- JSDoc env-var list marks the new variable as optional with the rationale inline.

### `__tests__/validator-batch.test.ts`

- `beforeEach` now calls `resetConfigCache()` so each test sees a fresh parse of `AWS_RESOURCE_CONFIG`. Without this, the cached allowlist from earlier tests leaked through and broke the new "not in allowlist" assertion (the cached config from the happy-path test suppressed the throw the new test relied on).
- Happy-path test asserts `VALIDATION_RESULTS_BUCKET` appears in the submitted container environment.
- New: "submits without VALIDATION_RESULTS_BUCKET when env var is unset" — confirms graceful skip with no log noise.
- New: "submits without VALIDATION_RESULTS_BUCKET when env var is set but not in the allowlist" — confirms graceful skip AND that the `"Submitting validator job without VALIDATION_RESULTS_BUCKET"` log line is emitted.

## Test plan

```
$ npm test -- validator-batch
PASS __tests__/validator-batch.test.ts
  submitDatasetValidationJob
    ✓ submits a Batch job with required env overrides
    ✓ throws when required env vars are missing
    ✓ submits without VALIDATION_RESULTS_BUCKET when env var is unset
    ✓ submits without VALIDATION_RESULTS_BUCKET when env var is set but not in the allowlist

Tests: 4 passed, 4 total
```

Lint + format clean.

## Out of scope

- Tracker SNS-receive / fetch-from-S3 / delete-after-DB-commit — that's #1255.
- Validator code that actually writes the payload — `clevercanary/hca-validation-tools#386`. The validator-side missing-env handling mirrors what this PR does on the submit side.

## End-to-end picture across the chain

| Failure point | Behavior |
|---|---|
| Validator container missing `VALIDATION_RESULTS_BUCKET` env var | validator skips S3 write, sends inline SNS as today |
| Validator container can't write to S3 (transient, permission) | per `#386` spec: log, send inline SNS as today |
| Tracker can't read from S3 | per #1255: log, fall back to inline SNS data |
| Tracker `AWS_VALIDATION_RESULTS_BUCKET` unset or misconfigured | per #1255: log, fall back to inline SNS data |
| **This PR**: tracker submits without `AWS_VALIDATION_RESULTS_BUCKET` env var | log + submit anyway; validator and tracker both fall back to inline SNS |
| **This PR**: tracker `AWS_VALIDATION_RESULTS_BUCKET` is set but not in allowlist | log + submit without forwarding; same end-state |

System is fully resilient to claim-check failures at any layer.

Refs #1239, #1255, `clevercanary/hca-atlas-tracker-tf-config#29`, `clevercanary/hca-validation-tools#386`.