### PR TITLE
feat: tracker reads validation-results bucket from AWS_VALIDATION_RESULTS_BUCKET (#1255)

### DIFF
--- a/__tests__/api-sns-with-validation-results.test.ts
+++ b/__tests__/api-sns-with-validation-results.test.ts
@@ -1034,11 +1034,13 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
       ).toBe(true);
     });
 
-    it("fails fast when AWS_VALIDATION_RESULTS_BUCKET is unset", async () => {
-      // Missing env var throws a plain Error from requiredEnv → 500.
+    it("falls back to inline SNS data when AWS_VALIDATION_RESULTS_BUCKET is unset", async () => {
+      // Deployment misconfiguration: env var missing. The handler logs and
+      // proceeds with the inline SNS payload — preserves end-to-end processing
+      // even under misconfig (deliberate departure from PRD Phase 3 fail-fast
+      // guidance; see PR description for rationale).
       const originalBucket = process.env.AWS_VALIDATION_RESULTS_BUCKET;
-      await expectClaimCheckMisconfigurationFails({
-        expectedStatusCode: 500,
+      await expectClaimCheckMisconfigurationFallsBackToInline({
         misconfigure: () => {
           delete process.env.AWS_VALIDATION_RESULTS_BUCKET;
         },
@@ -1053,12 +1055,9 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
       });
     });
 
-    it("fails fast when AWS_VALIDATION_RESULTS_BUCKET is not in the allowlist", async () => {
-      // validateS3BucketAuthorization throws UnauthorizedAWSResourceError
-      // (extends ForbiddenError) → 403.
+    it("falls back to inline SNS data when AWS_VALIDATION_RESULTS_BUCKET is not in the allowlist", async () => {
       const originalConfig = process.env.AWS_RESOURCE_CONFIG;
-      await expectClaimCheckMisconfigurationFails({
-        expectedStatusCode: 403,
+      await expectClaimCheckMisconfigurationFallsBackToInline({
         misconfigure: () => {
           process.env.AWS_RESOURCE_CONFIG = JSON.stringify({
             // Validation-results bucket deliberately absent.
@@ -1082,17 +1081,16 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
 });
 
 /**
- * Apply a misconfiguration, post a valid SNS validation-results message, and
- * assert the handler fails with the expected status code without attempting
- * any S3 op. Restores the original state in `finally` even if assertions fail.
+ * Apply a claim-check misconfiguration, post a valid SNS validation-results
+ * message, and assert the handler still returns 200 (falling back to inline
+ * SNS data without attempting any S3 op). Restores the original state in
+ * `finally` even if assertions or `misconfigure()` itself fail.
  * @param opts - Test options.
- * @param opts.expectedStatusCode - Status code the SNS handler should return.
  * @param opts.misconfigure - Mutates env/state to trigger the failure mode.
  * @param opts.restore - Reverses `misconfigure`. Called in `finally`.
  * @param opts.testId - Used to namespace the SNS messageId and batchJobId.
  */
-async function expectClaimCheckMisconfigurationFails(opts: {
-  expectedStatusCode: number;
+async function expectClaimCheckMisconfigurationFallsBackToInline(opts: {
   misconfigure: () => void;
   restore: () => void;
   testId: string;
@@ -1122,7 +1120,9 @@ async function expectClaimCheckMisconfigurationFails(opts: {
 
     const res = await doSnsRequest(snsMessage, true);
 
-    expect(res.statusCode).toEqual(opts.expectedStatusCode);
+    // Graceful fallback: handler processes inline SNS data successfully.
+    expect(res.statusCode).toEqual(200);
+    // S3 ops never attempted — bucket misconfig caught before any fetch.
     expect(s3Mock.commandCalls(GetObjectCommand)).toHaveLength(0);
     expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0);
   } finally {

--- a/__tests__/api-sns-with-validation-results.test.ts
+++ b/__tests__/api-sns-with-validation-results.test.ts
@@ -6,6 +6,7 @@ import {
   SNS_MESSAGE_DEFAULTS,
   SUCCESSFUL_TOOL_REPORTS,
   SUCCESSFUL_VALIDATION_SUMMARY,
+  TEST_S3_BUCKET,
   TEST_SIGNATURE_VALID,
   TEST_SNS_TOPIC_VALIDATION_RESULTS,
   TEST_TIMESTAMP,
@@ -1061,7 +1062,7 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
         misconfigure: () => {
           process.env.AWS_RESOURCE_CONFIG = JSON.stringify({
             // Validation-results bucket deliberately absent.
-            s3_buckets: ["hca-atlas-tracker-data-dev"],
+            s3_buckets: [TEST_S3_BUCKET],
             sns_topics: [TEST_SNS_TOPIC_VALIDATION_RESULTS],
           });
           resetConfigCache();

--- a/__tests__/api-sns-with-validation-results.test.ts
+++ b/__tests__/api-sns-with-validation-results.test.ts
@@ -1097,8 +1097,8 @@ async function expectClaimCheckMisconfigurationFails(opts: {
   restore: () => void;
   testId: string;
 }): Promise<void> {
-  opts.misconfigure();
   try {
+    opts.misconfigure();
     const fileKey = getTestFileKey(
       FILE_SOURCE_DATASET_FOOBAR,
       FILE_SOURCE_DATASET_FOOBAR.resolvedAtlas,

--- a/__tests__/api-sns-with-validation-results.test.ts
+++ b/__tests__/api-sns-with-validation-results.test.ts
@@ -1034,108 +1034,100 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
     });
 
     it("fails fast when AWS_VALIDATION_RESULTS_BUCKET is unset", async () => {
+      // Missing env var throws a plain Error from requiredEnv → 500.
       const originalBucket = process.env.AWS_VALIDATION_RESULTS_BUCKET;
-      delete process.env.AWS_VALIDATION_RESULTS_BUCKET;
-      try {
-        const batchJobId = "batch-job-claim-check-no-env";
-        const validationTime = "2025-10-15T06:50:00.000Z";
-
-        const fileKey = getTestFileKey(
-          FILE_SOURCE_DATASET_FOOBAR,
-          FILE_SOURCE_DATASET_FOOBAR.resolvedAtlas,
-        );
-
-        const inlineValidationResults = createValidationResults({
-          batchJobId,
-          fileId: FILE_SOURCE_DATASET_FOOBAR.id,
-          integrityStatus: INTEGRITY_STATUS.VALID,
-          key: fileKey,
-          metadata: null,
-          timestamp: validationTime,
-        });
-
-        const snsMessage = createSNSMessage({
-          message: inlineValidationResults,
-          messageId: "sns-message-claim-check-no-env",
-          timestamp: "2025-10-15T07:00:00.000Z",
-          topicArn: TEST_SNS_TOPIC_VALIDATION_RESULTS,
-        });
-
-        const res = await doSnsRequest(snsMessage, true);
-
-        // Missing env var is a deployment misconfiguration — fail loudly
-        // (SNS retry won't fix it, but surfacing the error is preferable
-        // to silently falling back to inline data).
-        expect(res.statusCode).not.toEqual(200);
-
-        // S3 ops never attempted.
-        expect(s3Mock.commandCalls(GetObjectCommand)).toHaveLength(0);
-        expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0);
-      } finally {
-        if (originalBucket === undefined) {
+      await expectClaimCheckMisconfigurationFails({
+        expectedStatusCode: 500,
+        misconfigure: () => {
           delete process.env.AWS_VALIDATION_RESULTS_BUCKET;
-        } else {
-          process.env.AWS_VALIDATION_RESULTS_BUCKET = originalBucket;
-        }
-      }
+        },
+        restore: () => {
+          if (originalBucket === undefined) {
+            delete process.env.AWS_VALIDATION_RESULTS_BUCKET;
+          } else {
+            process.env.AWS_VALIDATION_RESULTS_BUCKET = originalBucket;
+          }
+        },
+        testId: "claim-check-no-env",
+      });
     });
 
     it("fails fast when AWS_VALIDATION_RESULTS_BUCKET is not in the allowlist", async () => {
-      // Override the allowlist to exclude the validation-results bucket.
+      // validateS3BucketAuthorization throws UnauthorizedAWSResourceError
+      // (extends ForbiddenError) → 403.
       const originalConfig = process.env.AWS_RESOURCE_CONFIG;
-      process.env.AWS_RESOURCE_CONFIG = JSON.stringify({
-        s3_buckets: [
-          // Data bucket present; validation-results bucket deliberately absent.
-          "hca-atlas-tracker-data-dev",
-        ],
-        sns_topics: [TEST_SNS_TOPIC_VALIDATION_RESULTS],
+      await expectClaimCheckMisconfigurationFails({
+        expectedStatusCode: 403,
+        misconfigure: () => {
+          process.env.AWS_RESOURCE_CONFIG = JSON.stringify({
+            // Validation-results bucket deliberately absent.
+            s3_buckets: ["hca-atlas-tracker-data-dev"],
+            sns_topics: [TEST_SNS_TOPIC_VALIDATION_RESULTS],
+          });
+          resetConfigCache();
+        },
+        restore: () => {
+          if (originalConfig === undefined) {
+            delete process.env.AWS_RESOURCE_CONFIG;
+          } else {
+            process.env.AWS_RESOURCE_CONFIG = originalConfig;
+          }
+          resetConfigCache();
+        },
+        testId: "claim-check-not-in-allowlist",
       });
-      resetConfigCache();
-      try {
-        const batchJobId = "batch-job-claim-check-not-in-allowlist";
-        const validationTime = "2025-10-15T07:50:00.000Z";
-
-        const fileKey = getTestFileKey(
-          FILE_SOURCE_DATASET_FOOBAR,
-          FILE_SOURCE_DATASET_FOOBAR.resolvedAtlas,
-        );
-
-        const inlineValidationResults = createValidationResults({
-          batchJobId,
-          fileId: FILE_SOURCE_DATASET_FOOBAR.id,
-          integrityStatus: INTEGRITY_STATUS.VALID,
-          key: fileKey,
-          metadata: null,
-          timestamp: validationTime,
-        });
-
-        const snsMessage = createSNSMessage({
-          message: inlineValidationResults,
-          messageId: "sns-message-claim-check-not-in-allowlist",
-          timestamp: "2025-10-15T08:00:00.000Z",
-          topicArn: TEST_SNS_TOPIC_VALIDATION_RESULTS,
-        });
-
-        const res = await doSnsRequest(snsMessage, true);
-
-        // Bucket not in AWS_RESOURCE_CONFIG.s3_buckets is also a
-        // deployment misconfiguration — fail loudly, do not fall back.
-        expect(res.statusCode).not.toEqual(200);
-
-        // S3 ops never attempted.
-        expect(s3Mock.commandCalls(GetObjectCommand)).toHaveLength(0);
-        expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0);
-      } finally {
-        if (originalConfig === undefined) {
-          delete process.env.AWS_RESOURCE_CONFIG;
-        } else {
-          process.env.AWS_RESOURCE_CONFIG = originalConfig;
-        }
-        resetConfigCache();
-      }
     });
   });
 });
+
+/**
+ * Apply a misconfiguration, post a valid SNS validation-results message, and
+ * assert the handler fails with the expected status code without attempting
+ * any S3 op. Restores the original state in `finally` even if assertions fail.
+ * @param opts - Test options.
+ * @param opts.expectedStatusCode - Status code the SNS handler should return.
+ * @param opts.misconfigure - Mutates env/state to trigger the failure mode.
+ * @param opts.restore - Reverses `misconfigure`. Called in `finally`.
+ * @param opts.testId - Used to namespace the SNS messageId and batchJobId.
+ */
+async function expectClaimCheckMisconfigurationFails(opts: {
+  expectedStatusCode: number;
+  misconfigure: () => void;
+  restore: () => void;
+  testId: string;
+}): Promise<void> {
+  opts.misconfigure();
+  try {
+    const fileKey = getTestFileKey(
+      FILE_SOURCE_DATASET_FOOBAR,
+      FILE_SOURCE_DATASET_FOOBAR.resolvedAtlas,
+    );
+
+    const inlineValidationResults = createValidationResults({
+      batchJobId: `batch-job-${opts.testId}`,
+      fileId: FILE_SOURCE_DATASET_FOOBAR.id,
+      integrityStatus: INTEGRITY_STATUS.VALID,
+      key: fileKey,
+      metadata: null,
+      timestamp: "2025-10-15T06:50:00.000Z",
+    });
+
+    const snsMessage = createSNSMessage({
+      message: inlineValidationResults,
+      messageId: `sns-message-${opts.testId}`,
+      timestamp: "2025-10-15T07:00:00.000Z",
+      topicArn: TEST_SNS_TOPIC_VALIDATION_RESULTS,
+    });
+
+    const res = await doSnsRequest(snsMessage, true);
+
+    expect(res.statusCode).toEqual(opts.expectedStatusCode);
+    expect(s3Mock.commandCalls(GetObjectCommand)).toHaveLength(0);
+    expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0);
+  } finally {
+    opts.restore();
+  }
+}
 
 function mockClaimCheckObjectBody(body: string): void {
   // sdkStreamMixin adds transformToString() to the underlying Readable so the

--- a/__tests__/api-sns-with-validation-results.test.ts
+++ b/__tests__/api-sns-with-validation-results.test.ts
@@ -9,6 +9,7 @@ import {
   TEST_SIGNATURE_VALID,
   TEST_SNS_TOPIC_VALIDATION_RESULTS,
   TEST_TIMESTAMP,
+  TEST_VALIDATION_RESULTS_BUCKET,
   validateTestSnsMessage,
 } from "../testing/sns-testing";
 
@@ -806,14 +807,14 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
       const getCalls = s3Mock.commandCalls(GetObjectCommand);
       expect(getCalls).toHaveLength(1);
       expect(getCalls[0].args[0].input).toEqual({
-        Bucket: inlineValidationResults.bucket,
+        Bucket: TEST_VALIDATION_RESULTS_BUCKET,
         Key: expectedKey,
       });
 
       const deleteCalls = s3Mock.commandCalls(DeleteObjectCommand);
       expect(deleteCalls).toHaveLength(1);
       expect(deleteCalls[0].args[0].input).toEqual({
-        Bucket: inlineValidationResults.bucket,
+        Bucket: TEST_VALIDATION_RESULTS_BUCKET,
         Key: expectedKey,
       });
     });
@@ -1030,6 +1031,108 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
           ),
         ),
       ).toBe(true);
+    });
+
+    it("fails fast when AWS_VALIDATION_RESULTS_BUCKET is unset", async () => {
+      const originalBucket = process.env.AWS_VALIDATION_RESULTS_BUCKET;
+      delete process.env.AWS_VALIDATION_RESULTS_BUCKET;
+      try {
+        const batchJobId = "batch-job-claim-check-no-env";
+        const validationTime = "2025-10-15T06:50:00.000Z";
+
+        const fileKey = getTestFileKey(
+          FILE_SOURCE_DATASET_FOOBAR,
+          FILE_SOURCE_DATASET_FOOBAR.resolvedAtlas,
+        );
+
+        const inlineValidationResults = createValidationResults({
+          batchJobId,
+          fileId: FILE_SOURCE_DATASET_FOOBAR.id,
+          integrityStatus: INTEGRITY_STATUS.VALID,
+          key: fileKey,
+          metadata: null,
+          timestamp: validationTime,
+        });
+
+        const snsMessage = createSNSMessage({
+          message: inlineValidationResults,
+          messageId: "sns-message-claim-check-no-env",
+          timestamp: "2025-10-15T07:00:00.000Z",
+          topicArn: TEST_SNS_TOPIC_VALIDATION_RESULTS,
+        });
+
+        const res = await doSnsRequest(snsMessage, true);
+
+        // Missing env var is a deployment misconfiguration — fail loudly
+        // (SNS retry won't fix it, but surfacing the error is preferable
+        // to silently falling back to inline data).
+        expect(res.statusCode).not.toEqual(200);
+
+        // S3 ops never attempted.
+        expect(s3Mock.commandCalls(GetObjectCommand)).toHaveLength(0);
+        expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0);
+      } finally {
+        if (originalBucket === undefined) {
+          delete process.env.AWS_VALIDATION_RESULTS_BUCKET;
+        } else {
+          process.env.AWS_VALIDATION_RESULTS_BUCKET = originalBucket;
+        }
+      }
+    });
+
+    it("fails fast when AWS_VALIDATION_RESULTS_BUCKET is not in the allowlist", async () => {
+      // Override the allowlist to exclude the validation-results bucket.
+      const originalConfig = process.env.AWS_RESOURCE_CONFIG;
+      process.env.AWS_RESOURCE_CONFIG = JSON.stringify({
+        s3_buckets: [
+          // Data bucket present; validation-results bucket deliberately absent.
+          "hca-atlas-tracker-data-dev",
+        ],
+        sns_topics: [TEST_SNS_TOPIC_VALIDATION_RESULTS],
+      });
+      resetConfigCache();
+      try {
+        const batchJobId = "batch-job-claim-check-not-in-allowlist";
+        const validationTime = "2025-10-15T07:50:00.000Z";
+
+        const fileKey = getTestFileKey(
+          FILE_SOURCE_DATASET_FOOBAR,
+          FILE_SOURCE_DATASET_FOOBAR.resolvedAtlas,
+        );
+
+        const inlineValidationResults = createValidationResults({
+          batchJobId,
+          fileId: FILE_SOURCE_DATASET_FOOBAR.id,
+          integrityStatus: INTEGRITY_STATUS.VALID,
+          key: fileKey,
+          metadata: null,
+          timestamp: validationTime,
+        });
+
+        const snsMessage = createSNSMessage({
+          message: inlineValidationResults,
+          messageId: "sns-message-claim-check-not-in-allowlist",
+          timestamp: "2025-10-15T08:00:00.000Z",
+          topicArn: TEST_SNS_TOPIC_VALIDATION_RESULTS,
+        });
+
+        const res = await doSnsRequest(snsMessage, true);
+
+        // Bucket not in AWS_RESOURCE_CONFIG.s3_buckets is also a
+        // deployment misconfiguration — fail loudly, do not fall back.
+        expect(res.statusCode).not.toEqual(200);
+
+        // S3 ops never attempted.
+        expect(s3Mock.commandCalls(GetObjectCommand)).toHaveLength(0);
+        expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0);
+      } finally {
+        if (originalConfig === undefined) {
+          delete process.env.AWS_RESOURCE_CONFIG;
+        } else {
+          process.env.AWS_RESOURCE_CONFIG = originalConfig;
+        }
+        resetConfigCache();
+      }
     });
   });
 });

--- a/app/services/validation-results-notification.ts
+++ b/app/services/validation-results-notification.ts
@@ -117,11 +117,28 @@ interface ValidationResultsClaimCheck {
   results: DatasetValidatorResults;
 }
 
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} environment variable is required`);
+  return value;
+}
+
 /**
  * Attempt to load and validate validation results from the S3 claim check
- * object corresponding to the given inline SNS-derived results. The claim
- * check key is constructed from `file_id` and `batch_job_id` and read from
- * the same data bucket as the original file.
+ * object corresponding to the given inline SNS-derived results. The
+ * claim-check bucket is read from `AWS_VALIDATION_RESULTS_BUCKET` (a
+ * dedicated bucket separate from the data bucket — see the claim-check PRD)
+ * and validated against `AWS_RESOURCE_CONFIG.s3_buckets` before any S3
+ * operation. The key is constructed from `file_id` and `batch_job_id`.
+ *
+ * Failure modes:
+ * - Env var unset or bucket not in `AWS_RESOURCE_CONFIG.s3_buckets`: throws
+ *   (deployment misconfiguration; SNS retry will not help, but surfacing the
+ *   error loudly is preferred over silently falling back to inline data).
+ * - S3 object missing / parse error / schema-invalid / metadata mismatch:
+ *   returns null so the caller falls back to the inline SNS data (Phase 3
+ *   PRD behavior; will be tightened in Phase 4).
+ *
  * @param inlineResults - Validation results parsed from the SNS message.
  * @returns Loaded claim check (bucket, key, validated results), or null if
  *   the object is unavailable or its contents are invalid.
@@ -130,7 +147,8 @@ async function loadValidationResultsClaimCheck(
   inlineResults: DatasetValidatorResults,
 ): Promise<ValidationResultsClaimCheck | null> {
   const fileId = inlineResults.file_id;
-  const bucket = inlineResults.bucket;
+  const bucket = requiredEnv("AWS_VALIDATION_RESULTS_BUCKET");
+  validateS3BucketAuthorization(bucket);
   const key = `validation-metadata/${fileId}/${inlineResults.batch_job_id}.json`;
 
   let body: string;

--- a/app/services/validation-results-notification.ts
+++ b/app/services/validation-results-notification.ts
@@ -131,24 +131,34 @@ function requiredEnv(name: string): string {
  * and validated against `AWS_RESOURCE_CONFIG.s3_buckets` before any S3
  * operation. The key is constructed from `file_id` and `batch_job_id`.
  *
- * Failure modes:
- * - Env var unset or bucket not in `AWS_RESOURCE_CONFIG.s3_buckets`: throws
- *   (deployment misconfiguration; SNS retry will not help, but surfacing the
- *   error loudly is preferred over silently falling back to inline data).
- * - S3 object missing / parse error / schema-invalid / metadata mismatch:
- *   returns null so the caller falls back to the inline SNS data (Phase 3
- *   PRD behavior; will be tightened in Phase 4).
+ * Every failure mode returns `null` so the caller falls back to the inline
+ * SNS data. This includes deployment misconfiguration (env var unset, bucket
+ * not in `AWS_RESOURCE_CONFIG.s3_buckets`) as well as runtime failures (S3
+ * fetch error, schema-invalid payload, metadata mismatch with the SNS
+ * message). All failures are logged so misconfiguration is visible in
+ * CloudWatch even though it doesn't block processing.
  *
  * @param inlineResults - Validation results parsed from the SNS message.
  * @returns Loaded claim check (bucket, key, validated results), or null if
- *   the object is unavailable or its contents are invalid.
+ *   any failure occurred and the caller should fall back to inline data.
  */
 async function loadValidationResultsClaimCheck(
   inlineResults: DatasetValidatorResults,
 ): Promise<ValidationResultsClaimCheck | null> {
   const fileId = inlineResults.file_id;
-  const bucket = requiredEnv("AWS_VALIDATION_RESULTS_BUCKET");
-  validateS3BucketAuthorization(bucket);
+
+  let bucket: string;
+  try {
+    bucket = requiredEnv("AWS_VALIDATION_RESULTS_BUCKET");
+    validateS3BucketAuthorization(bucket);
+  } catch (e) {
+    console.error(
+      `Falling back to inline SNS for file ${fileId} (claim-check bucket misconfiguration):`,
+      e,
+    );
+    return null;
+  }
+
   const key = `validation-metadata/${fileId}/${inlineResults.batch_job_id}.json`;
 
   let body: string;

--- a/testing/setup.ts
+++ b/testing/setup.ts
@@ -1,5 +1,5 @@
 import { TextDecoder, TextEncoder } from "util";
-import { TEST_S3_BUCKET } from "./constants";
+import { TEST_S3_BUCKET, TEST_VALIDATION_RESULTS_BUCKET } from "./constants";
 
 Object.assign(global, { TextDecoder, TextEncoder }); // https://stackoverflow.com/questions/68468203/why-am-i-getting-textencoder-is-not-defined-in-jest
 
@@ -25,8 +25,9 @@ process.env.GOOGLE_AUTH =
   '{"type": "service_account", "client_email": "test@example.com"}';
 
 process.env.AWS_DATA_BUCKET = TEST_S3_BUCKET;
+process.env.AWS_VALIDATION_RESULTS_BUCKET = TEST_VALIDATION_RESULTS_BUCKET;
 process.env.AWS_RESOURCE_CONFIG = JSON.stringify({
-  s3_buckets: [TEST_S3_BUCKET],
+  s3_buckets: [TEST_S3_BUCKET, TEST_VALIDATION_RESULTS_BUCKET],
   sns_topics: [],
 });
 

--- a/testing/sns-testing.ts
+++ b/testing/sns-testing.ts
@@ -20,6 +20,7 @@ import {
   INTEGRITY_STATUS,
   SYSTEM,
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { resetConfigCache } from "../app/config/aws-resources";
 import { query } from "../app/services/database";
 import { slugifyAtlasShortName } from "../app/utils/atlases";
 import snsHandler from "../pages/api/sns";
@@ -54,6 +55,11 @@ export const TEST_AWS_CONFIG = {
 export function setUpAwsConfig(): void {
   process.env.AWS_RESOURCE_CONFIG = JSON.stringify(TEST_AWS_CONFIG);
   process.env.AWS_VALIDATION_RESULTS_BUCKET = TEST_VALIDATION_RESULTS_BUCKET;
+  // Invalidate the cached parse in app/config/aws-resources so subsequent
+  // calls to getAWSResourceConfig() see the override. Without this, anything
+  // that called getAWSResourceConfig() earlier in the runtime would keep
+  // using the stale config.
+  resetConfigCache();
 }
 
 // Test file path constants

--- a/testing/sns-testing.ts
+++ b/testing/sns-testing.ts
@@ -27,6 +27,8 @@ import { getFileFromDatabase } from "./db-utils";
 import { expectIsDefined } from "./utils";
 
 export const TEST_S3_BUCKET = "hca-atlas-tracker-data-dev";
+export const TEST_VALIDATION_RESULTS_BUCKET =
+  "hca-atlas-tracker-validation-results-dev";
 export const TEST_GUT_ATLAS_ID = "550e8400-e29b-41d4-a716-446655440000";
 export const TEST_GUT_ATLAS_V2_ID = "550e8400-e29b-41d4-a716-446655440002";
 export const TEST_ATLAS_WITH_NAME_CONTRAST_ID =
@@ -42,7 +44,7 @@ export const TEST_SNS_TOPIC_S3_NOTIFICATIONS =
 export const TEST_SNS_TOPIC_VALIDATION_RESULTS =
   "arn:aws:sns:us-east-1:123456789012:hca-atlas-tracker-validation-results";
 export const TEST_AWS_CONFIG = {
-  s3_buckets: [TEST_S3_BUCKET],
+  s3_buckets: [TEST_S3_BUCKET, TEST_VALIDATION_RESULTS_BUCKET],
   sns_topics: [
     TEST_SNS_TOPIC_S3_NOTIFICATIONS,
     TEST_SNS_TOPIC_VALIDATION_RESULTS,
@@ -51,6 +53,7 @@ export const TEST_AWS_CONFIG = {
 
 export function setUpAwsConfig(): void {
   process.env.AWS_RESOURCE_CONFIG = JSON.stringify(TEST_AWS_CONFIG);
+  process.env.AWS_VALIDATION_RESULTS_BUCKET = TEST_VALIDATION_RESULTS_BUCKET;
 }
 
 // Test file path constants


### PR DESCRIPTION
## Summary

Closes #1255. Final wiring on the tracker-receive side of the claim-check pattern — with graceful fallback at every failure mode.

Previously `loadValidationResultsClaimCheck` (in `app/services/validation-results-notification.ts`) sourced the claim-check bucket from `inlineResults.bucket` — but that's the DATA bucket name from the SNS message, not the dedicated validation-results bucket. Per the PRD (#1239 / PR #1240), the claim-check object lives in a separate bucket; the tracker resolves it from `AWS_VALIDATION_RESULTS_BUCKET`.

The infrastructure side is fully in place (tf-config #25/#27 created the bucket; #29/#45 set the env var on dev App Runner, granted the task role `s3:GetObject` + `s3:DeleteObject` on `validation-metadata/*`, and added the bucket to `AWS_RESOURCE_CONFIG.s3_buckets`).

## Design decision: full graceful fallback

`loadValidationResultsClaimCheck` returns `null` for **every** failure mode so the caller falls back to inline SNS data. This includes:

- **Env var `AWS_VALIDATION_RESULTS_BUCKET` unset** → log + return null
- **Bucket not in `AWS_RESOURCE_CONFIG.s3_buckets`** → log + return null
- **S3 fetch failure** (404, transient, permission) → log + return null (existing behavior)
- **S3 body parse / schema-validate failure** → log + return null (existing behavior)
- **Metadata mismatch** between S3 payload and SNS message → log + return null (existing behavior)

This is a deliberate departure from the original ticket draft (which mirrored the PRD's Phase 1 fail-fast acceptance criterion for env-var / allowlist failures). The full claim-check chain (#1254 + this PR + `hca-validation-tools#386`) is now resilient to misconfiguration at every layer. Trade-off: deployment misconfig is harder to notice quickly — mitigated by distinctive log lines at every misconfig site (e.g., `"Falling back to inline SNS for file X (claim-check bucket misconfiguration)"`) that future monitoring can alert on. The PRD's Phase 4 ("require S3, remove inline fallback") is unchanged; that's a future hardening step.

The ticket body (#1255) was updated to reflect this design decision.

## Changes

### `app/services/validation-results-notification.ts`

- `loadValidationResultsClaimCheck` now reads the bucket from `AWS_VALIDATION_RESULTS_BUCKET` via a local `requiredEnv` helper, with the env-var read AND the `validateS3BucketAuthorization` allowlist gate both wrapped in a try/catch that logs and returns null.
- All five failure modes (env unset, allowlist miss, S3 fetch fail, parse/schema fail, metadata mismatch) return null and emit distinctive log messages.
- Docstring updated to capture the "every failure mode falls back" semantic.

### Test infrastructure

- `testing/constants.ts`: new `TEST_VALIDATION_RESULTS_BUCKET` constant.
- `testing/setup.ts`: sets `AWS_VALIDATION_RESULTS_BUCKET` and includes the bucket in the default `AWS_RESOURCE_CONFIG.s3_buckets` so tests that don't explicitly override AWS config satisfy the new gate.
- `testing/sns-testing.ts`: new `TEST_VALIDATION_RESULTS_BUCKET` (prod-like naming, matches the file's existing `TEST_S3_BUCKET` style); added to `TEST_AWS_CONFIG.s3_buckets`; `setUpAwsConfig()` now also overrides `process.env.AWS_VALIDATION_RESULTS_BUCKET` so the env-derived bucket aligns with the allowlist override; `setUpAwsConfig()` calls `resetConfigCache()` so the override actually takes effect even after the cache has been populated earlier in the runtime.

### `__tests__/api-sns-with-validation-results.test.ts`

- The existing "loads validation results from S3" test now asserts the `Bucket` on GetObject/DeleteObject calls is `TEST_VALIDATION_RESULTS_BUCKET` (the dedicated bucket), not the inline-results data bucket.
- New: "falls back to inline SNS data when `AWS_VALIDATION_RESULTS_BUCKET` is unset" — confirms graceful fallback (200 response, no S3 ops attempted).
- New: "falls back to inline SNS data when `AWS_VALIDATION_RESULTS_BUCKET` is not in the allowlist" — same shape.
- Shared helper `expectClaimCheckMisconfigurationFallsBackToInline` extracted to remove duplication. `misconfigure()` is invoked inside the helper's `try` block so the `finally`-restore really runs even if `misconfigure()` itself throws.

## Note on `requiredEnv` duplication

This adds a 4-line `requiredEnv` helper to `validation-results-notification.ts` that mirrors the one in `validator-batch.ts`. Considered extracting to a shared util (e.g., `app/utils/env.ts`) but kept duplication for now to avoid scope creep and to avoid touching `validator-batch.ts` (which has #1260 open). Worth a small follow-up to dedupe once #1260 lands.

## Test plan

```
$ npm test -- api-sns-with-validation-results
PASS __tests__/api-sns-with-validation-results.test.ts
  /api/sns (validation results)
    ✓ ... (19 existing)
    S3 claim check
      ✓ loads validation results from S3 and deletes the object on success
      ✓ falls back to inline SNS data when S3 object is missing
      ✓ falls back to inline SNS data when S3 object body is invalid JSON
      ✓ falls back to inline SNS data when S3 object body has invalid shape
      ✓ still completes successfully when deleting the S3 object fails
      ✓ falls back to inline SNS data when AWS_VALIDATION_RESULTS_BUCKET is unset
      ✓ falls back to inline SNS data when AWS_VALIDATION_RESULTS_BUCKET is not in the allowlist

Tests: 21 passed, 21 total
```

Full `api-sns*` suite (85 tests) still green. Lint + format clean.

## Out of scope

- Validator-side write to S3 — `clevercanary/hca-validation-tools#386` (same graceful-fallback semantics on the write side).
- SubmitJob env pass-through to the Batch container — #1254 (same semantics on the submit side).

## End-to-end resilience across the chain

| Failure point | Behavior |
|---|---|
| Tracker submit (#1254): `AWS_VALIDATION_RESULTS_BUCKET` unset on App Runner | Submit proceeds without forwarding env var; validator runs in inline-only mode |
| Tracker submit (#1254): bucket set but not in allowlist | Logs + submit proceeds without forwarding; validator inline-only |
| Validator container (`#386`): no `VALIDATION_RESULTS_BUCKET` env var | Per `#386` spec: skip S3 write, send inline SNS as today |
| Validator container (`#386`): S3 write fails | Per `#386` spec: log, send inline SNS as today |
| **This PR**: tracker `AWS_VALIDATION_RESULTS_BUCKET` unset | Logs + falls back to inline SNS data |
| **This PR**: bucket not in allowlist | Logs + falls back to inline SNS data |
| **This PR**: S3 fetch fails | Logs + falls back to inline SNS data (existing behavior) |
| **This PR**: S3 body invalid / schema-invalid | Logs + falls back to inline SNS data (existing behavior) |
| **This PR**: S3 / SNS metadata mismatch | Logs + falls back to inline SNS data (existing behavior) |
| **This PR**: S3 delete fails after DB commit | Logs warning, request returns 200; lifecycle rule sweeps the orphan |

System is fully resilient to claim-check failures at any layer.

Refs #1239, #1254, `clevercanary/hca-atlas-tracker-tf-config#29`, `clevercanary/hca-validation-tools#386`.