### PR TITLE
feat: style validation error reports per cc-design#311 (#1310)

### DIFF
--- a/app/components/Entity/components/EntityView/components/ValidationReport/components/ReportContent/components/ValidationMessage/entities.ts
+++ b/app/components/Entity/components/EntityView/components/ValidationReport/components/ReportContent/components/ValidationMessage/entities.ts
@@ -1,0 +1,6 @@
+import { ReportSeverity } from "../../entities";
+
+export interface Props {
+  message: string;
+  severity: ReportSeverity;
+}

--- a/app/components/Entity/components/EntityView/components/ValidationReport/components/ReportContent/components/ValidationMessage/utils.ts
+++ b/app/components/Entity/components/EntityView/components/ValidationReport/components/ReportContent/components/ValidationMessage/utils.ts
@@ -1,0 +1,39 @@
+const SEVERITY_PREFIX_PATTERN = /^(ERROR|WARNING):\s*/i;
+// Single-quote alternative requires identifier-like content (letters, digits,
+// underscore, dot, hyphen, comma) optionally joined by spaces — so multi-word
+// quoted phrases ("gene annotation version") match, while contraction
+// apostrophes (e.g. "isn't") can't pair with surrounding quotes because the
+// content character class excludes apostrophes and disallows leading/trailing
+// whitespace.
+const QUOTED_CONTENT = "[A-Za-z0-9_.\\-,]+(?: [A-Za-z0-9_.\\-,]+)*";
+const CODE_PATTERN = new RegExp(`(\`[^\`]+\`|'${QUOTED_CONTENT}')`, "g");
+
+/**
+ * Splits a validation message into alternating plain-text and code segments,
+ * stripping any leading "ERROR: " / "WARNING: " prefix.
+ *
+ * A segment is treated as code when it is wrapped in backticks or in single
+ * quotes around an identifier-like token or space-joined sequence of such
+ * tokens (the convention used by the tracker validators for identifiers,
+ * dataframe names, column names, feature IDs, multi-word phrases).
+ * @param message - The raw validation message string.
+ * @returns An array of segments, each tagged as "text" or "code".
+ */
+export function parseValidationMessage(
+  message: string,
+): { type: "code" | "text"; value: string }[] {
+  const cleaned = message.replace(SEVERITY_PREFIX_PATTERN, "");
+  const parts = cleaned.split(CODE_PATTERN);
+  return parts
+    .filter((part) => part.length > 0)
+    .map((part) => {
+      const isBacktick = part.startsWith("`") && part.endsWith("`");
+      const isQuoted = part.startsWith("'") && part.endsWith("'");
+
+      if (isBacktick || isQuoted) {
+        return { type: "code", value: part.slice(1, -1) };
+      }
+
+      return { type: "text", value: part };
+    });
+}

--- a/app/components/Entity/components/EntityView/components/ValidationReport/components/ReportContent/components/ValidationMessage/validationMessage.styles.ts
+++ b/app/components/Entity/components/EntityView/components/ValidationReport/components/ReportContent/components/ValidationMessage/validationMessage.styles.ts
@@ -1,0 +1,23 @@
+import { FONT } from "@databiosphere/findable-ui/lib/styles/common/constants/font";
+import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
+import styled from "@emotion/styled";
+import { Alert } from "@mui/material";
+
+export const StyledAlert = styled(Alert)`
+  border-radius: 4px;
+  padding: 12px 16px;
+
+  .MuiAlert-message {
+    all: unset;
+    font: ${FONT.BODY_400};
+
+    code {
+      background-color: ${({ severity }) =>
+        severity === "error" ? PALETTE.ALERT_LIGHT : PALETTE.WARNING_LIGHT};
+      border-radius: 4px;
+      font: inherit;
+      font-family: "Roboto Mono", monospace;
+      padding: 0 4px;
+    }
+  }
+`;

