### PR TITLE
feat: group global filters into sections (integrated objects & source datasets) (#1343)

### DIFF
--- a/site-config/hca-atlas-tracker/local/index/integratedObjects/categoryGroupConfig.ts
+++ b/site-config/hca-atlas-tracker/local/index/integratedObjects/categoryGroupConfig.ts
@@ -6,7 +6,6 @@ import {
 import {
   CAP_INGEST_STATUS_CATEGORY_CONFIG,
   TIER1_VALIDATION_STATUS_CATEGORY_CONFIG,
-  VALIDATION_STATUS_CATEGORY_CONFIG,
 } from "../common/categoryConfig";
 
 export const CATEGORY_GROUP_CONFIG: SiteConfig["categoryGroupConfig"] = {
@@ -14,13 +13,18 @@ export const CATEGORY_GROUP_CONFIG: SiteConfig["categoryGroupConfig"] = {
     {
       categoryConfigs: [
         {
-          key: HCA_ATLAS_TRACKER_CATEGORY_KEY.NETWORKS,
-          label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.NETWORKS,
-        },
-        {
           key: HCA_ATLAS_TRACKER_CATEGORY_KEY.ATLAS_NAMES,
           label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.ATLAS_NAMES,
         },
+        {
+          key: HCA_ATLAS_TRACKER_CATEGORY_KEY.NETWORKS,
+          label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.NETWORKS,
+        },
+      ],
+      label: "Biological Network",
+    },
+    {
+      categoryConfigs: [
         {
           key: HCA_ATLAS_TRACKER_CATEGORY_KEY.ASSAY,
           label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.ASSAY,
@@ -37,11 +41,15 @@ export const CATEGORY_GROUP_CONFIG: SiteConfig["categoryGroupConfig"] = {
           key: HCA_ATLAS_TRACKER_CATEGORY_KEY.DISEASE,
           label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.DISEASE,
         },
-        TIER1_VALIDATION_STATUS_CATEGORY_CONFIG,
-        VALIDATION_STATUS_CATEGORY_CONFIG,
-        CAP_INGEST_STATUS_CATEGORY_CONFIG,
       ],
-      label: "",
+      label: "Dataset Metadata",
+    },
+    {
+      categoryConfigs: [
+        CAP_INGEST_STATUS_CATEGORY_CONFIG,
+        TIER1_VALIDATION_STATUS_CATEGORY_CONFIG,
+      ],
+      label: "Validation Status",
     },
   ],
   key: "integratedObjects",

--- a/site-config/hca-atlas-tracker/local/index/sourceDatasets/categoryGroupConfig.ts
+++ b/site-config/hca-atlas-tracker/local/index/sourceDatasets/categoryGroupConfig.ts
@@ -6,7 +6,6 @@ import {
 import {
   CAP_INGEST_STATUS_CATEGORY_CONFIG,
   TIER1_VALIDATION_STATUS_CATEGORY_CONFIG,
-  VALIDATION_STATUS_CATEGORY_CONFIG,
 } from "../common/categoryConfig";
 
 export const CATEGORY_GROUP_CONFIG: SiteConfig["categoryGroupConfig"] = {
@@ -14,13 +13,18 @@ export const CATEGORY_GROUP_CONFIG: SiteConfig["categoryGroupConfig"] = {
     {
       categoryConfigs: [
         {
-          key: HCA_ATLAS_TRACKER_CATEGORY_KEY.NETWORKS,
-          label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.NETWORKS,
-        },
-        {
           key: HCA_ATLAS_TRACKER_CATEGORY_KEY.ATLAS_NAMES,
           label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.ATLAS_NAMES,
         },
+        {
+          key: HCA_ATLAS_TRACKER_CATEGORY_KEY.NETWORKS,
+          label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.NETWORKS,
+        },
+      ],
+      label: "Biological Network",
+    },
+    {
+      categoryConfigs: [
         {
           key: HCA_ATLAS_TRACKER_CATEGORY_KEY.ASSAY,
           label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.ASSAY,
@@ -37,11 +41,15 @@ export const CATEGORY_GROUP_CONFIG: SiteConfig["categoryGroupConfig"] = {
           key: HCA_ATLAS_TRACKER_CATEGORY_KEY.DISEASE,
           label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.DISEASE,
         },
-        TIER1_VALIDATION_STATUS_CATEGORY_CONFIG,
-        VALIDATION_STATUS_CATEGORY_CONFIG,
-        CAP_INGEST_STATUS_CATEGORY_CONFIG,
       ],
-      label: "",
+      label: "Dataset Metadata",
+    },
+    {
+      categoryConfigs: [
+        CAP_INGEST_STATUS_CATEGORY_CONFIG,
+        TIER1_VALIDATION_STATUS_CATEGORY_CONFIG,
+      ],
+      label: "Validation Status",
     },
   ],
   key: "sourceDatasets",


### PR DESCRIPTION
## Summary

Reshapes the right-hand filter rail on both the global Integrated Objects and global Source Datasets lists from a flat 9-filter list into three labeled groups, and removes the standalone Validation Status filter.

**Biological Network**
- Atlas
- Network

**Dataset Metadata**
- Assay
- Tissue
- Suspension Type
- Disease

**Validation Status**
- CAP Ingest Status
- HCA Tier-1 Status

The standalone `VALIDATION_STATUS_CATEGORY_CONFIG` is dropped from both `integratedObjects/categoryGroupConfig.ts` and `sourceDatasets/categoryGroupConfig.ts` (the export itself in `common/categoryConfig.ts` is left in place for now).

Closes #1343

## Test plan

- [x] `npm run lint`
- [x] `npm run check-format`
- [x] `npx tsc --noEmit`
- [x] `npm run build:local`
- [x] `npm test` (1110/1110 passing)
- [x] Manual: on `/integrated-objects` and `/source-datasets`, confirm three labeled filter groups appear in the order **Biological Network → Dataset Metadata → Validation Status**, with the members above, in the given order; no standalone Validation Status facet; existing filters still produce counts and filter rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2560" height="929" alt="image" src="https://github.com/user-attachments/assets/18a0f0b1-b372-47d3-8ff4-4242605bc024" />

<img width="2560" height="981" alt="image" src="https://github.com/user-attachments/assets/d7d65f07-0445-4768-aca8-e291be75d026" />
