### PR TITLE
feat: collapse mid-priority nav items into a more menu at sm/md viewports (#1305)

### DIFF
--- a/site-config/hca-atlas-tracker/local/config.ts
+++ b/site-config/hca-atlas-tracker/local/config.ts
@@ -74,15 +74,47 @@ export function makeConfig(
               label: "Atlases",
               url: ROUTE.ATLASES,
             },
-            { label: "Source Studies", url: ROUTE.SOURCE_STUDIES },
-            { label: "Source Datasets", url: ROUTE.SOURCE_DATASETS },
-            { label: "Integrated Objects", url: ROUTE.INTEGRATED_OBJECTS },
-            { label: "Reports", url: ROUTE.REPORTS },
-            { label: "Team", url: ROUTE.USERS },
+            {
+              label: "Source Studies",
+              url: ROUTE.SOURCE_STUDIES,
+              visible: { md: false, sm: false },
+            },
+            {
+              label: "Source Datasets",
+              url: ROUTE.SOURCE_DATASETS,
+              visible: { md: false, sm: false },
+            },
+            {
+              label: "Integrated Objects",
+              url: ROUTE.INTEGRATED_OBJECTS,
+              visible: { md: false, sm: false },
+            },
+            {
+              label: "Reports",
+              url: ROUTE.REPORTS,
+              visible: { md: false, sm: false },
+            },
+            {
+              label: "Team",
+              url: ROUTE.USERS,
+              visible: { md: false, sm: false },
+            },
             {
               label: "Metadata Dictionary",
               target: ANCHOR_TARGET.BLANK,
               url: `${portalUrl}/metadata/tier-1`,
+            },
+            {
+              label: "More",
+              menuItems: [
+                { label: "Source Studies", url: ROUTE.SOURCE_STUDIES },
+                { label: "Source Datasets", url: ROUTE.SOURCE_DATASETS },
+                { label: "Integrated Objects", url: ROUTE.INTEGRATED_OBJECTS },
+                { label: "Reports", url: ROUTE.REPORTS },
+                { label: "Team", url: ROUTE.USERS },
+              ],
+              url: "",
+              visible: { lg: false, xs: false },
             },
           ],
           [


### PR DESCRIPTION
## Summary

At `sm` (1024–1279) and `md` (1280–1439) viewports the header was running out of room and the seven top-level links were getting cramped. This change collapses the five mid-priority items into a new **More** menu at those breakpoints, leaving the full top-level nav untouched at `lg` (1440+) and the burger drawer at `xs` (<1024) unchanged.

- Adds `visible: { sm: false, md: false }` to **Source Studies / Source Datasets / Integrated Objects / Reports / Team** so they vanish at `sm`/`md` only.
- Inserts a new `More` entry after **Metadata Dictionary** in the middle nav slot. It carries the same five items as `menuItems` and `visible: { lg: false, xs: false }` so it shows only at `sm`/`md`.
- No `flatten` needed — at `xs` the originals remain visible and the existing burger drawer renders them as today.

Resulting order at `sm`/`md`: Atlases → Metadata Dictionary → **More** → Help & Documentation.

### Implementation note

The ticket referenced anvil-portal's `VISIBLE.*` / `FLATTEN.*` constants. This repo's findable-ui (v51) doesn't export those helpers — its `NavLinkItem` takes `visible?: Partial<Record<BreakpointKey, boolean>>` and `flatten?: Partial<Record<BreakpointKey, boolean>>` directly, with the semantic `visible[bp] !== false`. Breakpoint keys are also restricted to `xs / sm / md / lg` (no `xl`) via findable-ui's `BreakpointOverrides`. The breakpoint values are set in this app to: `xs: 0`, `sm: 1024`, `md: 1280`, `lg: 1440`.

Closes #1305

## Test plan

- [x] `npm run lint`
- [x] `npm run check-format`
- [x] `npx tsc --noEmit`
- [x] `npm run build:local`
- [x] `npm test` (1110/1110 passing)
- [x] Manual: at 1024px (sm) and 1280px (md) the header shows Atlases / Metadata Dictionary / More / Help with the five items inside More; at 1440px (lg) the full top-level nav is unchanged; at <1024px (xs) the burger drawer behaves as today (no More, originals listed inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<img width="902" height="905" alt="image" src="https://github.com/user-attachments/assets/c6d43a39-2f3d-4e39-822f-1f2a1b48a747" />

<img width="900" height="904" alt="image" src="https://github.com/user-attachments/assets/6bf1c054-939b-4ae8-aa14-cf4581b54304" />

<img width="1272" height="913" alt="image" src="https://github.com/user-attachments/assets/e094d6c2-bba2-4209-8583-fdcd989081ab" />
