### PR TITLE
feat: group global source studies filters into sections; reorder top-nav (#1345)

### DIFF
--- a/site-config/hca-atlas-tracker/local/config.ts
+++ b/site-config/hca-atlas-tracker/local/config.ts
@@ -75,8 +75,8 @@ export function makeConfig(
               url: ROUTE.ATLASES,
             },
             {
-              label: "Source Studies",
-              url: ROUTE.SOURCE_STUDIES,
+              label: "Integrated Objects",
+              url: ROUTE.INTEGRATED_OBJECTS,
               visible: { md: false, sm: false },
             },
             {
@@ -85,8 +85,8 @@ export function makeConfig(
               visible: { md: false, sm: false },
             },
             {
-              label: "Integrated Objects",
-              url: ROUTE.INTEGRATED_OBJECTS,
+              label: "Source Studies",
+              url: ROUTE.SOURCE_STUDIES,
               visible: { md: false, sm: false },
             },
             {
@@ -107,9 +107,9 @@ export function makeConfig(
             {
               label: "More",
               menuItems: [
-                { label: "Source Studies", url: ROUTE.SOURCE_STUDIES },
-                { label: "Source Datasets", url: ROUTE.SOURCE_DATASETS },
                 { label: "Integrated Objects", url: ROUTE.INTEGRATED_OBJECTS },
+                { label: "Source Datasets", url: ROUTE.SOURCE_DATASETS },
+                { label: "Source Studies", url: ROUTE.SOURCE_STUDIES },
                 { label: "Reports", url: ROUTE.REPORTS },
                 { label: "Team", url: ROUTE.USERS },
               ],

--- a/site-config/hca-atlas-tracker/local/index/sourceStudies/categoryGroupConfig.ts
+++ b/site-config/hca-atlas-tracker/local/index/sourceStudies/categoryGroupConfig.ts
@@ -11,21 +11,18 @@ export const CATEGORY_GROUP_CONFIG: SiteConfig["categoryGroupConfig"] = {
     {
       categoryConfigs: [
         {
-          key: HCA_ATLAS_TRACKER_CATEGORY_KEY.NETWORKS,
-          label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.NETWORKS,
-        },
-        {
           key: HCA_ATLAS_TRACKER_CATEGORY_KEY.ATLAS_NAMES,
           label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.ATLAS_NAMES,
         },
         {
-          key: HCA_ATLAS_TRACKER_CATEGORY_KEY.HCA_DATA_REPOSITORY,
-          label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.HCA_DATA_REPOSITORY,
+          key: HCA_ATLAS_TRACKER_CATEGORY_KEY.NETWORKS,
+          label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.NETWORKS,
         },
-        {
-          key: HCA_ATLAS_TRACKER_CATEGORY_KEY.PUBLICATION_STATUS,
-          label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.PUBLICATION_STATUS,
-        },
+      ],
+      label: "Biological Network",
+    },
+    {
+      categoryConfigs: [
         {
           key: HCA_ATLAS_TRACKER_CATEGORY_KEY.JOURNAL,
           label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.JOURNAL,
@@ -33,8 +30,21 @@ export const CATEGORY_GROUP_CONFIG: SiteConfig["categoryGroupConfig"] = {
             (val) => val || UNPUBLISHED,
           ),
         },
+        {
+          key: HCA_ATLAS_TRACKER_CATEGORY_KEY.PUBLICATION_STATUS,
+          label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.PUBLICATION_STATUS,
+        },
       ],
-      label: "",
+      label: "Publication",
+    },
+    {
+      categoryConfigs: [
+        {
+          key: HCA_ATLAS_TRACKER_CATEGORY_KEY.HCA_DATA_REPOSITORY,
+          label: HCA_ATLAS_TRACKER_CATEGORY_LABEL.HCA_DATA_REPOSITORY,
+        },
+      ],
+      label: "Primary Data",
     },
   ],
   key: "sourceStudies",


### PR DESCRIPTION
## Summary

**Part 1 — group global Source Studies filters.** Replaces the single flat filter group with three labeled groups, consistent with the integrated-objects / source-datasets grouping from #1343:

- **Biological Network** — Atlas, Network
- **Publication** — Journal, Publication Status
- **Primary Data** — HCA Data Repository

The Journal filter keeps its `mapSelectCategoryValue` mapping (empty → "Unpublished").

**Part 2 — reorder top-level header nav.** Re-shuffles the three list links so the visual order matches the consumption order (Integrated Objects first, then Source Datasets, then Source Studies). The "More" overflow menu (shown at `sm`/`md` per #1305) is reordered to match. Each item retains its existing `visible` responsive flags.

Final header order across all breakpoints: **Atlases → Integrated Objects → Source Datasets → Source Studies → Reports → Team → Metadata Dictionary** (plus Help & Documentation at the end).

Closes #1345

## Test plan

- [x] `npm run lint`
- [x] `npm run check-format`
- [x] `npx tsc --noEmit`
- [x] `npm run build:local`
- [x] `npm test` (1119/1119 passing)
- [x] Manual: `/source-studies` shows three labeled filter groups in the expected order; Journal still buckets blanks under "Unpublished"; header order at lg and inside the More menu at sm/md matches the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2560" height="792" alt="image" src="https://github.com/user-attachments/assets/784e7ab2-9a69-4ed2-840c-6e2bbd2fc211" />

<img width="1198" height="750" alt="image" src="https://github.com/user-attachments/assets/d7ae8c11-604a-4574-ae18-9989cffa9214" />