--- a/app/components/Entity/components/EntityView/components/ValidationReport/components/ReportContent/components/ValidationMessage/validationMessage.tsx
+++ b/app/components/Entity/components/EntityView/components/ValidationReport/components/ReportContent/components/ValidationMessage/validationMessage.tsx
@@ -1,0 +1,36 @@
+import { Fragment, JSX, useMemo } from "react";
+import { Props } from "./entities";
+import { parseValidationMessage } from "./utils";
+import { StyledAlert } from "./validationMessage.styles";
+
+/**
+ * Pill-styled row that renders a single validation error or warning message,
+ * with inline code segments (backtick- or single-quote-delimited) rendered
+ * as monospace chips. Strips any leading "ERROR: " / "WARNING: " prefix.
+ *
+ * Renders with role="listitem" so the surrounding container (role="list" in
+ * `ReportContent`) suppresses MUI Alert's implicit assertive live-region
+ * behaviour — otherwise dozens of simultaneously-mounted alerts would all
+ * announce themselves at once to assistive tech.
+ * @param props - Component props.
+ * @param props.message - The raw validation message string.
+ * @param props.severity - Whether to style the row as an error or a warning.
+ * @returns The styled validation message row.
+ */
+export const ValidationMessage = ({
+  message,
+  severity,
+}: Props): JSX.Element => {
+  const segments = useMemo(() => parseValidationMessage(message), [message]);
+  return (
+    <StyledAlert icon={false} role="listitem" severity={severity}>
+      {segments.map((segment, i) =>
+        segment.type === "code" ? (
+          <code key={i}>{segment.value}</code>
+        ) : (
+          <Fragment key={i}>{segment.value}</Fragment>
+        ),
+      )}
+    </StyledAlert>
+  );
+};

