### PR TITLE
feat: save metadata coverage from file validation results (#1273)

### DIFF
--- a/__tests__/api-sns-with-validation-results.test.ts
+++ b/__tests__/api-sns-with-validation-results.test.ts
@@ -34,6 +34,8 @@ import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
 import { Readable } from "stream";
 import {
+  DatasetValidatorMetadataCoverage,
+  DatasetValidatorMetadataCoverageEntity,
   DatasetValidatorResults,
   DatasetValidatorResultsMetadata,
   DatasetValidatorToolReports,
@@ -346,19 +348,19 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
     });
 
     // Verify the file still has the first validation results (not overwritten)
-    await expectDbFileValidationFieldsToMatch(
-      FILE_SOURCE_DATASET_BAR.id,
-      firstValidationTime,
-      INTEGRITY_STATUS.VALID,
-      firstMetadata,
-      {
+    await expectDbFileValidationFieldsToMatch({
+      datasetInfo: firstMetadata,
+      fileId: FILE_SOURCE_DATASET_BAR.id,
+      integrityStatus: INTEGRITY_STATUS.VALID,
+      validationInfo: {
         batchJobId: firstBatchJobId,
         snsMessageId: firstSnsMessageId,
         snsMessageTime: firstSnsMessageTime,
       },
-      firstToolReports,
-      firstExpectedValidationSummary,
-    );
+      validationReports: firstToolReports,
+      validationSummary: firstExpectedValidationSummary,
+      validationTime: firstValidationTime,
+    });
   });
 
   it("successfully saves validation results for dataset file", async () => {
@@ -375,6 +377,43 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
       tissue: ["tissue-dataset-successful"],
       title: "Dataset Successful",
     };
+    const metadataCoverage = makeTestMetadataCoverage([
+      {
+        complete: 0,
+        entity_class: "sample",
+        field: "foo",
+        inconsistent: 6,
+        missing: 8,
+      },
+      {
+        complete: 12,
+        entity_class: "dataset",
+        field: "foo",
+        inconsistent: 0,
+        missing: 0,
+      },
+      {
+        complete: 0,
+        entity_class: "obs",
+        field: "bar",
+        inconsistent: 14,
+        missing: 0,
+      },
+      {
+        complete: 10,
+        entity_class: "donor",
+        field: "baz",
+        inconsistent: 0,
+        missing: 5,
+      },
+      {
+        complete: 2,
+        entity_class: "dataset",
+        field: "foobar",
+        inconsistent: 5,
+        missing: 5,
+      },
+    ]);
     const toolReports: DatasetValidatorToolReports = {
       cap: {
         errors: ["Error dataset successful CAP"],
@@ -423,6 +462,7 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
         FILE_SOURCE_DATASET_FOO.resolvedAtlas,
       ),
       metadata,
+      metadataCoverage,
       timestamp: validationTime,
       toolReports,
     });
@@ -435,19 +475,20 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
 
     expect((await doSnsRequest(snsMessage, true)).statusCode).toEqual(200);
 
-    await expectDbFileValidationFieldsToMatch(
-      FILE_SOURCE_DATASET_FOO.id,
-      validationTime,
-      INTEGRITY_STATUS.VALID,
-      metadata,
-      {
+    await expectDbFileValidationFieldsToMatch({
+      datasetInfo: metadata,
+      fileId: FILE_SOURCE_DATASET_FOO.id,
+      integrityStatus: INTEGRITY_STATUS.VALID,
+      metadataCoverage,
+      validationInfo: {
         batchJobId,
         snsMessageId,
         snsMessageTime,
       },
-      toolReports,
-      expectedValidationSummary,
-    );
+      validationReports: toolReports,
+      validationSummary: expectedValidationSummary,
+      validationTime,
+    });
   });
 
   it("successfully saves validation results for integrated object file", async () => {
@@ -468,6 +509,36 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
       ],
       title: "Integrated Object Successful",
     };
+    const metadataCoverage = makeTestMetadataCoverage([
+      {
+        complete: 1,
+        entity_class: "donor",
+        field: "bar",
+        inconsistent: 4,
+        missing: 6,
+      },
+      {
+        complete: 6,
+        entity_class: "sample",
+        field: "foobaz",
+        inconsistent: 0,
+        missing: 3,
+      },
+      {
+        complete: 7,
+        entity_class: "sample",
+        field: "baz",
+        inconsistent: 2,
+        missing: 0,
+      },
+      {
+        complete: 0,
+        entity_class: "obs",
+        field: "baz",
+        inconsistent: 0,
+        missing: 8,
+      },
+    ]);
     const toolReports: DatasetValidatorToolReports = {
       cap: {
         errors: ["Error IO successful CAP"],
@@ -516,6 +587,7 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
         FILE_COMPONENT_ATLAS_DRAFT_FOO.atlas(),
       ),
       metadata,
+      metadataCoverage,
       timestamp: validationTime,
       toolReports,
     });
@@ -528,19 +600,119 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
 
     expect((await doSnsRequest(snsMessage, true)).statusCode).toEqual(200);
 
