### PR TITLE
fix: detail-page back arrow should return to the originating list (#1299)

### DIFF
--- a/__tests__/back-button-utils.test.ts
+++ b/__tests__/back-button-utils.test.ts
@@ -25,6 +25,12 @@ describe("parseBackOrigin", () => {
     expect(parseBackOrigin("BOGUS_KEY")).toBeUndefined();
   });
 
+  it("rejects inherited Object.prototype keys (e.g. toString, __proto__)", () => {
+    expect(parseBackOrigin("toString")).toBeUndefined();
+    expect(parseBackOrigin("__proto__")).toBeUndefined();
+    expect(parseBackOrigin("hasOwnProperty")).toBeUndefined();
+  });
+
   it("returns the value for a valid global ROUTE key", () => {
     expect(parseBackOrigin("SOURCE_DATASETS")).toBe("SOURCE_DATASETS");
   });
@@ -93,5 +99,23 @@ describe("withBackOrigin", () => {
         "COMPONENT_ATLASES",
       ),
     ).toBe("/atlases/abc/integrated-objects/yyy?from=COMPONENT_ATLASES");
+  });
+
+  it("preserves an existing query string and joins with '&'", () => {
+    expect(withBackOrigin("/foo?bar=1", "SOURCE_DATASETS")).toBe(
+      "/foo?bar=1&from=SOURCE_DATASETS",
+    );
+  });
+
+  it("preserves a hash fragment", () => {
+    expect(withBackOrigin("/foo#section", "SOURCE_DATASETS")).toBe(
+      "/foo?from=SOURCE_DATASETS#section",
+    );
+  });
+
+  it("preserves both an existing query string and a hash fragment", () => {
+    expect(withBackOrigin("/foo?bar=1#section", "SOURCE_DATASETS")).toBe(
+      "/foo?bar=1&from=SOURCE_DATASETS#section",
+    );
   });
 });

