### PR TITLE
feat: top-nav: global integrated objects list (client-side filtering) (#1271)

### DIFF
--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -11,6 +11,7 @@ import {
   FileValidatorName,
   HCAAtlasTrackerAtlas,
   HCAAtlasTrackerComponentAtlas,
+  HCAAtlasTrackerGlobalComponentAtlas,
   HCAAtlasTrackerGlobalSourceDataset,
   HCAAtlasTrackerListAtlas,
   HCAAtlasTrackerListValidationRecord,
@@ -30,6 +31,12 @@ import {
 
 export function getAtlasId(atlas: HCAAtlasTrackerListAtlas): string {
   return atlas.id;
+}
+
+export function getComponentAtlasId(
+  componentAtlas: HCAAtlasTrackerGlobalComponentAtlas,
+): string {
+  return componentAtlas.id;
 }
 
 export function getSourceDatasetId(
@@ -366,7 +373,20 @@ export function isWaveValue(value: unknown): value is Wave {
 }
 
 /**
- * Maps the global API source dataset to the list source dataset.
+ * Identity mapper required by EntityConfig.entityMapper; included as a hook
+ * for future API → list-shape transformations.
+ * @param apiComponentAtlas - API component atlas.
+ * @returns list component atlas.
+ */
+export function componentAtlasInputMapper(
+  apiComponentAtlas: HCAAtlasTrackerGlobalComponentAtlas,
+): HCAAtlasTrackerGlobalComponentAtlas {
+  return apiComponentAtlas;
+}
+
+/**
+ * Identity mapper required by EntityConfig.entityMapper; included as a hook
+ * for future API → list-shape transformations.
  * @param apiSourceDataset - API source dataset.
  * @returns list source dataset.
  */

--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/entities.ts
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/entities.ts
@@ -1,5 +1,8 @@
 import { CellContext } from "@tanstack/react-table";
-import { HCAAtlasTrackerGlobalSourceDataset } from "../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
+import {
+  HCAAtlasTrackerGlobalComponentAtlas,
+  HCAAtlasTrackerGlobalSourceDataset,
+} from "../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { PathParameter } from "../../../../../../common/entities";
 import { RouteValue } from "../../../../../../routes/entities";
 import { AtlasSourceDataset } from "../../../../../../views/AtlasSourceDatasetsView/entities";
@@ -16,6 +19,11 @@ export type Props =
   | (CellContext<
       HCAAtlasTrackerGlobalSourceDataset,
       HCAAtlasTrackerGlobalSourceDataset["validationStatus"]
+    > &
+      TValue)
+  | (CellContext<
+      HCAAtlasTrackerGlobalComponentAtlas,
+      HCAAtlasTrackerGlobalComponentAtlas["validationStatus"]
     > &
       TValue);
 

--- a/app/routes/constants.ts
+++ b/app/routes/constants.ts
@@ -15,6 +15,7 @@ export const ROUTE = {
   CREATE_ATLAS: "/atlases/create",
   CREATE_SOURCE_STUDY: "/atlases/[atlasId]/source-studies/create",
   CREATE_USER: "/team/create",
+  INTEGRATED_OBJECTS: "/integrated-objects",
   INTEGRATED_OBJECT_SOURCE_DATASETS:
     "/atlases/[atlasId]/integrated-objects/[componentAtlasId]/source-datasets",
   INTEGRATED_OBJECT_VALIDATION:

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.tsx
@@ -25,6 +25,7 @@ import {
 import {
   ATLAS_STATUS,
   HCAAtlasTrackerComponentAtlas,
+  HCAAtlasTrackerGlobalComponentAtlas,
   HCAAtlasTrackerGlobalSourceDataset,
   HCAAtlasTrackerListAtlas,
   HCAAtlasTrackerListValidationRecord,
@@ -332,6 +333,108 @@ export const buildIngestionCountsHca = (
   atlas: HCAAtlasTrackerListAtlas,
 ): ComponentProps<typeof C.TaskCountsCell> => {
   return buildIngestionCountsForSystem(atlas, SYSTEM.HCA_DATA_REPOSITORY);
+};
+
+/**
+ * Build props for the global integrated object list Atlas(es) LinksCell component.
+ * @param integratedObject - Integrated object with linked atlas summaries.
+ * @returns Props to be used for the LinksCell component.
+ */
+export const buildIntegratedObjectAtlases = (
+  integratedObject: HCAAtlasTrackerGlobalComponentAtlas,
+): ComponentProps<typeof C.LinksCell> => {
+  const { atlases, id: componentAtlasId } = integratedObject;
+  return {
+    links: atlases.map((atlas) => ({
+      label: getAtlasName(atlas),
+      url: getRouteURL(ROUTE.COMPONENT_ATLAS, {
+        atlasId: atlas.id,
+        componentAtlasId,
+      }),
+    })),
+  };
+};
+
+/**
+ * Build props for the global integrated object list BioNetworksCell component.
+ * Renders one stacked row per unique network (component itself de-dupes).
+ * @param integratedObject - Integrated object with linked atlas summaries.
+ * @returns Props to be used for the BioNetworksCell component.
+ */
+export const buildIntegratedObjectBioNetworks = (
+  integratedObject: HCAAtlasTrackerGlobalComponentAtlas,
+): ComponentProps<typeof C.BioNetworksCell> => {
+  return {
+    networkKeys: integratedObject.networks,
+  };
+};
+
+/**
+ * Build props for the global integrated object list file name Link component.
+ * Links to the atlas-scoped detail page on the primary atlas.
+ * @param integratedObject - Integrated object with linked atlas summaries.
+ * @returns Props to be used for the Link component.
+ */
+export const buildIntegratedObjectFileName = (
+  integratedObject: HCAAtlasTrackerGlobalComponentAtlas,
+): ComponentProps<typeof C.Link> => {
+  const { atlasId, baseFileName, id: componentAtlasId } = integratedObject;
+  return {
+    label: baseFileName,
+    url: getRouteURL(ROUTE.COMPONENT_ATLAS, { atlasId, componentAtlasId }),
+  };
+};
+
+/**
+ * Build props for the global integrated object list source-dataset count BasicCell component.
+ * @param integratedObject - Integrated object entity.
+ * @returns Props to be used for the BasicCell component.
+ */
+export const buildIntegratedObjectSourceDatasetCount = (
+  integratedObject: HCAAtlasTrackerGlobalComponentAtlas,
+): ComponentProps<typeof C.BasicCell> => {
+  return {
+    value: integratedObject.sourceDatasetCount.toLocaleString(),
+  };
+};
+
+/**
+ * Build props for the global integrated object list title BasicCell component.
+ * @param integratedObject - Integrated object entity.
+ * @returns Props to be used for the BasicCell component.
+ */
+export const buildIntegratedObjectTitle = (
+  integratedObject: HCAAtlasTrackerGlobalComponentAtlas,
+): ComponentProps<typeof C.BasicCell> => {
+  return {
+    value: integratedObject.title,
+  };
+};
+
+/**
+ * Build props for the global integrated object list ValidationStatusCell component.
+ * Forwards the row's CellContext plus the componentAtlasId needed by
+ * ValidationSummary to build validator detail links.
+ * @param integratedObject - Integrated object entity.
+ * @param viewContext - View context carrying the row's CellContext.
+ * @returns Props to be used for the ValidationStatusCell component.
+ */
+export const buildIntegratedObjectValidationStatus = (
+  integratedObject: HCAAtlasTrackerGlobalComponentAtlas,
+  viewContext: ViewContext<HCAAtlasTrackerGlobalComponentAtlas>,
+): ComponentProps<typeof C.ValidationStatusCell> => {
+  const { cellContext } = viewContext;
+  if (!cellContext) {
+    throw new Error("ValidationStatusCell requires a row CellContext");
+  }
+  return {
+    ...(cellContext as CellContext<
+      HCAAtlasTrackerGlobalComponentAtlas,
+      HCAAtlasTrackerGlobalComponentAtlas["validationStatus"]
+    >),
+    componentAtlasId: integratedObject.id,
+    validationRoute: ROUTE.INTEGRATED_OBJECT_VALIDATION,
+  };
 };
 
 /**

--- a/site-config/hca-atlas-tracker/local/config.ts
+++ b/site-config/hca-atlas-tracker/local/config.ts
@@ -8,6 +8,7 @@ import { announcementsConfig } from "./announcements/announcementsConfig";
 import { authenticationConfig } from "./authentication/authentication";
 import { floating } from "./floating/floating";
 import { atlasEntityConfig } from "./index/atlas/atlasEntityConfig";
+import { integratedObjectsEntityConfig } from "./index/integratedObjects/integratedObjectsEntityConfig";
 import { sourceDatasetsEntityConfig } from "./index/sourceDatasets/sourceDatasetsEntityConfig";
 import { tasksEntityConfig } from "./index/tasks/tasksEntityConfig";
 import { userEntityConfig } from "./index/user/userEntityConfig";
@@ -40,6 +41,7 @@ export function makeConfig(
     entities: [
       atlasEntityConfig,
       sourceDatasetsEntityConfig,
+      integratedObjectsEntityConfig,
       tasksEntityConfig,
       userEntityConfig,
     ],
@@ -71,6 +73,7 @@ export function makeConfig(
               url: ROUTE.ATLASES,
             },
             { label: "Source Datasets", url: ROUTE.SOURCE_DATASETS },
+            { label: "Integrated Objects", url: ROUTE.INTEGRATED_OBJECTS },
             { label: "Reports", url: ROUTE.REPORTS },
             { label: "Team", url: ROUTE.USERS },
             {

--- a/site-config/hca-atlas-tracker/local/index/common/validationStatusCategoryConfig.ts
+++ b/site-config/hca-atlas-tracker/local/index/common/validationStatusCategoryConfig.ts
@@ -1,0 +1,18 @@
+import { CategoryConfig } from "@databiosphere/findable-ui/lib/common/categories/config/types";
+import { FILE_VALIDATION_STATUS_NAME_LABEL } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/constants";
+import { FILE_VALIDATION_STATUS } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { mapSelectCategoryValue } from "../../../../../app/config/utils";
+import {
+  HCA_ATLAS_TRACKER_CATEGORY_KEY,
+  HCA_ATLAS_TRACKER_CATEGORY_LABEL,
+} from "../../../category";
+
+export const VALIDATION_STATUS_CATEGORY_CONFIG: CategoryConfig = {
+  key: HCA_ATLAS_TRACKER_CATEGORY_KEY.VALIDATION_STATUS,
+  label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.VALIDATION_STATUS,
+  mapSelectCategoryValue: mapSelectCategoryValue(
+    (label) =>
+      FILE_VALIDATION_STATUS_NAME_LABEL[label as FILE_VALIDATION_STATUS] ??
+      label,
+  ),
+};

--- a/site-config/hca-atlas-tracker/local/index/integratedObjects/categoryGroupConfig.ts
+++ b/site-config/hca-atlas-tracker/local/index/integratedObjects/categoryGroupConfig.ts
@@ -29,10 +29,14 @@ export const CATEGORY_GROUP_CONFIG: SiteConfig["categoryGroupConfig"] = {
           key: HCA_ATLAS_TRACKER_CATEGORY_KEY.SUSPENSION_TYPE,
           label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.SUSPENSION_TYPE,
         },
+        {
+          key: HCA_ATLAS_TRACKER_CATEGORY_KEY.DISEASE,
+          label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.DISEASE,
+        },
         VALIDATION_STATUS_CATEGORY_CONFIG,
       ],
       label: "",
     },
   ],
-  key: "sourceDatasets",
+  key: "integratedObjects",
 };

--- a/site-config/hca-atlas-tracker/local/index/integratedObjects/column.ts
+++ b/site-config/hca-atlas-tracker/local/index/integratedObjects/column.ts
@@ -1,0 +1,155 @@
+import {
+  ColumnConfig,
+  ComponentConfig,
+} from "@databiosphere/findable-ui/lib/config/entities";
+import { HCAAtlasTrackerGlobalComponentAtlas } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
+import * as C from "../../../../../app/components";
+import * as V from "../../../../../app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders";
+import {
+  HCA_ATLAS_TRACKER_CATEGORY_KEY,
+  HCA_ATLAS_TRACKER_CATEGORY_LABEL,
+} from "../../../category";
+
+export const ASSAY: ColumnConfig<HCAAtlasTrackerGlobalComponentAtlas> = {
+  componentConfig: {
+    component: C.NTagCell,
+    viewBuilder: V.buildAssay,
+  } as ComponentConfig<typeof C.NTagCell, HCAAtlasTrackerGlobalComponentAtlas>,
+  enableGrouping: false,
+  header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.ASSAY,
+  id: HCA_ATLAS_TRACKER_CATEGORY_KEY.ASSAY,
+  width: { max: "1fr", min: "160px" },
+};
+
+export const ATLASES: ColumnConfig<HCAAtlasTrackerGlobalComponentAtlas> = {
+  componentConfig: {
+    component: C.LinksCell,
+    viewBuilder: V.buildIntegratedObjectAtlases,
+  } as ComponentConfig<typeof C.LinksCell, HCAAtlasTrackerGlobalComponentAtlas>,
+  enableGrouping: false,
+  enableSorting: false,
+  header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.ATLAS_NAMES,
+  id: HCA_ATLAS_TRACKER_CATEGORY_KEY.ATLAS_NAMES,
+  width: { max: "1fr", min: "180px" },
+};
+
+export const CELL_COUNT: ColumnConfig<HCAAtlasTrackerGlobalComponentAtlas> = {
+  componentConfig: {
+    component: C.BasicCell,
+    viewBuilder: V.buildCellCount,
+  } as ComponentConfig<typeof C.BasicCell, HCAAtlasTrackerGlobalComponentAtlas>,
+  enableGrouping: false,
+  header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.CELL_COUNT,
+  id: HCA_ATLAS_TRACKER_CATEGORY_KEY.CELL_COUNT,
+  width: { max: "0.5fr", min: "112px" },
+};
+
+export const DISEASE: ColumnConfig<HCAAtlasTrackerGlobalComponentAtlas> = {
+  componentConfig: {
+    component: C.PinnedNTagCell,
+    viewBuilder: V.buildDisease,
+  } as ComponentConfig<
+    typeof C.PinnedNTagCell,
+    HCAAtlasTrackerGlobalComponentAtlas
+  >,
+  enableGrouping: false,
+  enableHiding: false,
+  header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.DISEASE,
+  id: HCA_ATLAS_TRACKER_CATEGORY_KEY.DISEASE,
+  width: { max: "1fr", min: "160px" },
+};
+
+export const FILE_NAME: ColumnConfig<HCAAtlasTrackerGlobalComponentAtlas> = {
+  columnPinned: true,
+  componentConfig: {
+    component: C.Link,
+    viewBuilder: V.buildIntegratedObjectFileName,
+  } as ComponentConfig<typeof C.Link, HCAAtlasTrackerGlobalComponentAtlas>,
+  enableGrouping: false,
+  header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.FILE_NAME,
+  id: HCA_ATLAS_TRACKER_CATEGORY_KEY.FILE_NAME,
+  width: { max: "1.5fr", min: "240px" },
+};
+
+export const NETWORKS: ColumnConfig<HCAAtlasTrackerGlobalComponentAtlas> = {
+  componentConfig: {
+    component: C.BioNetworksCell,
+    viewBuilder: V.buildIntegratedObjectBioNetworks,
+  } as ComponentConfig<
+    typeof C.BioNetworksCell,
+    HCAAtlasTrackerGlobalComponentAtlas
+  >,
+  enableGrouping: false,
+  header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.NETWORKS,
+  id: HCA_ATLAS_TRACKER_CATEGORY_KEY.NETWORKS,
+  width: { max: "1fr", min: "212px" },
+};
+
+export const SOURCE_DATASET_COUNT: ColumnConfig<HCAAtlasTrackerGlobalComponentAtlas> =
+  {
+    componentConfig: {
+      component: C.BasicCell,
+      viewBuilder: V.buildIntegratedObjectSourceDatasetCount,
+    } as ComponentConfig<
+      typeof C.BasicCell,
+      HCAAtlasTrackerGlobalComponentAtlas
+    >,
+    enableGrouping: false,
+    header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.SOURCE_DATASET_COUNT,
+    id: HCA_ATLAS_TRACKER_CATEGORY_KEY.SOURCE_DATASET_COUNT,
+    width: { max: "0.5fr", min: "112px" },
+  };
+
+export const SUSPENSION_TYPE: ColumnConfig<HCAAtlasTrackerGlobalComponentAtlas> =
+  {
+    componentConfig: {
+      component: C.NTagCell,
+      viewBuilder: V.buildSuspensionType,
+    } as ComponentConfig<
+      typeof C.NTagCell,
+      HCAAtlasTrackerGlobalComponentAtlas
+    >,
+    enableGrouping: false,
+    enableHiding: false,
+    header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.SUSPENSION_TYPE,
+    id: HCA_ATLAS_TRACKER_CATEGORY_KEY.SUSPENSION_TYPE,
+    width: { max: "1fr", min: "160px" },
+  };
+
+export const TISSUE: ColumnConfig<HCAAtlasTrackerGlobalComponentAtlas> = {
+  componentConfig: {
+    component: C.NTagCell,
+    viewBuilder: V.buildTissue,
+  } as ComponentConfig<typeof C.NTagCell, HCAAtlasTrackerGlobalComponentAtlas>,
+  enableGrouping: false,
+  header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.TISSUE,
+  id: HCA_ATLAS_TRACKER_CATEGORY_KEY.TISSUE,
+  width: { max: "1fr", min: "160px" },
+};
+
+export const TITLE: ColumnConfig<HCAAtlasTrackerGlobalComponentAtlas> = {
+  componentConfig: {
+    component: C.BasicCell,
+    viewBuilder: V.buildIntegratedObjectTitle,
+  } as ComponentConfig<typeof C.BasicCell, HCAAtlasTrackerGlobalComponentAtlas>,
+  enableGrouping: false,
+  header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.TITLE,
+  id: HCA_ATLAS_TRACKER_CATEGORY_KEY.TITLE,
+  width: { max: "1.5fr", min: "220px" },
+};
+
+export const VALIDATION_STATUS: ColumnConfig<HCAAtlasTrackerGlobalComponentAtlas> =
+  {
+    componentConfig: {
+      component: C.ValidationStatusCell,
+      viewBuilder: V.buildIntegratedObjectValidationStatus,
+    } as ComponentConfig<
+      typeof C.ValidationStatusCell,
+      HCAAtlasTrackerGlobalComponentAtlas
+    >,
+    enableGrouping: false,
+    enableSorting: false,
+    header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.VALIDATION_STATUS,
+    id: HCA_ATLAS_TRACKER_CATEGORY_KEY.VALIDATION_STATUS,
+    width: { max: "1fr", min: "200px" },
+  };

--- a/site-config/hca-atlas-tracker/local/index/integratedObjects/columns.ts
+++ b/site-config/hca-atlas-tracker/local/index/integratedObjects/columns.ts
@@ -1,0 +1,17 @@
+import { ColumnConfig } from "@databiosphere/findable-ui/lib/config/entities";
+import { HCAAtlasTrackerGlobalComponentAtlas } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
+import * as COLUMN from "./column";
+
+export const COLUMNS: ColumnConfig<HCAAtlasTrackerGlobalComponentAtlas>[] = [
+  COLUMN.FILE_NAME,
+  COLUMN.TITLE,
+  COLUMN.ATLASES,
+  COLUMN.NETWORKS,
+  COLUMN.VALIDATION_STATUS,
+  COLUMN.SOURCE_DATASET_COUNT,
+  COLUMN.ASSAY,
+  COLUMN.TISSUE,
+  COLUMN.SUSPENSION_TYPE,
+  COLUMN.DISEASE,
+  COLUMN.CELL_COUNT,
+];

--- a/site-config/hca-atlas-tracker/local/index/integratedObjects/integratedObjectsEntityConfig.ts
+++ b/site-config/hca-atlas-tracker/local/index/integratedObjects/integratedObjectsEntityConfig.ts
@@ -1,0 +1,38 @@
+import {
+  EntityConfig,
+  ListConfig,
+} from "@databiosphere/findable-ui/lib/config/entities";
+import { EXPLORE_MODE } from "@databiosphere/findable-ui/lib/hooks/useExploreMode/types";
+import { HCAAtlasTrackerGlobalComponentAtlas } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
+import {
+  componentAtlasInputMapper,
+  getComponentAtlasId,
+} from "../../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
+import { CATEGORY_GROUP_CONFIG } from "./categoryGroupConfig";
+import { COLUMNS } from "./columns";
+import { TABLE_OPTIONS } from "./tableOptions";
+
+/**
+ * Entity config for the global /integrated-objects route — every integrated object across all atlases.
+ */
+export const integratedObjectsEntityConfig: EntityConfig = {
+  apiPath: "api/component-atlases",
+  categoryGroupConfig: CATEGORY_GROUP_CONFIG,
+  detail: {
+    detailOverviews: [],
+    staticLoad: true,
+    tabs: [],
+    top: [],
+  },
+  entityMapper: componentAtlasInputMapper,
+  exploreMode: EXPLORE_MODE.SS_FETCH_CS_FILTERING,
+  getId: getComponentAtlasId,
+  label: "Integrated Objects",
+  list: {
+    columns: COLUMNS,
+    tableOptions: TABLE_OPTIONS,
+  } as ListConfig<HCAAtlasTrackerGlobalComponentAtlas>,
+  listView: { disablePagination: true },
+  route: "integrated-objects",
+  ui: { title: "Integrated Objects" },
+};

--- a/site-config/hca-atlas-tracker/local/index/integratedObjects/tableOptions.ts
+++ b/site-config/hca-atlas-tracker/local/index/integratedObjects/tableOptions.ts
@@ -1,0 +1,13 @@
+import { ListConfig } from "@databiosphere/findable-ui/lib/config/entities";
+import { HCAAtlasTrackerGlobalComponentAtlas } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { HCA_ATLAS_TRACKER_CATEGORY_KEY } from "../../../category";
+
+export const TABLE_OPTIONS: ListConfig<HCAAtlasTrackerGlobalComponentAtlas>["tableOptions"] =
+  {
+    initialState: {
+      columnVisibility: {
+        [HCA_ATLAS_TRACKER_CATEGORY_KEY.DISEASE]: false,
+        [HCA_ATLAS_TRACKER_CATEGORY_KEY.SUSPENSION_TYPE]: false,
+      },
+    },
+  };


### PR DESCRIPTION
## Summary

Closes #1271

Adds a top-nav entry **"Integrated Objects"** between *Source Datasets* and *Reports*, listing every integrated object (component atlas) across all atlases, filterable client-side. Each row links to the existing atlas-scoped integrated-object detail page on its primary atlas.

Mirrors the pattern from the just-merged #1270 / PR #1292 (Source Datasets global list).

## What's included

- **New global list view** at `/integrated-objects`, wired via the existing `[entityListType]` dynamic page and `EntitiesView`.
- **Entity config** at `site-config/hca-atlas-tracker/local/index/integratedObjects/`: `categoryGroupConfig.ts`, `column.ts`, `columns.ts`, `tableOptions.ts`, `integratedObjectsEntityConfig.ts`.
- **Columns**: File Name (pinned), Title, Atlas(es), Network, Validation Status, Source Datasets, Assay, Tissue, Suspension Type (hidden — filter-only), Disease (hidden — filter-only), Cells.
- **Filter facets**: Network, Atlas, Assay, Tissue, Suspension Type, Disease, Validation Status. The Validation Status facet uses `mapSelectCategoryValue` with `FILE_VALIDATION_STATUS_NAME_LABEL` for friendly labels (extracted to a shared config — see refactor below).
- **Reused components**: `BioNetworksCell` (de-duplicating stacked networks, from #1292), `ValidationStatusCell` (Props union extended with `HCAAtlasTrackerGlobalComponentAtlas`; `componentAtlasId` threaded through via `ViewContext`).
- **Reused builders**: `buildAssay`, `buildCellCount`, `buildTissue`, `buildDisease`, `buildSuspensionType` — all already typed against `HCAAtlasTrackerComponentAtlas`, so no new builder needed.
- **New `ROUTE.INTEGRATED_OBJECTS`** constant (`/integrated-objects`).
- **Backend**: consumes the existing `/api/component-atlases` endpoint (from merged #1268) — no BE changes required.

## Out of scope (matched issue spec)

- **CAP Ingest Status** facet — proposed as optional in the issue, but `capIngestStatus` is computed at the atlas-scoped view layer (`AtlasIntegratedObject`), not on `HCAAtlasTrackerGlobalComponentAtlas`. Would require a BE change to expose it in the global response.

## Drive-by refactor (apply across this PR and last PR's sibling code)

- Hoisted the duplicated `VALIDATION_STATUS` `mapSelectCategoryValue` config to `site-config/.../local/index/common/validationStatusCategoryConfig.ts`. Both `integratedObjects/categoryGroupConfig.ts` and `sourceDatasets/categoryGroupConfig.ts` now import it instead of inlining the same 8-line closure.
- Documented the intent of the identity entity-mappers (`componentAtlasInputMapper`, `sourceDatasetInputMapper`) as "future transformation hook" rather than misleading "Maps API to list".

## Test plan

- [x] Visit `/integrated-objects` from the top-nav — table populates from `/api/component-atlases`.
- [x] Each File Name links to `/atlases/<primary atlasId>/integrated-objects/<componentAtlasId>`.
- [x] Atlas(es) column renders one link per atlas; each opens the integrated object's detail page within that atlas.
- [x] Network column shows stacked `BioNetworkCell`s for multi-network objects, de-duplicated.
- [x] Validation Status cell renders the same labels as the atlas-scoped view; validator detail links navigate correctly.
- [x] Facets — Network / Atlas / Assay / Tissue / Suspension Type / Disease / Validation Status — each filter the table.
- [x] Validation Status facet shows human-friendly labels ("Completed", "In progress", "Job failed", etc.).
- [x] Suspension Type and Disease columns remain hidden (filter-only); their data drives the corresponding facets.
- [x] Source Datasets PR #1292's validation status / source-study links unaffected by the shared config extraction.


<img width="1562" height="1121" alt="image" src="https://github.com/user-attachments/assets/98ad5272-9ba1-4a26-8354-08cab9d5fd72" />

<img width="1563" height="1125" alt="image" src="https://github.com/user-attachments/assets/697573a4-3e4c-4a89-aabb-72ae96ecb93c" />

<img width="1561" height="1107" alt="image" src="https://github.com/user-attachments/assets/e9f7cf65-d58d-4e1f-bdee-c8b1d1ad68d6" />

