### PR TITLE
feat: add atlas status summary api (#1339)

### DIFF
--- a/__tests__/api-atlases-id-status.test.ts
+++ b/__tests__/api-atlases-id-status.test.ts
@@ -154,14 +154,14 @@ const SOURCE_DATASET_HANDLERS: ((
     }),
     reprocessedStatus: REPROCESSED_STATUS.REPROCESSED,
   }),
-  // Original, CAP ready, CAP required
+  // Original, CAP ready
   (sourceDataset): TestSourceDataset => ({
     ...addValidationResults(sourceDataset, {
       cap: true,
     }),
     reprocessedStatus: REPROCESSED_STATUS.ORIGINAL,
   }),
-  // Original, CAP required
+  // Original
   // Note: this differs from the above in lacking CAP ready because CAP ingest status is partially based on validation status
   (sourceDataset): TestSourceDataset => ({
     ...addValidationResults(
@@ -185,7 +185,7 @@ const SOURCE_DATASET_HANDLERS: ((
     }),
     reprocessedStatus: REPROCESSED_STATUS.REPROCESSED,
   }),
-  // Original, CAP invalid, CAP required
+  // Original, CAP invalid
   (sourceDataset): TestSourceDataset => ({
     ...addValidationResults(sourceDataset, {
       cap: false,
@@ -208,7 +208,7 @@ const SOURCE_DATASET_HANDLERS: ((
     capUrl: makeTestSourceDatasetCapUrl(i),
     reprocessedStatus: REPROCESSED_STATUS.ORIGINAL,
   }),
-  // Original, Tier 1 valid, CAP invalid, CAP required
+  // Original, Tier 1 valid, CAP invalid
   // Note: because of how CAP ingest status is determined, validation results without CAP are counted as CAP invalid
   (sourceDataset): TestSourceDataset => ({
     ...addValidationResults(sourceDataset, {
@@ -216,7 +216,7 @@ const SOURCE_DATASET_HANDLERS: ((
     }),
     reprocessedStatus: REPROCESSED_STATUS.ORIGINAL,
   }),
-  // Original, Tier 1 invalid, CAP invalid, CAP required
+  // Original, Tier 1 invalid, CAP invalid
   // See note above re: CAP invalid
   (sourceDataset): TestSourceDataset => ({
     ...addValidationResults(sourceDataset, {
@@ -224,7 +224,7 @@ const SOURCE_DATASET_HANDLERS: ((
     }),
     reprocessedStatus: REPROCESSED_STATUS.ORIGINAL,
   }),
-  // Original, Tier 1 invalid, CAP ready, CAP required
+  // Original, Tier 1 invalid, CAP ready
   (sourceDataset): TestSourceDataset => ({
     ...addValidationResults(sourceDataset, {
       cap: true,
@@ -261,7 +261,6 @@ const EXPECTED_STATUS_SUMMARY: AtlasStatusSummary = {
     capInvalid: 3,
     capPublished: 1,
     capReady: 2,
-    capRequired: 6,
     original: 7,
     reprocessed: 3,
     tier1Invalid: 2,

--- a/__tests__/api-atlases-id-status.test.ts
+++ b/__tests__/api-atlases-id-status.test.ts
@@ -54,13 +54,16 @@ jest.mock("../app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 
-const ATLAS_ID = "0325474a-a038-4201-9651-f8f7406c3483";
+const ATLAS_ID_MAIN = "0325474a-a038-4201-9651-f8f7406c3483";
+const ATLAS_ID_ENDORSED = "ca70b4e8-ed0b-49ed-a683-9b78f20e0afa";
+const ATLAS_ID_PUBLISHED = "45c6ff6d-d138-4975-9e7d-dbac59e6327c";
+const ATLAS_ID_ENDORSED_PUBLISHED = "3594fded-6785-4382-9a95-5c2b9bda5073";
 
 const INTEGRATION_LEAD = makeTestUser(
   "test-integration-lead-atlas-status",
   ROLE.INTEGRATION_LEAD,
   false,
-  [ATLAS_ID],
+  [ATLAS_ID_MAIN],
 );
 
 const BASE_COMPONENT_ATLAS_ID = 0x9975ea7e331a429eacc2205368a6b645n;
@@ -241,7 +244,38 @@ const SOURCE_STUDIES: Array<{ published: boolean }> = [
   { published: true },
 ];
 
-const EXPECTED_STATUS_SUMMARY: AtlasStatusSummary = {
+const DEFAULT_STATUS_SUMMARY: AtlasStatusSummary = {
+  integratedObjects: {
+    capInvalid: 0,
+    capPublished: 0,
+    capReady: 0,
+    cellAnnotationInvalid: 0,
+    cellAnnotationValid: 0,
+    tier1Invalid: 0,
+    tier1Valid: 0,
+    total: 0,
+  },
+  ocEndorsed: false,
+  publishedOnPortal: false,
+  sourceDatasets: {
+    capInvalid: 0,
+    capPublished: 0,
+    capReady: 0,
+    original: 0,
+    reprocessed: 0,
+    tier1Invalid: 0,
+    tier1Valid: 0,
+    total: 0,
+  },
+  sourceStudies: {
+    published: 0,
+    total: 0,
+    unpublished: 0,
+  },
+};
+
+const EXPECTED_MAIN_STATUS_SUMMARY: AtlasStatusSummary = {
+  ...DEFAULT_STATUS_SUMMARY,
   integratedObjects: {
     capInvalid: 4,
     capPublished: 2,
@@ -252,8 +286,6 @@ const EXPECTED_STATUS_SUMMARY: AtlasStatusSummary = {
     tier1Valid: 2,
     total: 10,
   },
-  ocEndorsed: false,
-  publishedOnPortal: false,
   sourceDatasets: {
     capInvalid: 1,
     capPublished: 1,
@@ -286,7 +318,7 @@ describe(TEST_ROUTE, () => {
   it("returns error 405 for POST request", async () => {
     expect(
       (
-        await doStatusRequest(ATLAS_ID, USER_CONTENT_ADMIN, METHOD.POST)
+        await doStatusRequest(ATLAS_ID_MAIN, USER_CONTENT_ADMIN, METHOD.POST)
       )._getStatusCode(),
     ).toEqual(405);
   });
@@ -294,7 +326,7 @@ describe(TEST_ROUTE, () => {
   it("returns error 401 when status summary is requested by logged out user", async () => {
     expect(
       (
-        await doStatusRequest(ATLAS_ID, undefined, METHOD.GET, true)
+        await doStatusRequest(ATLAS_ID_MAIN, undefined, METHOD.GET, true)
       )._getStatusCode(),
     ).toEqual(401);
   });
@@ -302,7 +334,12 @@ describe(TEST_ROUTE, () => {
   it("returns error 403 when status summary is requested by unregistered user", async () => {
     expect(
       (
-        await doStatusRequest(ATLAS_ID, USER_UNREGISTERED, METHOD.GET, true)
+        await doStatusRequest(
+          ATLAS_ID_MAIN,
+          USER_UNREGISTERED,
+          METHOD.GET,
+          true,
+        )
       )._getStatusCode(),
     ).toEqual(403);
   });
@@ -311,7 +348,7 @@ describe(TEST_ROUTE, () => {
     expect(
       (
         await doStatusRequest(
-          ATLAS_ID,
+          ATLAS_ID_MAIN,
           USER_DISABLED_CONTENT_ADMIN,
           METHOD.GET,
           true,
@@ -340,13 +377,13 @@ describe(TEST_ROUTE, () => {
       statusHandler,
       METHOD.GET,
       role,
-      getQueryValues(ATLAS_ID),
+      getQueryValues(ATLAS_ID_MAIN),
       undefined,
       false,
       async (res) => {
         expect(res._getStatusCode()).toEqual(200);
         const summary = res._getJSONData() as AtlasStatusSummary;
-        expect(summary).toEqual(EXPECTED_STATUS_SUMMARY);
+        expect(summary).toEqual(EXPECTED_MAIN_STATUS_SUMMARY);
       },
       {
         usersByRole: {
@@ -357,10 +394,57 @@ describe(TEST_ROUTE, () => {
   }
 
   it("returns status summary when requested by content admin", async () => {
-    const res = await doStatusRequest(ATLAS_ID, USER_CONTENT_ADMIN, METHOD.GET);
+    const res = await doStatusRequest(
+      ATLAS_ID_MAIN,
+      USER_CONTENT_ADMIN,
+      METHOD.GET,
+    );
     expect(res._getStatusCode()).toEqual(200);
     const summary = res._getJSONData() as AtlasStatusSummary;
-    expect(summary).toEqual(EXPECTED_STATUS_SUMMARY);
+    expect(summary).toEqual(EXPECTED_MAIN_STATUS_SUMMARY);
+  });
+
+  it("returns status summary for OC endorsed atlas", async () => {
+    const res = await doStatusRequest(
+      ATLAS_ID_ENDORSED,
+      USER_CONTENT_ADMIN,
+      METHOD.GET,
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const summary = res._getJSONData() as AtlasStatusSummary;
+    expect(summary).toEqual({
+      ...DEFAULT_STATUS_SUMMARY,
+      ocEndorsed: true,
+    });
+  });
+
+  it("returns status summary for published atlas", async () => {
+    const res = await doStatusRequest(
+      ATLAS_ID_PUBLISHED,
+      USER_CONTENT_ADMIN,
+      METHOD.GET,
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const summary = res._getJSONData() as AtlasStatusSummary;
+    expect(summary).toEqual({
+      ...DEFAULT_STATUS_SUMMARY,
+      publishedOnPortal: true,
+    });
+  });
+
+  it("returns status summary for published OC endorsed atlas", async () => {
+    const res = await doStatusRequest(
+      ATLAS_ID_ENDORSED_PUBLISHED,
+      USER_CONTENT_ADMIN,
+      METHOD.GET,
+    );
+    expect(res._getStatusCode()).toEqual(200);
+    const summary = res._getJSONData() as AtlasStatusSummary;
+    expect(summary).toEqual({
+      ...DEFAULT_STATUS_SUMMARY,
+      ocEndorsed: true,
+      publishedOnPortal: true,
+    });
   });
 });
 
@@ -389,7 +473,7 @@ async function initStatusTestEntities(): Promise<void> {
       handler(
         {
           file: {
-            atlas: (): TestAtlas => testAtlas,
+            atlas: (): TestAtlas => mainAtlas,
             bucket: TEST_S3_BUCKET,
             etag: `atlas-status-component-atlas-${i}-etag`,
             eventTime: new Date().toISOString(),
@@ -411,7 +495,7 @@ async function initStatusTestEntities(): Promise<void> {
       handler(
         {
           file: {
-            atlas: (): TestAtlas => testAtlas,
+            atlas: (): TestAtlas => mainAtlas,
             bucket: TEST_S3_BUCKET,
             etag: `atlas-status-source-dataset-${i}-etag`,
             eventTime: new Date().toISOString(),
@@ -462,24 +546,29 @@ async function initStatusTestEntities(): Promise<void> {
     },
   );
 
-  const testAtlas: TestAtlas = {
-    cellxgeneAtlasCollection: null,
-    codeLinks: [],
+  const mainAtlas = makeTestAtlas(ATLAS_ID_MAIN, "test atlas status main", {
     componentAtlases: testComponentAtlases.map((c) => c.versionId),
-    description: "",
-    generation: 1,
-    highlights: "",
-    id: ATLAS_ID,
-    integrationLead: [INTEGRATION_LEAD],
-    network: "eye",
-    publications: [],
-    revision: 0,
-    shortName: "test atlas status",
     sourceDatasets: testSourceDatasets.map((d) => d.versionId),
     sourceStudies: testSourceStudies.map((s) => s.id),
-    status: ATLAS_STATUS.IN_PROGRESS,
-    wave: "1",
-  };
+  });
+
+  const testAtlases = [
+    mainAtlas,
+    makeTestAtlas(ATLAS_ID_ENDORSED, "test atlas status endorsed", {
+      status: ATLAS_STATUS.OC_ENDORSED,
+    }),
+    makeTestAtlas(ATLAS_ID_PUBLISHED, "test atlas status published", {
+      publishedAt: "2026-06-09T00:12:40.265Z",
+    }),
+    makeTestAtlas(
+      ATLAS_ID_ENDORSED_PUBLISHED,
+      "test atlas status published endorsed",
+      {
+        publishedAt: "2026-06-09T00:12:56.784Z",
+        status: ATLAS_STATUS.OC_ENDORSED,
+      },
+    ),
+  ];
 
   await doTransaction(async (client) => {
     await initUsers(client); // Since the default entities are not otherwise created for these tests, initialize default users here
@@ -490,9 +579,34 @@ async function initStatusTestEntities(): Promise<void> {
       sourceDatasets: testSourceDatasets,
     });
     await initSourceDatasets(client, testSourceDatasets);
-    await initAtlases(client, [testAtlas]);
+    await initAtlases(client, testAtlases);
     await initComponentAtlases(client, testComponentAtlases);
   });
+}
+
+function makeTestAtlas(
+  id: string,
+  shortName: string,
+  overrides?: Partial<TestAtlas>,
+): TestAtlas {
+  return {
+    cellxgeneAtlasCollection: null,
+    codeLinks: [],
+    componentAtlases: [],
+    description: "",
+    generation: 1,
+    highlights: "",
+    id,
+    integrationLead: [INTEGRATION_LEAD],
+    network: "eye",
+    publications: [],
+    revision: 0,
+    shortName,
+    sourceStudies: [],
+    status: ATLAS_STATUS.IN_PROGRESS,
+    wave: "1",
+    ...overrides,
+  };
 }
 
 function addValidationResults<T extends TestSourceDataset | TestComponentAtlas>(

--- a/__tests__/api-atlases-id-status.test.ts
+++ b/__tests__/api-atlases-id-status.test.ts
@@ -1,6 +1,6 @@
-import { FILE_VALIDATOR_NAMES } from "app/apis/catalog/hca-atlas-tracker/common/constants";
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
+import { FILE_VALIDATOR_NAMES } from "../app/apis/catalog/hca-atlas-tracker/common/constants";
 import {
   ATLAS_STATUS,
   AtlasStatusSummary,

--- a/__tests__/api-atlases-id-status.test.ts
+++ b/__tests__/api-atlases-id-status.test.ts
@@ -1,0 +1,563 @@
+import { FILE_VALIDATOR_NAMES } from "app/apis/catalog/hca-atlas-tracker/common/constants";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
+import {
+  ATLAS_STATUS,
+  AtlasStatusSummary,
+  DOI_STATUS,
+  FILE_TYPE,
+  FILE_VALIDATION_STATUS,
+  FileValidationSummary,
+  FileValidatorName,
+  REPROCESSED_STATUS,
+  ROLE,
+} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "../app/common/entities";
+import { doTransaction, endPgPool } from "../app/services/database";
+import statusHandler from "../pages/api/atlases/[atlasId]/status";
+import {
+  ATLAS_NONEXISTENT,
+  STAKEHOLDER_ANALOGOUS_ROLES,
+  TEST_S3_BUCKET,
+  USER_CONTENT_ADMIN,
+  USER_DISABLED_CONTENT_ADMIN,
+  USER_UNREGISTERED,
+} from "../testing/constants";
+import {
+  initAtlases,
+  initComponentAtlases,
+  initFiles,
+  initSourceDatasets,
+  initSourceStudies,
+  initUsers,
+  resetDatabase,
+} from "../testing/db-utils";
+import {
+  TestAtlas,
+  TestComponentAtlas,
+  TestSourceDataset,
+  TestSourceStudy,
+  TestUser,
+} from "../testing/entities";
+import {
+  makeTestUser,
+  testApiRole,
+  withConsoleErrorHiding,
+} from "../testing/utils";
+
+jest.mock(
+  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+);
+jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/cellxgene");
+jest.mock("../app/utils/pg-app-connect-config");
+
+jest.mock("next-auth");
+
+const ATLAS_ID = "0325474a-a038-4201-9651-f8f7406c3483";
+
+const INTEGRATION_LEAD = makeTestUser(
+  "test-integration-lead-atlas-status",
+  ROLE.INTEGRATION_LEAD,
+  false,
+  [ATLAS_ID],
+);
+
+const BASE_COMPONENT_ATLAS_ID = 0x9975ea7e331a429eacc2205368a6b645n;
+const BASE_COMPONENT_ATLAS_VERSION = 0x9e4697125b494b9cbd0fe34df2459a12n;
+const BASE_COMPONENT_ATLAS_FILE_ID = 0xee29c0e18fe44cbc864b7d8de45f058dn;
+
+const COMPONENT_ATLAS_HANDLERS: ((
+  componentAtlas: TestComponentAtlas,
+  i: number,
+) => TestComponentAtlas)[] = [
+  // No categories
+  (componentAtlas): TestComponentAtlas => componentAtlas,
+  // CAP ready
+  (componentAtlas): TestComponentAtlas =>
+    addValidationResults(componentAtlas, {
+      cap: true,
+    }),
+  // CAP invalid
+  (componentAtlas): TestComponentAtlas =>
+    addValidationResults(componentAtlas, {
+      cap: false,
+    }),
+  // CAP published
+  (componentAtlas, i): TestComponentAtlas => ({
+    ...addValidationResults(componentAtlas, {
+      cap: true,
+    }),
+    capUrl: makeTestComponentAtlasCapUrl(i),
+  }),
+  // CAP invalid
+  (componentAtlas, i): TestComponentAtlas => ({
+    ...addValidationResults(componentAtlas, {
+      cap: false,
+    }),
+    capUrl: makeTestComponentAtlasCapUrl(i),
+  }),
+  // CAP ready, Tier 1 valid, cell annotation invalid
+  (componentAtlas): TestComponentAtlas =>
+    addValidationResults(componentAtlas, {
+      cap: true,
+      hcaCellAnnotation: false,
+      hcaSchema: true,
+    }),
+  // CAP ready, Tier 1 invalid
+  (componentAtlas): TestComponentAtlas =>
+    addValidationResults(componentAtlas, {
+      cap: true,
+      hcaSchema: false,
+    }),
+  // CAP invalid, cell annotation valid
+  (componentAtlas): TestComponentAtlas =>
+    addValidationResults(componentAtlas, {
+      cap: false,
+      hcaCellAnnotation: true,
+    }),
+  // CAP invalid, cell annotation invalid
+  (componentAtlas): TestComponentAtlas =>
+    addValidationResults(componentAtlas, {
+      cap: false,
+      hcaCellAnnotation: false,
+    }),
+  // CAP published, Tier 1 valid
+  (componentAtlas, i): TestComponentAtlas => ({
+    ...addValidationResults(componentAtlas, {
+      cap: true,
+      hcaSchema: true,
+    }),
+    capUrl: makeTestComponentAtlasCapUrl(i),
+  }),
+];
+
+const BASE_SOURCE_DATASET_ID = 0x33746d883f854bfda9ddb899a74b5e8cn;
+const BASE_SOURCE_DATASET_VERSION = 0xee4a3c819120423bbac1696ced05dd4dn;
+const BASE_SOURCE_DATASET_FILE_ID = 0x3168eefc3db14fd49c8f8de4de697a27n;
+
+const SOURCE_DATASET_HANDLERS: ((
+  sourceDataset: TestSourceDataset,
+  i: number,
+) => TestSourceDataset)[] = [
+  // No categories
+  (sourceDataset): TestSourceDataset => sourceDataset,
+  // No categories
+  (sourceDataset): TestSourceDataset =>
+    addValidationResults(sourceDataset, {
+      cap: true,
+    }),
+  // Reprocessed
+  (sourceDataset): TestSourceDataset => ({
+    ...addValidationResults(sourceDataset, {
+      cap: true,
+    }),
+    reprocessedStatus: REPROCESSED_STATUS.REPROCESSED,
+  }),
+  // Original, CAP ready, CAP required
+  (sourceDataset): TestSourceDataset => ({
+    ...addValidationResults(sourceDataset, {
+      cap: true,
+    }),
+    reprocessedStatus: REPROCESSED_STATUS.ORIGINAL,
+  }),
+  // Original, CAP required
+  // Note: this differs from the above in lacking CAP ready because CAP ingest status is partially based on validation status
+  (sourceDataset): TestSourceDataset => ({
+    ...addValidationResults(
+      sourceDataset,
+      {
+        cap: true,
+      },
+      FILE_VALIDATION_STATUS.REQUESTED,
+    ),
+    reprocessedStatus: REPROCESSED_STATUS.ORIGINAL,
+  }),
+  // No categories
+  (sourceDataset): TestSourceDataset =>
+    addValidationResults(sourceDataset, {
+      cap: false,
+    }),
+  // Reprocessed
+  (sourceDataset): TestSourceDataset => ({
+    ...addValidationResults(sourceDataset, {
+      cap: false,
+    }),
+    reprocessedStatus: REPROCESSED_STATUS.REPROCESSED,
+  }),
+  // Original, CAP invalid, CAP required
+  (sourceDataset): TestSourceDataset => ({
+    ...addValidationResults(sourceDataset, {
+      cap: false,
+    }),
+    reprocessedStatus: REPROCESSED_STATUS.ORIGINAL,
+  }),
+  // Reprocessed
+  (sourceDataset, i): TestSourceDataset => ({
+    ...addValidationResults(sourceDataset, {
+      cap: true,
+    }),
+    capUrl: makeTestSourceDatasetCapUrl(i),
+    reprocessedStatus: REPROCESSED_STATUS.REPROCESSED,
+  }),
+  // Original, CAP published
+  (sourceDataset, i): TestSourceDataset => ({
+    ...addValidationResults(sourceDataset, {
+      cap: true,
+    }),
+    capUrl: makeTestSourceDatasetCapUrl(i),
+    reprocessedStatus: REPROCESSED_STATUS.ORIGINAL,
+  }),
+  // Original, Tier 1 valid, CAP invalid, CAP required
+  // Note: because of how CAP ingest status is determined, validation results without CAP are counted as CAP invalid
+  (sourceDataset): TestSourceDataset => ({
+    ...addValidationResults(sourceDataset, {
+      hcaSchema: true,
+    }),
+    reprocessedStatus: REPROCESSED_STATUS.ORIGINAL,
+  }),
+  // Original, Tier 1 invalid, CAP invalid, CAP required
+  // See note above re: CAP invalid
+  (sourceDataset): TestSourceDataset => ({
+    ...addValidationResults(sourceDataset, {
+      hcaSchema: false,
+    }),
+    reprocessedStatus: REPROCESSED_STATUS.ORIGINAL,
+  }),
+  // Original, Tier 1 invalid, CAP ready, CAP required
+  (sourceDataset): TestSourceDataset => ({
+    ...addValidationResults(sourceDataset, {
+      cap: true,
+      hcaSchema: false,
+    }),
+    reprocessedStatus: REPROCESSED_STATUS.ORIGINAL,
+  }),
+];
+
+const BASE_SOURCE_STUDY_ID = 0x473b6a1e90914cd8aafc2a66402e691dn;
+
+const SOURCE_STUDIES: Array<{ published: boolean }> = [
+  { published: true },
+  { published: true },
+  { published: false },
+  { published: false },
+  { published: true },
+];
+
+const EXPECTED_STATUS_SUMMARY: AtlasStatusSummary = {
+  integratedObjects: {
+    capInvalid: 4,
+    capPublished: 2,
+    capReady: 3,
+    cellAnnotationInvalid: 2,
+    cellAnnotationValid: 1,
+    tier1Invalid: 1,
+    tier1Valid: 2,
+    total: 10,
+  },
+  ocEndorsed: false,
+  publishedOnPortal: false,
+  sourceDatasets: {
+    capInvalid: 3,
+    capPublished: 1,
+    capReady: 2,
+    capRequired: 6,
+    original: 7,
+    reprocessed: 3,
+    tier1Invalid: 2,
+    tier1Valid: 1,
+    total: 13,
+  },
+  sourceStudies: {
+    published: 3,
+    total: 5,
+    unpublished: 2,
+  },
+};
+
+const TEST_ROUTE = "/api/atlases/[atlasId]/status";
+
+beforeAll(async () => {
+  await resetDatabase(false);
+  await initStatusTestEntities();
+});
+
+afterAll(async () => {
+  endPgPool();
+});
+
+describe(TEST_ROUTE, () => {
+  it("returns error 405 for POST request", async () => {
+    expect(
+      (
+        await doStatusRequest(ATLAS_ID, USER_CONTENT_ADMIN, METHOD.POST)
+      )._getStatusCode(),
+    ).toEqual(405);
+  });
+
+  it("returns error 401 when status summary is requested by logged out user", async () => {
+    expect(
+      (
+        await doStatusRequest(ATLAS_ID, undefined, METHOD.GET, true)
+      )._getStatusCode(),
+    ).toEqual(401);
+  });
+
+  it("returns error 403 when status summary is requested by unregistered user", async () => {
+    expect(
+      (
+        await doStatusRequest(ATLAS_ID, USER_UNREGISTERED, METHOD.GET, true)
+      )._getStatusCode(),
+    ).toEqual(403);
+  });
+
+  it("returns error 403 when status summary is requested by disabled user", async () => {
+    expect(
+      (
+        await doStatusRequest(
+          ATLAS_ID,
+          USER_DISABLED_CONTENT_ADMIN,
+          METHOD.GET,
+          true,
+        )
+      )._getStatusCode(),
+    ).toEqual(403);
+  });
+
+  it("returns error 404 when status summary is requested from nonexistent atlas", async () => {
+    expect(
+      (
+        await doStatusRequest(
+          ATLAS_NONEXISTENT.id,
+          USER_CONTENT_ADMIN,
+          METHOD.GET,
+          true,
+        )
+      )._getStatusCode(),
+    ).toEqual(404);
+  });
+
+  for (const role of STAKEHOLDER_ANALOGOUS_ROLES) {
+    testApiRole(
+      "returns status summary",
+      TEST_ROUTE,
+      statusHandler,
+      METHOD.GET,
+      role,
+      getQueryValues(ATLAS_ID),
+      undefined,
+      false,
+      async (res) => {
+        expect(res._getStatusCode()).toEqual(200);
+        const summary = res._getJSONData() as AtlasStatusSummary;
+        expect(summary).toEqual(EXPECTED_STATUS_SUMMARY);
+      },
+      {
+        usersByRole: {
+          [ROLE.INTEGRATION_LEAD]: INTEGRATION_LEAD,
+        },
+      },
+    );
+  }
+
+  it("returns status summary when requested by content admin", async () => {
+    const res = await doStatusRequest(ATLAS_ID, USER_CONTENT_ADMIN, METHOD.GET);
+    expect(res._getStatusCode()).toEqual(200);
+    const summary = res._getJSONData() as AtlasStatusSummary;
+    expect(summary).toEqual(EXPECTED_STATUS_SUMMARY);
+  });
+});
+
+async function doStatusRequest(
+  atlasId: string,
+  user: TestUser | undefined,
+  method: METHOD,
+  hideConsoleError = false,
+): Promise<httpMocks.MockResponse<NextApiResponse>> {
+  const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>({
+    headers: { authorization: user?.authorization },
+    method,
+    query: getQueryValues(atlasId),
+  });
+  await withConsoleErrorHiding(() => statusHandler(req, res), hideConsoleError);
+  return res;
+}
+
+function getQueryValues(atlasId: string): Record<string, string> {
+  return { atlasId };
+}
+
+async function initStatusTestEntities(): Promise<void> {
+  const testComponentAtlases = COMPONENT_ATLAS_HANDLERS.map(
+    (handler, i): TestComponentAtlas =>
+      handler(
+        {
+          file: {
+            atlas: (): TestAtlas => testAtlas,
+            bucket: TEST_S3_BUCKET,
+            etag: `atlas-status-component-atlas-${i}-etag`,
+            eventTime: new Date().toISOString(),
+            fileName: `atlas-status-component-atlas-${i}.h5ad`,
+            fileType: FILE_TYPE.INTEGRATED_OBJECT,
+            id: deriveTestUuid(BASE_COMPONENT_ATLAS_FILE_ID, i),
+            sizeBytes: String((i + 1) * 100),
+            versionId: null,
+          },
+          id: deriveTestUuid(BASE_COMPONENT_ATLAS_ID, i),
+          versionId: deriveTestUuid(BASE_COMPONENT_ATLAS_VERSION, i),
+        },
+        i,
+      ),
+  );
+
+  const testSourceDatasets = SOURCE_DATASET_HANDLERS.map(
+    (handler, i): TestSourceDataset =>
+      handler(
+        {
+          file: {
+            atlas: (): TestAtlas => testAtlas,
+            bucket: TEST_S3_BUCKET,
+            etag: `atlas-status-source-dataset-${i}-etag`,
+            eventTime: new Date().toISOString(),
+            fileName: `atlas-status-source-dataset-${i}.h5ad`,
+            fileType: FILE_TYPE.SOURCE_DATASET,
+            id: deriveTestUuid(BASE_SOURCE_DATASET_FILE_ID, i),
+            sizeBytes: String((i + 1) * 100),
+            versionId: null,
+          },
+          id: deriveTestUuid(BASE_SOURCE_DATASET_ID, i),
+          versionId: deriveTestUuid(BASE_SOURCE_DATASET_VERSION, i),
+        },
+        i,
+      ),
+  );
+
+  const testSourceStudies = SOURCE_STUDIES.map(
+    ({ published }, i): TestSourceStudy => {
+      const commonFields = {
+        cellxgeneCollectionId: null,
+        hcaProjectId: null,
+        id: deriveTestUuid(BASE_SOURCE_STUDY_ID, i),
+      };
+      return published
+        ? {
+            ...commonFields,
+            doi: `10.123/atlas-status-${i}`,
+            doiStatus: DOI_STATUS.OK,
+            publication: {
+              authors: [
+                { name: `Atlas Status Author ${i}`, personalName: null },
+              ],
+              hasPreprintDoi: null,
+              journal: `Atlas Status Journal ${i}`,
+              preprintOfDoi: null,
+              publicationDate: new Date().toISOString(),
+              title: `Atlas Status ${i}`,
+            },
+          }
+        : {
+            ...commonFields,
+            unpublishedInfo: {
+              contactEmail: `atlas-status-${i}@example.com`,
+              referenceAuthor: `Atlas Status Author ${i}`,
+              title: `Atlas Status ${i}`,
+            },
+          };
+    },
+  );
+
+  const testAtlas: TestAtlas = {
+    cellxgeneAtlasCollection: null,
+    codeLinks: [],
+    componentAtlases: testComponentAtlases.map((c) => c.versionId),
+    description: "",
+    generation: 1,
+    highlights: "",
+    id: ATLAS_ID,
+    integrationLead: [INTEGRATION_LEAD],
+    network: "eye",
+    publications: [],
+    revision: 0,
+    shortName: "test atlas status",
+    sourceDatasets: testSourceDatasets.map((d) => d.versionId),
+    sourceStudies: testSourceStudies.map((s) => s.id),
+    status: ATLAS_STATUS.IN_PROGRESS,
+    wave: "1",
+  };
+
+  await doTransaction(async (client) => {
+    await initUsers(client); // Since the default entities are not otherwise created for these tests, initialize default users here
+    await initUsers(client, [INTEGRATION_LEAD]);
+    await initSourceStudies(client, testSourceStudies);
+    await initFiles(client, {
+      componentAtlases: testComponentAtlases,
+      sourceDatasets: testSourceDatasets,
+    });
+    await initSourceDatasets(client, testSourceDatasets);
+    await initAtlases(client, [testAtlas]);
+    await initComponentAtlases(client, testComponentAtlases);
+  });
+}
+
+function addValidationResults<T extends TestSourceDataset | TestComponentAtlas>(
+  entity: T,
+  tools?: Partial<Record<FileValidatorName, boolean>>,
+  validationStatus?: FILE_VALIDATION_STATUS,
+): T {
+  let validationSummary: FileValidationSummary | undefined;
+  if (tools) {
+    if (validationStatus === undefined)
+      validationStatus = FILE_VALIDATION_STATUS.COMPLETED;
+    validationSummary = {
+      overallValid: true,
+      validators: {},
+    };
+    for (const validator of FILE_VALIDATOR_NAMES) {
+      if (tools[validator] !== undefined) {
+        if (tools[validator]) {
+          validationSummary.validators[validator] = {
+            errorCount: 0,
+            valid: true,
+            warningCount: 0,
+          };
+        } else {
+          validationSummary.validators[validator] = {
+            errorCount: 1,
+            valid: false,
+            warningCount: 0,
+          };
+          validationSummary.overallValid = false;
+        }
+      }
+    }
+  }
+  return {
+    ...entity,
+    file: {
+      ...entity.file,
+      validationStatus,
+      validationSummary,
+    },
+  };
+}
+
+function makeTestSourceDatasetCapUrl(i: number): string {
+  return `https://celltype.info/project/${145346 + i}`;
+}
+
+function makeTestComponentAtlasCapUrl(i: number): string {
+  return `https://celltype.info/project/${652834 + i}`;
+}
+
+/**
+ * Derive a test UUID from a base ID and an index by performing a bitwise XOR of the two.
+ * @param baseId - Base UUID, as a bigint.
+ * @param index - Nonnegative index to mark the UUID with.
+ * @returns derived UUID as string.
+ */
+function deriveTestUuid(baseId: bigint, index: number): string {
+  return (baseId ^ BigInt(index))
+    .toString(16)
+    .padStart(32, "0")
+    .replace(/^(.{8})(.{4})(.{4})(.{4})(.{12})$/, "$1-$2-$3-$4-$5");
+}

--- a/__tests__/api-atlases-id-status.test.ts
+++ b/__tests__/api-atlases-id-status.test.ts
@@ -161,8 +161,7 @@ const SOURCE_DATASET_HANDLERS: ((
     }),
     reprocessedStatus: REPROCESSED_STATUS.ORIGINAL,
   }),
-  // Original
-  // Note: this differs from the above in lacking CAP ready because CAP ingest status is partially based on validation status
+  // Original, CAP ready
   (sourceDataset): TestSourceDataset => ({
     ...addValidationResults(
       sourceDataset,
@@ -208,16 +207,14 @@ const SOURCE_DATASET_HANDLERS: ((
     capUrl: makeTestSourceDatasetCapUrl(i),
     reprocessedStatus: REPROCESSED_STATUS.ORIGINAL,
   }),
-  // Original, Tier 1 valid, CAP invalid
-  // Note: because of how CAP ingest status is determined, validation results without CAP are counted as CAP invalid
+  // Original, Tier 1 valid
   (sourceDataset): TestSourceDataset => ({
     ...addValidationResults(sourceDataset, {
       hcaSchema: true,
     }),
     reprocessedStatus: REPROCESSED_STATUS.ORIGINAL,
   }),
-  // Original, Tier 1 invalid, CAP invalid
-  // See note above re: CAP invalid
+  // Original, Tier 1 invalid
   (sourceDataset): TestSourceDataset => ({
     ...addValidationResults(sourceDataset, {
       hcaSchema: false,
@@ -258,9 +255,9 @@ const EXPECTED_STATUS_SUMMARY: AtlasStatusSummary = {
   ocEndorsed: false,
   publishedOnPortal: false,
   sourceDatasets: {
-    capInvalid: 3,
+    capInvalid: 1,
     capPublished: 1,
-    capReady: 2,
+    capReady: 3,
     original: 7,
     reprocessed: 3,
     tier1Invalid: 2,

--- a/__tests__/api-atlases-id-status.test.ts
+++ b/__tests__/api-atlases-id-status.test.ts
@@ -133,6 +133,14 @@ const COMPONENT_ATLAS_HANDLERS: ((
     }),
     capUrl: makeTestComponentAtlasCapUrl(i),
   }),
+  // Not counted
+  (componentAtlas): TestComponentAtlas => ({
+    ...componentAtlas,
+    file: {
+      ...componentAtlas.file,
+      isArchived: true,
+    },
+  }),
 ];
 
 const BASE_SOURCE_DATASET_ID = 0x33746d883f854bfda9ddb899a74b5e8cn;
@@ -231,6 +239,14 @@ const SOURCE_DATASET_HANDLERS: ((
       hcaSchema: false,
     }),
     reprocessedStatus: REPROCESSED_STATUS.ORIGINAL,
+  }),
+  // Not counted
+  (sourceDataset): TestSourceDataset => ({
+    ...sourceDataset,
+    file: {
+      ...sourceDataset.file,
+      isArchived: true,
+    },
   }),
 ];
 

--- a/__tests__/cap-ingest-status.utils.test.ts
+++ b/__tests__/cap-ingest-status.utils.test.ts
@@ -39,6 +39,40 @@ describe("getCapIngestStatus", () => {
     expect(status).toBe(CAP_INGEST_STATUS.NEEDS_VALIDATION);
   });
 
+  it("returns CAP_VALIDATION_FAILED when CAP validator is unsuccessful and capUrl is not set", () => {
+    const status = getCapIngestStatus(
+      createComponentAtlas({
+        capUrl: null,
+        validationStatus: FILE_VALIDATION_STATUS.COMPLETED,
+        validationSummary: {
+          overallValid: true,
+          validators: {
+            cap: { errorCount: 3, valid: false, warningCount: 0 },
+          },
+        },
+      }),
+    );
+
+    expect(status).toBe(CAP_INGEST_STATUS.CAP_VALIDATION_FAILED);
+  });
+
+  it("returns CAP_VALIDATION_FAILED when CAP validator is unsuccessful and capUrl is set", () => {
+    const status = getCapIngestStatus(
+      createComponentAtlas({
+        capUrl: "https://celltype.info/cellxgene/foo",
+        validationStatus: FILE_VALIDATION_STATUS.COMPLETED,
+        validationSummary: {
+          overallValid: true,
+          validators: {
+            cap: { errorCount: 3, valid: false, warningCount: 0 },
+          },
+        },
+      }),
+    );
+
+    expect(status).toBe(CAP_INGEST_STATUS.CAP_VALIDATION_FAILED);
+  });
+
   it("returns CAP_READY when CAP validator is successful and capUrl is not set", () => {
     const status = getCapIngestStatus(
       createComponentAtlas({
@@ -73,7 +107,7 @@ describe("getCapIngestStatus", () => {
     expect(status).toBe(CAP_INGEST_STATUS.PUBLISHED);
   });
 
-  it("returns CAP_VALIDATION_FAILED when validation completed with errors", () => {
+  it("returns NEEDS_VALIDATION when validation completed without CAP results (not expected in practice)", () => {
     const status = getCapIngestStatus(
       createComponentAtlas({
         validationStatus: FILE_VALIDATION_STATUS.COMPLETED,
@@ -84,7 +118,7 @@ describe("getCapIngestStatus", () => {
       }),
     );
 
-    expect(status).toBe(CAP_INGEST_STATUS.CAP_VALIDATION_FAILED);
+    expect(status).toBe(CAP_INGEST_STATUS.NEEDS_VALIDATION);
   });
 
   it("returns NEEDS_VALIDATION when validation is not completed", () => {
@@ -95,6 +129,23 @@ describe("getCapIngestStatus", () => {
     );
 
     expect(status).toBe(CAP_INGEST_STATUS.NEEDS_VALIDATION);
+  });
+
+  it("returns CAP_READY when validation status is requested, existing summary has CAP validator successful, and capUrl is not set", () => {
+    const status = getCapIngestStatus(
+      createComponentAtlas({
+        capUrl: null,
+        validationStatus: FILE_VALIDATION_STATUS.REQUESTED,
+        validationSummary: {
+          overallValid: true,
+          validators: {
+            cap: { errorCount: 0, valid: true, warningCount: 0 },
+          },
+        },
+      }),
+    );
+
+    expect(status).toBe(CAP_INGEST_STATUS.CAP_READY);
   });
 });
 

--- a/__tests__/cap-ingest-status.utils.test.ts
+++ b/__tests__/cap-ingest-status.utils.test.ts
@@ -107,7 +107,7 @@ describe("getCapIngestStatus", () => {
     expect(status).toBe(CAP_INGEST_STATUS.PUBLISHED);
   });
 
-  it("returns NEEDS_VALIDATION when validation completed without CAP results (not expected in practice)", () => {
+  it("returns NEEDS_VALIDATION when validation completed with validation summary but no CAP results (not expected in practice)", () => {
     const status = getCapIngestStatus(
       createComponentAtlas({
         validationStatus: FILE_VALIDATION_STATUS.COMPLETED,

--- a/__tests__/hca-tier1-validation-status.utils.test.ts
+++ b/__tests__/hca-tier1-validation-status.utils.test.ts
@@ -7,7 +7,7 @@ import {
 import { getHcaTier1ValidationStatus } from "../app/apis/catalog/hca-atlas-tracker/common/utils";
 
 describe("getHcaTier1ValidationStatus", () => {
-  it("returns UNKNOWN when validation status is not completed", () => {
+  it("returns UNKNOWN when validation status is pending with no existing summary", () => {
     const status = getHcaTier1ValidationStatus(
       createComponentAtlas({
         validationStatus: FILE_VALIDATION_STATUS.PENDING,
@@ -17,7 +17,7 @@ describe("getHcaTier1ValidationStatus", () => {
     expect(status).toBe(HCA_TIER1_VALIDATION_STATUS.UNKNOWN);
   });
 
-  it("returns UNKNOWN when validation status is job failed", () => {
+  it("returns UNKNOWN when validation status is job failed with no existing summary", () => {
     const status = getHcaTier1ValidationStatus(
       createComponentAtlas({
         validationStatus: FILE_VALIDATION_STATUS.JOB_FAILED,
@@ -52,7 +52,7 @@ describe("getHcaTier1ValidationStatus", () => {
     expect(status).toBe(HCA_TIER1_VALIDATION_STATUS.UNKNOWN);
   });
 
-  it("returns INVALID when hcaSchema has errors (warnings ignored)", () => {
+  it("returns INVALID when hcaSchema has `valid` set to false and nonzero errors", () => {
     const status = getHcaTier1ValidationStatus(
       createSourceDataset({
         validationStatus: FILE_VALIDATION_STATUS.COMPLETED,
@@ -68,7 +68,7 @@ describe("getHcaTier1ValidationStatus", () => {
     expect(status).toBe(HCA_TIER1_VALIDATION_STATUS.INVALID);
   });
 
-  it("returns VALID when hcaSchema has zero errors regardless of warnings", () => {
+  it("returns VALID when hcaSchema has `valid` set to true and zero errors, regardless of warnings", () => {
     const status = getHcaTier1ValidationStatus(
       createSourceDataset({
         validationStatus: FILE_VALIDATION_STATUS.COMPLETED,
@@ -76,6 +76,56 @@ describe("getHcaTier1ValidationStatus", () => {
           overallValid: true,
           validators: {
             hcaSchema: { errorCount: 0, valid: true, warningCount: 7 },
+          },
+        },
+      }),
+    );
+
+    expect(status).toBe(HCA_TIER1_VALIDATION_STATUS.VALID);
+  });
+
+  it("returns INVALID specifically when hcaSchema has `valid` set to false, even with error count 0 (not expected in practice)", () => {
+    const status = getHcaTier1ValidationStatus(
+      createSourceDataset({
+        validationStatus: FILE_VALIDATION_STATUS.COMPLETED,
+        validationSummary: {
+          overallValid: false,
+          validators: {
+            hcaSchema: { errorCount: 0, valid: false, warningCount: 0 },
+          },
+        },
+      }),
+    );
+
+    expect(status).toBe(HCA_TIER1_VALIDATION_STATUS.INVALID);
+  });
+
+  // `valid` set to true with nonzero error count would be fully contradictory, so behavior in that case is unspecified.
+
+  it("returns VALID when status is job failed but existing summary has hcaSchema with `valid` set to true", () => {
+    const status = getHcaTier1ValidationStatus(
+      createSourceDataset({
+        validationStatus: FILE_VALIDATION_STATUS.JOB_FAILED,
+        validationSummary: {
+          overallValid: true,
+          validators: {
+            hcaSchema: { errorCount: 0, valid: true, warningCount: 0 },
+          },
+        },
+      }),
+    );
+
+    expect(status).toBe(HCA_TIER1_VALIDATION_STATUS.VALID);
+  });
+
+  it("returns VALID when status is requested and existing summary has hcaSchema with `valid` set to true", () => {
+    const status = getHcaTier1ValidationStatus(
+      createSourceDataset({
+        validationStatus: FILE_VALIDATION_STATUS.REQUESTED,
+        validationSummary: {
+          overallValid: true,
+          validators: {
+            hcaSchema: { errorCount: 0, valid: true, warningCount: 0 },
           },
         },
       }),

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -367,16 +367,27 @@ export interface HCAAtlasTrackerDBAtlasForStatusSummary extends Pick<
   HCAAtlasTrackerDBAtlas,
   "status" | "published_at"
 > {
-  component_atlases: Array<
-    Pick<HCAAtlasTrackerDBComponentAtlas, "component_info"> &
-      Pick<HCAAtlasTrackerDBFile, "validation_summary" | "validation_status">
-  >;
-  source_datasets: Array<
-    Pick<HCAAtlasTrackerDBSourceDataset, "reprocessed_status" | "sd_info"> &
-      Pick<HCAAtlasTrackerDBFile, "validation_status" | "validation_summary">
-  >;
-  source_studies: Array<Pick<HCAAtlasTrackerDBSourceStudy, "doi">>;
+  component_atlases: HCAAtlasTrackerDBComponentAtlasForStatusSummary[];
+  source_datasets: HCAAtlasTrackerDBSourceDatasetForStatusSummary[];
+  source_studies: HCAAtlasTrackerDBSourceStudyForStatusSummary[];
 }
+
+export type HCAAtlasTrackerDBComponentAtlasForStatusSummary = Pick<
+  HCAAtlasTrackerDBComponentAtlas,
+  "component_info"
+> &
+  Pick<HCAAtlasTrackerDBFile, "validation_summary" | "validation_status">;
+
+export type HCAAtlasTrackerDBSourceDatasetForStatusSummary = Pick<
+  HCAAtlasTrackerDBSourceDataset,
+  "reprocessed_status" | "sd_info"
+> &
+  Pick<HCAAtlasTrackerDBFile, "validation_status" | "validation_summary">;
+
+export type HCAAtlasTrackerDBSourceStudyForStatusSummary = Pick<
+  HCAAtlasTrackerDBSourceStudy,
+  "doi"
+>;
 
 export interface HCAAtlasTrackerDBComponentAtlas {
   component_info: HCAAtlasTrackerDBComponentAtlasInfo;
@@ -695,6 +706,37 @@ export type HCAAtlasTrackerDBUserWithAssociatedResources =
   HCAAtlasTrackerDBUser & {
     role_associated_resource_names: string[];
   };
+
+export interface AtlasStatusSummary {
+  integratedObjects: {
+    capInvalid: number;
+    capPublished: number;
+    capReady: number;
+    cellAnnotationInvalid: number;
+    cellAnnotationValid: number;
+    tier1Invalid: number;
+    tier1Valid: number;
+    total: number;
+  };
+  ocEndorsed: boolean;
+  publishedOnPortal: boolean;
+  sourceDatasets: {
+    capInvalid: number;
+    capPublished: number;
+    capReady: number;
+    capRequired: number;
+    original: number;
+    reprocessed: number;
+    tier1Invalid: number;
+    tier1Valid: number;
+    total: number;
+  };
+  sourceStudies: {
+    published: number;
+    total: number;
+    unpublished: number;
+  };
+}
 
 export type WithLinkedAtlases<T> = T & { atlases: LinkedAtlasSummary[] };
 

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -724,7 +724,6 @@ export interface AtlasStatusSummary {
     capInvalid: number;
     capPublished: number;
     capReady: number;
-    capRequired: number;
     original: number;
     reprocessed: number;
     tier1Invalid: number;

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -376,13 +376,13 @@ export type HCAAtlasTrackerDBComponentAtlasForStatusSummary = Pick<
   HCAAtlasTrackerDBComponentAtlas,
   "component_info"
 > &
-  Pick<HCAAtlasTrackerDBFile, "validation_summary" | "validation_status">;
+  Pick<HCAAtlasTrackerDBFile, "validation_summary">;
 
 export type HCAAtlasTrackerDBSourceDatasetForStatusSummary = Pick<
   HCAAtlasTrackerDBSourceDataset,
   "reprocessed_status" | "sd_info"
 > &
-  Pick<HCAAtlasTrackerDBFile, "validation_status" | "validation_summary">;
+  Pick<HCAAtlasTrackerDBFile, "validation_summary">;
 
 export type HCAAtlasTrackerDBSourceStudyForStatusSummary = Pick<
   HCAAtlasTrackerDBSourceStudy,

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -363,6 +363,21 @@ export interface HCAAtlasTrackerDBAtlasOverview {
   wave: Wave;
 }
 
+export interface HCAAtlasTrackerDBAtlasForStatusSummary extends Pick<
+  HCAAtlasTrackerDBAtlas,
+  "status" | "published_at"
+> {
+  component_atlases: Array<
+    Pick<HCAAtlasTrackerDBComponentAtlas, "component_info"> &
+      Pick<HCAAtlasTrackerDBFile, "validation_summary" | "validation_status">
+  >;
+  source_datasets: Array<
+    Pick<HCAAtlasTrackerDBSourceDataset, "reprocessed_status" | "sd_info"> &
+      Pick<HCAAtlasTrackerDBFile, "validation_status" | "validation_summary">
+  >;
+  source_studies: Array<Pick<HCAAtlasTrackerDBSourceStudy, "doi">>;
+}
+
 export interface HCAAtlasTrackerDBComponentAtlas {
   component_info: HCAAtlasTrackerDBComponentAtlasInfo;
   created_at: Date;

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -10,7 +10,6 @@ import {
   CAP_INGEST_STATUS,
   DOI_STATUS,
   DoiPublicationInfo,
-  FILE_VALIDATION_STATUS,
   FileValidationSummary,
   FileValidatorName,
   HCA_TIER1_VALIDATION_STATUS,
@@ -133,7 +132,6 @@ export function getCapIngestStatus(
   original: HCAAtlasTrackerComponentAtlas | HCAAtlasTrackerSourceDataset,
 ): CAP_INGEST_STATUS {
   return getCapIngestStatusFromParameters(
-    original.validationStatus,
     original.validationSummary,
     original.capUrl,
     "reprocessedStatus" in original ? original.reprocessedStatus : undefined,
@@ -142,14 +140,12 @@ export function getCapIngestStatus(
 
 /**
  * Determine CAP ingest status based on individual parameters.
- * @param validationStatus - File validation status.
  * @param validationSummary - File validation summary.
  * @param capUrl - Entity CAP URL.
  * @param reprocessedStatus - Entity reprocessed status.
  * @returns CAP ingest status.
  */
 export function getCapIngestStatusFromParameters(
-  validationStatus: FILE_VALIDATION_STATUS,
   validationSummary: FileValidationSummary | null,
   capUrl: string | null,
   reprocessedStatus?: REPROCESSED_STATUS,
@@ -166,14 +162,11 @@ export function getCapIngestStatusFromParameters(
     }
   }
 
-  // Determine CAP ingest status with validation status of "COMPLETED".
-  if (validationStatus === FILE_VALIDATION_STATUS.COMPLETED) {
-    // No validation summary available.
-    if (!validationSummary) {
-      return CAP_INGEST_STATUS.NEEDS_VALIDATION;
-    }
+  // Determine CAP ingest status with CAP validation results present.
+  const capValid = validationSummary?.validators.cap?.valid;
+  if (capValid !== undefined) {
     // Status is "PUBLISHED" when CAP validator passes and the row has been published to CAP; otherwise "CAP_READY".
-    if (validationSummary.validators.cap?.valid) {
+    if (capValid) {
       return capUrl !== null
         ? CAP_INGEST_STATUS.PUBLISHED
         : CAP_INGEST_STATUS.CAP_READY;
@@ -220,17 +213,17 @@ export function getCompositeTierOneMetadataStatus(
 export function getHcaTier1ValidationStatus(
   original: HCAAtlasTrackerComponentAtlas | HCAAtlasTrackerSourceDataset,
 ): HCA_TIER1_VALIDATION_STATUS {
-  const { validationStatus, validationSummary } = original;
-  if (validationStatus !== FILE_VALIDATION_STATUS.COMPLETED) {
+  const { validationSummary } = original;
+  if (validationSummary === null) {
     return HCA_TIER1_VALIDATION_STATUS.UNKNOWN;
   }
-  const hcaSchema = validationSummary?.validators.hcaSchema;
+  const hcaSchema = validationSummary.validators.hcaSchema;
   if (!hcaSchema) {
     return HCA_TIER1_VALIDATION_STATUS.UNKNOWN;
   }
-  return hcaSchema.errorCount > 0
-    ? HCA_TIER1_VALIDATION_STATUS.INVALID
-    : HCA_TIER1_VALIDATION_STATUS.VALID;
+  return hcaSchema.valid
+    ? HCA_TIER1_VALIDATION_STATUS.VALID
+    : HCA_TIER1_VALIDATION_STATUS.INVALID;
 }
 
 /**

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -11,6 +11,7 @@ import {
   DOI_STATUS,
   DoiPublicationInfo,
   FILE_VALIDATION_STATUS,
+  FileValidationSummary,
   FileValidatorName,
   HCA_TIER1_VALIDATION_STATUS,
   HCAAtlasTrackerAtlas,
@@ -131,15 +132,35 @@ export function getAtlasGenerationName(atlas: HCAAtlasTrackerAtlas): string {
 export function getCapIngestStatus(
   original: HCAAtlasTrackerComponentAtlas | HCAAtlasTrackerSourceDataset,
 ): CAP_INGEST_STATUS {
-  const { validationStatus, validationSummary } = original;
+  return getCapIngestStatusFromParameters(
+    original.validationStatus,
+    original.validationSummary,
+    original.capUrl,
+    "reprocessedStatus" in original ? original.reprocessedStatus : undefined,
+  );
+}
 
+/**
+ * Determine CAP ingest status based on individual parameters.
+ * @param validationStatus - File validation status.
+ * @param validationSummary - File validation summary.
+ * @param capUrl - Entity CAP URL.
+ * @param reprocessedStatus - Entity reprocessed status.
+ * @returns CAP ingest status.
+ */
+export function getCapIngestStatusFromParameters(
+  validationStatus: FILE_VALIDATION_STATUS,
+  validationSummary: FileValidationSummary | null,
+  capUrl: string | null,
+  reprocessedStatus?: REPROCESSED_STATUS,
+): CAP_INGEST_STATUS {
   // Determine CAP ingest status for source datasets with reprocessed status of "REPROCESSED" or "UNSPECIFIED".
-  if ("reprocessedStatus" in original) {
-    if (original.reprocessedStatus === REPROCESSED_STATUS.REPROCESSED) {
+  if (reprocessedStatus !== undefined) {
+    if (reprocessedStatus === REPROCESSED_STATUS.REPROCESSED) {
       // Status is "NOT_REQUIRED" for reprocessed source datasets.
       return CAP_INGEST_STATUS.NOT_REQUIRED;
     }
-    if (original.reprocessedStatus === REPROCESSED_STATUS.UNSPECIFIED) {
+    if (reprocessedStatus === REPROCESSED_STATUS.UNSPECIFIED) {
       // Status is "INFO_REQUIRED" for unspecified source datasets.
       return CAP_INGEST_STATUS.INFO_REQUIRED;
     }
@@ -153,7 +174,7 @@ export function getCapIngestStatus(
     }
     // Status is "PUBLISHED" when CAP validator passes and the row has been published to CAP; otherwise "CAP_READY".
     if (validationSummary.validators.cap?.valid) {
-      return original.capUrl !== null
+      return capUrl !== null
         ? CAP_INGEST_STATUS.PUBLISHED
         : CAP_INGEST_STATUS.CAP_READY;
     }

--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -205,8 +205,9 @@ export function getCompositeTierOneMetadataStatus(
  * Determine the HCA Tier-1 validation status from an entity's validation
  * summary. Collapses the underlying `hcaSchema` validator result into the
  * three values used by the HCA Tier-1 Status filter on the global Source
- * Datasets and Integrated Objects lists. Warnings are ignored — only the
- * presence of errors distinguishes Invalid from Valid.
+ * Datasets and Integrated Objects lists. Validity is detemined by the `valid`
+ * field of the validator result, which by convention is true iff the error
+ * count is positive.
  * @param original - Component atlas or source dataset.
  * @returns HCA Tier-1 validation status.
  */

--- a/app/data/atlases.ts
+++ b/app/data/atlases.ts
@@ -43,9 +43,9 @@ export async function getAtlasForStatusSummary(
       SELECT
         a.status,
         a.published_at,
-        (SELECT ARRAY_AGG(to_jsonb(s)) FROM atlas_source_studies s) AS source_studies,
-        (SELECT ARRAY_AGG(to_jsonb(d)) FROM atlas_source_datasets d) AS source_datasets,
-        (SELECT ARRAY_AGG(to_jsonb(c)) FROM atlas_component_atlases c) AS component_atlases
+        (SELECT COALESCE(ARRAY_AGG(to_jsonb(s)), '{}') FROM atlas_source_studies s) AS source_studies,
+        (SELECT COALESCE(ARRAY_AGG(to_jsonb(d)), '{}') FROM atlas_source_datasets d) AS source_datasets,
+        (SELECT COALESCE(ARRAY_AGG(to_jsonb(c)), '{}') FROM atlas_component_atlases c) AS component_atlases
       FROM hat.atlases a
       WHERE id = $1
     `,

--- a/app/data/atlases.ts
+++ b/app/data/atlases.ts
@@ -31,14 +31,14 @@ export async function getAtlasForStatusSummary(
           FROM hat.source_datasets d
           JOIN hat.files f ON f.id = d.file_id
           JOIN hat.atlases a ON d.version_id = ANY(a.source_datasets)
-          WHERE a.id = $1
+          WHERE a.id = $1 AND NOT f.is_archived
         ),
         atlas_component_atlases AS (
           SELECT c.component_info, f.validation_status, f.validation_summary
           FROM hat.component_atlases c
           JOIN hat.files f ON f.id = c.file_id
           JOIN hat.atlases a ON c.version_id = ANY(a.component_atlases)
-          WHERE a.id = $1
+          WHERE a.id = $1 AND NOT f.is_archived
         )
       SELECT
         a.status,

--- a/app/data/atlases.ts
+++ b/app/data/atlases.ts
@@ -1,11 +1,58 @@
 import pg from "pg";
-import { HCAAtlasTrackerDBAtlas } from "../apis/catalog/hca-atlas-tracker/common/entities";
+import {
+  HCAAtlasTrackerDBAtlas,
+  HCAAtlasTrackerDBAtlasForStatusSummary,
+} from "../apis/catalog/hca-atlas-tracker/common/entities";
 import { query } from "../services/database";
 import { InvalidOperationError, NotFoundError } from "../utils/api-errors";
 import { AtlasSlugNameAndVersion } from "../utils/atlases";
 
 export const CONSTRAINT_ATLAS_SLUG_VERSION_UNIQUE =
   "atlases_slug_version_unique";
+
+/**
+ * Get data for an atlas and its linked entities to use to create an atlas status summary.
+ * @param atlasId - ID of the atlas to get status summary source data for.
+ * @returns atlas and linked entities for status summary.
+ */
+export async function getAtlasForStatusSummary(
+  atlasId: string,
+): Promise<HCAAtlasTrackerDBAtlasForStatusSummary> {
+  const queryResult = await query<HCAAtlasTrackerDBAtlasForStatusSummary>(
+    `
+      WITH atlas_source_studies AS (
+          SELECT s.doi
+          FROM hat.source_studies s
+          JOIN hat.atlases a ON a.source_studies ? s.id::text
+          WHERE a.id = $1
+        ),
+        atlas_source_datasets AS (
+          SELECT d.reprocessed_status, d.sd_info, f.validation_status, f.validation_summary
+          FROM hat.source_datasets d
+          JOIN hat.files f ON f.id = d.file_id
+          JOIN hat.atlases a ON d.version_id = ANY(a.source_datasets)
+          WHERE a.id = $1
+        ),
+        atlas_component_atlases AS (
+          SELECT c.component_info, f.validation_status, f.validation_summary
+          FROM hat.component_atlases c
+          JOIN hat.files f ON f.id = c.file_id
+          JOIN hat.atlases a ON c.version_id = ANY(a.component_atlases)
+          WHERE a.id = $1
+        )
+      SELECT
+        a.status,
+        a.published_at,
+        (SELECT ARRAY_AGG(to_jsonb(s)) FROM atlas_source_studies s) AS source_studies,
+        (SELECT ARRAY_AGG(to_jsonb(d)) FROM atlas_source_datasets d) AS source_datasets,
+        (SELECT ARRAY_AGG(to_jsonb(c)) FROM atlas_component_atlases c) AS component_atlases
+      FROM hat.atlases a
+      WHERE id = $1
+    `,
+    [atlasId],
+  );
+  return getAtlasInfoFromIdBasedQuery(queryResult, atlasId);
+}
 
 /**
  * Get an atlas ID based on a case-insensitive short name slug, a generation number, and a revision number.

--- a/app/data/atlases.ts
+++ b/app/data/atlases.ts
@@ -27,14 +27,14 @@ export async function getAtlasForStatusSummary(
           WHERE a.id = $1
         ),
         atlas_source_datasets AS (
-          SELECT d.reprocessed_status, d.sd_info, f.validation_status, f.validation_summary
+          SELECT d.reprocessed_status, d.sd_info, f.validation_summary
           FROM hat.source_datasets d
           JOIN hat.files f ON f.id = d.file_id
           JOIN hat.atlases a ON d.version_id = ANY(a.source_datasets)
           WHERE a.id = $1 AND NOT f.is_archived
         ),
         atlas_component_atlases AS (
-          SELECT c.component_info, f.validation_status, f.validation_summary
+          SELECT c.component_info, f.validation_summary
           FROM hat.component_atlases c
           JOIN hat.files f ON f.id = c.file_id
           JOIN hat.atlases a ON c.version_id = ANY(a.component_atlases)

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -1,4 +1,3 @@
-import { normalizeValidationSummary } from "app/utils/files";
 import pg from "pg";
 import { ValidationError } from "yup";
 import { InvalidOperationError } from "../../app/utils/api-errors";
@@ -42,6 +41,7 @@ import { publishUnpublishedSourceDatasetsOfAtlas } from "../data/source-datasets
 import { addAssociatedEntityToUsersAssociatedWith } from "../data/users";
 import { parseAtlasNameUrlSlug, slugifyAtlasShortName } from "../utils/atlases";
 import { normalizeDoi } from "../utils/doi";
+import { normalizeValidationSummary } from "../utils/files";
 import { getSheetTitleForApi } from "../utils/google-sheets-api";
 import { doTransaction, mapDatabaseError, query } from "./database";
 import { updateSourceStudyValidationsByEntityIds } from "./source-studies";

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -8,7 +8,6 @@ import {
   AtlasStatusSummary,
   CAP_INGEST_STATUS,
   DoiPublicationInfo,
-  FILE_VALIDATION_STATUS,
   FileValidationSummary,
   HCAAtlasTrackerDBAtlas,
   HCAAtlasTrackerDBAtlasForAPI,
@@ -220,7 +219,6 @@ export async function getAtlasStatusSummary(
 
     countMetadataEntityForStatusSummary(
       summary.integratedObjects,
-      componentAtlas.validation_status,
       validationSummary,
       componentAtlas.component_info.capUrl,
     );
@@ -242,7 +240,6 @@ export async function getAtlasStatusSummary(
 
     countMetadataEntityForStatusSummary(
       summary.sourceDatasets,
-      sourceDataset.validation_status,
       validationSummary,
       sourceDataset.sd_info.capUrl,
       sourceDataset.reprocessed_status,
@@ -264,7 +261,6 @@ export async function getAtlasStatusSummary(
 /**
  * Update counts in a metadata entity status summary to account for a given metadata entity.
  * @param entitySummary - Summary section to update counts in.
- * @param validationStatus - Validation status of the metadata entity to count.
  * @param validationSummary - Normalized validation summary of the metadata entity to count.
  * @param capUrl - CAP URL of the metadata entity to count.
  * @param reprocessedStatus - Reprocessed status, if applicable, of the metadata entity to count.
@@ -273,13 +269,11 @@ function countMetadataEntityForStatusSummary(
   entitySummary:
     | AtlasStatusSummary["integratedObjects"]
     | AtlasStatusSummary["sourceDatasets"],
-  validationStatus: FILE_VALIDATION_STATUS,
   validationSummary: FileValidationSummary | null,
   capUrl: string | null,
   reprocessedStatus?: REPROCESSED_STATUS,
 ): void {
   const capIngestStatus = getCapIngestStatusFromParameters(
-    validationStatus,
     validationSummary,
     capUrl,
     reprocessedStatus,

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -192,7 +192,6 @@ export async function getAtlasStatusSummary(
       capInvalid: 0,
       capPublished: 0,
       capReady: 0,
-      capRequired: 0,
       original: 0,
       reprocessed: 0,
       tier1Invalid: 0,
@@ -235,8 +234,6 @@ export async function getAtlasStatusSummary(
 
     if (sourceDataset.reprocessed_status === REPROCESSED_STATUS.ORIGINAL) {
       summary.sourceDatasets.original++;
-      if (sourceDataset.sd_info.capUrl === null)
-        summary.sourceDatasets.capRequired++;
     } else if (
       sourceDataset.reprocessed_status === REPROCESSED_STATUS.REPROCESSED
     ) {

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -1,13 +1,19 @@
+import { normalizeValidationSummary } from "app/utils/files";
 import pg from "pg";
 import { ValidationError } from "yup";
 import { InvalidOperationError } from "../../app/utils/api-errors";
 import { getCrossrefPublicationInfo } from "../../app/utils/crossref/crossref";
 import {
   ATLAS_STATUS,
+  AtlasStatusSummary,
+  CAP_INGEST_STATUS,
   DoiPublicationInfo,
+  FILE_VALIDATION_STATUS,
+  FileValidationSummary,
   HCAAtlasTrackerDBAtlas,
   HCAAtlasTrackerDBAtlasForAPI,
   HCAAtlasTrackerDBAtlasOverview,
+  REPROCESSED_STATUS,
   SYSTEM,
 } from "../apis/catalog/hca-atlas-tracker/common/entities";
 import {
@@ -15,6 +21,7 @@ import {
   NewAtlasData,
 } from "../apis/catalog/hca-atlas-tracker/common/schema";
 import {
+  getCapIngestStatusFromParameters,
   getPublishedFromPublishedAt,
   isUuid,
 } from "../apis/catalog/hca-atlas-tracker/common/utils";
@@ -24,6 +31,7 @@ import {
   CONSTRAINT_ATLAS_SLUG_VERSION_UNIQUE,
   createAtlasRevision,
   getAdvisoryLockForAtlas,
+  getAtlasForStatusSummary,
   getAtlasIdBySlugNameAndVersion,
   getAtlasInfoFromIdBasedQuery,
   getAtlasNotFoundError,
@@ -153,6 +161,144 @@ export async function getBaseModelAtlas(
   );
 
   return getAtlasInfoFromIdBasedQuery(queryResult, id);
+}
+
+/**
+ * Get the status summary for an atlas.
+ * @param atlasId - ID of the atlas to get status summary for.
+ * @returns status summary.
+ */
+export async function getAtlasStatusSummary(
+  atlasId: string,
+): Promise<AtlasStatusSummary> {
+  // Get info for atlas and linked entities
+  const atlasInfo = await getAtlasForStatusSummary(atlasId);
+
+  // Initialize summary with basic atlas info, and counts set to 0
+  const summary: AtlasStatusSummary = {
+    integratedObjects: {
+      capInvalid: 0,
+      capPublished: 0,
+      capReady: 0,
+      cellAnnotationInvalid: 0,
+      cellAnnotationValid: 0,
+      tier1Invalid: 0,
+      tier1Valid: 0,
+      total: 0,
+    },
+    ocEndorsed: atlasInfo.status === ATLAS_STATUS.OC_ENDORSED,
+    publishedOnPortal: getPublishedFromPublishedAt(atlasInfo.published_at),
+    sourceDatasets: {
+      capInvalid: 0,
+      capPublished: 0,
+      capReady: 0,
+      capRequired: 0,
+      original: 0,
+      reprocessed: 0,
+      tier1Invalid: 0,
+      tier1Valid: 0,
+      total: 0,
+    },
+    sourceStudies: {
+      published: 0,
+      total: 0,
+      unpublished: 0,
+    },
+  };
+
+  // Count integrated objects
+  for (const componentAtlas of atlasInfo.component_atlases) {
+    const validationSummary = normalizeValidationSummary(
+      componentAtlas.validation_summary,
+    );
+
+    const cellAnnotationValid =
+      validationSummary?.validators.hcaCellAnnotation?.valid;
+    if (cellAnnotationValid === true)
+      summary.integratedObjects.cellAnnotationValid++;
+    else if (cellAnnotationValid === false)
+      summary.integratedObjects.cellAnnotationInvalid++;
+
+    countMetadataEntityForStatusSummary(
+      summary.integratedObjects,
+      componentAtlas.validation_status,
+      validationSummary,
+      componentAtlas.component_info.capUrl,
+    );
+  }
+
+  // Count source datasets
+  for (const sourceDataset of atlasInfo.source_datasets) {
+    const validationSummary = normalizeValidationSummary(
+      sourceDataset.validation_summary,
+    );
+
+    if (sourceDataset.reprocessed_status === REPROCESSED_STATUS.ORIGINAL) {
+      summary.sourceDatasets.original++;
+      if (sourceDataset.sd_info.capUrl === null)
+        summary.sourceDatasets.capRequired++;
+    } else if (
+      sourceDataset.reprocessed_status === REPROCESSED_STATUS.REPROCESSED
+    ) {
+      summary.sourceDatasets.reprocessed++;
+    }
+
+    countMetadataEntityForStatusSummary(
+      summary.sourceDatasets,
+      sourceDataset.validation_status,
+      validationSummary,
+      sourceDataset.sd_info.capUrl,
+      sourceDataset.reprocessed_status,
+    );
+  }
+
+  // Count source studies
+  for (const sourceStudy of atlasInfo.source_studies) {
+    if (sourceStudy.doi === null) summary.sourceStudies.unpublished++;
+    else summary.sourceStudies.published++;
+
+    summary.sourceStudies.total++;
+  }
+
+  // Return completed summary
+  return summary;
+}
+
+/**
+ * Update counts in a metadata entity status summary to account for a given metadata entity.
+ * @param entitySummary - Summary section to update counts in.
+ * @param validationStatus - Validation status of the metadata entity to count.
+ * @param validationSummary - Normalized validation summary of the metadata entity to count.
+ * @param capUrl - CAP URL of the metadata entity to count.
+ * @param reprocessedStatus - Reprocessed status, if applicable, of the metadata entity to count.
+ */
+function countMetadataEntityForStatusSummary(
+  entitySummary:
+    | AtlasStatusSummary["integratedObjects"]
+    | AtlasStatusSummary["sourceDatasets"],
+  validationStatus: FILE_VALIDATION_STATUS,
+  validationSummary: FileValidationSummary | null,
+  capUrl: string | null,
+  reprocessedStatus?: REPROCESSED_STATUS,
+): void {
+  const capIngestStatus = getCapIngestStatusFromParameters(
+    validationStatus,
+    validationSummary,
+    capUrl,
+    reprocessedStatus,
+  );
+
+  if (capIngestStatus === CAP_INGEST_STATUS.CAP_READY) entitySummary.capReady++;
+  else if (capIngestStatus === CAP_INGEST_STATUS.PUBLISHED)
+    entitySummary.capPublished++;
+  else if (capIngestStatus === CAP_INGEST_STATUS.CAP_VALIDATION_FAILED)
+    entitySummary.capInvalid++;
+
+  const tier1Valid = validationSummary?.validators.hcaSchema?.valid;
+  if (tier1Valid === true) entitySummary.tier1Valid++;
+  else if (tier1Valid === false) entitySummary.tier1Invalid++;
+
+  entitySummary.total++;
 }
 
 export async function createAtlas(

--- a/pages/api/atlases/[atlasId]/status.ts
+++ b/pages/api/atlases/[atlasId]/status.ts
@@ -1,0 +1,15 @@
+import { METHOD } from "../../../../app/common/entities";
+import { getAtlasStatusSummary } from "../../../../app/services/atlases";
+import {
+  handler,
+  method,
+  registeredUser,
+} from "../../../../app/utils/api-handler";
+
+/**
+ * API route to get an atlas's status summary.
+ */
+export default handler(method(METHOD.GET), registeredUser, async (req, res) => {
+  const atlasId = req.query.atlasId as string;
+  res.status(200).json(await getAtlasStatusSummary(atlasId));
+});

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -44,6 +44,7 @@ import {
 } from "./constants";
 import {
   TestComponentAtlas,
+  TestConcept,
   TestEntrySheetValidation,
   TestFile,
   TestSourceDataset,
@@ -78,18 +79,7 @@ export async function resetDatabase(initEntities = true): Promise<void> {
 }
 
 async function initDatabaseEntries(client: pg.PoolClient): Promise<void> {
-  for (const user of INITIAL_TEST_USERS) {
-    await client.query(
-      "INSERT INTO hat.users (disabled, email, full_name, role, role_associated_resource_ids) VALUES ($1, $2, $3, $4, $5)",
-      [
-        user.disabled.toString(),
-        user.email,
-        user.name,
-        user.role,
-        user.roleAssociatedResourceIds,
-      ],
-    );
-  }
+  await initUsers(client);
 
   const dbUsersByEmail = await getDbUsersByEmail(client);
 
@@ -121,8 +111,29 @@ async function initDatabaseEntries(client: pg.PoolClient): Promise<void> {
   await updateTaskCounts(client);
 }
 
-async function initSourceStudies(client: pg.PoolClient): Promise<void> {
-  for (const study of INITIAL_TEST_SOURCE_STUDIES) {
+export async function initUsers(
+  client: pg.PoolClient,
+  testUsers = INITIAL_TEST_USERS,
+): Promise<void> {
+  for (const user of testUsers) {
+    await client.query(
+      "INSERT INTO hat.users (disabled, email, full_name, role, role_associated_resource_ids) VALUES ($1, $2, $3, $4, $5)",
+      [
+        user.disabled.toString(),
+        user.email,
+        user.name,
+        user.role,
+        user.roleAssociatedResourceIds,
+      ],
+    );
+  }
+}
+
+export async function initSourceStudies(
+  client: pg.PoolClient,
+  testSourceStudies = INITIAL_TEST_SOURCE_STUDIES,
+): Promise<void> {
+  for (const study of testSourceStudies) {
     const sdInfo = makeTestSourceStudyOverview(study);
     await client.query(
       "INSERT INTO hat.source_studies (doi, id, study_info) VALUES ($1, $2, $3)",
@@ -156,8 +167,11 @@ export async function initSourceDatasets(
   }
 }
 
-async function initAtlases(client: pg.PoolClient): Promise<void> {
-  for (const atlas of INITIAL_TEST_ATLASES) {
+export async function initAtlases(
+  client: pg.PoolClient,
+  testAtlases = INITIAL_TEST_ATLASES,
+): Promise<void> {
+  for (const atlas of testAtlases) {
     const overview = makeTestAtlasOverview(atlas);
     await client.query(
       `
@@ -181,8 +195,11 @@ async function initAtlases(client: pg.PoolClient): Promise<void> {
   }
 }
 
-async function initComponentAtlases(client: pg.PoolClient): Promise<void> {
-  for (const componentAtlas of INITIAL_TEST_COMPONENT_ATLASES) {
+export async function initComponentAtlases(
+  client: pg.PoolClient,
+  testComponentAtlases = INITIAL_TEST_COMPONENT_ATLASES,
+): Promise<void> {
+  for (const componentAtlas of testComponentAtlases) {
     const info: HCAAtlasTrackerDBComponentAtlasInfo = {
       capUrl: componentAtlas.capUrl ?? null,
     };
@@ -208,12 +225,30 @@ async function initComponentAtlases(client: pg.PoolClient): Promise<void> {
   }
 }
 
-async function initFiles(client: pg.PoolClient): Promise<void> {
+export async function initFiles(
+  client: pg.PoolClient,
+  testEntities: {
+    componentAtlases?: TestComponentAtlas[];
+    explicitConcepts?: TestConcept[];
+    sourceDatasets?: TestSourceDataset[];
+    standaloneFiles?: TestFile[];
+  } = {
+    componentAtlases: INITIAL_TEST_COMPONENT_ATLASES,
+    explicitConcepts: INITIAL_EXPLICIT_TEST_CONCEPTS,
+    sourceDatasets: INITIAL_TEST_SOURCE_DATASETS,
+    standaloneFiles: INITIAL_STANDALONE_TEST_FILES,
+  },
+): Promise<void> {
+  const {
+    componentAtlases = [],
+    explicitConcepts = [],
+    sourceDatasets = [],
+    standaloneFiles = [],
+  } = testEntities;
+
   const createdFiles = new Set<TestFile>();
-  const createdConcepts = new Set<string>(
-    INITIAL_EXPLICIT_TEST_CONCEPTS.map((c) => c.id),
-  );
-  for (const componentAtlas of INITIAL_TEST_COMPONENT_ATLASES) {
+  const createdConcepts = new Set<string>(explicitConcepts.map((c) => c.id));
+  for (const componentAtlas of componentAtlases) {
     await initTestFile(
       client,
       componentAtlas.file,
@@ -222,7 +257,7 @@ async function initFiles(client: pg.PoolClient): Promise<void> {
       componentAtlas.id,
     );
   }
-  for (const sourceDataset of INITIAL_TEST_SOURCE_DATASETS) {
+  for (const sourceDataset of sourceDatasets) {
     await initTestFile(
       client,
       sourceDataset.file,
@@ -231,7 +266,7 @@ async function initFiles(client: pg.PoolClient): Promise<void> {
       sourceDataset.id,
     );
   }
-  for (const file of INITIAL_STANDALONE_TEST_FILES) {
+  for (const file of standaloneFiles) {
     await initTestFile(client, file, createdFiles, createdConcepts);
   }
 }

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -461,6 +461,7 @@ export function testApiRole(
     res: httpMocks.MockResponse<NextApiResponse>,
     user: TestUser,
   ) => void | Promise<void>,
+  additionalParams?: { usersByRole?: Partial<Record<ROLE, TestUser>> },
 ): void {
   let user: TestUser;
   let testName: string;
@@ -477,12 +478,14 @@ export function testApiRole(
           : USER_INTEGRATION_LEAD_DRAFT;
       testName = `${testNameBase} when GET requested by user with INTEGRATION_LEAD role for another atlas`;
     } else {
-      user = INTEGRATION_LEADS_BY_ATLAS_ID[query.atlasId];
+      user =
+        additionalParams?.usersByRole?.INTEGRATION_LEAD ??
+        INTEGRATION_LEADS_BY_ATLAS_ID[query.atlasId];
       if (!user) throw new Error("No appropriate user found for test");
       testName = `${testNameBase} when ${method} requested by user with INTEGRATION_LEAD role for the atlas`;
     }
   } else {
-    user = DEFAULT_USERS_BY_ROLE[role];
+    user = additionalParams?.usersByRole?.[role] ?? DEFAULT_USERS_BY_ROLE[role];
     testName = `${testNameBase} when ${method} requested by user with ${role} role`;
   }
   it(testName, async () => {


### PR DESCRIPTION
Closes #1339

Notes (EDIT: now all resolved - see updated ticket):
- `capRequired` likely needs revision of some sort. I implemented it as only counting original datasets that *lack a CAP URL*, despite the ticket not explicitly specifying that restriction, because otherwise it would be identical to the `original` count. However, I'm currently not really sure what the original intent was (i.e. revision might be needed to align with intent), and even if we were to stick with what I've implemented, it seems to me that it would be good to also have `capRequired` for integrated objects.
- The CAP counts are a bit weird because they're split into `capInvalid`, `capReady`, and `capPublished` (no `capValid`) based on the `CAP_INGEST_STATUS` value calculated for the entity; I wonder if instead maybe `capValid` and `capInvalid` should be calculated separately from `capReady` and `capPublished`, in the same way as the other validator counts, and/or perhaps the CAP ingest status calculation function should be adjusted, because as it is:
  - None of the CAP categories are counted if the entity is in the process of being revalidated, due to the ingest status function requiring the validation status to be `COMPLETED` (whereas it's `REQUESTED` when revalidating, even though validation results may be present).
  - If CAP is not present in the validation results, the ingest status function treats it as failed, although this is probably not a concern in practice because recent and future validation results will always have CAP results.
- EDIT: As indicated by Copilot, there's a similar issue regarding the Tier 1 status; I've implemented it as being based on the `valid` boolean from the validation results (in line with how I've done the cell annotation counts, which *don't* have any special preexisting logic), but the ticket implies that it should be based on `getHcaTier1ValidationStatus`, which uses the error count instead (though that should theoretically be equivalent to the boolean) and, like CAP status, ignores existing results if revalidation is in progress.