--- a/app/components/Entity/components/EntityView/components/ValidationReport/components/ReportContent/entities.ts
+++ b/app/components/Entity/components/EntityView/components/ValidationReport/components/ReportContent/entities.ts
@@ -1,3 +1,4 @@
+import { AlertProps } from "@mui/material";
 import {
   FILE_VALIDATION_STATUS,
   FileValidationReports,
@@ -8,4 +9,15 @@ export interface Props {
   validationReports?: FileValidationReports | null;
   validationStatus: FILE_VALIDATION_STATUS;
   validatorName?: FileValidatorName;
+}
+
+export type ReportSeverity = Extract<
+  AlertProps["severity"],
+  "error" | "warning"
+>;
+
+export interface ReportSummary {
+  messages: string[];
+  severity: ReportSeverity;
+  title: string;
 }

--- a/app/components/Entity/components/EntityView/components/ValidationReport/components/ReportContent/reportContent.styles.ts
+++ b/app/components/Entity/components/EntityView/components/ValidationReport/components/ReportContent/reportContent.styles.ts
@@ -1,8 +1,8 @@
 import styled from "@emotion/styled";
-import { Container } from "@mui/material";
+import { Stack } from "@mui/material";
 
-export const StyledContainer = styled(Container)`
-  & {
-    padding: 24px;
-  }
+export const StyledStack = styled(Stack)`
+  align-items: stretch;
+  align-self: stretch;
+  padding: 20px;
 `;

--- a/app/components/Entity/components/EntityView/components/ValidationReport/components/ReportContent/reportContent.tsx
+++ b/app/components/Entity/components/EntityView/components/ValidationReport/components/ReportContent/reportContent.tsx
@@ -1,26 +1,65 @@
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
-import { Typography } from "@mui/material";
+import { Stack, Typography } from "@mui/material";
 import { JSX } from "react";
+import { ValidationMessage } from "./components/ValidationMessage/validationMessage";
 import { Props } from "./entities";
-import { StyledContainer } from "./reportContent.styles";
-import { getReportValues } from "./utils";
+import { StyledStack } from "./reportContent.styles";
+import { getReportSummaries } from "./utils";
 
+/**
+ * Renders the body of the per-validator validation report. When
+ * `getReportSummaries` returns a list of summaries, renders each as a
+ * severity-styled section: heading `{title}` followed by a stack of
+ * `ValidationMessage` alert rows. When `getReportSummaries` returns a
+ * string, renders that string as a fallback status message.
+ * @param props - Component props.
+ * @param props.validationReports - Map of per-validator reports for the file.
+ * @param props.validationStatus - The overall file-validation status.
+ * @param props.validatorName - The validator whose report should be rendered.
+ * @returns The validation report content.
+ */
 export const ReportContent = ({
   validationReports,
   validationStatus,
   validatorName,
 }: Props): JSX.Element => {
+  const summaries = getReportSummaries(
+    validationStatus,
+    validationReports,
+    validatorName,
+  );
+
+  if (typeof summaries === "string") {
+    return (
+      <StyledStack>
+        <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400}>
+          {summaries}
+        </Typography>
+      </StyledStack>
+    );
+  }
+
   return (
-    <StyledContainer maxWidth={false}>
-      <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_400}>
-        {getReportValues(
-          validationStatus,
-          validationReports,
-          validatorName,
-        ).map((value, i) => (
-          <div key={i}>{value}</div>
-        ))}
-      </Typography>
-    </StyledContainer>
+    <>
+      {summaries.map(({ messages, severity, title }) => (
+        <StyledStack key={severity} spacing={5} useFlexGap>
+          <Typography
+            component="h3"
+            variant={TYPOGRAPHY_PROPS.VARIANT.BODY_500}
+          >
+            {title}
+          </Typography>
+          <Stack role="list" spacing={2} useFlexGap>
+            {messages.map((message) => (
+              <ValidationMessage
+                key={message}
+                message={message}
+                severity={severity}
+              />
+            ))}
+          </Stack>
+        </StyledStack>
+      ))}
+    </>
   );
 };

--- a/app/components/Entity/components/EntityView/components/ValidationReport/components/ReportContent/reportContent.tsx
+++ b/app/components/Entity/components/EntityView/components/ValidationReport/components/ReportContent/reportContent.tsx
@@ -50,9 +50,9 @@ export const ReportContent = ({
             {title}
           </Typography>
           <Stack role="list" spacing={2} useFlexGap>
-            {messages.map((message) => (
+            {messages.map((message, i) => (
               <ValidationMessage
-                key={message}
+                key={`${message}-${i}`}
                 message={message}
                 severity={severity}
               />

--- a/app/components/Entity/components/EntityView/components/ValidationReport/components/ReportContent/utils.ts
+++ b/app/components/Entity/components/EntityView/components/ValidationReport/components/ReportContent/utils.ts
@@ -1,44 +1,55 @@
+import { SEVERITY } from "@databiosphere/findable-ui/lib/styles/common/mui/alert";
 import { FILE_VALIDATION_STATUS_NAME_LABEL } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/constants";
 import {
   FILE_VALIDATION_STATUS,
   FileValidationReports,
   FileValidatorName,
 } from "../../../../../../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { ReportSeverity, ReportSummary } from "./entities";
 
 /**
- * Returns error and warning report values for a given validator.
+ * Builds an ordered list of severity-tagged report summaries (Errors first,
+ * Warnings second) for a given validator, omitting empty sections. Returns a
+ * fallback status string instead when no structured report is available for
+ * the validator, or when the report contains no errors or warnings.
  * @param validationStatus - Validation status.
  * @param validationReports - Validation reports.
  * @param validatorName - Validator name.
- * @returns Error and warning report values.
+ * @returns Either a non-empty list of report summaries to render, or a
+ * fallback status string when there is nothing to summarise.
  */
-export function getReportValues(
+export function getReportSummaries(
   validationStatus: FILE_VALIDATION_STATUS,
   validationReports?: FileValidationReports | null,
   validatorName?: FileValidatorName,
-): string[] {
-  const values: string[] = [];
-
+): ReportSummary[] | string {
   if (!validatorName || !validationReports) {
-    // If no validator name or validation reports are provided, return the validation status.
-    values.push(
-      `Validation Status: ${FILE_VALIDATION_STATUS_NAME_LABEL[validationStatus]}`,
-    );
-    return values;
+    return `Validation Status: ${FILE_VALIDATION_STATUS_NAME_LABEL[validationStatus]}`;
   }
 
-  // Get the validation report for the given validator.
   const { errors = [], warnings = [] } = validationReports[validatorName] || {};
 
-  // Add the errors and warnings to the values array.
-  values.push(...errors);
-  values.push(...warnings);
+  const summaries: ReportSummary[] = [];
 
-  if (values.length === 0) {
-    // If no errors or warnings are found, return a message indicating that no errors or warnings were reported.
-    values.push("No errors or warnings reported.");
+  if (errors.length > 0) {
+    summaries.push({
+      messages: errors,
+      severity: SEVERITY.ERROR as ReportSeverity,
+      title: `Errors (${errors.length})`,
+    });
   }
 
-  // Return the validation report values.
-  return values;
+  if (warnings.length > 0) {
+    summaries.push({
+      messages: warnings,
+      severity: SEVERITY.WARNING as ReportSeverity,
+      title: `Warnings (${warnings.length})`,
+    });
+  }
+
+  if (summaries.length === 0) {
+    return "No errors or warnings reported.";
+  }
+
+  return summaries;
 }


### PR DESCRIPTION
## Summary

- Applies the Figma styling from [cc-design#311](https://github.com/clevercanary/cc-design/issues/311) to the file / source-dataset validation report (`app/components/Entity/components/EntityView/components/ValidationReport/components/ReportContent/`).
- New `ValidationMessage` component — pill-styled MUI Alert per severity with inline code chips for backtick- or single-quote-delimited tokens; strips leading `ERROR: ` / `WARNING: ` prefix.
- New `parseValidationMessage` utility — segments raw validator strings into text + code parts. Identifier-like content inside single quotes (including multi-word phrases like `'gene annotation version'`) is recognised; contraction apostrophes can't accidentally form code chips.
- `getReportSummaries` (renamed from `getReportValues`) — returns an ordered list of severity-tagged sections (Errors first, Warnings second; empty sections omitted), or a fallback status string when no structured report is available or the report is empty.
- `ReportContent` rebuilt — maps over summaries: one heading + list of alert rows per section; falls back to a single Typography for the status-string case.
- **Accessibility**: alert rows are `role="listitem"` inside a `role="list"` container, so dozens of simultaneously-mounted alerts don't blast assistive tech as assertive live regions.
- **Type safety**: `ReportSeverity` narrows the section severity to `"error" | "warning"` (no `info`/`success`/`undefined`); `useMemo` on per-row message parsing; row keys are message strings; section keys are severity strings (not the count-including title, which would force unmounts on count change).

## Out of scope

- Entry-sheet validation report (`AtlasMetadataEntrySheetValidationView/components/ValidationReport/`) — same design language to be applied separately.

## Test plan

- [x] `npm run check-format` — clean
- [x] `npm run lint` — clean
- [x] TypeScript compile (`tsc --noEmit`) — clean
- [ ] Manual verification in dev: visit a file's Validations tab against a dataset with mixed errors + warnings (e.g. an hcaSchema-failing file) and confirm:
  - Errors section renders before Warnings
  - Code chips appear for `'identifier'` tokens (including multi-word phrases)
  - Tab switching does not flicker / remount the whole section
  - VoiceOver / NVDA does not blast assertive announcements when the page opens with many rows

Closes #1310

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1866" height="1126" alt="image 128" src="https://github.com/user-attachments/assets/a6203a19-5d34-409d-ab4b-be1dddf8149d" />

<img width="1869" height="1147" alt="image 127" src="https://github.com/user-attachments/assets/2af9b63b-0f07-4268-9a80-2aff48b7a8f6" />

