### PR TITLE
feat: rename top-nav metadata tab to metadata dictionary (#1276)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ _templates
 venv/
 __pycache__
 
+# claude
+.claude/rules*
+

--- a/site-config/hca-atlas-tracker/local/config.ts
+++ b/site-config/hca-atlas-tracker/local/config.ts
@@ -67,7 +67,7 @@ export function makeConfig(
             { label: "Reports", url: ROUTE.REPORTS },
             { label: "Team", url: ROUTE.USERS },
             {
-              label: "Metadata",
+              label: "Metadata Dictionary",
               target: ANCHOR_TARGET.BLANK,
               url: `${portalUrl}/metadata/tier-1`,
             },


### PR DESCRIPTION
## Summary

Closes #1276.

- Renames the top-nav tab label from `Metadata` to `Metadata Dictionary` (`site-config/hca-atlas-tracker/local/config.ts:70`). URL target and external-link behaviour unchanged.
- `dev/` and `prod/` configs unchanged — they both call `makeConfig` from `local/config.ts`, so the rename propagates automatically.

Also bundles a small chore: gitignore `.claude/rules*`.

## Test plan

- [ ] Top-nav reads "Metadata Dictionary" in local, dev, and prod builds.
- [ ] Clicking the tab still opens `{portalUrl}/metadata/tier-1` in a new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2560" height="796" alt="image" src="https://github.com/user-attachments/assets/66b66bc2-b5c9-4b1b-9ea7-42b82366218a" />
