### PR TITLE
feat: clean up atlases columns and filters (#1314)

### DIFF
--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.tsx
@@ -1254,19 +1254,6 @@ export const buildValidationType = (
 };
 
 /**
- * Build props for the wave BasicCell component.
- * @param atlas - Atlas entity.
- * @returns Props to be used for the BasicCell component.
- */
-export const buildWave = (
-  atlas: HCAAtlasTrackerListAtlas,
-): ComponentProps<typeof C.BasicCell> => {
-  return {
-    value: atlas.wave,
-  };
-};
-
-/**
  * Get props for the publish status badge component for the given published-at value.
  * @param publishedAt - Atlas published-at value.
  * @returns status badge props.

--- a/site-config/hca-atlas-tracker/category.ts
+++ b/site-config/hca-atlas-tracker/category.ts
@@ -49,7 +49,6 @@ export const HCA_ATLAS_TRACKER_CATEGORY_KEY = {
   VALIDATION_STATUS: "validationStatus",
   VALIDATION_TYPE: "validationType",
   VERSION: "version",
-  WAVE: "wave",
   WAVES: "waves",
 };
 
@@ -107,6 +106,5 @@ export const HCA_ATLAS_TRACKER_CATEGORY_LABEL = {
   VALIDATION_STATUS: "Validation Status",
   VALIDATION_TYPE: "Task Type",
   VERSION: "Atlas Version",
-  WAVE: "Wave",
   WAVES: "Wave",
 };

--- a/site-config/hca-atlas-tracker/local/index/atlas/atlasEntityConfig.ts
+++ b/site-config/hca-atlas-tracker/local/index/atlas/atlasEntityConfig.ts
@@ -10,8 +10,6 @@ import {
   getAtlasId,
 } from "../../../../../app/apis/catalog/hca-atlas-tracker/common/utils";
 import * as C from "../../../../../app/components";
-import { mapSelectCategoryValue } from "../../../../../app/config/utils";
-import { formatDateToQuarterYear } from "../../../../../app/utils/date-fns";
 import * as V from "../../../../../app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders";
 import {
   HCA_ATLAS_TRACKER_CATEGORY_KEY,
@@ -45,26 +43,8 @@ export const atlasEntityConfig: EntityConfig = {
             label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.INTEGRATION_LEAD,
           },
           {
-            key: HCA_ATLAS_TRACKER_CATEGORY_KEY.PUBLISHED_AT,
-            label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.PUBLISHED_AT,
-            mapSelectCategoryValue: mapSelectCategoryValue(
-              (val) => val || "Unpublished",
-            ),
-          },
-          {
             key: HCA_ATLAS_TRACKER_CATEGORY_KEY.ENDORSEMENT_STATUS,
             label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.ENDORSEMENT_STATUS,
-          },
-          {
-            key: HCA_ATLAS_TRACKER_CATEGORY_KEY.TARGET_COMPLETION_DATE,
-            label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.TARGET_COMPLETION_DATE,
-            mapSelectCategoryValue: mapSelectCategoryValue(
-              formatDateToQuarterYear,
-            ),
-          },
-          {
-            key: HCA_ATLAS_TRACKER_CATEGORY_KEY.WAVE,
-            label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.WAVE,
           },
         ],
       },
@@ -127,16 +107,6 @@ export const atlasEntityConfig: EntityConfig = {
       },
       {
         componentConfig: {
-          component: C.BasicCell,
-          viewBuilder: V.buildWave,
-        } as ComponentConfig<typeof C.BasicCell, HCAAtlasTrackerListAtlas>,
-        enableGrouping: true,
-        header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.WAVE,
-        id: HCA_ATLAS_TRACKER_CATEGORY_KEY.WAVE,
-        width: { max: "0.5fr", min: "112px" },
-      },
-      {
-        componentConfig: {
           component: C.Link,
           viewBuilder: V.buildSourceStudyCount,
         } as ComponentConfig<typeof C.Link, HCAAtlasTrackerListAtlas>,
@@ -182,7 +152,7 @@ export const atlasEntityConfig: EntityConfig = {
         } as ComponentConfig<typeof C.TaskCountsCell, HCAAtlasTrackerListAtlas>,
         enableGrouping: false,
         header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.INGESTION_COUNTS_HCA,
-        width: { max: "128px", min: "128px" },
+        width: { max: "0.5fr", min: "128px" },
       },
       {
         componentConfig: {
@@ -192,7 +162,7 @@ export const atlasEntityConfig: EntityConfig = {
         enableGrouping: false,
         header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.INGESTION_COUNTS_CAP,
         id: HCA_ATLAS_TRACKER_CATEGORY_KEY.INGESTION_COUNTS_CAP,
-        width: { max: "128px", min: "128px" },
+        width: { max: "0.5fr", min: "128px" },
       },
       {
         componentConfig: {
@@ -202,7 +172,7 @@ export const atlasEntityConfig: EntityConfig = {
         enableGrouping: true,
         header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.ENDORSEMENT_STATUS,
         id: HCA_ATLAS_TRACKER_CATEGORY_KEY.ENDORSEMENT_STATUS,
-        width: { max: "132px", min: "132px" },
+        width: { max: "0.5fr", min: "132px" },
       },
       {
         componentConfig: {
@@ -215,16 +185,6 @@ export const atlasEntityConfig: EntityConfig = {
         header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.PUBLISHED_AT,
         id: HCA_ATLAS_TRACKER_CATEGORY_KEY.PUBLISHED_AT,
         width: { max: "132px", min: "132px" },
-      },
-      {
-        componentConfig: {
-          component: C.BasicCell,
-          viewBuilder: V.buildTargetCompletion,
-        } as ComponentConfig<typeof C.BasicCell, HCAAtlasTrackerListAtlas>,
-        enableGrouping: true,
-        header: HCA_ATLAS_TRACKER_CATEGORY_LABEL.TARGET_COMPLETION_DATE,
-        id: HCA_ATLAS_TRACKER_CATEGORY_KEY.TARGET_COMPLETION_DATE,
-        width: { max: "0.5fr", min: "168px" },
       },
     ],
     tableOptions: TABLE_OPTIONS,

--- a/site-config/hca-atlas-tracker/local/index/atlas/tableOptions.ts
+++ b/site-config/hca-atlas-tracker/local/index/atlas/tableOptions.ts
@@ -16,8 +16,8 @@ export const TABLE_OPTIONS: ListConfig<HCAAtlasTrackerListAtlas>["tableOptions"]
         [HCA_ATLAS_TRACKER_CATEGORY_KEY.INGESTION_COUNTS_CAP]: false,
         [HCA_ATLAS_TRACKER_CATEGORY_KEY.INTEGRATION_LEAD]: false,
         [HCA_ATLAS_TRACKER_CATEGORY_KEY.METADATA_SPECIFICATION_URL]: false,
+        [HCA_ATLAS_TRACKER_CATEGORY_KEY.PUBLISHED_AT]: false,
         [HCA_ATLAS_TRACKER_CATEGORY_KEY.VERSION]: false,
-        [HCA_ATLAS_TRACKER_CATEGORY_KEY.WAVE]: false,
       },
       expanded: true,
       sorting: [


### PR DESCRIPTION
## Summary

- **Atlases page columns**: removes `TARGET_COMPLETION_DATE` and `WAVE` column entries (no longer in use). Keeps `PUBLISHED_AT` (Release Date) column but hides it by default via `tableOptions.initialState.columnVisibility`; users can re-enable through Edit Columns.
- **Atlases page filters**: removes the `TARGET_COMPLETION_DATE`, `PUBLISHED_AT`, and `WAVE` facets from the left filter rail. Atlas / Version / Bionetwork / Integration Lead / Endorsement Status remain in place.
- **Cleanup**:
  - `tableOptions.ts`: drops `WAVE: false`, adds `PUBLISHED_AT: false`.
  - Removes the now-unused `buildWave` view builder (`buildTargetCompletion` is retained — still used by the Tasks page).
  - Drops the now-unused `WAVE` (singular) entries from `site-config/hca-atlas-tracker/category.ts`. `WAVES` (plural) and `TARGET_COMPLETION_DATE` keys/labels remain because the Tasks page still uses them.
- `dev` and `prod` env configs re-use the local config (`makeConfig` from `local/config.ts`), so only the local files need editing.

Closes #1314

## Test plan

- [x] `npm run lint`
- [x] `npm run check-format`
- [x] `npx tsc --noEmit`
- [x] `npm run build:local`
- [x] `npm test` (1104/1104 passing)
- [x] Manual: `/atlases` page no longer shows Target Completion or Wave columns; Release Date hidden on initial load but available via Edit Columns; left filter rail no longer offers Target Completion / Release Date / Wave facets; remaining columns and filters unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1258" height="787" alt="image" src="https://github.com/user-attachments/assets/1d5b5783-c8c3-43c0-9ba8-ffe3fb085953" />