-    await expectDbFileValidationFieldsToMatch(
-      FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
-      validationTime,
-      INTEGRITY_STATUS.VALID,
-      metadata,
-      {
+    await expectDbFileValidationFieldsToMatch({
+      datasetInfo: metadata,
+      fileId: FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
+      integrityStatus: INTEGRITY_STATUS.VALID,
+      metadataCoverage,
+      validationInfo: {
         batchJobId,
         snsMessageId,
         snsMessageTime,
       },
+      validationReports: toolReports,
+      validationSummary: expectedValidationSummary,
+      validationTime,
+    });
+  });
+
+  it("successfully saves validation results without metadata coverage", async () => {
+    const snsMessageId = "sns-message-no-metadata-coverage";
+    const snsMessageTime = "2026-05-30T03:00:04.483Z";
+    const batchJobId = "batch-job-no-metadata-coverage";
+    const validationTime = "2026-05-30T02:59:55.978Z";
+    const metadata: Required<HCAAtlasTrackerDBFileDatasetInfo> = {
+      assay: [
+        "assay-no-metadata-coverage-a",
+        "assay-no-metadata-coverage-b",
+        "disease-no-metadata-coverage-c",
+      ],
+      cellCount: 12356,
+      disease: ["disease-no-metadata-coverage"],
+      geneCount: 34462,
+      suspensionType: ["suspension-type-no-metadata-coverage"],
+      tissue: [
+        "tissue-no-metadata-coverage-a",
+        "tissue-no-metadata-coverage-b",
+      ],
+      title: "No Metadata Coverage",
+    };
+    const toolReports: DatasetValidatorToolReports = {
+      cap: {
+        errors: [],
+        finished_at: validationTime,
+        started_at: validationTime,
+        valid: true,
+        warnings: ["Warning no metadata coverage CAP"],
+      },
+      cellxgene: {
+        errors: ["Error no metadata coverage CxG"],
+        finished_at: validationTime,
+        started_at: validationTime,
+        valid: false,
+        warnings: [],
+      },
+      hcaCellAnnotation: {
+        errors: [],
+        finished_at: validationTime,
+        started_at: validationTime,
+        valid: true,
+        warnings: [],
+      },
+      hcaSchema: {
+        errors: [
+          "Error A no metadata coverage HCA",
+          "Error B no metadata coverage HCA",
+        ],
+        finished_at: validationTime,
+        started_at: validationTime,
+        valid: false,
+        warnings: [],
+      },
+    };
+    const expectedValidationSummary: FileValidationSummary = {
+      overallValid: false,
+      validators: {
+        cap: { errorCount: 0, valid: true, warningCount: 1 },
+        cellxgene: { errorCount: 1, valid: false, warningCount: 0 },
+        hcaCellAnnotation: { errorCount: 0, valid: true, warningCount: 0 },
+        hcaSchema: { errorCount: 2, valid: false, warningCount: 0 },
+      },
+    };
+    const validationMetadata = initValidationResults({
+      batchJobId,
+      fileId: FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
+      integrityStatus: INTEGRITY_STATUS.VALID,
+      key: getTestFileKey(
+        FILE_COMPONENT_ATLAS_DRAFT_FOO,
+        FILE_COMPONENT_ATLAS_DRAFT_FOO.atlas(),
+      ),
+      metadata,
+      timestamp: validationTime,
       toolReports,
-      expectedValidationSummary,
-    );
+    });
+    const snsMessage = createSNSMessage({
+      message: validationMetadata,
+      messageId: snsMessageId,
+      timestamp: snsMessageTime,
+      topicArn: TEST_SNS_TOPIC_VALIDATION_RESULTS,
+    });
+
+    expect((await doSnsRequest(snsMessage, true)).statusCode).toEqual(200);
+
+    await expectDbFileValidationFieldsToMatch({
+      datasetInfo: metadata,
+      fileId: FILE_COMPONENT_ATLAS_DRAFT_FOO.id,
+      integrityStatus: INTEGRITY_STATUS.VALID,
+      validationInfo: {
+        batchJobId,
+        snsMessageId,
+        snsMessageTime,
+      },
+      validationReports: toolReports,
+      validationSummary: expectedValidationSummary,
+      validationTime,
+    });
   });
 
   it("successfully saves validation results when timestamp has a timezone offset", async () => {
@@ -618,19 +790,19 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
 
     expect((await doSnsRequest(snsMessage, true)).statusCode).toEqual(200);
 
-    await expectDbFileValidationFieldsToMatch(
-      FILE_SOURCE_DATASET_FOO.id,
-      validationTimeUtc,
-      INTEGRITY_STATUS.VALID,
-      metadata,
-      {
+    await expectDbFileValidationFieldsToMatch({
+      datasetInfo: metadata,
+      fileId: FILE_SOURCE_DATASET_FOO.id,
+      integrityStatus: INTEGRITY_STATUS.VALID,
+      validationInfo: {
         batchJobId,
         snsMessageId,
         snsMessageTime,
       },
-      toolReports,
-      expectedValidationSummary,
-    );
+      validationReports: toolReports,
+      validationSummary: expectedValidationSummary,
+      validationTime: validationTimeUtc,
+    });
   });
 
   it("successfully saves validation results from duplicate notification", async () => {
@@ -672,37 +844,37 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
 
     expect((await doSnsRequest(snsMessage, true)).statusCode).toEqual(200);
 
-    await expectDbFileValidationFieldsToMatch(
-      FILE_SOURCE_DATASET_BAZ.id,
-      validationTime,
-      INTEGRITY_STATUS.VALID,
-      metadata,
-      {
+    await expectDbFileValidationFieldsToMatch({
+      datasetInfo: metadata,
+      fileId: FILE_SOURCE_DATASET_BAZ.id,
+      integrityStatus: INTEGRITY_STATUS.VALID,
+      validationInfo: {
         batchJobId,
         snsMessageId,
         snsMessageTime,
       },
-      SUCCESSFUL_TOOL_REPORTS,
-      SUCCESSFUL_VALIDATION_SUMMARY,
-    );
+      validationReports: SUCCESSFUL_TOOL_REPORTS,
+      validationSummary: SUCCESSFUL_VALIDATION_SUMMARY,
+      validationTime,
+    });
 
     // Expect second, duplicate request to be successful
 
     expect((await doSnsRequest(snsMessage, true)).statusCode).toEqual(200);
 
-    await expectDbFileValidationFieldsToMatch(
-      FILE_SOURCE_DATASET_BAZ.id,
-      validationTime,
-      INTEGRITY_STATUS.VALID,
-      metadata,
-      {
+    await expectDbFileValidationFieldsToMatch({
+      datasetInfo: metadata,
+      fileId: FILE_SOURCE_DATASET_BAZ.id,
+      integrityStatus: INTEGRITY_STATUS.VALID,
+      validationInfo: {
         batchJobId,
         snsMessageId,
         snsMessageTime,
       },
-      SUCCESSFUL_TOOL_REPORTS,
-      SUCCESSFUL_VALIDATION_SUMMARY,
-    );
+      validationReports: SUCCESSFUL_TOOL_REPORTS,
+      validationSummary: SUCCESSFUL_VALIDATION_SUMMARY,
+      validationTime,
+    });
   });
 
   it.each([
@@ -869,19 +1041,19 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
       expect((await doSnsRequest(snsMessage, true)).statusCode).toEqual(200);
 
       // S3 data should be persisted, not inline data.
-      await expectDbFileValidationFieldsToMatch(
-        FILE_SOURCE_DATASET_FOOBAR.id,
-        validationTime,
-        INTEGRITY_STATUS.VALID,
-        s3Metadata,
-        {
+      await expectDbFileValidationFieldsToMatch({
+        datasetInfo: s3Metadata,
+        fileId: FILE_SOURCE_DATASET_FOOBAR.id,
+        integrityStatus: INTEGRITY_STATUS.VALID,
+        validationInfo: {
           batchJobId,
           snsMessageId,
           snsMessageTime,
         },
-        s3ToolReports,
-        s3ExpectedSummary,
-      );
+        validationReports: s3ToolReports,
+        validationSummary: s3ExpectedSummary,
+        validationTime,
+      });
 
       const expectedKey = `validation-metadata/${FILE_SOURCE_DATASET_FOOBAR.id}/${batchJobId}.json`;
       const getCalls = s3Mock.commandCalls(GetObjectCommand);
@@ -1348,4 +1520,34 @@ async function doSnsRequest(
     consoleMessageOutputArrays,
   );
   return res;
+}
+
+function makeTestMetadataCoverage(
+  fieldCoverage: DatasetValidatorMetadataCoverage["field_coverage"],
+): DatasetValidatorMetadataCoverage {
+  const entities: DatasetValidatorMetadataCoverage["entities"] = {
+    dataset: getEntityInfo("dataset"),
+    donor: getEntityInfo("donor"),
+    obs: getEntityInfo("obs"),
+    sample: getEntityInfo("sample"),
+  };
+  return {
+    entities,
+    field_coverage: fieldCoverage,
+    schema_name: "Test",
+    schema_version: "1.0-test",
+  };
+
+  function getEntityInfo(
+    entityType: keyof DatasetValidatorMetadataCoverage["entities"],
+  ): DatasetValidatorMetadataCoverageEntity {
+    // Find an arbitrary field for the specified entity type, which can be used to determine the total record count
+    const fieldInfo = fieldCoverage.find((f) => f.entity_class === entityType);
+    return {
+      record_count:
+        fieldInfo === undefined
+          ? 0
+          : fieldInfo.complete + fieldInfo.inconsistent + fieldInfo.missing,
+    };
+  }
 }

--- a/__tests__/api-sns-with-validation-results.test.ts
+++ b/__tests__/api-sns-with-validation-results.test.ts
@@ -616,6 +616,55 @@ describe(`${TEST_ROUTE} (validation results)`, () => {
     });
   });
 
+  it("successfully saves validation results representing an integrity failure", async () => {
+    const snsMessageId = "sns-message-integrity-failure";
+    const snsMessageTime = "2025-09-14T00:05:36.672Z";
+    const batchJobId = "batch-job-integrity-failure";
+    const validationTime = "2025-09-13T22:58:03.314Z";
+    const errorMessage = "File integrity verification failed";
+    const validationMetadata = initValidationResults({
+      batchJobId,
+      errorMessage,
+      fileId: FILE_SOURCE_DATASET_FOO.id,
+      integrityStatus: INTEGRITY_STATUS.INVALID,
+      key: getTestFileKey(
+        FILE_SOURCE_DATASET_FOO,
+        FILE_SOURCE_DATASET_FOO.resolvedAtlas,
+      ),
+      metadata: null,
+      metadataCoverage: null,
+      sha256: "test-sha256-a",
+      sourceSha256: "test-sha256-b",
+      status: "failure",
+      timestamp: validationTime,
+      toolReports: null,
+    });
+    const snsMessage = createSNSMessage({
+      message: validationMetadata,
+      messageId: snsMessageId,
+      timestamp: snsMessageTime,
+      topicArn: TEST_SNS_TOPIC_VALIDATION_RESULTS,
+    });
+
+    expect((await doSnsRequest(snsMessage, true)).statusCode).toEqual(200);
+
+    await expectDbFileValidationFieldsToMatch({
+      datasetInfo: null,
+      fileId: FILE_SOURCE_DATASET_FOO.id,
+      integrityStatus: INTEGRITY_STATUS.INVALID,
+      metadataCoverage: null,
+      validationInfo: {
+        batchJobId,
+        errorMessage,
+        snsMessageId,
+        snsMessageTime,
+      },
+      validationReports: null,
+      validationSummary: null,
+      validationTime,
+    });
+  });
+
   it("successfully saves validation results without metadata coverage", async () => {
     const snsMessageId = "sns-message-no-metadata-coverage";
     const snsMessageTime = "2026-05-30T03:00:04.483Z";

--- a/__tests__/api-sns-with-validation-results.test.ts
+++ b/__tests__/api-sns-with-validation-results.test.ts
@@ -1534,7 +1534,7 @@ function makeTestMetadataCoverage(
   return {
     entities,
     field_coverage: fieldCoverage,
-    schema_name: "Test",
+    schema_name: "test",
     schema_version: "1.0-test",
   };
 

--- a/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
+++ b/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
@@ -145,6 +145,9 @@ export type S3EventRecord = InferType<typeof s3RecordSchema>;
 export type S3Event = InferType<typeof s3EventSchema>;
 export type SNSMessage = InferType<typeof snsMessageSchema>;
 
+export type DatasetValidatorMetadataCoverage = InferType<
+  typeof datasetValidatorMetadataCoverageSchema
+>;
 export type DatasetValidatorToolReport = InferType<
   typeof datasetValidatorToolReportSchema
 >;

--- a/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
+++ b/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
@@ -70,7 +70,7 @@ const datasetValidatorMetadataCoverageSchema = object({
         complete: number().integer().required(),
         entity_class: string()
           .required()
-          .oneOf(["dataset", "donor", "obs", "sample"]),
+          .oneOf(["dataset", "donor", "obs", "sample"] as const),
         field: string().required(),
         inconsistent: number().integer().required(),
         missing: number().integer().required(),
@@ -145,6 +145,9 @@ export type S3EventRecord = InferType<typeof s3RecordSchema>;
 export type S3Event = InferType<typeof s3EventSchema>;
 export type SNSMessage = InferType<typeof snsMessageSchema>;
 
+export type DatasetValidatorMetadataCoverageEntity = InferType<
+  typeof datasetValidatorMetadataCoverageEntitySchema
+>;
 export type DatasetValidatorMetadataCoverage = InferType<
   typeof datasetValidatorMetadataCoverageSchema
 >;

--- a/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
+++ b/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
@@ -120,7 +120,9 @@ export const datasetValidatorResultsSchema =
         .oneOf(Object.values(INTEGRITY_STATUS))
         .defined()
         .nullable(),
-      metadata_coverage: datasetValidatorMetadataCoverageSchema.optional(),
+      metadata_coverage: datasetValidatorMetadataCoverageSchema
+        .nullable()
+        .optional(),
       metadata_summary: object({
         assay: array(string().required()).required(),
         cell_count: number().required(),

--- a/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
+++ b/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
@@ -53,6 +53,34 @@ export const snsMessageSchema = object({
 // Dataset validator results schemas
 // Validates the structure of validation results received via SNS notification
 
+const datasetValidatorMetadataCoverageEntitySchema = object({
+  record_count: number().integer().required(),
+});
+
+const datasetValidatorMetadataCoverageSchema = object({
+  entities: object({
+    dataset: datasetValidatorMetadataCoverageEntitySchema.required(),
+    donor: datasetValidatorMetadataCoverageEntitySchema.required(),
+    obs: datasetValidatorMetadataCoverageEntitySchema.required(),
+    sample: datasetValidatorMetadataCoverageEntitySchema.required(),
+  }).required(),
+  field_coverage: array()
+    .of(
+      object({
+        complete: number().integer().required(),
+        entity_class: string()
+          .required()
+          .oneOf(["dataset", "donor", "obs", "sample"]),
+        field: string().required(),
+        inconsistent: number().integer().required(),
+        missing: number().integer().required(),
+      }),
+    )
+    .required(),
+  schema_name: string().required(),
+  schema_version: string().required(),
+});
+
 const datasetValidatorToolReportSchema = object({
   errors: array(string().required()).required(),
   finished_at: string().required(),
@@ -91,6 +119,7 @@ export const datasetValidatorResultsSchema =
         .oneOf(Object.values(INTEGRITY_STATUS))
         .defined()
         .nullable(),
+      metadata_coverage: datasetValidatorMetadataCoverageSchema.optional(),
       metadata_summary: object({
         assay: array(string().required()).required(),
         cell_count: number().required(),

--- a/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
+++ b/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
@@ -1,4 +1,5 @@
 import { array, boolean, InferType, number, object, string } from "yup";
+import { FILE_METADATA_COVERAGE_ENTITY_TYPES } from "../common/constants";
 import { INTEGRITY_STATUS } from "../common/entities";
 
 // AWS S3 and SNS Event Validation Schemas
@@ -70,7 +71,7 @@ const datasetValidatorMetadataCoverageSchema = object({
         complete: number().integer().required(),
         entity_class: string()
           .required()
-          .oneOf(["dataset", "donor", "obs", "sample"] as const),
+          .oneOf(FILE_METADATA_COVERAGE_ENTITY_TYPES),
         field: string().required(),
         inconsistent: number().integer().required(),
         missing: number().integer().required(),

--- a/app/apis/catalog/hca-atlas-tracker/common/constants.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/constants.ts
@@ -213,6 +213,13 @@ export const FILE_VALIDATOR_NAMES = [
   "hcaCellAnnotation",
 ] as const;
 
+export const FILE_METADATA_COVERAGE_ENTITY_TYPES = [
+  "dataset",
+  "donor",
+  "obs",
+  "sample",
+] as const;
+
 export const FILE_VALIDATOR_NAME_LABEL: Record<FileValidatorName, string> = {
   cap: "CAP Upload",
   cellxgene: "CELLxGENE",

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -3,6 +3,7 @@ import {
   EntrySheetValidationSummary,
   GoogleLastUpdateInfo,
 } from "../../../../utils/hca-validation-tools/hca-validation-tools";
+import { DatasetValidatorMetadataCoverage } from "../aws/schemas";
 import { API } from "./api";
 import { FILE_VALIDATOR_NAMES, NETWORK_KEYS, WAVES } from "./constants";
 
@@ -530,6 +531,7 @@ export interface HCAAtlasTrackerDBFile {
   is_archived: boolean;
   is_latest: boolean;
   key: string;
+  metadata_coverage: DatasetValidatorMetadataCoverage | null;
   sha256_client: string | null;
   sha256_server: string | null;
   size_bytes: string;

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -3,7 +3,6 @@ import {
   EntrySheetValidationSummary,
   GoogleLastUpdateInfo,
 } from "../../../../utils/hca-validation-tools/hca-validation-tools";
-import { DatasetValidatorMetadataCoverage } from "../aws/schemas";
 import { API } from "./api";
 import { FILE_VALIDATOR_NAMES, NETWORK_KEYS, WAVES } from "./constants";
 
@@ -531,7 +530,7 @@ export interface HCAAtlasTrackerDBFile {
   is_archived: boolean;
   is_latest: boolean;
   key: string;
-  metadata_coverage: DatasetValidatorMetadataCoverage | null;
+  metadata_coverage: FileMetadataCoverage | null;
   sha256_client: string | null;
   sha256_server: string | null;
   size_bytes: string;
@@ -786,6 +785,30 @@ export enum TIER_ONE_METADATA_STATUS {
 export interface FileEventInfo {
   eventName: string;
   eventTime: string;
+}
+
+export interface FileMetadataCoverage {
+  entities: {
+    dataset: FileMetadataCoverageEntity;
+    donor: FileMetadataCoverageEntity;
+    obs: FileMetadataCoverageEntity;
+    sample: FileMetadataCoverageEntity;
+  };
+  fieldCoverage: FileMetadataFieldCoverage[];
+  schemaName: string;
+  schemaVersion: string;
+}
+
+export interface FileMetadataCoverageEntity {
+  recordCount: number;
+}
+
+export interface FileMetadataFieldCoverage {
+  complete: number;
+  entityClass: "dataset" | "donor" | "obs" | "sample";
+  field: string;
+  inconsistent: number;
+  missing: number;
 }
 
 export type FileValidationReports = Partial<

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -4,7 +4,12 @@ import {
   GoogleLastUpdateInfo,
 } from "../../../../utils/hca-validation-tools/hca-validation-tools";
 import { API } from "./api";
-import { FILE_VALIDATOR_NAMES, NETWORK_KEYS, WAVES } from "./constants";
+import {
+  FILE_METADATA_COVERAGE_ENTITY_TYPES,
+  FILE_VALIDATOR_NAMES,
+  NETWORK_KEYS,
+  WAVES,
+} from "./constants";
 
 export type APIKey = keyof typeof API;
 export type APIValue = (typeof API)[APIKey];
@@ -787,13 +792,11 @@ export interface FileEventInfo {
   eventTime: string;
 }
 
+export type FileMetadataCoverageEntityType =
+  (typeof FILE_METADATA_COVERAGE_ENTITY_TYPES)[number];
+
 export interface FileMetadataCoverage {
-  entities: {
-    dataset: FileMetadataCoverageEntity;
-    donor: FileMetadataCoverageEntity;
-    obs: FileMetadataCoverageEntity;
-    sample: FileMetadataCoverageEntity;
-  };
+  entities: Record<FileMetadataCoverageEntityType, FileMetadataCoverageEntity>;
   fieldCoverage: FileMetadataFieldCoverage[];
   schemaName: string;
   schemaVersion: string;
@@ -805,7 +808,7 @@ export interface FileMetadataCoverageEntity {
 
 export interface FileMetadataFieldCoverage {
   complete: number;
-  entityClass: "dataset" | "donor" | "obs" | "sample";
+  entityClass: FileMetadataCoverageEntityType;
   field: string;
   inconsistent: number;
   missing: number;

--- a/app/data/files.ts
+++ b/app/data/files.ts
@@ -1,9 +1,9 @@
 import pg from "pg";
 import { ETagMismatchError } from "../apis/catalog/hca-atlas-tracker/aws/errors";
-import { DatasetValidatorMetadataCoverage } from "../apis/catalog/hca-atlas-tracker/aws/schemas";
 import {
   FILE_TYPE,
   FILE_VALIDATION_STATUS,
+  FileMetadataCoverage,
   FileValidationReports,
   FileValidationSummary,
   HCAAtlasTrackerDBComponentAtlas,
@@ -506,7 +506,7 @@ export interface AddValidationResultsToFileParams {
   datasetInfo: HCAAtlasTrackerDBFileDatasetInfo | null;
   fileId: string;
   integrityStatus: INTEGRITY_STATUS;
-  metadataCoverage: DatasetValidatorMetadataCoverage | null;
+  metadataCoverage: FileMetadataCoverage | null;
   validatedAt: Date;
   validationInfo: HCAAtlasTrackerDBFileValidationInfo;
   validationReports: FileValidationReports | null;

--- a/app/data/files.ts
+++ b/app/data/files.ts
@@ -554,10 +554,10 @@ export async function addValidationResultsToFile(
         validation_status = $5,
         validation_reports = $6,
         validation_summary = $7,
-        metadata_coverage = $10
+        metadata_coverage = $8
       -- To avoid saving results for a message that has already been received,
       -- don't update a file record if its existing SNS message ID is the same as the new one
-      WHERE id = $8 AND validation_info->>'snsMessageId' IS DISTINCT FROM $9
+      WHERE id = $9 AND validation_info->>'snsMessageId' IS DISTINCT FROM $10
     `,
     [
       integrityStatus,
@@ -567,9 +567,9 @@ export async function addValidationResultsToFile(
       validationStatus,
       JSON.stringify(validationReports),
       JSON.stringify(validationSummary),
+      JSON.stringify(metadataCoverage),
       fileId,
       validationInfo.snsMessageId,
-      JSON.stringify(metadataCoverage),
     ],
   );
 }

--- a/app/data/files.ts
+++ b/app/data/files.ts
@@ -569,7 +569,7 @@ export async function addValidationResultsToFile(
       JSON.stringify(validationSummary),
       fileId,
       validationInfo.snsMessageId,
-      metadataCoverage,
+      JSON.stringify(metadataCoverage),
     ],
   );
 }

--- a/app/data/files.ts
+++ b/app/data/files.ts
@@ -1,5 +1,6 @@
 import pg from "pg";
 import { ETagMismatchError } from "../apis/catalog/hca-atlas-tracker/aws/errors";
+import { DatasetValidatorMetadataCoverage } from "../apis/catalog/hca-atlas-tracker/aws/schemas";
 import {
   FILE_TYPE,
   FILE_VALIDATION_STATUS,
@@ -505,6 +506,7 @@ export interface AddValidationResultsToFileParams {
   datasetInfo: HCAAtlasTrackerDBFileDatasetInfo | null;
   fileId: string;
   integrityStatus: INTEGRITY_STATUS;
+  metadataCoverage: DatasetValidatorMetadataCoverage | null;
   validatedAt: Date;
   validationInfo: HCAAtlasTrackerDBFileValidationInfo;
   validationReports: FileValidationReports | null;
@@ -519,6 +521,7 @@ export interface AddValidationResultsToFileParams {
  * @param params.datasetInfo - Dataset info to add to the file.
  * @param params.fileId - ID of the file to update.
  * @param params.integrityStatus - Integrity status to set on the file.
+ * @param params.metadataCoverage - Metadata coverage to set on the file.
  * @param params.validatedAt - Time at which the validation started.
  * @param params.validationInfo - Metadata of the validation.
  * @param params.validationReports - Validation reports for individual tools.
@@ -533,6 +536,7 @@ export async function addValidationResultsToFile(
     datasetInfo,
     fileId,
     integrityStatus,
+    metadataCoverage,
     validatedAt,
     validationInfo,
     validationReports,
@@ -549,7 +553,8 @@ export async function addValidationResultsToFile(
         integrity_checked_at = $4,
         validation_status = $5,
         validation_reports = $6,
-        validation_summary = $7
+        validation_summary = $7,
+        metadata_coverage = $10
       -- To avoid saving results for a message that has already been received,
       -- don't update a file record if its existing SNS message ID is the same as the new one
       WHERE id = $8 AND validation_info->>'snsMessageId' IS DISTINCT FROM $9
@@ -564,6 +569,7 @@ export async function addValidationResultsToFile(
       JSON.stringify(validationSummary),
       fileId,
       validationInfo.snsMessageId,
+      metadataCoverage,
     ],
   );
 }

--- a/app/services/validation-results-notification.ts
+++ b/app/services/validation-results-notification.ts
@@ -99,6 +99,7 @@ export async function processValidationResultsMessage(
     fileId,
     integrityStatus:
       validationResults.integrity_status ?? INTEGRITY_STATUS.PENDING,
+    metadataCoverage: validationResults.metadata_coverage ?? null,
     s3Uri,
     validatedAt: newValidationTime,
     validationInfo,
@@ -143,6 +144,7 @@ async function saveClaimCheckErrorResult(
     datasetInfo: null,
     fileId: validationMetadata.file_id,
     integrityStatus: INTEGRITY_STATUS.PENDING,
+    metadataCoverage: null,
     s3Uri: getS3UriFromValidationResults(validationMetadata),
     validatedAt: new Date(validationMetadata.timestamp),
     validationInfo: getValidationInfo(

--- a/app/services/validation-results-notification.ts
+++ b/app/services/validation-results-notification.ts
@@ -1,6 +1,7 @@
 import { formatFileSize } from "@databiosphere/findable-ui/lib/utils/formatFileSize";
 import { FILE_VALIDATOR_NAMES } from "app/apis/catalog/hca-atlas-tracker/common/constants";
 import {
+  DatasetValidatorMetadataCoverageEntity,
   DatasetValidatorResults,
   DatasetValidatorResultsMetadata,
   datasetValidatorResultsMetadataSchema,
@@ -10,6 +11,9 @@ import {
 } from "../apis/catalog/hca-atlas-tracker/aws/schemas";
 import {
   FILE_VALIDATION_STATUS,
+  FileMetadataCoverage,
+  FileMetadataCoverageEntity,
+  FileMetadataFieldCoverage,
   FileValidationReports,
   FileValidationSummary,
   HCAAtlasTrackerDBFileDatasetInfo,
@@ -99,7 +103,8 @@ export async function processValidationResultsMessage(
     fileId,
     integrityStatus:
       validationResults.integrity_status ?? INTEGRITY_STATUS.PENDING,
-    metadataCoverage: validationResults.metadata_coverage ?? null,
+    metadataCoverage:
+      getMetadataCoverageFromValidationResults(validationResults),
     s3Uri,
     validatedAt: newValidationTime,
     validationInfo,
@@ -497,6 +502,45 @@ function getDatasetInfoFromValidationResults(
     tissue: metadataSummary.tissue,
     title: metadataSummary.title,
   };
+}
+
+/**
+ * Convert metadata coverage info from the given validation results into info to be saved in a file record.
+ * @param validationResults - Validation results to get metadata coverage from.
+ * @returns - Metadata coverage, or null if metadata coverage is not present in the validation results.
+ */
+function getMetadataCoverageFromValidationResults(
+  validationResults: DatasetValidatorResults,
+): FileMetadataCoverage | null {
+  const metadataCoverage = validationResults.metadata_coverage;
+  if (!metadataCoverage) return null;
+  return {
+    entities: {
+      dataset: convertEntity(metadataCoverage.entities.dataset),
+      donor: convertEntity(metadataCoverage.entities.donor),
+      obs: convertEntity(metadataCoverage.entities.obs),
+      sample: convertEntity(metadataCoverage.entities.sample),
+    },
+    fieldCoverage: metadataCoverage.field_coverage.map(
+      (fieldInfo): FileMetadataFieldCoverage => ({
+        complete: fieldInfo.complete,
+        entityClass: fieldInfo.entity_class,
+        field: fieldInfo.field,
+        inconsistent: fieldInfo.inconsistent,
+        missing: fieldInfo.missing,
+      }),
+    ),
+    schemaName: metadataCoverage.schema_name,
+    schemaVersion: metadataCoverage.schema_version,
+  };
+
+  function convertEntity(
+    entity: DatasetValidatorMetadataCoverageEntity,
+  ): FileMetadataCoverageEntity {
+    return {
+      recordCount: entity.record_count,
+    };
+  }
 }
 
 /**

--- a/db_scripts/generate-test-validation-results.ts
+++ b/db_scripts/generate-test-validation-results.ts
@@ -7,6 +7,8 @@ import { FILE_VALIDATOR_NAMES } from "../app/apis/catalog/hca-atlas-tracker/comm
 import {
   FILE_VALIDATION_STATUS,
   FileMetadataCoverage,
+  FileMetadataCoverageEntity,
+  FileMetadataFieldCoverage,
   FileValidationReports,
   FileValidationSummary,
   HCAAtlasTrackerDBComponentAtlas,
@@ -47,6 +49,12 @@ const FAILED_REQUEST_PROBABILITY = 0.2;
 const OVERALL_VALID_PROBABILITY = 0.5;
 
 // (Below use uninclusive max)
+
+const MIN_METADATA_RECORD_COUNT = 100;
+const MAX_METADATA_RECORD_COUNT = 1000;
+
+const MIN_FIELD_COVERAGE_ENTRIES = 10;
+const MAX_FIELD_COVERAGE_ENTRIES = 50;
 
 const MIN_CELL_COUNT = 100;
 const MAX_CELL_COUNT = 10000;
@@ -211,7 +219,52 @@ function getSuccessfulValidationFields(
 }
 
 function makeMetadataCoverage(): FileMetadataCoverage {
-  return "TODO" as unknown as FileMetadataCoverage;
+  const ENTITY_TYPES = ["dataset", "donor", "obs", "sample"] as const;
+
+  const entities: FileMetadataCoverage["entities"] = {
+    dataset: generateEntity(),
+    donor: generateEntity(),
+    obs: generateEntity(),
+    sample: generateEntity(),
+  };
+
+  const fieldCoverage = generateArrayVia(
+    (l) => "field_" + l,
+    MIN_FIELD_COVERAGE_ENTRIES,
+    MAX_FIELD_COVERAGE_ENTRIES,
+  ).map((fieldName): FileMetadataFieldCoverage => {
+    const entityType =
+      ENTITY_TYPES[Math.floor(Math.random() * ENTITY_TYPES.length)];
+    const { recordCount } = entities[entityType];
+    const completeCount = Math.floor(Math.random() * (recordCount + 1));
+    const missingCount = Math.floor(
+      Math.random() * (recordCount - completeCount + 1),
+    );
+    return {
+      complete: completeCount,
+      entityClass: entityType,
+      field: fieldName,
+      inconsistent: recordCount - completeCount - missingCount,
+      missing: missingCount,
+    };
+  });
+
+  return {
+    entities,
+    fieldCoverage,
+    schemaName: "test",
+    schemaVersion: "1.0-test",
+  };
+
+  function generateEntity(): FileMetadataCoverageEntity {
+    return {
+      recordCount:
+        Math.floor(
+          Math.random() *
+            (MAX_METADATA_RECORD_COUNT - MIN_METADATA_RECORD_COUNT),
+        ) + MIN_METADATA_RECORD_COUNT,
+    };
+  }
 }
 
 function makeValidationReports(): [
@@ -256,13 +309,23 @@ function generateArray(itemBase: string): string[] {
   return generateArrayVia((l) => `${itemBase}-${l}`);
 }
 
-function generateArrayVia(makeItem: (letter: string) => string): string[] {
-  const lettersLeft = Array.from(LETTERS);
+function generateArrayVia(
+  makeItem: (letter: string) => string,
+  minLength = MIN_ARRAY_LENGTH,
+  maxLength = MAX_ARRAY_LENGTH,
+): string[] {
+  let prevLetters = Array.from(LETTERS);
+  let lettersLeft = prevLetters.slice();
   const amount =
-    Math.floor(Math.random() * (MAX_ARRAY_LENGTH - MIN_ARRAY_LENGTH)) +
-    MIN_ARRAY_LENGTH;
+    Math.floor(Math.random() * (maxLength - minLength)) + minLength;
   const result: string[] = [];
   for (let i = 0; i < amount; i++) {
+    if (lettersLeft.length === 0) {
+      prevLetters = prevLetters
+        .map((s) => Array.from(LETTERS, (l) => s + l))
+        .flat();
+      lettersLeft = prevLetters.slice();
+    }
     const j = Math.floor(Math.random() * lettersLeft.length);
     result.push(makeItem(lettersLeft[j]));
     lettersLeft.splice(j, 1);

--- a/db_scripts/generate-test-validation-results.ts
+++ b/db_scripts/generate-test-validation-results.ts
@@ -6,6 +6,7 @@ import {
 import { FILE_VALIDATOR_NAMES } from "../app/apis/catalog/hca-atlas-tracker/common/constants";
 import {
   FILE_VALIDATION_STATUS,
+  FileMetadataCoverage,
   FileValidationReports,
   FileValidationSummary,
   HCAAtlasTrackerDBComponentAtlas,
@@ -62,6 +63,7 @@ interface SuccessRelatedFields {
   datasetInfo: HCAAtlasTrackerDBFileDatasetInfo | null;
   errorMessage?: string;
   integrityStatus: INTEGRITY_STATUS;
+  metadataCoverage: FileMetadataCoverage | null;
   validationReports: FileValidationReports | null;
   validationStatus: FILE_VALIDATION_STATUS;
   validationSummary: FileValidationSummary | null;
@@ -115,7 +117,7 @@ async function addValidationResultsToFiles(
       datasetInfo: successRelatedFields.datasetInfo,
       fileId,
       integrityStatus: successRelatedFields.integrityStatus,
-      metadataCoverage: null, // TODO
+      metadataCoverage: successRelatedFields.metadataCoverage,
       validatedAt,
       validationInfo,
       validationReports: successRelatedFields.validationReports,
@@ -133,6 +135,7 @@ function getFailedValidationFields(): SuccessRelatedFields {
       datasetInfo: null,
       errorMessage: "Error in dataset validator",
       integrityStatus: INTEGRITY_STATUS.VALID,
+      metadataCoverage: null,
       validationReports: null,
       validationStatus: FILE_VALIDATION_STATUS.JOB_FAILED,
       validationSummary: null,
@@ -145,6 +148,7 @@ function getFailedValidationFields(): SuccessRelatedFields {
       datasetInfo: null,
       errorMessage: "Error while reading claim check",
       integrityStatus: INTEGRITY_STATUS.PENDING,
+      metadataCoverage: null,
       validationReports: null,
       validationStatus: FILE_VALIDATION_STATUS.RESULTS_NOT_LOADED,
       validationSummary: null,
@@ -157,6 +161,7 @@ function getFailedValidationFields(): SuccessRelatedFields {
       errorMessage:
         "No source SHA256 metadata found - cannot validate file integrity",
       integrityStatus: INTEGRITY_STATUS.ERROR,
+      metadataCoverage: null,
       validationReports: null,
       validationStatus: FILE_VALIDATION_STATUS.JOB_FAILED,
       validationSummary: null,
@@ -166,6 +171,7 @@ function getFailedValidationFields(): SuccessRelatedFields {
       datasetInfo: null,
       errorMessage: "File integrity verification failed",
       integrityStatus: INTEGRITY_STATUS.INVALID,
+      metadataCoverage: null,
       validationReports: null,
       validationStatus: FILE_VALIDATION_STATUS.COMPLETED,
       validationSummary: null,
@@ -194,6 +200,7 @@ function getSuccessfulValidationFields(
       title: `Test ${(key && key.split("/").pop()) || fileId}`,
     },
     integrityStatus: INTEGRITY_STATUS.VALID,
+    metadataCoverage: makeMetadataCoverage(),
     validationReports: validationReports,
     validationStatus:
       Math.random() < FAILED_REQUEST_PROBABILITY
@@ -201,6 +208,10 @@ function getSuccessfulValidationFields(
         : FILE_VALIDATION_STATUS.COMPLETED,
     validationSummary: validationSummary,
   };
+}
+
+function makeMetadataCoverage(): FileMetadataCoverage {
+  return "TODO" as unknown as FileMetadataCoverage;
 }
 
 function makeValidationReports(): [

--- a/db_scripts/generate-test-validation-results.ts
+++ b/db_scripts/generate-test-validation-results.ts
@@ -115,6 +115,7 @@ async function addValidationResultsToFiles(
       datasetInfo: successRelatedFields.datasetInfo,
       fileId,
       integrityStatus: successRelatedFields.integrityStatus,
+      metadataCoverage: null, // TODO
       validatedAt,
       validationInfo,
       validationReports: successRelatedFields.validationReports,

--- a/db_scripts/generate-test-validation-results.ts
+++ b/db_scripts/generate-test-validation-results.ts
@@ -3,7 +3,10 @@ import {
   DatasetValidatorToolReport,
   DatasetValidatorToolReports,
 } from "../app/apis/catalog/hca-atlas-tracker/aws/schemas";
-import { FILE_VALIDATOR_NAMES } from "../app/apis/catalog/hca-atlas-tracker/common/constants";
+import {
+  FILE_METADATA_COVERAGE_ENTITY_TYPES,
+  FILE_VALIDATOR_NAMES,
+} from "../app/apis/catalog/hca-atlas-tracker/common/constants";
 import {
   FILE_VALIDATION_STATUS,
   FileMetadataCoverage,
@@ -225,8 +228,6 @@ function getSuccessfulValidationFields(
 }
 
 function makeMetadataCoverage(): FileMetadataCoverage {
-  const ENTITY_TYPES = ["dataset", "donor", "obs", "sample"] as const;
-
   const entities: FileMetadataCoverage["entities"] = {
     dataset: generateEntity(),
     donor: generateEntity(),
@@ -245,7 +246,9 @@ function makeMetadataCoverage(): FileMetadataCoverage {
 
   const fieldCoverage = fields.map((fieldName): FileMetadataFieldCoverage => {
     const entityType =
-      ENTITY_TYPES[Math.floor(Math.random() * ENTITY_TYPES.length)];
+      FILE_METADATA_COVERAGE_ENTITY_TYPES[
+        Math.floor(Math.random() * FILE_METADATA_COVERAGE_ENTITY_TYPES.length)
+      ];
 
     const { recordCount } = entities[entityType];
 

--- a/db_scripts/generate-test-validation-results.ts
+++ b/db_scripts/generate-test-validation-results.ts
@@ -32,6 +32,12 @@ import { toolReportsToValidationReportsAndSummary } from "../app/services/valida
  * added to them.
  */
 
+// Probability of all fields listed by metadata coverage being forced to be entirely complete
+const METADATA_COVERAGE_ALL_COMPLETE_PROBABILITY = 0.3;
+
+// Probability of an individual field in metadata coverage being forced to be entirely complete
+const METADATA_COVERAGE_FIELD_ALL_COMPLETE_PROBABILITY = 0.2;
+
 // Probability of failed validation (of various types) vs. successful validation containing tool reports etc.
 const FAILED_VALIDATION_PROBABILITY = 0.5;
 
@@ -228,18 +234,33 @@ function makeMetadataCoverage(): FileMetadataCoverage {
     sample: generateEntity(),
   };
 
-  const fieldCoverage = generateArrayVia(
+  const fields = generateArrayVia(
     (l) => "field_" + l,
     MIN_FIELD_COVERAGE_ENTRIES,
     MAX_FIELD_COVERAGE_ENTRIES,
-  ).map((fieldName): FileMetadataFieldCoverage => {
+  );
+
+  const allComplete =
+    Math.random() < METADATA_COVERAGE_ALL_COMPLETE_PROBABILITY;
+
+  const fieldCoverage = fields.map((fieldName): FileMetadataFieldCoverage => {
     const entityType =
       ENTITY_TYPES[Math.floor(Math.random() * ENTITY_TYPES.length)];
+
     const { recordCount } = entities[entityType];
-    const completeCount = Math.floor(Math.random() * (recordCount + 1));
+
+    const fieldAllComplete =
+      allComplete ||
+      Math.random() < METADATA_COVERAGE_FIELD_ALL_COMPLETE_PROBABILITY;
+
+    const completeCount = fieldAllComplete
+      ? recordCount
+      : Math.floor(Math.random() * (recordCount + 1));
+
     const missingCount = Math.floor(
       Math.random() * (recordCount - completeCount + 1),
     );
+
     return {
       complete: completeCount,
       entityClass: entityType,

--- a/migrations/1780085483223_metadata-coverage.ts
+++ b/migrations/1780085483223_metadata-coverage.ts
@@ -1,0 +1,12 @@
+import { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumns(
+    { name: "files", schema: "hat" },
+    {
+      metadata_coverage: {
+        type: "jsonb",
+      },
+    },
+  );
+}

--- a/schema.sql
+++ b/schema.sql
@@ -157,6 +157,7 @@ CREATE TABLE hat.files (
     is_archived boolean DEFAULT false NOT NULL,
     is_latest boolean DEFAULT true NOT NULL,
     concept_id uuid,
+    metadata_coverage jsonb,
     CONSTRAINT ck_files_integrity_status CHECK (((integrity_status)::text = ANY ((ARRAY['pending'::character varying, 'requested'::character varying, 'valid'::character varying, 'invalid'::character varying, 'error'::character varying])::text[]))),
     CONSTRAINT ck_files_validation_status CHECK (((validation_status)::text = ANY ((ARRAY['completed'::character varying, 'job_failed'::character varying, 'pending'::character varying, 'request_failed'::character varying, 'requested'::character varying, 'results_not_loaded'::character varying, 'stale'::character varying])::text[])))
 );

--- a/testing/sns-testing.ts
+++ b/testing/sns-testing.ts
@@ -214,10 +214,10 @@ export interface ValidationResultsOptions extends ValidationResultsMetadataOptio
     tissue: string[];
     title: string;
   } | null;
-  metadataCoverage?: DatasetValidatorMetadataCoverage;
+  metadataCoverage?: DatasetValidatorMetadataCoverage | null;
   sha256?: string | null;
   sourceSha256?: string | null;
-  toolReports?: DatasetValidatorToolReports;
+  toolReports?: DatasetValidatorToolReports | null;
 }
 
 export function createValidationResultsMetadata(
@@ -261,7 +261,10 @@ export function createValidationResults(
         }
       : null,
     source_sha256: sourceSha256,
-    tool_reports: options.toolReports ?? SUCCESSFUL_TOOL_REPORTS,
+    tool_reports:
+      options.toolReports === undefined
+        ? SUCCESSFUL_TOOL_REPORTS
+        : options.toolReports,
   };
 }
 
@@ -464,7 +467,7 @@ export async function doS3Event(
 }
 
 export async function expectDbFileValidationFieldsToMatch(params: {
-  datasetInfo: HCAAtlasTrackerDBFileDatasetInfo;
+  datasetInfo: HCAAtlasTrackerDBFileDatasetInfo | null;
   fileId: string;
   integrityStatus: INTEGRITY_STATUS;
   metadataCoverage?: DatasetValidatorMetadataCoverage | null;

--- a/testing/sns-testing.ts
+++ b/testing/sns-testing.ts
@@ -11,6 +11,7 @@ import {
   S3Object,
   SNSMessage,
 } from "../app/apis/catalog/hca-atlas-tracker/aws/schemas";
+import { FILE_METADATA_COVERAGE_ENTITY_TYPES } from "../app/apis/catalog/hca-atlas-tracker/common/constants";
 import {
   FileMetadataCoverage,
   FileValidationReport,
@@ -522,10 +523,11 @@ function expectFileMetadataCoverageToMatchInput(
   metadataCoverage: FileMetadataCoverage,
   inputMetadataCoverage: DatasetValidatorMetadataCoverage,
 ): void {
-  expectEntityToMatch("dataset");
-  expectEntityToMatch("donor");
-  expectEntityToMatch("obs");
-  expectEntityToMatch("sample");
+  for (const entityClass of FILE_METADATA_COVERAGE_ENTITY_TYPES) {
+    expect(metadataCoverage.entities[entityClass].recordCount).toEqual(
+      inputMetadataCoverage.entities[entityClass].record_count,
+    );
+  }
 
   expect(metadataCoverage.fieldCoverage).toHaveLength(
     inputMetadataCoverage.field_coverage.length,
@@ -545,14 +547,6 @@ function expectFileMetadataCoverageToMatchInput(
   expect(metadataCoverage.schemaVersion).toEqual(
     inputMetadataCoverage.schema_version,
   );
-
-  function expectEntityToMatch(
-    entityType: keyof FileMetadataCoverage["entities"],
-  ): void {
-    expect(metadataCoverage.entities[entityType].recordCount).toEqual(
-      inputMetadataCoverage.entities[entityType].record_count,
-    );
-  }
 }
 
 function expectFileValidationReportsToMatchInput(

--- a/testing/sns-testing.ts
+++ b/testing/sns-testing.ts
@@ -2,6 +2,7 @@ import { METHOD } from "app/common/entities";
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
 import {
+  DatasetValidatorMetadataCoverage,
   DatasetValidatorResults,
   DatasetValidatorResultsMetadata,
   DatasetValidatorToolReport,
@@ -11,6 +12,7 @@ import {
   SNSMessage,
 } from "../app/apis/catalog/hca-atlas-tracker/aws/schemas";
 import {
+  FileMetadataCoverage,
   FileValidationReport,
   FileValidationReports,
   FileValidationSummary,
@@ -211,6 +213,7 @@ export interface ValidationResultsOptions extends ValidationResultsMetadataOptio
     tissue: string[];
     title: string;
   } | null;
+  metadataCoverage?: DatasetValidatorMetadataCoverage;
   sha256?: string | null;
   sourceSha256?: string | null;
   toolReports?: DatasetValidatorToolReports;
@@ -244,6 +247,7 @@ export function createValidationResults(
     downloaded_sha256: downloadedSha256,
     error_message: options.errorMessage ?? null,
     integrity_status: integrityStatus,
+    metadata_coverage: options.metadataCoverage,
     metadata_summary: options.metadata
       ? {
           assay: options.metadata.assay,
@@ -458,15 +462,27 @@ export async function doS3Event(
   return fileRows.rows;
 }
 
-export async function expectDbFileValidationFieldsToMatch(
-  fileId: string,
-  validationTime: string,
-  integrityStatus: INTEGRITY_STATUS,
-  datasetInfo: HCAAtlasTrackerDBFileDatasetInfo,
-  validationInfo: HCAAtlasTrackerDBFileValidationInfo,
-  validationReports: DatasetValidatorToolReports | null,
-  validationSummary: FileValidationSummary | null,
-): Promise<void> {
+export async function expectDbFileValidationFieldsToMatch(params: {
+  datasetInfo: HCAAtlasTrackerDBFileDatasetInfo;
+  fileId: string;
+  integrityStatus: INTEGRITY_STATUS;
+  metadataCoverage?: DatasetValidatorMetadataCoverage | null;
+  validationInfo: HCAAtlasTrackerDBFileValidationInfo;
+  validationReports: DatasetValidatorToolReports | null;
+  validationSummary: FileValidationSummary | null;
+  validationTime: string;
+}): Promise<void> {
+  const {
+    datasetInfo,
+    fileId,
+    integrityStatus,
+    metadataCoverage = null,
+    validationInfo,
+    validationReports,
+    validationSummary,
+    validationTime,
+  } = params;
+
   const file = await getFileFromDatabase(fileId);
   if (!expectIsDefined(file)) return;
 
@@ -474,6 +490,18 @@ export async function expectDbFileValidationFieldsToMatch(
   expect(file.integrity_checked_at?.toISOString()).toEqual(validationTime);
   expect(file.integrity_status).toEqual(integrityStatus);
   expect(file.validation_info).toEqual(validationInfo);
+
+  if (metadataCoverage === null) {
+    expect(file.metadata_coverage).toBeNull();
+  } else {
+    expect(file.metadata_coverage).not.toBeNull();
+    if (file.metadata_coverage !== null) {
+      expectFileMetadataCoverageToMatchInput(
+        file.metadata_coverage,
+        metadataCoverage,
+      );
+    }
+  }
 
   if (validationReports === null) {
     expect(file.validation_reports).toBeNull();
@@ -488,6 +516,43 @@ export async function expectDbFileValidationFieldsToMatch(
   }
 
   expect(file.validation_summary).toEqual(validationSummary);
+}
+
+function expectFileMetadataCoverageToMatchInput(
+  metadataCoverage: FileMetadataCoverage,
+  inputMetadataCoverage: DatasetValidatorMetadataCoverage,
+): void {
+  expectEntityToMatch("dataset");
+  expectEntityToMatch("donor");
+  expectEntityToMatch("obs");
+  expectEntityToMatch("sample");
+
+  expect(metadataCoverage.fieldCoverage).toHaveLength(
+    inputMetadataCoverage.field_coverage.length,
+  );
+  for (const [i, fieldInfo] of metadataCoverage.fieldCoverage.entries()) {
+    const inputFieldInfo = inputMetadataCoverage.field_coverage[i];
+    expect(fieldInfo.complete).toEqual(inputFieldInfo.complete);
+    expect(fieldInfo.entityClass).toEqual(inputFieldInfo.entity_class);
+    expect(fieldInfo.field).toEqual(inputFieldInfo.field);
+    expect(fieldInfo.inconsistent).toEqual(inputFieldInfo.inconsistent);
+    expect(fieldInfo.missing).toEqual(inputFieldInfo.missing);
+  }
+
+  expect(metadataCoverage.schemaName).toEqual(
+    inputMetadataCoverage.schema_name,
+  );
+  expect(metadataCoverage.schemaVersion).toEqual(
+    inputMetadataCoverage.schema_version,
+  );
+
+  function expectEntityToMatch(
+    entityType: keyof FileMetadataCoverage["entities"],
+  ): void {
+    expect(metadataCoverage.entities[entityType].recordCount).toEqual(
+      inputMetadataCoverage.entities[entityType].record_count,
+    );
+  }
 }
 
 function expectFileValidationReportsToMatchInput(


### PR DESCRIPTION
Closes #1273

Notes:

- The schema and types are written to support exactly the entity types `dataset`, `donor`, `obs`, and `sample`; if we were to e.g. remove `obs` or add `library`, we would need to update the tracker. This would likely not be too complex though, especially given the type separation described below.
- The metadata coverage info is copied field-by-field to new objects before being saved; this accomplishes two things: it ensures that only fields perfectly consistent with the types are able to make their way in (making future changes to the shape safer), and allows the data that's saved to use camel case property names. Something that comes implicitly with the different property names, and that is beneficial in its own right, is that the types used for metadata coverage as saved in the database are defined on their own rather than being derived from the schema used for the SNS data; this would make it easier to update the shape of the SNS data in the future.
- I wasn't sure how closely metadata coverage generated for manual testing should resemble actual metadata coverage results; I went with what felt like the simplest option of using fake schema name, schema version, and field names.