--- a/__tests__/back-button-utils.test.ts
+++ b/__tests__/back-button-utils.test.ts
@@ -1,0 +1,97 @@
+import {
+  parseBackOrigin,
+  resolveBackPath,
+} from "../app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/utils";
+import { withBackOrigin } from "../app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/utils";
+
+describe("parseBackOrigin", () => {
+  it("returns undefined for undefined", () => {
+    expect(parseBackOrigin(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for null", () => {
+    expect(parseBackOrigin(null)).toBeUndefined();
+  });
+
+  it("returns undefined for a non-string value", () => {
+    expect(parseBackOrigin(123)).toBeUndefined();
+  });
+
+  it("returns undefined for a string[] (Next.js can yield string arrays in query)", () => {
+    expect(parseBackOrigin(["SOURCE_DATASETS"])).toBeUndefined();
+  });
+
+  it("returns undefined for a string that is not a ROUTE key", () => {
+    expect(parseBackOrigin("BOGUS_KEY")).toBeUndefined();
+  });
+
+  it("returns the value for a valid global ROUTE key", () => {
+    expect(parseBackOrigin("SOURCE_DATASETS")).toBe("SOURCE_DATASETS");
+  });
+
+  it("returns the value for a valid atlas-scoped ROUTE key", () => {
+    expect(parseBackOrigin("ATLAS_SOURCE_DATASETS")).toBe(
+      "ATLAS_SOURCE_DATASETS",
+    );
+  });
+});
+
+describe("resolveBackPath", () => {
+  it("returns undefined when origin is undefined", () => {
+    expect(
+      resolveBackPath({ origin: undefined, pathParameter: {} }),
+    ).toBeUndefined();
+  });
+
+  it("resolves a global ROUTE key with no dynamic segments", () => {
+    expect(
+      resolveBackPath({ origin: "SOURCE_DATASETS", pathParameter: {} }),
+    ).toBe("/source-datasets");
+  });
+
+  it("resolves an atlas-scoped ROUTE key against pathParameter.atlasId", () => {
+    expect(
+      resolveBackPath({
+        origin: "ATLAS_SOURCE_DATASETS",
+        pathParameter: { atlasId: "abc-123" },
+      }),
+    ).toBe("/atlases/abc-123/source-datasets");
+  });
+
+  it("ignores extra pathParameter keys not present in the route template", () => {
+    expect(
+      resolveBackPath({
+        origin: "ATLAS_SOURCE_STUDIES",
+        pathParameter: { atlasId: "abc", sourceDatasetId: "xyz" },
+      }),
+    ).toBe("/atlases/abc/source-studies");
+  });
+
+  it("returns undefined when the route template has dynamic segments not satisfied by pathParameter", () => {
+    // INTEGRATED_OBJECT_SOURCE_DATASETS needs [atlasId] + [componentAtlasId];
+    // a source-dataset-detail pathParameter only carries atlasId + sourceDatasetId.
+    expect(
+      resolveBackPath({
+        origin: "INTEGRATED_OBJECT_SOURCE_DATASETS",
+        pathParameter: { atlasId: "abc", sourceDatasetId: "xyz" },
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("withBackOrigin", () => {
+  it("appends ?from=<origin> to a URL with no existing query string", () => {
+    expect(
+      withBackOrigin("/atlases/abc/source-datasets/xyz", "SOURCE_DATASETS"),
+    ).toBe("/atlases/abc/source-datasets/xyz?from=SOURCE_DATASETS");
+  });
+
+  it("uses the literal ROUTE key as the from value", () => {
+    expect(
+      withBackOrigin(
+        "/atlases/abc/integrated-objects/yyy",
+        "COMPONENT_ATLASES",
+      ),
+    ).toBe("/atlases/abc/integrated-objects/yyy?from=COMPONENT_ATLASES");
+  });
+});

--- a/__tests__/use-back-path.test.ts
+++ b/__tests__/use-back-path.test.ts
@@ -1,0 +1,71 @@
+import { renderHook } from "@testing-library/react";
+
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock requires require()-style import after mock is set up.
+import { useRouter } from "next/router";
+import { useBackPath } from "../app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook";
+
+const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
+
+/**
+ * Returns a partial NextRouter mock containing only the `query` field that
+ * `useBackPath` reads. Cast to the full type so TypeScript accepts it as a
+ * mock return value.
+ * @param query - Query object to expose on `useRouter()`.
+ * @returns Router mock cast to the full NextRouter type.
+ */
+function routerWith(
+  query: Record<string, string | string[] | undefined>,
+): ReturnType<typeof useRouter> {
+  return { query } as ReturnType<typeof useRouter>;
+}
+
+describe("useBackPath", () => {
+  beforeEach(() => {
+    mockUseRouter.mockReset();
+  });
+
+  it("returns undefined when query.from is missing", () => {
+    mockUseRouter.mockReturnValue(routerWith({}));
+    const { result } = renderHook(() => useBackPath({ atlasId: "abc" }));
+    expect(result.current).toBeUndefined();
+  });
+
+  it("returns undefined when query.from is an unknown value", () => {
+    mockUseRouter.mockReturnValue(routerWith({ from: "BOGUS" }));
+    const { result } = renderHook(() => useBackPath({ atlasId: "abc" }));
+    expect(result.current).toBeUndefined();
+  });
+
+  it("resolves a global ROUTE key with no dynamic segments", () => {
+    mockUseRouter.mockReturnValue(routerWith({ from: "SOURCE_DATASETS" }));
+    const { result } = renderHook(() => useBackPath({ atlasId: "abc" }));
+    expect(result.current).toBe("/source-datasets");
+  });
+
+  it("resolves an atlas-scoped ROUTE key against pathParameter.atlasId", () => {
+    mockUseRouter.mockReturnValue(
+      routerWith({ from: "ATLAS_SOURCE_DATASETS" }),
+    );
+    const { result } = renderHook(() => useBackPath({ atlasId: "abc-123" }));
+    expect(result.current).toBe("/atlases/abc-123/source-datasets");
+  });
+
+  it("snapshots origin at first render — subsequent query changes don't repoint backPath", () => {
+    // First render with from=SOURCE_DATASETS.
+    mockUseRouter.mockReturnValue(routerWith({ from: "SOURCE_DATASETS" }));
+    const { rerender, result } = renderHook(() =>
+      useBackPath({ atlasId: "abc" }),
+    );
+    expect(result.current).toBe("/source-datasets");
+
+    // Simulate a tab change that drops `from` from the query.
+    mockUseRouter.mockReturnValue(routerWith({}));
+    rerender();
+    // The ref-captured origin still resolves to the original list.
+    expect(result.current).toBe("/source-datasets");
+  });
+});

--- a/__tests__/use-back-path.test.ts
+++ b/__tests__/use-back-path.test.ts
@@ -4,7 +4,6 @@ jest.mock("next/router", () => ({
   useRouter: jest.fn(),
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports -- jest.mock requires require()-style import after mock is set up.
 import { useRouter } from "next/router";
 import { useBackPath } from "../app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook";
 

--- a/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/constants.ts
+++ b/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/constants.ts
@@ -1,0 +1,8 @@
+import { RouteKey } from "../../../../../../../../routes/entities";
+
+/**
+ * A back-arrow origin is a `ROUTE` key naming the list (global or atlas-
+ * scoped) that the user came from. The detail page resolves the back URL by
+ * looking up `ROUTE[origin]` and substituting the current path parameters.
+ */
+export type BackOrigin = RouteKey;

--- a/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/entities.ts
+++ b/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/entities.ts
@@ -1,0 +1,7 @@
+import { PathParameter } from "../../../../../../../../../../common/entities";
+import { BackOrigin } from "../../constants";
+
+export interface ResolveBackPathInput {
+  origin: BackOrigin | undefined;
+  pathParameter: PathParameter;
+}

--- a/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook.ts
+++ b/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook.ts
@@ -1,0 +1,22 @@
+import { useRouter } from "next/router";
+import { useRef } from "react";
+import { PathParameter } from "../../../../../../../../../../common/entities";
+import { parseBackOrigin, resolveBackPath } from "./utils";
+
+/**
+ * Captures the back-arrow origin from `useRouter().query.from` once at first
+ * render and resolves the back path for the current detail view. The snapshot
+ * survives tab navigation (the ref locks at mount) so a tab switch within
+ * the detail view doesn't repoint the back arrow.
+ * @param pathParameter - Path parameter of the current detail view.
+ * @returns Resolved back path, or undefined for deep links / direct entry
+ *   (in which case `BackButton` falls back to its URL-segment trim).
+ */
+export function useBackPath(pathParameter: PathParameter): string | undefined {
+  const { query } = useRouter();
+  const { from } = query;
+  const originRef = useRef(parseBackOrigin(from));
+  const origin = originRef.current;
+
+  return resolveBackPath({ origin, pathParameter });
+}

--- a/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/utils.ts
+++ b/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/utils.ts
@@ -37,6 +37,13 @@ export function resolveBackPath({
  * @returns Recognised back origin or undefined.
  */
 export function parseBackOrigin(value: unknown): BackOrigin | undefined {
-  if (typeof value === "string" && value in ROUTE) return value as BackOrigin;
+  // Use `hasOwnProperty` (not the `in` operator) to reject inherited keys
+  // like `__proto__` / `toString` that arrive from untrusted router query.
+  if (
+    typeof value === "string" &&
+    Object.prototype.hasOwnProperty.call(ROUTE, value)
+  ) {
+    return value as BackOrigin;
+  }
   return undefined;
 }

--- a/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/utils.ts
+++ b/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/utils.ts
@@ -1,0 +1,42 @@
+import { getRouteURL } from "../../../../../../../../../../common/utils";
+import { ROUTE } from "../../../../../../../../../../routes/constants";
+import { BackOrigin } from "../../constants";
+import { ResolveBackPathInput } from "./entities";
+
+/**
+ * Resolves the back-arrow path for a detail view from the `from` query
+ * captured at first render.
+ * If `origin` is a known `ROUTE` key, returns the route URL with the current
+ * path parameter substituted. Otherwise (deep link / direct entry) returns
+ * `undefined`, letting `BackButton` fall through to its URL-segment trim.
+ * @param input - Resolve-back-path input.
+ * @param input.origin - Back origin captured from `query.from`.
+ * @param input.pathParameter - Path parameter for route substitution.
+ * @returns Resolved back path, or undefined to fall through to `BackButton`'s default.
+ */
+export function resolveBackPath({
+  origin,
+  pathParameter,
+}: ResolveBackPathInput): string | undefined {
+  if (!origin) return undefined;
+  try {
+    return getRouteURL(ROUTE[origin], pathParameter);
+  } catch {
+    // `getRouteURL` throws if the route template has dynamic segments that
+    // aren't satisfied by the current pathParameter (e.g. a sub-list route
+    // referenced from a detail page that doesn't carry the sub-list's
+    // parent id). Fall through so `BackButton`'s URL-segment trim runs.
+    return undefined;
+  }
+}
+
+/**
+ * Parses an unknown `from` query value into a known back-origin (a `ROUTE`
+ * key), or `undefined` if the value isn't a recognised key.
+ * @param value - Raw `from` query value (from `useRouter().query.from`).
+ * @returns Recognised back origin or undefined.
+ */
+export function parseBackOrigin(value: unknown): BackOrigin | undefined {
+  if (typeof value === "string" && value in ROUTE) return value as BackOrigin;
+  return undefined;
+}

--- a/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/utils.ts
+++ b/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/utils.ts
@@ -1,14 +1,21 @@
 import { BackOrigin } from "./constants";
 
+// Dummy base for parsing relative URLs through the URL API; never appears
+// in the output. We always return `pathname + search + hash`.
+const DUMMY_BASE = "http://x";
+
 /**
- * Appends a `from=<origin>` query parameter to a URL so the target view can
+ * Adds a `from=<origin>` query parameter to a URL so the target view can
  * resolve its back-arrow against the originating list. Centralises the query-
  * string format used by all row links into the source-dataset, integrated-
  * object, source-study, and validation detail pages.
- * @param url - Target detail-page URL.
+ * Preserves any pre-existing query string and hash fragment on the URL.
+ * @param url - Target detail-page URL (relative path).
  * @param origin - Back origin (a `ROUTE` key) to record.
- * @returns URL with `?from=<origin>` appended.
+ * @returns URL with `from=<origin>` added to the query string.
  */
 export function withBackOrigin(url: string, origin: BackOrigin): string {
-  return `${url}?from=${origin}`;
+  const parsed = new URL(url, DUMMY_BASE);
+  parsed.searchParams.set("from", origin);
+  return `${parsed.pathname}${parsed.search}${parsed.hash}`;
 }

--- a/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/utils.ts
+++ b/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/utils.ts
@@ -1,0 +1,14 @@
+import { BackOrigin } from "./constants";
+
+/**
+ * Appends a `from=<origin>` query parameter to a URL so the target view can
+ * resolve its back-arrow against the originating list. Centralises the query-
+ * string format used by all row links into the source-dataset, integrated-
+ * object, source-study, and validation detail pages.
+ * @param url - Target detail-page URL.
+ * @param origin - Back origin (a `ROUTE` key) to record.
+ * @returns URL with `?from=<origin>` appended.
+ */
+export function withBackOrigin(url: string, origin: BackOrigin): string {
+  return `${url}?from=${origin}`;
+}

--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/entities.ts
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/entities.ts
@@ -4,8 +4,10 @@ import {
 } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { PathParameter } from "../../../../../../../../common/entities";
 import { RouteValue } from "../../../../../../../../routes/entities";
+import { BackOrigin } from "../../../../../../../Layout/components/Detail/components/DetailViewHero/components/BackButton/constants";
 
 export interface Props extends PathParameter {
+  backOrigin: BackOrigin;
   reprocessedStatus?: REPROCESSED_STATUS;
   validationRoute: RouteValue;
   validationSummary: FileValidationSummary;

--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.tsx
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.tsx
@@ -22,6 +22,7 @@ import { StyledStack } from "./validationSummary.styles";
 
 export const ValidationSummary = ({
   atlasId,
+  backOrigin,
   componentAtlasId,
   reprocessedStatus,
   sourceDatasetId,
@@ -59,7 +60,7 @@ export const ValidationSummary = ({
               <ValidatorIcon status={value} />
               <Link
                 as={url}
-                href={{ pathname: url, query: { from: "list" } }}
+                href={{ pathname: url, query: { from: backOrigin } }}
                 rel={REL_ATTRIBUTE.NO_OPENER}
                 target={ANCHOR_TARGET.SELF}
               >

--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/entities.ts
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/entities.ts
@@ -7,6 +7,7 @@ import { PathParameter } from "../../../../../../common/entities";
 import { RouteValue } from "../../../../../../routes/entities";
 import { AtlasSourceDataset } from "../../../../../../views/AtlasSourceDatasetsView/entities";
 import { AtlasIntegratedObject } from "../../../../../../views/ComponentAtlasesView/entities";
+import { BackOrigin } from "../../../../../Layout/components/Detail/components/DetailViewHero/components/BackButton/constants";
 
 export type Props =
   | (CellContext<
@@ -28,5 +29,6 @@ export type Props =
       TValue);
 
 interface TValue extends PathParameter {
+  backOrigin: BackOrigin;
   validationRoute: RouteValue;
 }

--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/validationStatusCell.tsx
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/validationStatusCell.tsx
@@ -10,6 +10,7 @@ import { ValidationSummary } from "./components/ValidationSummary/validationSumm
 import { Props } from "./entities";
 
 export const ValidationStatusCell = ({
+  backOrigin,
   componentAtlasId,
   row,
   sourceDatasetId,
@@ -28,6 +29,7 @@ export const ValidationStatusCell = ({
       return (
         <ValidationSummary
           atlasId={atlasId}
+          backOrigin={backOrigin}
           componentAtlasId={componentAtlasId}
           reprocessedStatus={reprocessedStatus}
           sourceDatasetId={sourceDatasetId}

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.tsx
@@ -52,6 +52,7 @@ import {
 import { PathParameter } from "../../../../common/entities";
 import { getRouteURL } from "../../../../common/utils";
 import * as C from "../../../../components";
+import { withBackOrigin } from "../../../../components/Layout/components/Detail/components/DetailViewHero/components/BackButton/utils";
 import { CAPIngestStatusCell } from "../../../../components/Table/components/TableCell/components/CAPIngestStatusCell/capIngestStatusCell";
 import { ICON_STATUS } from "../../../../components/Table/components/TableCell/components/IconStatusBadge/iconStatusBadge";
 import { ROUTE } from "../../../../routes/constants";
@@ -114,7 +115,10 @@ export const buildAtlasSourceDatasetCount = (
   const { id: atlasId } = atlas;
   return {
     label: atlas.sourceDatasetCount,
-    url: getRouteURL(ROUTE.ATLAS_SOURCE_DATASETS, { atlasId }),
+    url: withBackOrigin(
+      getRouteURL(ROUTE.ATLAS_SOURCE_DATASETS, { atlasId }),
+      "ATLASES",
+    ),
   };
 };
 
@@ -168,7 +172,10 @@ export const buildComponentAtlasCount = (
   const { id: atlasId } = atlas;
   return {
     label: atlas.componentAtlasCount,
-    url: getRouteURL(ROUTE.COMPONENT_ATLASES, { atlasId }),
+    url: withBackOrigin(
+      getRouteURL(ROUTE.COMPONENT_ATLASES, { atlasId }),
+      "ATLASES",
+    ),
   };
 };
 
@@ -192,7 +199,10 @@ export const buildComponentAtlasFileName = ({
   return {
     getValue: () => ({
       children: fileName,
-      href: getRouteURL(ROUTE.COMPONENT_ATLAS, { atlasId, componentAtlasId }),
+      href: withBackOrigin(
+        getRouteURL(ROUTE.COMPONENT_ATLAS, { atlasId, componentAtlasId }),
+        "COMPONENT_ATLASES",
+      ),
     }),
   };
 };
@@ -349,10 +359,13 @@ export const buildIntegratedObjectAtlases = (
   return {
     links: atlases.map((atlas) => ({
       label: getAtlasName(atlas),
-      url: getRouteURL(ROUTE.COMPONENT_ATLAS, {
-        atlasId: atlas.id,
-        componentAtlasId,
-      }),
+      url: withBackOrigin(
+        getRouteURL(ROUTE.COMPONENT_ATLAS, {
+          atlasId: atlas.id,
+          componentAtlasId,
+        }),
+        "INTEGRATED_OBJECTS",
+      ),
     })),
   };
 };
@@ -383,7 +396,10 @@ export const buildIntegratedObjectFileName = (
   const { atlasId, baseFileName, id: componentAtlasId } = integratedObject;
   return {
     label: baseFileName,
-    url: getRouteURL(ROUTE.COMPONENT_ATLAS, { atlasId, componentAtlasId }),
+    url: withBackOrigin(
+      getRouteURL(ROUTE.COMPONENT_ATLAS, { atlasId, componentAtlasId }),
+      "INTEGRATED_OBJECTS",
+    ),
   };
 };
 
@@ -434,6 +450,7 @@ export const buildIntegratedObjectValidationStatus = (
       HCAAtlasTrackerGlobalComponentAtlas,
       HCAAtlasTrackerGlobalComponentAtlas["validationStatus"]
     >),
+    backOrigin: "INTEGRATED_OBJECTS",
     componentAtlasId: integratedObject.id,
     validationRoute: ROUTE.INTEGRATED_OBJECT_VALIDATION,
   };
@@ -535,10 +552,13 @@ export const buildSourceDatasetAtlases = (
   return {
     links: atlases.map((atlas) => ({
       label: getAtlasName(atlas),
-      url: getRouteURL(ROUTE.ATLAS_SOURCE_DATASET, {
-        atlasId: atlas.id,
-        sourceDatasetId,
-      }),
+      url: withBackOrigin(
+        getRouteURL(ROUTE.ATLAS_SOURCE_DATASET, {
+          atlasId: atlas.id,
+          sourceDatasetId,
+        }),
+        "SOURCE_DATASETS",
+      ),
     })),
   };
 };
@@ -582,7 +602,10 @@ export const buildSourceDatasetFileName = (
   const { atlasId, baseFileName, id: sourceDatasetId } = sourceDataset;
   return {
     label: baseFileName,
-    url: getRouteURL(ROUTE.ATLAS_SOURCE_DATASET, { atlasId, sourceDatasetId }),
+    url: withBackOrigin(
+      getRouteURL(ROUTE.ATLAS_SOURCE_DATASET, { atlasId, sourceDatasetId }),
+      "SOURCE_DATASETS",
+    ),
   };
 };
 
@@ -620,6 +643,7 @@ export const buildSourceDatasetValidationStatus = (
       HCAAtlasTrackerGlobalSourceDataset,
       HCAAtlasTrackerGlobalSourceDataset["validationStatus"]
     >),
+    backOrigin: "SOURCE_DATASETS",
     sourceDatasetId: sourceDataset.id,
     validationRoute: ROUTE.ATLAS_SOURCE_DATASET_VALIDATION,
   };
@@ -637,10 +661,13 @@ export const buildSourceStudyAtlases = (
   return {
     links: atlases.map((atlas) => ({
       label: getAtlasName(atlas),
-      url: getRouteURL(ROUTE.ATLAS_SOURCE_STUDY, {
-        atlasId: atlas.id,
-        sourceStudyId,
-      }),
+      url: withBackOrigin(
+        getRouteURL(ROUTE.ATLAS_SOURCE_STUDY, {
+          atlasId: atlas.id,
+          sourceStudyId,
+        }),
+        "SOURCE_STUDIES",
+      ),
     })),
   };
 };
@@ -722,10 +749,13 @@ export const buildSourceStudyName = (
   return {
     label: getSourceStudyCitation(sourceStudy),
     url: linkAtlas
-      ? getRouteURL(ROUTE.ATLAS_SOURCE_STUDY, {
-          atlasId: linkAtlas.id,
-          sourceStudyId,
-        })
+      ? withBackOrigin(
+          getRouteURL(ROUTE.ATLAS_SOURCE_STUDY, {
+            atlasId: linkAtlas.id,
+            sourceStudyId,
+          }),
+          "SOURCE_STUDIES",
+        )
       : "",
   };
 };
@@ -786,10 +816,13 @@ export const buildSourceStudyTitle = (
   const { id: sourceStudyId } = sourceStudy;
   return {
     label: getSourceStudyCitation(sourceStudy),
-    url: getRouteURL(ROUTE.ATLAS_SOURCE_STUDY, {
-      ...pathParameter,
-      sourceStudyId,
-    }),
+    url: withBackOrigin(
+      getRouteURL(ROUTE.ATLAS_SOURCE_STUDY, {
+        ...pathParameter,
+        sourceStudyId,
+      }),
+      "ATLAS_SOURCE_STUDIES",
+    ),
   };
 };
 
@@ -804,7 +837,10 @@ export const buildSourceStudyCount = (
   const { id: atlasId } = atlas;
   return {
     label: atlas.sourceStudyCount,
-    url: getRouteURL(ROUTE.ATLAS_SOURCE_STUDIES, { atlasId }),
+    url: withBackOrigin(
+      getRouteURL(ROUTE.ATLAS_SOURCE_STUDIES, { atlasId }),
+      "ATLASES",
+    ),
   };
 };
 
@@ -969,7 +1005,10 @@ export const buildTaskPublicationString = (
   const atlasId = atlasIds[0];
   return {
     label: task.publicationString ?? "",
-    url: getRouteURL(ROUTE.ATLAS_SOURCE_STUDY, { atlasId, sourceStudyId }),
+    url: withBackOrigin(
+      getRouteURL(ROUTE.ATLAS_SOURCE_STUDY, { atlasId, sourceStudyId }),
+      "REPORTS",
+    ),
   };
 };
 
@@ -1642,6 +1681,7 @@ function getIntegratedObjectValidationStatusColumnDef(): ColumnDef<
     cell: (ctx): JSX.Element | null => {
       return C.ValidationStatusCell({
         ...ctx,
+        backOrigin: "COMPONENT_ATLASES",
         componentAtlasId: ctx.row.original.id,
         validationRoute: ROUTE.INTEGRATED_OBJECT_VALIDATION,
       });

--- a/app/views/AtlasMetadataEntrySheetsView/common/viewBuilders.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/common/viewBuilders.ts
@@ -3,6 +3,7 @@ import { LinkProps } from "@mui/material";
 import { CellContext } from "@tanstack/react-table";
 import { formatDistanceToNowStrict } from "date-fns";
 import { getRouteURL } from "../../../common/utils";
+import { withBackOrigin } from "../../../components/Layout/components/Detail/components/DetailViewHero/components/BackButton/utils";
 import { getPartialCellContext } from "../../../components/Table/components/utils";
 import { ROUTE } from "../../../routes/constants";
 import { buildSheetsUrl } from "../../../utils/google-sheets";
@@ -80,7 +81,10 @@ export function buildPublicationString(
   const { atlasId, publicationString, sourceStudyId } = row.original;
   return getPartialCellContext({
     children: publicationString,
-    href: getRouteURL(ROUTE.ATLAS_SOURCE_STUDY, { atlasId, sourceStudyId }),
+    href: withBackOrigin(
+      getRouteURL(ROUTE.ATLAS_SOURCE_STUDY, { atlasId, sourceStudyId }),
+      "METADATA_ENTRY_SHEETS",
+    ),
   });
 }
 

--- a/app/views/AtlasSourceDatasetValidationView/atlasSourceDatasetValidationView.tsx
+++ b/app/views/AtlasSourceDatasetValidationView/atlasSourceDatasetValidationView.tsx
@@ -1,19 +1,17 @@
 import { ConditionalComponent } from "@databiosphere/findable-ui/lib/components/ComponentCreator/components/ConditionalComponent/conditionalComponent";
-import { useRouter } from "next/router";
-import { Fragment, JSX, useRef } from "react";
+import { Fragment, JSX } from "react";
 import { PathParameter } from "../../common/entities";
-import { getRouteURL } from "../../common/utils";
 import { AccessPrompt } from "../../components/common/Form/components/FormManager/components/AccessPrompt/accessPrompt";
 import { shouldRenderView } from "../../components/Detail/common/utils";
 import { Breadcrumbs } from "../../components/Detail/components/TrackerForm/components/Breadcrumbs/breadcrumbs";
 import { Tabs } from "../../components/Entity/components/common/Tabs/tabs";
 import { EntityView } from "../../components/Entity/components/EntityView/entityView";
+import { useBackPath } from "../../components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook";
 import { DetailView } from "../../components/Layout/components/Detail/detailView";
 import { useFetchAtlas } from "../../hooks/useFetchAtlas";
 import { FormManager } from "../../hooks/useFormManager/common/entities";
 import { useFormManager } from "../../hooks/useFormManager/useFormManager";
 import { EntityProvider } from "../../providers/entity/provider";
-import { ROUTE } from "../../routes/constants";
 import { useFetchAtlasSourceDataset } from "../AtlasSourceDatasetView/hooks/useFetchAtlasSourceDataset";
 import { VIEW_SOURCE_DATASET_VALIDATION_SECTION_CONFIGS } from "./common/config";
 import { getBreadcrumbs, getTabs } from "./common/utils";
@@ -25,8 +23,6 @@ interface Props {
 export const AtlasSourceDatasetValidationView = ({
   pathParameter,
 }: Props): JSX.Element => {
-  const { query } = useRouter();
-  const fromList = useRef(query.from === "list");
   const { atlas } = useFetchAtlas(pathParameter);
   const { sourceDataset } = useFetchAtlasSourceDataset(pathParameter);
   const formManager = useFormManager();
@@ -34,10 +30,10 @@ export const AtlasSourceDatasetValidationView = ({
     access: { canView },
     isLoading,
   } = formManager;
-  const backPath = fromList.current
-    ? getRouteURL(ROUTE.ATLAS_SOURCE_DATASETS, pathParameter)
-    : getRouteURL(ROUTE.ATLAS_SOURCE_DATASET, pathParameter);
+  const backPath = useBackPath(pathParameter);
+
   if (isLoading) return <Fragment />;
+
   return (
     <EntityProvider data={{ sourceDataset }} pathParameter={pathParameter}>
       <ConditionalComponent

--- a/app/views/AtlasSourceDatasetValidationView/atlasSourceDatasetValidationView.tsx
+++ b/app/views/AtlasSourceDatasetValidationView/atlasSourceDatasetValidationView.tsx
@@ -1,6 +1,7 @@
 import { ConditionalComponent } from "@databiosphere/findable-ui/lib/components/ComponentCreator/components/ConditionalComponent/conditionalComponent";
 import { Fragment, JSX } from "react";
 import { PathParameter } from "../../common/entities";
+import { getRouteURL } from "../../common/utils";
 import { AccessPrompt } from "../../components/common/Form/components/FormManager/components/AccessPrompt/accessPrompt";
 import { shouldRenderView } from "../../components/Detail/common/utils";
 import { Breadcrumbs } from "../../components/Detail/components/TrackerForm/components/Breadcrumbs/breadcrumbs";
@@ -12,6 +13,7 @@ import { useFetchAtlas } from "../../hooks/useFetchAtlas";
 import { FormManager } from "../../hooks/useFormManager/common/entities";
 import { useFormManager } from "../../hooks/useFormManager/useFormManager";
 import { EntityProvider } from "../../providers/entity/provider";
+import { ROUTE } from "../../routes/constants";
 import { useFetchAtlasSourceDataset } from "../AtlasSourceDatasetView/hooks/useFetchAtlasSourceDataset";
 import { VIEW_SOURCE_DATASET_VALIDATION_SECTION_CONFIGS } from "./common/config";
 import { getBreadcrumbs, getTabs } from "./common/utils";
@@ -30,7 +32,11 @@ export const AtlasSourceDatasetValidationView = ({
     access: { canView },
     isLoading,
   } = formManager;
-  const backPath = useBackPath(pathParameter);
+  // Deep-link fallback: source-dataset detail (not URL-trim, which would
+  // land on the validator-index route that server-redirects to "cap").
+  const backPath =
+    useBackPath(pathParameter) ??
+    getRouteURL(ROUTE.ATLAS_SOURCE_DATASET, pathParameter);
 
   if (isLoading) return <Fragment />;
 

--- a/app/views/AtlasSourceDatasetView/atlasSourceDatasetView.tsx
+++ b/app/views/AtlasSourceDatasetView/atlasSourceDatasetView.tsx
@@ -7,6 +7,7 @@ import { shouldRenderView } from "../../components/Detail/common/utils";
 import { Breadcrumbs } from "../../components/Detail/components/TrackerForm/components/Breadcrumbs/breadcrumbs";
 import { Tabs } from "../../components/Entity/components/common/Tabs/tabs";
 import { EntityForm } from "../../components/Entity/components/EntityForm/entityForm";
+import { useBackPath } from "../../components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook";
 import { DetailView } from "../../components/Layout/components/Detail/detailView";
 import { Payload } from "../../hooks/UseEditFileArchived/entities";
 import { useFetchAtlas } from "../../hooks/useFetchAtlas";
@@ -40,8 +41,12 @@ export const AtlasSourceDatasetView = ({
     isLoading,
   } = formManager;
   const { data: sourceDataset } = formMethod;
+  const backPath = useBackPath(pathParameter);
+
   if (isLoading) return <Fragment />;
+
   const accessFallback = renderAccessFallback(formManager);
+
   return (
     <EntityProvider pathParameter={pathParameter}>
       <ConditionalComponent
@@ -60,6 +65,7 @@ export const AtlasSourceDatasetView = ({
               />
             )
           }
+          backPath={backPath}
           breadcrumbs={
             <Breadcrumbs
               breadcrumbs={getBreadcrumbs(pathParameter, atlas)}

--- a/app/views/AtlasSourceDatasetsView/atlasSourceDatasetsView.tsx
+++ b/app/views/AtlasSourceDatasetsView/atlasSourceDatasetsView.tsx
@@ -8,6 +8,7 @@ import { shouldRenderView } from "../../components/Detail/common/utils";
 import { Tabs } from "../../components/Detail/components/ViewAtlas/components/Tabs/tabs";
 import { EntityView } from "../../components/Entity/components/EntityView/entityView";
 import { AtlasStatuses } from "../../components/Layout/components/Detail/components/DetailViewHero/components/AtlasStatuses/atlasStatuses";
+import { useBackPath } from "../../components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook";
 import { StyledDetailView } from "../../components/Layout/components/Detail/sticky/detailView.styles";
 import { useFetchAtlas } from "../../hooks/useFetchAtlas";
 import { FormManager } from "../../hooks/useFormManager/common/entities";
@@ -33,6 +34,7 @@ export const AtlasSourceDatasetsView = ({
   const { atlas } = useFetchAtlas(pathParameter);
   const { atlasSourceDatasets } = useFetchAtlasSourceDatasets(pathParameter);
   const { sourceStudies } = useFetchSourceStudies(pathParameter);
+  const backPath = useBackPath(pathParameter);
 
   if (isLoading) return <Fragment />;
 
@@ -46,6 +48,7 @@ export const AtlasSourceDatasetsView = ({
         isIn={shouldRenderView(canView, Boolean(atlas && atlasSourceDatasets))}
       >
         <StyledDetailView
+          backPath={backPath}
           breadcrumbs={
             <Breadcrumbs breadcrumbs={getBreadcrumbs(pathParameter, atlas)} />
           }

--- a/app/views/AtlasSourceDatasetsView/components/Table/columns.tsx
+++ b/app/views/AtlasSourceDatasetsView/components/Table/columns.tsx
@@ -5,6 +5,7 @@ import { CellContext, ColumnDef } from "@tanstack/react-table";
 import { getApiEntityFileVersion } from "../../../../apis/catalog/hca-atlas-tracker/common/utils";
 import { getRouteURL } from "../../../../common/utils";
 import * as C from "../../../../components";
+import { withBackOrigin } from "../../../../components/Layout/components/Detail/components/DetailViewHero/components/BackButton/utils";
 import { CAPIngestStatusCell } from "../../../../components/Table/components/TableCell/components/CAPIngestStatusCell/capIngestStatusCell";
 import { ROUTE } from "../../../../routes/constants";
 import { formatISOToUTCDateTime } from "../../../../utils/date-fns";
@@ -80,10 +81,13 @@ const COLUMN_FILE_NAME = {
   cell: ({ row }) =>
     C.Link({
       label: row.original.baseFileName,
-      url: getRouteURL(ROUTE.ATLAS_SOURCE_DATASET, {
-        atlasId: row.original.atlasId,
-        sourceDatasetId: row.original.id,
-      }),
+      url: withBackOrigin(
+        getRouteURL(ROUTE.ATLAS_SOURCE_DATASET, {
+          atlasId: row.original.atlasId,
+          sourceDatasetId: row.original.id,
+        }),
+        "ATLAS_SOURCE_DATASETS",
+      ),
     }),
   header: "File Name",
   id: "fileName",
@@ -146,10 +150,13 @@ const COLUMN_SOURCE_STUDY = {
     C.Link({
       label: row.original.publicationString || LABEL.UNSPECIFIED,
       url: row.original.sourceStudyId
-        ? getRouteURL(ROUTE.ATLAS_SOURCE_STUDY, {
-            atlasId: row.original.atlasId,
-            sourceStudyId: row.original.sourceStudyId,
-          })
+        ? withBackOrigin(
+            getRouteURL(ROUTE.ATLAS_SOURCE_STUDY, {
+              atlasId: row.original.atlasId,
+              sourceStudyId: row.original.sourceStudyId,
+            }),
+            "ATLAS_SOURCE_DATASETS",
+          )
         : "",
     }),
   header: "Source Study",

--- a/app/views/AtlasSourceDatasetsView/components/Table/viewBuilders.ts
+++ b/app/views/AtlasSourceDatasetsView/components/Table/viewBuilders.ts
@@ -72,6 +72,7 @@ export function renderSourceDatasetValidationStatus(
   const { id: sourceDatasetId } = row.original;
   return C.ValidationStatusCell({
     ...ctx,
+    backOrigin: "ATLAS_SOURCE_DATASETS",
     sourceDatasetId,
     validationRoute: ROUTE.ATLAS_SOURCE_DATASET_VALIDATION,
   });

--- a/app/views/ComponentAtlasView/componentAtlasView.tsx
+++ b/app/views/ComponentAtlasView/componentAtlasView.tsx
@@ -7,6 +7,7 @@ import { shouldRenderView } from "../../components/Detail/common/utils";
 import { Breadcrumbs } from "../../components/Detail/components/TrackerForm/components/Breadcrumbs/breadcrumbs";
 import { Tabs } from "../../components/Entity/components/common/Tabs/tabs";
 import { EntityForm } from "../../components/Entity/components/EntityForm/entityForm";
+import { useBackPath } from "../../components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook";
 import { DetailView } from "../../components/Layout/components/Detail/detailView";
 import { Payload } from "../../hooks/UseEditFileArchived/entities";
 import { useFetchAtlas } from "../../hooks/useFetchAtlas";
@@ -41,7 +42,10 @@ export const ComponentAtlasView = ({
     isLoading,
   } = formManager;
   const { data: componentAtlas } = formMethod;
+  const backPath = useBackPath(pathParameter);
+
   if (isLoading) return <Fragment />;
+
   return (
     <EntityProvider
       data={{ atlas, componentAtlas }}
@@ -65,6 +69,7 @@ export const ComponentAtlasView = ({
               />
             )
           }
+          backPath={backPath}
           breadcrumbs={
             <Breadcrumbs
               breadcrumbs={getBreadcrumbs(pathParameter, atlas)}

--- a/app/views/ComponentAtlasesView/componentAtlasesView.tsx
+++ b/app/views/ComponentAtlasesView/componentAtlasesView.tsx
@@ -7,6 +7,7 @@ import { shouldRenderView } from "../../components/Detail/common/utils";
 import { Tabs } from "../../components/Detail/components/ViewAtlas/components/Tabs/tabs";
 import { ViewComponentAtlases } from "../../components/Detail/components/ViewComponentAtlases/viewComponentAtlases";
 import { AtlasStatuses } from "../../components/Layout/components/Detail/components/DetailViewHero/components/AtlasStatuses/atlasStatuses";
+import { useBackPath } from "../../components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook";
 import { StyledDetailView } from "../../components/Layout/components/Detail/sticky/detailView.styles";
 import { useFetchAtlas } from "../../hooks/useFetchAtlas";
 import { useFormManager } from "../../hooks/useFormManager/useFormManager";
@@ -23,6 +24,7 @@ export const ComponentAtlasesView = ({
   const { atlas } = useFetchAtlas(pathParameter);
   const { componentAtlases } = useFetchComponentAtlases(pathParameter);
   const formManager = useFormManager();
+  const backPath = useBackPath(pathParameter);
   const {
     access: { canView },
   } = formManager;
@@ -36,6 +38,7 @@ export const ComponentAtlasesView = ({
         isIn={shouldRenderView(canView, Boolean(atlas && componentAtlases))}
       >
         <StyledDetailView
+          backPath={backPath}
           breadcrumbs={
             <Breadcrumbs breadcrumbs={getBreadcrumbs(pathParameter, atlas)} />
           }

--- a/app/views/IntegratedObjectValidationView/integratedObjectValidationView.tsx
+++ b/app/views/IntegratedObjectValidationView/integratedObjectValidationView.tsx
@@ -1,6 +1,7 @@
 import { ConditionalComponent } from "@databiosphere/findable-ui/lib/components/ComponentCreator/components/ConditionalComponent/conditionalComponent";
 import { Fragment, JSX } from "react";
 import { PathParameter } from "../../common/entities";
+import { getRouteURL } from "../../common/utils";
 import { AccessPrompt } from "../../components/common/Form/components/FormManager/components/AccessPrompt/accessPrompt";
 import { shouldRenderView } from "../../components/Detail/common/utils";
 import { Breadcrumbs } from "../../components/Detail/components/TrackerForm/components/Breadcrumbs/breadcrumbs";
@@ -12,6 +13,7 @@ import { useFetchAtlas } from "../../hooks/useFetchAtlas";
 import { FormManager } from "../../hooks/useFormManager/common/entities";
 import { useFormManager } from "../../hooks/useFormManager/useFormManager";
 import { EntityProvider } from "../../providers/entity/provider";
+import { ROUTE } from "../../routes/constants";
 import { useFetchComponentAtlas } from "../ComponentAtlasView/hooks/useFetchComponentAtlas";
 import { VIEW_INTEGRATED_OBJECT_VALIDATION_SECTION_CONFIGS } from "./common/config";
 import { getBreadcrumbs, getTabs } from "./common/utils";
@@ -30,7 +32,11 @@ export const IntegratedObjectValidationView = ({
     access: { canView },
     isLoading,
   } = formManager;
-  const backPath = useBackPath(pathParameter);
+  // Deep-link fallback: integrated-object detail (not URL-trim, which would
+  // land on the validator-index route that server-redirects to "cap").
+  const backPath =
+    useBackPath(pathParameter) ??
+    getRouteURL(ROUTE.COMPONENT_ATLAS, pathParameter);
 
   if (isLoading) return <Fragment />;
 

--- a/app/views/IntegratedObjectValidationView/integratedObjectValidationView.tsx
+++ b/app/views/IntegratedObjectValidationView/integratedObjectValidationView.tsx
@@ -1,19 +1,17 @@
 import { ConditionalComponent } from "@databiosphere/findable-ui/lib/components/ComponentCreator/components/ConditionalComponent/conditionalComponent";
-import { useRouter } from "next/router";
-import { Fragment, JSX, useRef } from "react";
+import { Fragment, JSX } from "react";
 import { PathParameter } from "../../common/entities";
-import { getRouteURL } from "../../common/utils";
 import { AccessPrompt } from "../../components/common/Form/components/FormManager/components/AccessPrompt/accessPrompt";
 import { shouldRenderView } from "../../components/Detail/common/utils";
 import { Breadcrumbs } from "../../components/Detail/components/TrackerForm/components/Breadcrumbs/breadcrumbs";
 import { Tabs } from "../../components/Entity/components/common/Tabs/tabs";
 import { EntityView } from "../../components/Entity/components/EntityView/entityView";
+import { useBackPath } from "../../components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook";
 import { DetailView } from "../../components/Layout/components/Detail/detailView";
 import { useFetchAtlas } from "../../hooks/useFetchAtlas";
 import { FormManager } from "../../hooks/useFormManager/common/entities";
 import { useFormManager } from "../../hooks/useFormManager/useFormManager";
 import { EntityProvider } from "../../providers/entity/provider";
-import { ROUTE } from "../../routes/constants";
 import { useFetchComponentAtlas } from "../ComponentAtlasView/hooks/useFetchComponentAtlas";
 import { VIEW_INTEGRATED_OBJECT_VALIDATION_SECTION_CONFIGS } from "./common/config";
 import { getBreadcrumbs, getTabs } from "./common/utils";
@@ -25,8 +23,6 @@ interface Props {
 export const IntegratedObjectValidationView = ({
   pathParameter,
 }: Props): JSX.Element => {
-  const { query } = useRouter();
-  const fromList = useRef(query.from === "list");
   const { atlas } = useFetchAtlas(pathParameter);
   const { componentAtlas } = useFetchComponentAtlas(pathParameter);
   const formManager = useFormManager();
@@ -34,10 +30,10 @@ export const IntegratedObjectValidationView = ({
     access: { canView },
     isLoading,
   } = formManager;
-  const backPath = fromList.current
-    ? getRouteURL(ROUTE.COMPONENT_ATLASES, pathParameter)
-    : getRouteURL(ROUTE.COMPONENT_ATLAS, pathParameter);
+  const backPath = useBackPath(pathParameter);
+
   if (isLoading) return <Fragment />;
+
   return (
     <EntityProvider data={{ componentAtlas }} pathParameter={pathParameter}>
       <ConditionalComponent

--- a/app/views/SourceStudiesView/sourceStudiesView.tsx
+++ b/app/views/SourceStudiesView/sourceStudiesView.tsx
@@ -7,6 +7,7 @@ import { shouldRenderView } from "../../components/Detail/common/utils";
 import { Tabs } from "../../components/Detail/components/ViewAtlas/components/Tabs/tabs";
 import { ViewSourceStudies } from "../../components/Detail/components/ViewSourceStudies/viewSourceStudies";
 import { AtlasStatuses } from "../../components/Layout/components/Detail/components/DetailViewHero/components/AtlasStatuses/atlasStatuses";
+import { useBackPath } from "../../components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook";
 import { StyledDetailView } from "../../components/Layout/components/Detail/sticky/detailView.styles";
 import { useFetchAtlas } from "../../hooks/useFetchAtlas";
 import { useFetchSourceStudiesSourceDatasets } from "../../hooks/useFetchSourceStudiesSourceDatasets";
@@ -28,6 +29,7 @@ export const SourceStudiesView = ({
   const sourceStudiesSourceDatasets =
     useFetchSourceStudiesSourceDatasets(pathParameter);
   const formManager = useFormManager();
+  const backPath = useBackPath(pathParameter);
   const {
     access: { canView },
   } = formManager;
@@ -36,6 +38,7 @@ export const SourceStudiesView = ({
       isIn={shouldRenderView(canView, Boolean(atlas && sourceStudies))}
     >
       <StyledDetailView
+        backPath={backPath}
         breadcrumbs={
           <Breadcrumbs breadcrumbs={getBreadcrumbs(pathParameter, atlas)} />
         }

--- a/app/views/SourceStudyView/sourceStudyView.tsx
+++ b/app/views/SourceStudyView/sourceStudyView.tsx
@@ -7,6 +7,7 @@ import { Breadcrumbs } from "../../components/Detail/components/TrackerForm/comp
 import { Actions } from "../../components/Detail/components/ViewSourceStudy/components/Actions/actions";
 import { Tabs } from "../../components/Detail/components/ViewSourceStudy/components/Tabs/tabs";
 import { ViewSourceStudy } from "../../components/Detail/components/ViewSourceStudy/viewSourceStudy";
+import { useBackPath } from "../../components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook";
 import { DetailView } from "../../components/Layout/components/Detail/detailView";
 import { useFetchAtlas } from "../../hooks/useFetchAtlas";
 import { getBreadcrumbs } from "./common/utils";
@@ -23,6 +24,7 @@ export const SourceStudyView = ({
   const { atlas } = useFetchAtlas(pathParameter);
   const formMethod = useEditSourceStudyForm(pathParameter);
   const formManager = useEditSourceStudyFormManager(pathParameter, formMethod);
+  const backPath = useBackPath(pathParameter);
   const {
     access: { canEdit, canView },
     formAction,
@@ -30,7 +32,9 @@ export const SourceStudyView = ({
     isLoading,
   } = formManager;
   const { data: sourceStudy } = formMethod;
+
   if (isLoading) return <Fragment />;
+
   return (
     <ConditionalComponent
       isIn={shouldRenderView(canView, Boolean(atlas && sourceStudy))}
@@ -39,6 +43,7 @@ export const SourceStudyView = ({
         actions={
           canEdit && <Actions isDirty={isDirty} pathParameter={pathParameter} />
         }
+        backPath={backPath}
         breadcrumbs={
           <Breadcrumbs
             breadcrumbs={getBreadcrumbs(pathParameter, atlas)}


### PR DESCRIPTION
## Summary

Fixes the back arrow on source-dataset, integrated-object, and source-study detail pages (plus their validation views) so it returns to the originating list — global or atlas-scoped — instead of falling through to a URL-segment trim that often landed users in the wrong place.

## Mechanism

- Row links to detail pages now carry a `?from=<ROUTE_KEY>` query (the ROUTE key naming the originating list).
- New `useBackPath(pathParameter)` hook snapshots `query.from` via `useRef` at first render (so a tab switch within the detail view doesn't repoint the back arrow), then resolves the back path by looking up `ROUTE[origin]` and substituting the current `pathParameter`.
- Five detail views + three atlas-scoped list views adopt the hook and pass `backPath` into `<DetailView>` / `<StyledDetailView>`.
- `ValidationStatusCell` + `ValidationSummary` gain a `backOrigin: BackOrigin` prop so the same cell rendered in atlas-scoped vs global lists emits the right `from` query. This migrates away from the old hardcoded `from=list` introduced in #1206.

## Origin vocabulary

`BackOrigin = keyof typeof ROUTE` (aliased from the existing `RouteKey` type). Origins used:

- `ATLASES` — `/atlases` count cells (source-datasets / integrated-objects / source-studies columns)
- `SOURCE_DATASETS`, `SOURCE_STUDIES`, `INTEGRATED_OBJECTS` — top-nav global lists
- `ATLAS_SOURCE_DATASETS`, `ATLAS_SOURCE_STUDIES`, `COMPONENT_ATLASES` — atlas-scoped lists
- `METADATA_ENTRY_SHEETS` — source-study links from the metadata-entry-sheets table
- `REPORTS` — source-study links from the reports task table

## Resolution

`resolveBackPath` calls `getRouteURL(ROUTE[origin], pathParameter)` inside a try/catch — unsatisfiable origin (e.g. a sub-list route whose dynamic segments aren't in the destination detail page's `pathParameter`) falls through to `undefined`, letting `BackButton`'s existing URL-segment trim run. So deep links / direct URL entries behave exactly as before this PR.

## Sub-lists deliberately untouched

`IntegratedObjectSourceDatasetsView` and `ATLAS_SOURCE_STUDY_SOURCE_DATASETS` row links aren't wrapped — their natural origin route includes `[componentAtlasId]` / `[sourceStudyId]` not present in the source-dataset detail page's `pathParameter`. Behaviour matches `main` (URL-trim fallback). Filed as future work if needed.

## Tests

Two new test files, **19 tests, all pass**:

- `__tests__/back-button-utils.test.ts` — 14 pure-function assertions covering `parseBackOrigin`, `resolveBackPath` (including the unsatisfiable-segment catch case), and `withBackOrigin`.
- `__tests__/use-back-path.test.ts` — 5 hook tests with mocked `next/router`, including the snapshot-stability case (proves `useRef` lock survives a `query.from` change mid-lifecycle).

## Test plan

See [test plan in the conversation](https://github.com/clevercanary/hca-atlas-tracker/issues/1299) — 17 manual scenarios covering each origin × detail view, validation views, tab persistence, deep-link fallback, and edge cases (unknown `from`, browser back/forward).

Headline checks:
- [x] From `/source-datasets` → row → back arrow returns to `/source-datasets`
- [x] From `/atlases/X/source-datasets` → row → back arrow returns to `/atlases/X/source-datasets`
- [x] From `/atlases` → count cell → back arrow returns to `/atlases`
- [x] From `/reports` → source-study link → back arrow returns to `/reports`
- [x] From an atlas metadata-entry-sheets table → source-study link → back arrow returns to that table
- [x] Tab switch on a detail page doesn't change where the back arrow points
- [x] Deep-linked URL with no `from` → back arrow behaves as it did on `main`

Closes #1299

🤖 Generated with [Claude Code](https://claude.com/claude-code)