### PR TITLE
feat: return component atlas lists from source dataset list apis (#1320)

### DIFF
--- a/__tests__/api-atlases-id-component-atlases-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id-source-datasets.test.ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
 import {
   HCAAtlasTrackerDBComponentAtlas,
+  HCAAtlasTrackerLocalListSourceDataset,
   HCAAtlasTrackerSourceDataset,
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 import {
@@ -14,19 +15,24 @@ import sourceDatasetsHandler from "../pages/api/atlases/[atlasId]/component-atla
 import {
   ATLAS_DRAFT,
   ATLAS_PUBLIC,
+  ATLAS_WITH_MISC_SOURCE_STUDIES,
   ATLAS_WITH_MISC_SOURCE_STUDIES_B,
   ATLAS_WITH_NON_LATEST_METADATA_ENTITIES,
   COMPONENT_ATLAS_ARCHIVED_FOO,
   COMPONENT_ATLAS_DRAFT_BAR,
   COMPONENT_ATLAS_DRAFT_FOO,
   COMPONENT_ATLAS_ID_NON_LATEST_METADATA_ENTITIES_BAR,
+  COMPONENT_ATLAS_ID_NON_LATEST_METADATA_ENTITIES_BAZ,
   COMPONENT_ATLAS_ID_NON_LATEST_METADATA_ENTITIES_FOO,
   COMPONENT_ATLAS_ID_WITH_MULTIPLE_FILES,
+  COMPONENT_ATLAS_MISC_BAR,
+  COMPONENT_ATLAS_MISC_BAZ,
   COMPONENT_ATLAS_MISC_FOO,
   COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAR_W1,
   COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAR_W2,
   COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_FOO_W2,
   COMPONENT_ATLAS_WITH_MULTIPLE_FILES_W3,
+  FILE_A_COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ,
   SOURCE_DATASET_ARCHIVED_BAR,
   SOURCE_DATASET_ARCHIVED_FOO,
   SOURCE_DATASET_BAR,
@@ -59,6 +65,8 @@ import {
 } from "../testing/db-utils";
 import { TestComponentAtlas, TestUser } from "../testing/entities";
 import {
+  assertExpectDefined,
+  expectApiSourceDatasetsToHaveComponentAtlases,
   expectApiSourceDatasetsToMatchTest,
   testApiRole,
   withConsoleErrorHiding,
@@ -267,6 +275,56 @@ describe(TEST_ROUTE, () => {
     const sourceDatasets = res._getJSONData() as HCAAtlasTrackerSourceDataset[];
     expectApiSourceDatasetsToMatchTest(sourceDatasets, [
       SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_BAR_W2,
+    ]);
+  });
+
+  it("returns component atlas lists", async () => {
+    const res = await doSourceDatasetsRequest(
+      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+      COMPONENT_ATLAS_MISC_BAR.id,
+      USER_CONTENT_ADMIN,
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const sourceDatasets =
+      res._getJSONData() as HCAAtlasTrackerLocalListSourceDataset[];
+    expectApiSourceDatasetsToHaveComponentAtlases(sourceDatasets, [
+      {
+        componentAtlases: [COMPONENT_ATLAS_MISC_FOO, COMPONENT_ATLAS_MISC_BAR],
+        sourceDataset: SOURCE_DATASET_FOO,
+      },
+      {
+        componentAtlases: [COMPONENT_ATLAS_MISC_BAR],
+        sourceDataset: SOURCE_DATASET_BAR,
+      },
+      {
+        componentAtlases: [
+          COMPONENT_ATLAS_MISC_FOO,
+          COMPONENT_ATLAS_MISC_BAR,
+          COMPONENT_ATLAS_MISC_BAZ,
+        ],
+        sourceDataset: SOURCE_DATASET_FOOFOO,
+      },
+    ]);
+  });
+
+  it("returns component atlas list for source dataset linked to only a non-latest component atlas version", async () => {
+    const res = await doSourceDatasetsRequest(
+      ATLAS_WITH_NON_LATEST_METADATA_ENTITIES.id,
+      COMPONENT_ATLAS_ID_NON_LATEST_METADATA_ENTITIES_BAZ,
+      USER_CONTENT_ADMIN,
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const sourceDatasets =
+      res._getJSONData() as HCAAtlasTrackerLocalListSourceDataset[];
+    const sourceDatasetBaz = sourceDatasets.find(
+      (d) => d.id === SOURCE_DATASET_ID_NON_LATEST_METADATA_ENTITIES_BAZ,
+    );
+    assertExpectDefined(sourceDatasetBaz);
+    expect(sourceDatasetBaz.componentAtlases).toEqual([
+      {
+        id: COMPONENT_ATLAS_ID_NON_LATEST_METADATA_ENTITIES_BAZ,
+        name: FILE_A_COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ.fileName,
+      },
     ]);
   });
 

--- a/__tests__/api-atlases-id-component-atlases-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id-source-datasets.test.ts
@@ -184,7 +184,7 @@ describe(TEST_ROUTE, () => {
 
   for (const role of STAKEHOLDER_ANALOGOUS_ROLES) {
     testApiRole(
-      "returns source datasets",
+      "returns source datasets that are also linked to the atlas",
       TEST_ROUTE,
       sourceDatasetsHandler,
       METHOD.GET,
@@ -199,13 +199,12 @@ describe(TEST_ROUTE, () => {
         expectApiSourceDatasetsToMatchTest(sourceDatasets, [
           SOURCE_DATASET_FOOFOO,
           SOURCE_DATASET_FOOBAR,
-          SOURCE_DATASET_FOOBAZ,
         ]);
       },
     );
   }
 
-  it("returns source datasets when requested by logged in user with CONTENT_ADMIN role", async () => {
+  it("returns source datasets that are also linked to the atlas when requested by logged in user with CONTENT_ADMIN role", async () => {
     const res = await doSourceDatasetsRequest(
       ATLAS_DRAFT.id,
       COMPONENT_ATLAS_DRAFT_FOO.id,
@@ -216,7 +215,6 @@ describe(TEST_ROUTE, () => {
     expectApiSourceDatasetsToMatchTest(sourceDatasets, [
       SOURCE_DATASET_FOOFOO,
       SOURCE_DATASET_FOOBAR,
-      SOURCE_DATASET_FOOBAZ,
     ]);
   });
 

--- a/__tests__/api-atlases-id-component-atlases-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id-source-datasets.test.ts
@@ -30,10 +30,9 @@ import {
   COMPONENT_ATLAS_MISC_FOO,
   COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAR_W1,
   COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAR_W2,
+  COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ_W1,
   COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_FOO_W2,
   COMPONENT_ATLAS_WITH_MULTIPLE_FILES_W3,
-  FILE_A_COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ,
-  FILE_C_COMPONENT_ATLAS_WITH_MULTIPLE_FILES,
   SOURCE_DATASET_ARCHIVED_BAR,
   SOURCE_DATASET_ARCHIVED_FOO,
   SOURCE_DATASET_BAR,
@@ -70,6 +69,7 @@ import {
   assertExpectDefined,
   expectApiSourceDatasetsToHaveComponentAtlases,
   expectApiSourceDatasetsToMatchTest,
+  getTestEntityDownloadName,
   testApiRole,
   withConsoleErrorHiding,
 } from "../testing/utils";
@@ -325,7 +325,7 @@ describe(TEST_ROUTE, () => {
     expect(sourceDatasetMultipleFiles.componentAtlases).toEqual([
       {
         id: COMPONENT_ATLAS_ID_WITH_MULTIPLE_FILES,
-        name: FILE_C_COMPONENT_ATLAS_WITH_MULTIPLE_FILES.fileName,
+        name: getTestEntityDownloadName(COMPONENT_ATLAS_WITH_MULTIPLE_FILES_W3),
       },
     ]);
   });
@@ -346,7 +346,9 @@ describe(TEST_ROUTE, () => {
     expect(sourceDatasetBaz.componentAtlases).toEqual([
       {
         id: COMPONENT_ATLAS_ID_NON_LATEST_METADATA_ENTITIES_BAZ,
-        name: FILE_A_COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ.fileName,
+        name: getTestEntityDownloadName(
+          COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ_W1,
+        ),
       },
     ]);
   });

--- a/__tests__/api-atlases-id-component-atlases-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id-source-datasets.test.ts
@@ -33,6 +33,7 @@ import {
   COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_FOO_W2,
   COMPONENT_ATLAS_WITH_MULTIPLE_FILES_W3,
   FILE_A_COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ,
+  FILE_C_COMPONENT_ATLAS_WITH_MULTIPLE_FILES,
   SOURCE_DATASET_ARCHIVED_BAR,
   SOURCE_DATASET_ARCHIVED_FOO,
   SOURCE_DATASET_BAR,
@@ -45,6 +46,7 @@ import {
   SOURCE_DATASET_ID_NON_LATEST_METADATA_ENTITIES_BAR,
   SOURCE_DATASET_ID_NON_LATEST_METADATA_ENTITIES_BAZ,
   SOURCE_DATASET_ID_NON_LATEST_METADATA_ENTITIES_FOO,
+  SOURCE_DATASET_ID_WITH_MULTIPLE_FILES,
   SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_BAR_W2,
   SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_BAZ_W1,
   SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_FOO_W2,
@@ -303,6 +305,27 @@ describe(TEST_ROUTE, () => {
           COMPONENT_ATLAS_MISC_BAZ,
         ],
         sourceDataset: SOURCE_DATASET_FOOFOO,
+      },
+    ]);
+  });
+
+  it("does not include archived component atlas in component atlas list", async () => {
+    const res = await doSourceDatasetsRequest(
+      ATLAS_WITH_MISC_SOURCE_STUDIES_B.id,
+      COMPONENT_ATLAS_ID_WITH_MULTIPLE_FILES,
+      USER_CONTENT_ADMIN,
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const sourceDatasets =
+      res._getJSONData() as HCAAtlasTrackerLocalListSourceDataset[];
+    const sourceDatasetMultipleFiles = sourceDatasets.find(
+      (d) => d.id === SOURCE_DATASET_ID_WITH_MULTIPLE_FILES,
+    );
+    assertExpectDefined(sourceDatasetMultipleFiles);
+    expect(sourceDatasetMultipleFiles.componentAtlases).toEqual([
+      {
+        id: COMPONENT_ATLAS_ID_WITH_MULTIPLE_FILES,
+        name: FILE_C_COMPONENT_ATLAS_WITH_MULTIPLE_FILES.fileName,
       },
     ]);
   });

--- a/__tests__/api-atlases-id-component-atlases.test.ts
+++ b/__tests__/api-atlases-id-component-atlases.test.ts
@@ -276,7 +276,7 @@ describe(TEST_ROUTE, () => {
         COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAR_W2,
         COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ_W1,
       ],
-      [1, 1, 0],
+      [1, 1, 1],
     );
   });
 

--- a/__tests__/api-atlases-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-source-datasets.test.ts
@@ -1,6 +1,9 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
-import { HCAAtlasTrackerSourceDataset } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import {
+  HCAAtlasTrackerLocalListSourceDataset,
+  HCAAtlasTrackerSourceDataset,
+} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD } from "../app/common/entities";
 import { endPgPool } from "../app/services/database";
 import sourceDatasetsHandler from "../pages/api/atlases/[atlasId]/source-datasets";
@@ -10,7 +13,12 @@ import {
   ATLAS_WITH_MISC_SOURCE_STUDIES_B,
   ATLAS_WITH_MISC_SOURCE_STUDIES_C,
   ATLAS_WITH_NON_LATEST_METADATA_ENTITIES,
+  COMPONENT_ATLAS_ID_NON_LATEST_METADATA_ENTITIES_BAZ,
+  COMPONENT_ATLAS_MISC_BAR,
+  COMPONENT_ATLAS_MISC_BAZ,
+  COMPONENT_ATLAS_MISC_FOO,
   CONCEPT_SOURCE_DATASET_OUTDATED_FILENAME,
+  FILE_A_COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ,
   FILE_C_SOURCE_DATASET_WITH_MULTIPLE_FILES,
   SOURCE_DATASET_ARCHIVED_BAR,
   SOURCE_DATASET_ARCHIVED_BAZ,
@@ -29,6 +37,7 @@ import {
   SOURCE_DATASET_FOOBAR,
   SOURCE_DATASET_FOOBAZ,
   SOURCE_DATASET_FOOFOO,
+  SOURCE_DATASET_ID_NON_LATEST_METADATA_ENTITIES_BAZ,
   SOURCE_DATASET_ID_OUTDATED_FILENAME,
   SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_BAR_W2,
   SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_BAZ_W1,
@@ -47,6 +56,7 @@ import { resetDatabase } from "../testing/db-utils";
 import { TestUser } from "../testing/entities";
 import {
   assertExpectDefined,
+  expectApiSourceDatasetsToHaveComponentAtlases,
   expectApiSourceDatasetsToMatchTest,
   expectApiSourceDatasetToMatchTest,
   expectIsDefined,
@@ -328,6 +338,94 @@ describe(TEST_ROUTE, () => {
       CONCEPT_SOURCE_DATASET_OUTDATED_FILENAME.baseFilename,
     );
     expect(sourceDataset.baseFileName).not.toEqual(sourceDataset.fileName);
+  });
+
+  it("returns component atlas lists", async () => {
+    const res = await doSourceDatasetsRequest(
+      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+      USER_CONTENT_ADMIN,
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const sourceDatasets =
+      res._getJSONData() as HCAAtlasTrackerLocalListSourceDataset[];
+    expectApiSourceDatasetsToHaveComponentAtlases(sourceDatasets, [
+      {
+        componentAtlases: [COMPONENT_ATLAS_MISC_FOO, COMPONENT_ATLAS_MISC_BAR],
+        sourceDataset: SOURCE_DATASET_FOO,
+      },
+      {
+        componentAtlases: [COMPONENT_ATLAS_MISC_BAR],
+        sourceDataset: SOURCE_DATASET_BAR,
+      },
+      {
+        componentAtlases: [],
+        sourceDataset: SOURCE_DATASET_BAZ,
+      },
+      {
+        componentAtlases: [
+          COMPONENT_ATLAS_MISC_FOO,
+          COMPONENT_ATLAS_MISC_BAR,
+          COMPONENT_ATLAS_MISC_BAZ,
+        ],
+        sourceDataset: SOURCE_DATASET_FOOFOO,
+      },
+      {
+        componentAtlases: [],
+        sourceDataset: SOURCE_DATASET_FOOBAR,
+      },
+      {
+        componentAtlases: [],
+        sourceDataset: SOURCE_DATASET_FOOBAZ,
+      },
+      {
+        componentAtlases: [],
+        sourceDataset: SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE,
+      },
+      {
+        componentAtlases: [],
+        sourceDataset: SOURCE_DATASET_CELLXGENE_WITH_UPDATE,
+      },
+      {
+        componentAtlases: [],
+        sourceDataset: SOURCE_DATASET_ATLAS_LINKED_A_FOO,
+      },
+      {
+        componentAtlases: [],
+        sourceDataset: SOURCE_DATASET_ATLAS_LINKED_A_BAR,
+      },
+      {
+        componentAtlases: [],
+        sourceDataset: SOURCE_DATASET_ATLAS_LINKED_B_FOO,
+      },
+      {
+        componentAtlases: [],
+        sourceDataset: SOURCE_DATASET_ATLAS_LINKED_B_BAR,
+      },
+      {
+        componentAtlases: [],
+        sourceDataset: SOURCE_DATASET_PUBLISHED_WITHOUT_CELLXGENE_ID_FOO,
+      },
+    ]);
+  });
+
+  it("returns component atlas list for source dataset linked to only a non-latest component atlas version", async () => {
+    const res = await doSourceDatasetsRequest(
+      ATLAS_WITH_NON_LATEST_METADATA_ENTITIES.id,
+      USER_CONTENT_ADMIN,
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const sourceDatasets =
+      res._getJSONData() as HCAAtlasTrackerLocalListSourceDataset[];
+    const sourceDatasetBaz = sourceDatasets.find(
+      (d) => d.id === SOURCE_DATASET_ID_NON_LATEST_METADATA_ENTITIES_BAZ,
+    );
+    assertExpectDefined(sourceDatasetBaz);
+    expect(sourceDatasetBaz.componentAtlases).toEqual([
+      {
+        id: COMPONENT_ATLAS_ID_NON_LATEST_METADATA_ENTITIES_BAZ,
+        name: FILE_A_COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ.fileName,
+      },
+    ]);
   });
 });
 

--- a/__tests__/api-atlases-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-source-datasets.test.ts
@@ -18,9 +18,9 @@ import {
   COMPONENT_ATLAS_MISC_BAR,
   COMPONENT_ATLAS_MISC_BAZ,
   COMPONENT_ATLAS_MISC_FOO,
+  COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ_W1,
+  COMPONENT_ATLAS_WITH_MULTIPLE_FILES_W3,
   CONCEPT_SOURCE_DATASET_OUTDATED_FILENAME,
-  FILE_A_COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ,
-  FILE_C_COMPONENT_ATLAS_WITH_MULTIPLE_FILES,
   FILE_C_SOURCE_DATASET_WITH_MULTIPLE_FILES,
   SOURCE_DATASET_ARCHIVED_BAR,
   SOURCE_DATASET_ARCHIVED_BAZ,
@@ -64,6 +64,7 @@ import {
   expectApiSourceDatasetToMatchTest,
   expectIsDefined,
   getTestAtlasShortNameSlug,
+  getTestEntityDownloadName,
   testApiRole,
   withConsoleErrorHiding,
 } from "../testing/utils";
@@ -426,7 +427,7 @@ describe(TEST_ROUTE, () => {
     expect(sourceDatasetMultipleFiles.componentAtlases).toEqual([
       {
         id: COMPONENT_ATLAS_ID_WITH_MULTIPLE_FILES,
-        name: FILE_C_COMPONENT_ATLAS_WITH_MULTIPLE_FILES.fileName,
+        name: getTestEntityDownloadName(COMPONENT_ATLAS_WITH_MULTIPLE_FILES_W3),
       },
     ]);
   });
@@ -446,7 +447,9 @@ describe(TEST_ROUTE, () => {
     expect(sourceDatasetBaz.componentAtlases).toEqual([
       {
         id: COMPONENT_ATLAS_ID_NON_LATEST_METADATA_ENTITIES_BAZ,
-        name: FILE_A_COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ.fileName,
+        name: getTestEntityDownloadName(
+          COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ_W1,
+        ),
       },
     ]);
   });

--- a/__tests__/api-atlases-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-source-datasets.test.ts
@@ -14,11 +14,13 @@ import {
   ATLAS_WITH_MISC_SOURCE_STUDIES_C,
   ATLAS_WITH_NON_LATEST_METADATA_ENTITIES,
   COMPONENT_ATLAS_ID_NON_LATEST_METADATA_ENTITIES_BAZ,
+  COMPONENT_ATLAS_ID_WITH_MULTIPLE_FILES,
   COMPONENT_ATLAS_MISC_BAR,
   COMPONENT_ATLAS_MISC_BAZ,
   COMPONENT_ATLAS_MISC_FOO,
   CONCEPT_SOURCE_DATASET_OUTDATED_FILENAME,
   FILE_A_COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ,
+  FILE_C_COMPONENT_ATLAS_WITH_MULTIPLE_FILES,
   FILE_C_SOURCE_DATASET_WITH_MULTIPLE_FILES,
   SOURCE_DATASET_ARCHIVED_BAR,
   SOURCE_DATASET_ARCHIVED_BAZ,
@@ -39,6 +41,7 @@ import {
   SOURCE_DATASET_FOOFOO,
   SOURCE_DATASET_ID_NON_LATEST_METADATA_ENTITIES_BAZ,
   SOURCE_DATASET_ID_OUTDATED_FILENAME,
+  SOURCE_DATASET_ID_WITH_MULTIPLE_FILES,
   SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_BAR_W2,
   SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_BAZ_W1,
   SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_FOO_W2,
@@ -404,6 +407,26 @@ describe(TEST_ROUTE, () => {
       {
         componentAtlases: [],
         sourceDataset: SOURCE_DATASET_PUBLISHED_WITHOUT_CELLXGENE_ID_FOO,
+      },
+    ]);
+  });
+
+  it("does not include archived component atlas in component atlas list", async () => {
+    const res = await doSourceDatasetsRequest(
+      ATLAS_WITH_MISC_SOURCE_STUDIES_B.id,
+      USER_CONTENT_ADMIN,
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const sourceDatasets =
+      res._getJSONData() as HCAAtlasTrackerLocalListSourceDataset[];
+    const sourceDatasetMultipleFiles = sourceDatasets.find(
+      (d) => d.id === SOURCE_DATASET_ID_WITH_MULTIPLE_FILES,
+    );
+    assertExpectDefined(sourceDatasetMultipleFiles);
+    expect(sourceDatasetMultipleFiles.componentAtlases).toEqual([
+      {
+        id: COMPONENT_ATLAS_ID_WITH_MULTIPLE_FILES,
+        name: FILE_C_COMPONENT_ATLAS_WITH_MULTIPLE_FILES.fileName,
       },
     ]);
   });

--- a/__tests__/api-atlases-id-source-studies-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id-source-datasets.test.ts
@@ -1,6 +1,9 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
-import { HCAAtlasTrackerSourceDataset } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import {
+  HCAAtlasTrackerLocalListSourceDataset,
+  HCAAtlasTrackerSourceDataset,
+} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD } from "../app/common/entities";
 import { endPgPool } from "../app/services/database";
 import sourceDatasetsHandler from "../pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets";
@@ -8,6 +11,11 @@ import {
   ATLAS_WITH_MISC_SOURCE_STUDIES,
   ATLAS_WITH_MISC_SOURCE_STUDIES_B,
   ATLAS_WITH_NON_LATEST_METADATA_ENTITIES,
+  COMPONENT_ATLAS_ID_NON_LATEST_METADATA_ENTITIES_BAZ,
+  COMPONENT_ATLAS_MISC_BAR,
+  COMPONENT_ATLAS_MISC_BAZ,
+  COMPONENT_ATLAS_MISC_FOO,
+  FILE_A_COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ,
   FILE_C_SOURCE_DATASET_WITH_MULTIPLE_FILES,
   SOURCE_DATASET_BAR,
   SOURCE_DATASET_BAZ,
@@ -17,8 +25,10 @@ import {
   SOURCE_DATASET_FOOBAR,
   SOURCE_DATASET_FOOBAZ,
   SOURCE_DATASET_FOOFOO,
+  SOURCE_DATASET_ID_NON_LATEST_METADATA_ENTITIES_BAZ,
   SOURCE_DATASET_ID_WITH_MULTIPLE_FILES,
   SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_BAR_W2,
+  SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_BAZ_W1,
   SOURCE_DATASET_WITH_MULTIPLE_FILES_W3,
   SOURCE_STUDY_WITH_ATLAS_LINKED_DATASETS_A,
   SOURCE_STUDY_WITH_NON_LATEST_METADATA_ENTITIES,
@@ -31,6 +41,8 @@ import {
 import { resetDatabase } from "../testing/db-utils";
 import { TestUser } from "../testing/entities";
 import {
+  assertExpectDefined,
+  expectApiSourceDatasetsToHaveComponentAtlases,
   expectApiSourceDatasetsToMatchTest,
   expectIsDefined,
   testApiRole,
@@ -192,6 +204,77 @@ describe(TEST_ROUTE, () => {
     const sourceDatasets = res._getJSONData() as HCAAtlasTrackerSourceDataset[];
     expectApiSourceDatasetsToMatchTest(sourceDatasets, [
       SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_BAR_W2,
+      SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_BAZ_W1,
+    ]);
+  });
+
+  it("returns component atlas lists", async () => {
+    const res = await doSourceDatasetsRequest(
+      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+      SOURCE_STUDY_WITH_SOURCE_DATASETS.id,
+      USER_CONTENT_ADMIN,
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const sourceDatasets =
+      res._getJSONData() as HCAAtlasTrackerLocalListSourceDataset[];
+    expectApiSourceDatasetsToHaveComponentAtlases(sourceDatasets, [
+      {
+        componentAtlases: [COMPONENT_ATLAS_MISC_FOO, COMPONENT_ATLAS_MISC_BAR],
+        sourceDataset: SOURCE_DATASET_FOO,
+      },
+      {
+        componentAtlases: [COMPONENT_ATLAS_MISC_BAR],
+        sourceDataset: SOURCE_DATASET_BAR,
+      },
+      {
+        componentAtlases: [],
+        sourceDataset: SOURCE_DATASET_BAZ,
+      },
+      {
+        componentAtlases: [
+          COMPONENT_ATLAS_MISC_FOO,
+          COMPONENT_ATLAS_MISC_BAR,
+          COMPONENT_ATLAS_MISC_BAZ,
+        ],
+        sourceDataset: SOURCE_DATASET_FOOFOO,
+      },
+      {
+        componentAtlases: [],
+        sourceDataset: SOURCE_DATASET_FOOBAR,
+      },
+      {
+        componentAtlases: [],
+        sourceDataset: SOURCE_DATASET_FOOBAZ,
+      },
+      {
+        componentAtlases: [],
+        sourceDataset: SOURCE_DATASET_CELLXGENE_WITHOUT_UPDATE,
+      },
+      {
+        componentAtlases: [],
+        sourceDataset: SOURCE_DATASET_CELLXGENE_WITH_UPDATE,
+      },
+    ]);
+  });
+
+  it("returns component atlas list for source dataset linked to only a non-latest component atlas version", async () => {
+    const res = await doSourceDatasetsRequest(
+      ATLAS_WITH_NON_LATEST_METADATA_ENTITIES.id,
+      SOURCE_STUDY_WITH_NON_LATEST_METADATA_ENTITIES.id,
+      USER_CONTENT_ADMIN,
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const sourceDatasets =
+      res._getJSONData() as HCAAtlasTrackerLocalListSourceDataset[];
+    const sourceDatasetBaz = sourceDatasets.find(
+      (d) => d.id === SOURCE_DATASET_ID_NON_LATEST_METADATA_ENTITIES_BAZ,
+    );
+    assertExpectDefined(sourceDatasetBaz);
+    expect(sourceDatasetBaz.componentAtlases).toEqual([
+      {
+        id: COMPONENT_ATLAS_ID_NON_LATEST_METADATA_ENTITIES_BAZ,
+        name: FILE_A_COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ.fileName,
+      },
     ]);
   });
 });

--- a/__tests__/api-atlases-id-source-studies-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id-source-datasets.test.ts
@@ -16,8 +16,8 @@ import {
   COMPONENT_ATLAS_MISC_BAR,
   COMPONENT_ATLAS_MISC_BAZ,
   COMPONENT_ATLAS_MISC_FOO,
-  FILE_A_COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ,
-  FILE_C_COMPONENT_ATLAS_WITH_MULTIPLE_FILES,
+  COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ_W1,
+  COMPONENT_ATLAS_WITH_MULTIPLE_FILES_W3,
   FILE_C_SOURCE_DATASET_WITH_MULTIPLE_FILES,
   SOURCE_DATASET_BAR,
   SOURCE_DATASET_BAZ,
@@ -47,6 +47,7 @@ import {
   expectApiSourceDatasetsToHaveComponentAtlases,
   expectApiSourceDatasetsToMatchTest,
   expectIsDefined,
+  getTestEntityDownloadName,
   testApiRole,
   withConsoleErrorHiding,
 } from "../testing/utils";
@@ -275,7 +276,7 @@ describe(TEST_ROUTE, () => {
     expect(sourceDatasetMultipleFiles.componentAtlases).toEqual([
       {
         id: COMPONENT_ATLAS_ID_WITH_MULTIPLE_FILES,
-        name: FILE_C_COMPONENT_ATLAS_WITH_MULTIPLE_FILES.fileName,
+        name: getTestEntityDownloadName(COMPONENT_ATLAS_WITH_MULTIPLE_FILES_W3),
       },
     ]);
   });
@@ -296,7 +297,9 @@ describe(TEST_ROUTE, () => {
     expect(sourceDatasetBaz.componentAtlases).toEqual([
       {
         id: COMPONENT_ATLAS_ID_NON_LATEST_METADATA_ENTITIES_BAZ,
-        name: FILE_A_COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ.fileName,
+        name: getTestEntityDownloadName(
+          COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ_W1,
+        ),
       },
     ]);
   });

--- a/__tests__/api-atlases-id-source-studies-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id-source-datasets.test.ts
@@ -12,10 +12,12 @@ import {
   ATLAS_WITH_MISC_SOURCE_STUDIES_B,
   ATLAS_WITH_NON_LATEST_METADATA_ENTITIES,
   COMPONENT_ATLAS_ID_NON_LATEST_METADATA_ENTITIES_BAZ,
+  COMPONENT_ATLAS_ID_WITH_MULTIPLE_FILES,
   COMPONENT_ATLAS_MISC_BAR,
   COMPONENT_ATLAS_MISC_BAZ,
   COMPONENT_ATLAS_MISC_FOO,
   FILE_A_COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ,
+  FILE_C_COMPONENT_ATLAS_WITH_MULTIPLE_FILES,
   FILE_C_SOURCE_DATASET_WITH_MULTIPLE_FILES,
   SOURCE_DATASET_BAR,
   SOURCE_DATASET_BAZ,
@@ -253,6 +255,27 @@ describe(TEST_ROUTE, () => {
       {
         componentAtlases: [],
         sourceDataset: SOURCE_DATASET_CELLXGENE_WITH_UPDATE,
+      },
+    ]);
+  });
+
+  it("does not include archived component atlas in component atlas list", async () => {
+    const res = await doSourceDatasetsRequest(
+      ATLAS_WITH_MISC_SOURCE_STUDIES_B.id,
+      SOURCE_STUDY_WITH_ATLAS_LINKED_DATASETS_A.id,
+      USER_CONTENT_ADMIN,
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const sourceDatasets =
+      res._getJSONData() as HCAAtlasTrackerLocalListSourceDataset[];
+    const sourceDatasetMultipleFiles = sourceDatasets.find(
+      (d) => d.id === SOURCE_DATASET_ID_WITH_MULTIPLE_FILES,
+    );
+    assertExpectDefined(sourceDatasetMultipleFiles);
+    expect(sourceDatasetMultipleFiles.componentAtlases).toEqual([
+      {
+        id: COMPONENT_ATLAS_ID_WITH_MULTIPLE_FILES,
+        name: FILE_C_COMPONENT_ATLAS_WITH_MULTIPLE_FILES.fileName,
       },
     ]);
   });

--- a/__tests__/api-source-studies.test.ts
+++ b/__tests__/api-source-studies.test.ts
@@ -87,7 +87,7 @@ const EXPECTED_PRESENT_SOURCE_STUDIES: Array<{
   {
     atlases: [ATLAS_WITH_NON_LATEST_METADATA_ENTITIES],
     latestAtlasIds: [ATLAS_WITH_NON_LATEST_METADATA_ENTITIES.id],
-    sourceDatasetCount: 1,
+    sourceDatasetCount: 2,
     sourceStudy: SOURCE_STUDY_WITH_NON_LATEST_METADATA_ENTITIES,
   },
   {

--- a/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
@@ -24,6 +24,7 @@ import {
   HCAAtlasTrackerDBSourceDatasetForAPI,
   HCAAtlasTrackerDBSourceDatasetForDetailAPI,
   HCAAtlasTrackerDBSourceDatasetForGlobalAPI,
+  HCAAtlasTrackerDBSourceDatasetForListAPI,
   HCAAtlasTrackerDBSourceStudy,
   HCAAtlasTrackerDBSourceStudyForGlobalAPI,
   HCAAtlasTrackerDBSourceStudyWithRelatedEntities,
@@ -37,6 +38,7 @@ import {
   HCAAtlasTrackerGlobalSourceDataset,
   HCAAtlasTrackerGlobalSourceStudy,
   HCAAtlasTrackerListEntrySheetValidation,
+  HCAAtlasTrackerLocalListSourceDataset,
   HCAAtlasTrackerSourceDataset,
   HCAAtlasTrackerSourceStudy,
   HCAAtlasTrackerUser,
@@ -234,6 +236,15 @@ export function dbSourceDatasetToDetailApiSourceDataset(
   return {
     ...dbSourceDatasetToApiSourceDataset(dbSourceDataset),
     validationReports: dbSourceDataset.validation_reports,
+  };
+}
+
+export function dbSourceDatasetToListApiSourceDataset(
+  dbSourceDataset: HCAAtlasTrackerDBSourceDatasetForListAPI,
+): HCAAtlasTrackerLocalListSourceDataset {
+  return {
+    ...dbSourceDatasetToApiSourceDataset(dbSourceDataset),
+    componentAtlases: dbSourceDataset.component_atlases,
   };
 }
 

--- a/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
@@ -244,7 +244,12 @@ export function dbSourceDatasetToListApiSourceDataset(
 ): HCAAtlasTrackerLocalListSourceDataset {
   return {
     ...dbSourceDatasetToApiSourceDataset(dbSourceDataset),
-    componentAtlases: dbSourceDataset.component_atlases,
+    componentAtlases: dbSourceDataset.component_atlases.map(
+      ({ baseFilename, id }) => ({
+        id,
+        name: removeFileExtension(baseFilename),
+      }),
+    ),
   };
 }
 

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -518,6 +518,9 @@ export type HCAAtlasTrackerDBSourceDatasetForAPI = WithSourceStudyInfo<
 export type HCAAtlasTrackerDBSourceDatasetForGlobalAPI =
   WithLinkedAtlases<HCAAtlasTrackerDBSourceDatasetForAPI>;
 
+export type HCAAtlasTrackerDBSourceDatasetForListAPI =
+  HCAAtlasTrackerDBSourceDatasetForAPI;
+
 export type HCAAtlasTrackerDBSourceDatasetForDetailAPI =
   HCAAtlasTrackerDBSourceDatasetForAPI &
     Pick<HCAAtlasTrackerDBFile, "validation_reports">;

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -199,6 +199,10 @@ export interface HCAAtlasTrackerGlobalSourceDataset
   atlasId: string;
 }
 
+export interface HCAAtlasTrackerLocalListSourceDataset extends HCAAtlasTrackerSourceDataset {
+  componentAtlases: LinkedComponentAtlasSummary[];
+}
+
 export type HCAAtlasTrackerListSourceDataset =
   HCAAtlasTrackerGlobalSourceDataset & {
     capIngestStatus: CAP_INGEST_STATUS;
@@ -519,7 +523,9 @@ export type HCAAtlasTrackerDBSourceDatasetForGlobalAPI =
   WithLinkedAtlases<HCAAtlasTrackerDBSourceDatasetForAPI>;
 
 export type HCAAtlasTrackerDBSourceDatasetForListAPI =
-  HCAAtlasTrackerDBSourceDatasetForAPI;
+  HCAAtlasTrackerDBSourceDatasetForAPI & {
+    component_atlases: LinkedComponentAtlasSummary[];
+  };
 
 export type HCAAtlasTrackerDBSourceDatasetForDetailAPI =
   HCAAtlasTrackerDBSourceDatasetForAPI &
@@ -685,6 +691,11 @@ export interface LinkedAtlasSummary {
   network: NetworkKey;
   revision: number;
   shortName: string;
+}
+
+export interface LinkedComponentAtlasSummary {
+  id: string;
+  name: string;
 }
 
 export interface Heatmap {

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -524,7 +524,7 @@ export type HCAAtlasTrackerDBSourceDatasetForGlobalAPI =
 
 export type HCAAtlasTrackerDBSourceDatasetForListAPI =
   HCAAtlasTrackerDBSourceDatasetForAPI & {
-    component_atlases: LinkedComponentAtlasSummary[];
+    component_atlases: DBLinkedComponentAtlasSummary[];
   };
 
 export type HCAAtlasTrackerDBSourceDatasetForDetailAPI =
@@ -696,6 +696,11 @@ export interface LinkedAtlasSummary {
 export interface LinkedComponentAtlasSummary {
   id: string;
   name: string;
+}
+
+export interface DBLinkedComponentAtlasSummary {
+  baseFilename: string;
+  id: string;
 }
 
 export interface Heatmap {

--- a/app/data/source-datasets.ts
+++ b/app/data/source-datasets.ts
@@ -178,8 +178,8 @@ export async function getSourceDatasetsForListApi(
               COALESCE(
                 ARRAY_AGG(
                   jsonb_build_object(
-                    'id', ca.id,
-                    'name', ccon.base_filename
+                    'baseFilename', ccon.base_filename,
+                    'id', ca.id
                   )
                 ),
                 '{}'

--- a/app/data/source-datasets.ts
+++ b/app/data/source-datasets.ts
@@ -185,7 +185,8 @@ export async function getSourceDatasetsForListApi(
               )
             FROM hat.component_atlases ca
             JOIN hat.concepts ccon ON ccon.id = ca.id
-            WHERE d.version_id = ANY(ca.source_datasets) AND ca.version_id = ANY(a.component_atlases)
+            JOIN hat.files cf ON cf.id = ca.file_id
+            WHERE d.version_id = ANY(ca.source_datasets) AND ca.version_id = ANY(a.component_atlases) AND NOT cf.is_archived
           ) as component_atlases
         FROM hat.source_datasets d
         JOIN hat.files f ON f.id = d.file_id

--- a/app/data/source-datasets.ts
+++ b/app/data/source-datasets.ts
@@ -143,7 +143,6 @@ export async function getSourceDatasetsForGlobalApi(): Promise<
  * Only source datasets linked to the given atlas are returned; specified datasets not linked to the atlas are excluded.
  * @param atlasId - ID of the atlas that the source datasets are accessed through, used to scope results to the atlas and to determine linked component atlas versions.
  * @param sourceDatasetVersions - Version IDs of source datasets to get.
- * @param acceptSubset - If false, an error will be thrown if any of the specified source datasets are unavailable. (Default false)
  * @param isArchivedValues - Values of `is_archived` to filter source datasets by. (Default `[false]`)
  * @param client - Postgres client to use.
  * @returns source datasets with fields for list APIs.
@@ -151,7 +150,6 @@ export async function getSourceDatasetsForGlobalApi(): Promise<
 export async function getSourceDatasetsForListApi(
   atlasId: string,
   sourceDatasetVersions: string[],
-  acceptSubset = false,
   isArchivedValues = [false],
   client?: pg.PoolClient,
 ): Promise<HCAAtlasTrackerDBSourceDatasetForListAPI[]> {
@@ -198,13 +196,6 @@ export async function getSourceDatasetsForListApi(
       `,
       [sourceDatasetVersions, isArchivedValues, atlasId],
       client,
-    );
-
-  if (!acceptSubset)
-    confirmQueryRowsContainVersionIds(
-      sourceDatasets,
-      sourceDatasetVersions,
-      PLURAL_ENTITY_NAME,
     );
 
   return sourceDatasets;

--- a/app/data/source-datasets.ts
+++ b/app/data/source-datasets.ts
@@ -3,9 +3,9 @@ import {
   HCAAtlasTrackerDBAtlas,
   HCAAtlasTrackerDBComponentAtlas,
   HCAAtlasTrackerDBSourceDataset,
-  HCAAtlasTrackerDBSourceDatasetForAPI,
   HCAAtlasTrackerDBSourceDatasetForDetailAPI,
   HCAAtlasTrackerDBSourceDatasetForGlobalAPI,
+  HCAAtlasTrackerDBSourceDatasetForListAPI,
   HCAAtlasTrackerDBSourceDatasetInfo,
   PUBLICATION_STATUS,
 } from "../apis/catalog/hca-atlas-tracker/common/entities";
@@ -139,21 +139,21 @@ export async function getSourceDatasetsForGlobalApi(): Promise<
 }
 
 /**
- * Get specified source datasets joined with data used for API responses.
+ * Get specified source datasets joined with data used for list API responses.
  * @param sourceDatasetVersions - Version IDs of source datasets to get.
  * @param acceptSubset - If false, an error will be thrown if any of the specified source datasets are unavailable. (Default false)
  * @param isArchivedValues - Values of `is_archived` to filter source datasets by. (Default `[false]`)
  * @param client - Postgres client to use.
- * @returns source datasets with fields for APIs.
+ * @returns source datasets with fields for list APIs.
  */
-export async function getSourceDatasetsForApi(
+export async function getSourceDatasetsForListApi(
   sourceDatasetVersions: string[],
   acceptSubset = false,
   isArchivedValues = [false],
   client?: pg.PoolClient,
-): Promise<HCAAtlasTrackerDBSourceDatasetForAPI[]> {
+): Promise<HCAAtlasTrackerDBSourceDatasetForListAPI[]> {
   const { rows: sourceDatasets } =
-    await query<HCAAtlasTrackerDBSourceDatasetForAPI>(
+    await query<HCAAtlasTrackerDBSourceDatasetForListAPI>(
       `
         SELECT
           d.*,

--- a/app/data/source-datasets.ts
+++ b/app/data/source-datasets.ts
@@ -140,6 +140,7 @@ export async function getSourceDatasetsForGlobalApi(): Promise<
 
 /**
  * Get specified source datasets joined with data used for list API responses.
+ * @param atlasId - ID of the atlas that the source datasets are accessed through, to determine linked component atlas versions.
  * @param sourceDatasetVersions - Version IDs of source datasets to get.
  * @param acceptSubset - If false, an error will be thrown if any of the specified source datasets are unavailable. (Default false)
  * @param isArchivedValues - Values of `is_archived` to filter source datasets by. (Default `[false]`)
@@ -147,6 +148,7 @@ export async function getSourceDatasetsForGlobalApi(): Promise<
  * @returns source datasets with fields for list APIs.
  */
 export async function getSourceDatasetsForListApi(
+  atlasId: string,
   sourceDatasetVersions: string[],
   acceptSubset = false,
   isArchivedValues = [false],
@@ -169,14 +171,30 @@ export async function getSourceDatasetsForListApi(
           f.validation_summary,
           con.base_filename,
           s.doi,
-          s.study_info
+          s.study_info,
+          (
+            SELECT
+              COALESCE(
+                ARRAY_AGG(
+                  jsonb_build_object(
+                    'id', ca.id,
+                    'name', ccon.base_filename
+                  )
+                ),
+                '{}'
+              )
+            FROM hat.component_atlases ca
+            JOIN hat.concepts ccon ON ccon.id = ca.id
+            WHERE d.version_id = ANY(ca.source_datasets) AND ca.version_id = ANY(a.component_atlases)
+          ) as component_atlases
         FROM hat.source_datasets d
         JOIN hat.files f ON f.id = d.file_id
         JOIN hat.concepts con ON con.id = d.id
         LEFT JOIN hat.source_studies s ON d.source_study_id = s.id
-        WHERE d.version_id = ANY($1) AND f.is_archived = ANY($2)
+        JOIN hat.atlases a ON d.version_id = ANY(a.source_datasets)
+        WHERE d.version_id = ANY($1) AND f.is_archived = ANY($2) AND a.id = $3
       `,
-      [sourceDatasetVersions, isArchivedValues],
+      [sourceDatasetVersions, isArchivedValues, atlasId],
       client,
     );
 

--- a/app/data/source-datasets.ts
+++ b/app/data/source-datasets.ts
@@ -140,7 +140,8 @@ export async function getSourceDatasetsForGlobalApi(): Promise<
 
 /**
  * Get specified source datasets joined with data used for list API responses.
- * @param atlasId - ID of the atlas that the source datasets are accessed through, to determine linked component atlas versions.
+ * Only source datasets linked to the given atlas are returned; specified datasets not linked to the atlas are excluded.
+ * @param atlasId - ID of the atlas that the source datasets are accessed through, used to scope results to the atlas and to determine linked component atlas versions.
  * @param sourceDatasetVersions - Version IDs of source datasets to get.
  * @param acceptSubset - If false, an error will be thrown if any of the specified source datasets are unavailable. (Default false)
  * @param isArchivedValues - Values of `is_archived` to filter source datasets by. (Default `[false]`)

--- a/app/data/source-datasets.ts
+++ b/app/data/source-datasets.ts
@@ -156,6 +156,13 @@ export async function getSourceDatasetsForListApi(
   const { rows: sourceDatasets } =
     await query<HCAAtlasTrackerDBSourceDatasetForListAPI>(
       `
+        WITH component_atlases AS (
+          SELECT c.id, c.source_datasets, c.version_id, ccon.base_filename
+          FROM hat.component_atlases c
+          JOIN hat.concepts ccon ON ccon.id = c.id
+          JOIN hat.files cf ON cf.id = c.file_id
+          WHERE NOT cf.is_archived
+        )
         SELECT
           d.*,
           f.event_info,
@@ -171,28 +178,23 @@ export async function getSourceDatasetsForListApi(
           con.base_filename,
           s.doi,
           s.study_info,
-          (
-            SELECT
-              COALESCE(
-                ARRAY_AGG(
-                  jsonb_build_object(
-                    'baseFilename', ccon.base_filename,
-                    'id', ca.id
-                  )
-                ),
-                '{}'
+          COALESCE(
+            ARRAY_AGG(
+              jsonb_build_object(
+                'baseFilename', ca.base_filename,
+                'id', ca.id
               )
-            FROM hat.component_atlases ca
-            JOIN hat.concepts ccon ON ccon.id = ca.id
-            JOIN hat.files cf ON cf.id = ca.file_id
-            WHERE d.version_id = ANY(ca.source_datasets) AND ca.version_id = ANY(a.component_atlases) AND NOT cf.is_archived
+            ) FILTER (WHERE ca.id IS NOT NULL),
+            '{}'
           ) as component_atlases
         FROM hat.source_datasets d
         JOIN hat.files f ON f.id = d.file_id
         JOIN hat.concepts con ON con.id = d.id
         LEFT JOIN hat.source_studies s ON d.source_study_id = s.id
         JOIN hat.atlases a ON d.version_id = ANY(a.source_datasets)
+        LEFT JOIN component_atlases ca ON d.version_id = ANY(ca.source_datasets) AND ca.version_id = ANY(a.component_atlases)
         WHERE d.version_id = ANY($1) AND f.is_archived = ANY($2) AND a.id = $3
+        GROUP BY d.version_id, f.id, con.id, s.id, a.id
       `,
       [sourceDatasetVersions, isArchivedValues, atlasId],
       client,

--- a/app/hooks/useFetchSourceStudiesSourceDatasets.ts
+++ b/app/hooks/useFetchSourceStudiesSourceDatasets.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { API } from "../apis/catalog/hca-atlas-tracker/common/api";
 import {
-  HCAAtlasTrackerSourceDataset,
+  HCAAtlasTrackerLocalListSourceDataset,
   HCAAtlasTrackerSourceStudy,
   SourceStudyId,
 } from "../apis/catalog/hca-atlas-tracker/common/entities";
@@ -11,9 +11,9 @@ import { useFetchData } from "./useFetchData";
 
 export const useFetchSourceStudiesSourceDatasets = (
   pathParameter: PathParameter,
-): HCAAtlasTrackerSourceDataset[] | undefined => {
+): HCAAtlasTrackerLocalListSourceDataset[] | undefined => {
   const [sourceStudiesSourceDatasets, setSourceStudiesSourceDatasets] =
-    useState<HCAAtlasTrackerSourceDataset[]>();
+    useState<HCAAtlasTrackerLocalListSourceDataset[]>();
   const { data: sourceStudies } = useFetchData<
     HCAAtlasTrackerSourceStudy[] | undefined
   >(getRequestURL(API.ATLAS_SOURCE_STUDIES, pathParameter), METHOD.GET);

--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -58,7 +58,6 @@ export async function getSourceStudyDatasets(
   return await getSourceDatasetsForListApi(
     atlasId,
     await getSourceStudySourceDatasetVersionIds(sourceStudyId, atlasId),
-    true,
   );
 }
 
@@ -75,7 +74,6 @@ export async function getAtlasDatasets(
   return await getSourceDatasetsForListApi(
     atlasId,
     await getAtlasSourceDatasetVersionIds(atlasId),
-    true,
     [isArchivedValue],
   );
 }
@@ -97,7 +95,6 @@ export async function getComponentAtlasDatasets(
   return await getSourceDatasetsForListApi(
     atlasId,
     await getComponentAtlasSourceDatasetVersionIds(componentAtlasVersion),
-    true,
   );
 }
 

--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -3,6 +3,7 @@ import {
   HCAAtlasTrackerDBSourceDataset,
   HCAAtlasTrackerDBSourceDatasetForAPI,
   HCAAtlasTrackerDBSourceDatasetForDetailAPI,
+  HCAAtlasTrackerDBSourceDatasetForListAPI,
   HCAAtlasTrackerDBSourceDatasetInfo,
   PUBLICATION_STATUS,
 } from "../apis/catalog/hca-atlas-tracker/common/entities";
@@ -52,9 +53,10 @@ export interface UpdatedSourceDatasetsInfo {
 export async function getSourceStudyDatasets(
   atlasId: string,
   sourceStudyId: string,
-): Promise<HCAAtlasTrackerDBSourceDatasetForAPI[]> {
+): Promise<HCAAtlasTrackerDBSourceDatasetForListAPI[]> {
   await confirmSourceStudyExistsOnAtlas(sourceStudyId, atlasId);
   return await getSourceDatasetsForListApi(
+    atlasId,
     await getSourceStudySourceDatasetVersionIds(sourceStudyId, atlasId),
     true,
   );
@@ -69,8 +71,9 @@ export async function getSourceStudyDatasets(
 export async function getAtlasDatasets(
   atlasId: string,
   isArchivedValue = false,
-): Promise<HCAAtlasTrackerDBSourceDatasetForAPI[]> {
+): Promise<HCAAtlasTrackerDBSourceDatasetForListAPI[]> {
   return await getSourceDatasetsForListApi(
+    atlasId,
     await getAtlasSourceDatasetVersionIds(atlasId),
     true,
     [isArchivedValue],
@@ -86,12 +89,13 @@ export async function getAtlasDatasets(
 export async function getComponentAtlasDatasets(
   atlasId: string,
   componentAtlasId: string,
-): Promise<HCAAtlasTrackerDBSourceDatasetForAPI[]> {
+): Promise<HCAAtlasTrackerDBSourceDatasetForListAPI[]> {
   const componentAtlasVersion = await getComponentAtlasVersionForAtlas(
     componentAtlasId,
     atlasId,
   );
   return await getSourceDatasetsForListApi(
+    atlasId,
     await getComponentAtlasSourceDatasetVersionIds(componentAtlasVersion),
     true,
   );

--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -17,7 +17,7 @@ import {
   getAtlasSourceDatasetVersionIds,
   getComponentAtlasSourceDatasetVersionIds,
   getSourceDatasetForDetailApi,
-  getSourceDatasetsForApi,
+  getSourceDatasetsForListApi,
   getSourceDatasetVersionForAtlas,
   getSourceDatasetVersionForComponentAtlas,
   getSourceDatasetVersionsForAtlas,
@@ -54,7 +54,7 @@ export async function getSourceStudyDatasets(
   sourceStudyId: string,
 ): Promise<HCAAtlasTrackerDBSourceDatasetForAPI[]> {
   await confirmSourceStudyExistsOnAtlas(sourceStudyId, atlasId);
-  return await getSourceDatasetsForApi(
+  return await getSourceDatasetsForListApi(
     await getSourceStudySourceDatasetVersionIds(sourceStudyId, atlasId),
     true,
   );
@@ -70,7 +70,7 @@ export async function getAtlasDatasets(
   atlasId: string,
   isArchivedValue = false,
 ): Promise<HCAAtlasTrackerDBSourceDatasetForAPI[]> {
-  return await getSourceDatasetsForApi(
+  return await getSourceDatasetsForListApi(
     await getAtlasSourceDatasetVersionIds(atlasId),
     true,
     [isArchivedValue],
@@ -91,7 +91,7 @@ export async function getComponentAtlasDatasets(
     componentAtlasId,
     atlasId,
   );
-  return await getSourceDatasetsForApi(
+  return await getSourceDatasetsForListApi(
     await getComponentAtlasSourceDatasetVersionIds(componentAtlasVersion),
     true,
   );
@@ -137,12 +137,7 @@ export async function getComponentAtlasSourceDataset(
     sourceDatasetId,
     componentAtlasVersion,
   );
-  const [sourceDataset] = await getSourceDatasetsForApi(
-    [sourceDatasetVersion],
-    false,
-    [true, false],
-  );
-  return sourceDataset;
+  return await getSourceDatasetForDetailApi(sourceDatasetVersion);
 }
 
 /**

--- a/app/views/AtlasSourceDatasetsView/entities.ts
+++ b/app/views/AtlasSourceDatasetsView/entities.ts
@@ -2,13 +2,13 @@ import {
   AtlasId,
   CAP_INGEST_STATUS,
   HCAAtlasTrackerAtlas,
-  HCAAtlasTrackerSourceDataset,
+  HCAAtlasTrackerLocalListSourceDataset,
   HCAAtlasTrackerSourceStudy,
 } from "../../apis/catalog/hca-atlas-tracker/common/entities";
 import { PathParameter } from "../../common/entities";
 import { FormManager } from "../../hooks/useFormManager/common/entities";
 
-export interface AtlasSourceDataset extends HCAAtlasTrackerSourceDataset {
+export interface AtlasSourceDataset extends HCAAtlasTrackerLocalListSourceDataset {
   atlasId: AtlasId;
   capIngestStatus: CAP_INGEST_STATUS;
 }

--- a/app/views/AtlasSourceDatasetsView/hooks/useFetchAtlasSourceDatasets.ts
+++ b/app/views/AtlasSourceDatasetsView/hooks/useFetchAtlasSourceDatasets.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { API } from "../../../apis/catalog/hca-atlas-tracker/common/api";
-import { HCAAtlasTrackerSourceDataset } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { HCAAtlasTrackerLocalListSourceDataset } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { getCapIngestStatus } from "../../../apis/catalog/hca-atlas-tracker/common/utils";
 import { METHOD, PathParameter } from "../../../common/entities";
 import { getRequestURL } from "../../../common/utils";
@@ -30,7 +30,7 @@ export const useFetchAtlasSourceDatasets = (
   if (!pathParameter.atlasId) throw new Error("Atlas ID is required");
 
   const { data, progress } = useFetchData<
-    HCAAtlasTrackerSourceDataset[] | undefined
+    HCAAtlasTrackerLocalListSourceDataset[] | undefined
   >(
     `${getRequestURL(
       API.ATLAS_SOURCE_DATASETS,
@@ -61,7 +61,7 @@ export const useFetchAtlasSourceDatasets = (
  */
 function mapData(
   atlasId: string,
-  data: HCAAtlasTrackerSourceDataset[] = [],
+  data: HCAAtlasTrackerLocalListSourceDataset[] = [],
 ): AtlasSourceDataset[] {
   return data.map((atlasSourceDataset) => ({
     atlasId,

--- a/app/views/IntegratedObjectSourceDatasetsView/entities.ts
+++ b/app/views/IntegratedObjectSourceDatasetsView/entities.ts
@@ -1,6 +1,7 @@
 import {
   HCAAtlasTrackerAtlas,
   HCAAtlasTrackerDetailComponentAtlas,
+  HCAAtlasTrackerLocalListSourceDataset,
   HCAAtlasTrackerSourceDataset,
 } from "../../apis/catalog/hca-atlas-tracker/common/entities";
 import { PathParameter } from "../../common/entities";
@@ -19,6 +20,6 @@ export interface EntityData {
   integratedObjectSourceDatasets?: IntegratedObjectSourceDataset[];
 }
 
-export interface IntegratedObjectSourceDataset extends HCAAtlasTrackerSourceDataset {
+export interface IntegratedObjectSourceDataset extends HCAAtlasTrackerLocalListSourceDataset {
   atlasId: string;
 }

--- a/app/views/IntegratedObjectSourceDatasetsView/hooks/useFetchAssociatedAtlasSourceDatasets.ts
+++ b/app/views/IntegratedObjectSourceDatasetsView/hooks/useFetchAssociatedAtlasSourceDatasets.ts
@@ -1,5 +1,5 @@
 import { API } from "../../../apis/catalog/hca-atlas-tracker/common/api";
-import { HCAAtlasTrackerSourceDataset } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { HCAAtlasTrackerLocalListSourceDataset } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD, PathParameter } from "../../../common/entities";
 import { getRequestURL } from "../../../common/utils";
 import { useFetchData } from "../../../hooks/useFetchData";
@@ -10,7 +10,7 @@ export const INTEGRATED_OBJECT_ATLAS_SOURCE_DATASETS =
   "integratedObjectAtlasSourceDatasets";
 
 interface UseFetchAssociatedAtlasSourceDatasets {
-  atlasSourceDatasets?: HCAAtlasTrackerSourceDataset[];
+  atlasSourceDatasets?: HCAAtlasTrackerLocalListSourceDataset[];
 }
 
 export const useFetchAssociatedAtlasSourceDatasets = (
@@ -22,7 +22,7 @@ export const useFetchAssociatedAtlasSourceDatasets = (
   const shouldFetch = shouldFetchByKey[INTEGRATED_OBJECT_ATLAS_SOURCE_DATASETS];
 
   const { data: atlasSourceDatasets, progress } = useFetchData<
-    HCAAtlasTrackerSourceDataset[] | undefined
+    HCAAtlasTrackerLocalListSourceDataset[] | undefined
   >(
     getRequestURL(API.ATLAS_SOURCE_DATASETS, pathParameter),
     METHOD.GET,

--- a/app/views/IntegratedObjectSourceDatasetsView/hooks/useFetchIntegratedObjectSourceDatasets.ts
+++ b/app/views/IntegratedObjectSourceDatasetsView/hooks/useFetchIntegratedObjectSourceDatasets.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { API } from "../../../apis/catalog/hca-atlas-tracker/common/api";
-import { HCAAtlasTrackerSourceDataset } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { HCAAtlasTrackerLocalListSourceDataset } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD, PathParameter } from "../../../common/entities";
 import { getRequestURL } from "../../../common/utils";
 import { useFetchData } from "../../../hooks/useFetchData";
@@ -27,7 +27,7 @@ export const useFetchIntegratedObjectSourceDatasets = (
   if (!pathParameter.atlasId) throw new Error("Atlas ID is required");
 
   const { data, progress } = useFetchData<
-    HCAAtlasTrackerSourceDataset[] | undefined
+    HCAAtlasTrackerLocalListSourceDataset[] | undefined
   >(
     getRequestURL(API.ATLAS_COMPONENT_ATLAS_SOURCE_DATASETS, pathParameter),
     METHOD.GET,
@@ -55,7 +55,7 @@ export const useFetchIntegratedObjectSourceDatasets = (
  */
 function mapData(
   atlasId: string,
-  data: HCAAtlasTrackerSourceDataset[] = [],
+  data: HCAAtlasTrackerLocalListSourceDataset[] = [],
 ): IntegratedObjectSourceDataset[] {
   return data.map((sourceDataset) => ({
     atlasId,

--- a/app/views/SourceDatasetsView/hooks/useFetchSourceDatasets.ts
+++ b/app/views/SourceDatasetsView/hooks/useFetchSourceDatasets.ts
@@ -1,5 +1,5 @@
 import { API } from "../../../apis/catalog/hca-atlas-tracker/common/api";
-import { HCAAtlasTrackerSourceDataset } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
+import { HCAAtlasTrackerLocalListSourceDataset } from "../../../apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD, PathParameter } from "../../../common/entities";
 import { getRequestURL } from "../../../common/utils";
 import { useFetchData } from "../../../hooks/useFetchData";
@@ -7,7 +7,7 @@ import { useFetchDataState } from "../../../hooks/useFetchDataState";
 import { useResetFetchStatus } from "../../../hooks/useResetFetchStatus";
 
 interface UseFetchSourceDatasets {
-  sourceDatasets?: HCAAtlasTrackerSourceDataset[];
+  sourceDatasets?: HCAAtlasTrackerLocalListSourceDataset[];
 }
 
 export const useFetchSourceDatasets = (
@@ -17,7 +17,7 @@ export const useFetchSourceDatasets = (
     fetchDataState: { shouldFetch },
   } = useFetchDataState();
   const { data: sourceDatasets, progress } = useFetchData<
-    HCAAtlasTrackerSourceDataset[] | undefined
+    HCAAtlasTrackerLocalListSourceDataset[] | undefined
   >(
     getRequestURL(API.ATLAS_SOURCE_STUDY_SOURCE_DATASETS, pathParameter),
     METHOD.GET,

--- a/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId]/source-datasets.ts
+++ b/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId]/source-datasets.ts
@@ -1,5 +1,5 @@
 import { ROLE_GROUP } from "app/apis/catalog/hca-atlas-tracker/common/constants";
-import { dbSourceDatasetToApiSourceDataset } from "../../../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
+import { dbSourceDatasetToListApiSourceDataset } from "../../../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE } from "../../../../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { componentAtlasAddSourceDatasetsSchema } from "../../../../../../app/apis/catalog/hca-atlas-tracker/common/schema";
 import { METHOD } from "../../../../../../app/common/entities";
@@ -22,7 +22,7 @@ const getHandler = handler(role(ROLE_GROUP.READ), async (req, res) => {
     .status(200)
     .json(
       (await getComponentAtlasDatasets(atlasId, componentAtlasId)).map(
-        dbSourceDatasetToApiSourceDataset,
+        dbSourceDatasetToListApiSourceDataset,
       ),
     );
 });

--- a/pages/api/atlases/[atlasId]/source-datasets.ts
+++ b/pages/api/atlases/[atlasId]/source-datasets.ts
@@ -1,4 +1,4 @@
-import { dbSourceDatasetToApiSourceDataset } from "../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
+import { dbSourceDatasetToListApiSourceDataset } from "../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE_GROUP } from "../../../../app/apis/catalog/hca-atlas-tracker/common/constants";
 import { METHOD } from "../../../../app/common/entities";
 import { getAtlasDatasets } from "../../../../app/services/source-datasets";
@@ -28,7 +28,7 @@ export default handler(
       .status(200)
       .json(
         (await getAtlasDatasets(atlasId, isArchivedValue)).map(
-          dbSourceDatasetToApiSourceDataset,
+          dbSourceDatasetToListApiSourceDataset,
         ),
       );
   },

--- a/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets.ts
+++ b/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets.ts
@@ -1,4 +1,4 @@
-import { dbSourceDatasetToApiSourceDataset } from "../../../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
+import { dbSourceDatasetToListApiSourceDataset } from "../../../../../../app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE_GROUP } from "../../../../../../app/apis/catalog/hca-atlas-tracker/common/constants";
 import { METHOD } from "../../../../../../app/common/entities";
 import { getSourceStudyDatasets } from "../../../../../../app/services/source-datasets";
@@ -17,7 +17,7 @@ export default handler(
       .status(200)
       .json(
         (await getSourceStudyDatasets(atlasId, sourceStudyId)).map(
-          dbSourceDatasetToApiSourceDataset,
+          dbSourceDatasetToListApiSourceDataset,
         ),
       );
   },

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -2449,6 +2449,7 @@ export const SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_BAZ_W1 = {
   },
   id: SOURCE_DATASET_ID_NON_LATEST_METADATA_ENTITIES_BAZ,
   isLatest: false,
+  sourceStudyId: SOURCE_STUDY_WITH_NON_LATEST_METADATA_ENTITIES.id,
   versionId: "616798c6-e7ba-44dc-9e98-df7306030120",
   wipNumber: 1,
 } satisfies TestSourceDataset;
@@ -3384,7 +3385,11 @@ export const COMPONENT_ATLAS_MISC_BAR = {
     versionId: null,
   },
   id: "c8286c32-6e7a-40c4-89cc-175ac7361b61",
-  sourceDatasets: [],
+  sourceDatasets: [
+    SOURCE_DATASET_FOO,
+    SOURCE_DATASET_BAR,
+    SOURCE_DATASET_FOOFOO,
+  ],
   versionId: "3f2bfe87-e5a8-492a-a926-47af2171e1e2",
 } satisfies TestComponentAtlas;
 
@@ -3411,7 +3416,7 @@ export const COMPONENT_ATLAS_MISC_BAZ = {
     versionId: null,
   },
   id: "23f603d3-57cd-44b9-a3c0-14e671fb2835",
-  sourceDatasets: [],
+  sourceDatasets: [SOURCE_DATASET_FOOFOO],
   versionId: "89b3236e-64ed-45cf-997a-9816d01bc1ff",
 } satisfies TestComponentAtlas;
 
@@ -3916,7 +3921,7 @@ export const COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ_W1 = {
   file: FILE_A_COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ,
   id: COMPONENT_ATLAS_ID_NON_LATEST_METADATA_ENTITIES_BAZ,
   isLatest: false,
-  sourceDatasets: [],
+  sourceDatasets: [SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_BAZ_W1],
   versionId: "d3e4f5a6-b7c8-9d0e-1f2a-3b4c5d6e7f8a",
   wipNumber: 1,
 } satisfies TestComponentAtlas;

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -47,7 +47,6 @@ import { METHOD } from "../app/common/entities";
 import { Handler } from "../app/utils/api-handler";
 import { slugifyAtlasShortName } from "../app/utils/atlases";
 import {
-  getFileBaseName,
   normalizeValidationSummary,
   removeFileExtension,
 } from "../app/utils/files";
@@ -724,7 +723,7 @@ export function expectApiSourceDatasetsToHaveComponentAtlases(
       );
       expect(componentAtlasSummary).toEqual({
         id: componentAtlas.id,
-        name: getFileBaseName(componentAtlas.file.fileName),
+        name: getTestEntityBaseFilename(componentAtlas),
       });
     }
   }

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -21,6 +21,7 @@ import {
   HCAAtlasTrackerDBValidation,
   HCAAtlasTrackerDetailComponentAtlas,
   HCAAtlasTrackerDetailSourceDataset,
+  HCAAtlasTrackerLocalListSourceDataset,
   HCAAtlasTrackerSourceDataset,
   HCAAtlasTrackerSourceStudy,
   HCAAtlasTrackerUser,
@@ -46,6 +47,7 @@ import { METHOD } from "../app/common/entities";
 import { Handler } from "../app/utils/api-handler";
 import { slugifyAtlasShortName } from "../app/utils/atlases";
 import {
+  getFileBaseName,
   normalizeValidationSummary,
   removeFileExtension,
 } from "../app/utils/files";
@@ -697,6 +699,34 @@ export function expectSourceStudyToMatch(
       expect(apiStudy.title).toBeNull();
     }
     expect(apiStudy.contactEmail).toBeNull();
+  }
+}
+
+export function expectApiSourceDatasetsToHaveComponentAtlases(
+  apiSourceDatasets: HCAAtlasTrackerLocalListSourceDataset[],
+  expectedComponentAtlases: Array<{
+    componentAtlases: TestComponentAtlas[];
+    sourceDataset: TestSourceDataset;
+  }>,
+): void {
+  expect(apiSourceDatasets).toHaveLength(expectedComponentAtlases.length);
+  for (const { componentAtlases, sourceDataset } of expectedComponentAtlases) {
+    const apiSourceDataset = apiSourceDatasets.find(
+      (d) => d.id === sourceDataset.id,
+    );
+    assertExpectDefined(apiSourceDataset);
+    expect(apiSourceDataset.componentAtlases).toHaveLength(
+      componentAtlases.length,
+    );
+    for (const componentAtlas of componentAtlases) {
+      const componentAtlasSummary = apiSourceDataset.componentAtlases.find(
+        (c) => c.id === componentAtlas.id,
+      );
+      expect(componentAtlasSummary).toEqual({
+        id: componentAtlas.id,
+        name: getFileBaseName(componentAtlas.file.fileName),
+      });
+    }
   }
 }
 

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -723,7 +723,7 @@ export function expectApiSourceDatasetsToHaveComponentAtlases(
       );
       expect(componentAtlasSummary).toEqual({
         id: componentAtlas.id,
-        name: getTestEntityBaseFilename(componentAtlas),
+        name: getTestEntityDownloadName(componentAtlas),
       });
     }
   }


### PR DESCRIPTION
Closes #1320

Notes:
- For consistency, all three source dataset list APIs (atlas, component atlas, and source study) are updated
- Updating the query to join with the atlas happened to make it so that the component atlas source datasets API excludes source datasets not linked to the atlas, which I think is probably actually the behavior that we want
- The API for getting an individual source dataset of a component atlas previously used the same dataset-querying function as the dataset list APIs; I've updated it to use the function used for the dataset detail page. This means that it's unnecessarily querying the validation reports, but this API isn't actually used, so possibly we could just remove it in a separate PR