### PR TITLE
feat: add api to get metadata coverage reports for atlases (#1274)

### DIFF
--- a/__tests__/api-metadata-coverage-atlases.test.ts
+++ b/__tests__/api-metadata-coverage-atlases.test.ts
@@ -181,10 +181,10 @@ describe(TEST_ROUTE, () => {
     expect(atlas.name).toEqual(ATLAS_WITH_MISC_SOURCE_STUDIES.shortName);
     expect(atlas.version).toEqual("2.3");
     expect(atlas.generation).toEqual(2);
-    expect(atlas.bionetwork).toEqual({ id: "adipose", label: "Adipose" });
+    expect(atlas.bionetwork).toEqual("adipose");
     expect(atlas.integrationLeads).toEqual([
       {
-        id: INTEGRATION_LEAD_BAZ_BAZ.email,
+        email: INTEGRATION_LEAD_BAZ_BAZ.email,
         name: INTEGRATION_LEAD_BAZ_BAZ.name,
       },
     ]);

--- a/__tests__/api-metadata-coverage-atlases.test.ts
+++ b/__tests__/api-metadata-coverage-atlases.test.ts
@@ -1,0 +1,333 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
+import {
+  AtlasMetadataCoverage,
+  AtlasMetadataCoverageRollup,
+  FileMetadataCoverage,
+} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "../app/common/entities";
+import { endPgPool, query } from "../app/services/database";
+import metadataCoverageAtlasesHandler from "../pages/api/metadata-coverage/atlases";
+import {
+  ATLAS_WITH_MISC_SOURCE_STUDIES,
+  ATLAS_WITH_MISC_SOURCE_STUDIES_B,
+  COMPONENT_ATLAS_MISC_FOO,
+  INTEGRATION_LEAD_BAZ_BAZ,
+  SOURCE_DATASET_BAR,
+  SOURCE_DATASET_FOO,
+  STAKEHOLDER_ANALOGOUS_ROLES,
+  USER_CONTENT_ADMIN,
+  USER_UNREGISTERED,
+} from "../testing/constants";
+import { resetDatabase } from "../testing/db-utils";
+import { TestUser } from "../testing/entities";
+import { testApiRole, withConsoleErrorHiding } from "../testing/utils";
+
+jest.mock(
+  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+);
+jest.mock("../app/services/hca-projects");
+jest.mock("../app/services/cellxgene");
+jest.mock("../app/utils/pg-app-connect-config");
+
+jest.mock("next-auth");
+
+const TEST_ROUTE = "/api/metadata-coverage/atlases";
+
+// Coverage blob set on SOURCE_DATASET_FOO's file (a source dataset of
+// ATLAS_WITH_MISC_SOURCE_STUDIES). Includes an `obs` entry and an unknown
+// dataset field, both of which must be ignored by the rollup.
+const COVERAGE_SOURCE_DATASET_FOO: FileMetadataCoverage = {
+  entities: {
+    dataset: { recordCount: 1 },
+    donor: { recordCount: 10 },
+    obs: { recordCount: 100 },
+    sample: { recordCount: 5 },
+  },
+  fieldCoverage: [
+    fieldCoverage("dataset", "alignment_software", 1, 0, 0),
+    fieldCoverage("dataset", "assay_ontology_term_id", 0, 1, 0),
+    fieldCoverage("dataset", "batch_condition", 1, 0, 0), // recommended
+    fieldCoverage("dataset", "not_a_real_field", 5, 5, 5), // ignored: not in dictionary
+    fieldCoverage("donor", "donor_id", 7, 2, 1),
+    fieldCoverage("obs", "ignored_field", 9, 9, 9), // ignored: obs class
+    fieldCoverage("sample", "cell_enrichment", 4, 1, 0),
+    fieldCoverage("sample", "age_range", 2, 3, 0), // recommended
+  ],
+  schemaName: "test-schema",
+  schemaVersion: "1.0.0",
+};
+
+// Coverage blob set on SOURCE_DATASET_BAR's file (another source dataset of the
+// same atlas), to verify summing across an atlas's files.
+const COVERAGE_SOURCE_DATASET_BAR: FileMetadataCoverage = {
+  entities: {
+    dataset: { recordCount: 1 },
+    donor: { recordCount: 5 },
+    obs: { recordCount: 50 },
+    sample: { recordCount: 3 },
+  },
+  fieldCoverage: [
+    fieldCoverage("dataset", "alignment_software", 1, 0, 0),
+    fieldCoverage("donor", "donor_id", 3, 2, 0),
+    fieldCoverage("sample", "cell_enrichment", 2, 1, 0),
+  ],
+  schemaName: "test-schema",
+  schemaVersion: "1.0.0",
+};
+
+// Coverage blob set on COMPONENT_ATLAS_MISC_FOO's file (an integrated object of
+// the same atlas).
+const COVERAGE_INTEGRATED_OBJECT_FOO: FileMetadataCoverage = {
+  entities: {
+    dataset: { recordCount: 1 },
+    donor: { recordCount: 20 },
+    obs: { recordCount: 200 },
+    sample: { recordCount: 8 },
+  },
+  fieldCoverage: [
+    fieldCoverage("dataset", "alignment_software", 1, 0, 0),
+    fieldCoverage("donor", "donor_id", 15, 5, 0),
+    fieldCoverage("sample", "cell_enrichment", 6, 2, 0),
+  ],
+  schemaName: "test-schema",
+  schemaVersion: "1.0.0",
+};
+
+beforeAll(async () => {
+  await resetDatabase();
+  await setFileMetadataCoverage(
+    SOURCE_DATASET_FOO.file.id,
+    COVERAGE_SOURCE_DATASET_FOO,
+  );
+  await setFileMetadataCoverage(
+    SOURCE_DATASET_BAR.file.id,
+    COVERAGE_SOURCE_DATASET_BAR,
+  );
+  await setFileMetadataCoverage(
+    COMPONENT_ATLAS_MISC_FOO.file.id,
+    COVERAGE_INTEGRATED_OBJECT_FOO,
+  );
+});
+
+afterAll(async () => {
+  endPgPool();
+});
+
+describe(TEST_ROUTE, () => {
+  it("returns error 405 for non-GET request", async () => {
+    expect(
+      (await doRequest(USER_CONTENT_ADMIN, METHOD.POST))._getStatusCode(),
+    ).toEqual(405);
+  });
+
+  it("returns error 401 for logged out user", async () => {
+    expect(
+      (await doRequest(undefined, METHOD.GET, {}, true))._getStatusCode(),
+    ).toEqual(401);
+  });
+
+  it("returns error 403 for unregistered user", async () => {
+    expect(
+      (
+        await doRequest(USER_UNREGISTERED, METHOD.GET, {}, true)
+      )._getStatusCode(),
+    ).toEqual(403);
+  });
+
+  it("returns error 400 for invalid source parameter", async () => {
+    expect(
+      (
+        await doRequest(USER_CONTENT_ADMIN, METHOD.GET, { source: "foo" }, true)
+      )._getStatusCode(),
+    ).toEqual(400);
+  });
+
+  it("returns error 400 for invalid required parameter", async () => {
+    expect(
+      (
+        await doRequest(
+          USER_CONTENT_ADMIN,
+          METHOD.GET,
+          { required: "required,bogus" },
+          true,
+        )
+      )._getStatusCode(),
+    ).toEqual(400);
+  });
+
+  for (const role of STAKEHOLDER_ANALOGOUS_ROLES) {
+    testApiRole(
+      "returns metadata coverage rollup",
+      TEST_ROUTE,
+      metadataCoverageAtlasesHandler,
+      METHOD.GET,
+      role,
+      undefined,
+      undefined,
+      false,
+      (res) => {
+        expect(res._getStatusCode()).toEqual(200);
+      },
+    );
+  }
+
+  it("aggregates source dataset coverage for the required tier by default", async () => {
+    const atlas = await getAtlasFromResponse(
+      await doRequest(USER_CONTENT_ADMIN, METHOD.GET, {}),
+      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+    );
+
+    expect(atlas.name).toEqual(ATLAS_WITH_MISC_SOURCE_STUDIES.shortName);
+    expect(atlas.version).toEqual("2.3");
+    expect(atlas.generation).toEqual(2);
+    expect(atlas.bionetwork).toEqual({ id: "adipose", label: "Adipose" });
+    expect(atlas.integrationLeads).toEqual([
+      {
+        id: INTEGRATION_LEAD_BAZ_BAZ.email,
+        name: INTEGRATION_LEAD_BAZ_BAZ.name,
+      },
+    ]);
+
+    // dataset: required alignment_software (1/1 + 1/1) and assay_ontology_term_id (0/1)
+    expect(atlas.classes.dataset).toEqual({
+      completion: 2 / 3,
+      entityCount: 2,
+      filledSlots: 2,
+      totalSlots: 3,
+    });
+    // donor: required donor_id (7/10 + 3/5)
+    expect(atlas.classes.donor).toEqual({
+      completion: 10 / 15,
+      entityCount: 15,
+      filledSlots: 10,
+      totalSlots: 15,
+    });
+    // sample: required cell_enrichment (4/5 + 2/3)
+    expect(atlas.classes.sample).toEqual({
+      completion: 6 / 8,
+      entityCount: 8,
+      filledSlots: 6,
+      totalSlots: 8,
+    });
+    expect(atlas.total).toEqual((2 / 3 + 10 / 15 + 6 / 8) / 3);
+  });
+
+  it("includes recommended fields when requested", async () => {
+    const atlas = await getAtlasFromResponse(
+      await doRequest(USER_CONTENT_ADMIN, METHOD.GET, {
+        required: "required,recommended",
+      }),
+      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+    );
+
+    // dataset gains recommended batch_condition (1/1)
+    expect(atlas.classes.dataset).toEqual({
+      completion: 3 / 4,
+      entityCount: 2,
+      filledSlots: 3,
+      totalSlots: 4,
+    });
+    // sample gains recommended age_range (2/5)
+    expect(atlas.classes.sample).toEqual({
+      completion: 8 / 13,
+      entityCount: 8,
+      filledSlots: 8,
+      totalSlots: 13,
+    });
+  });
+
+  it("aggregates integrated object coverage when source is integrated_object", async () => {
+    const atlas = await getAtlasFromResponse(
+      await doRequest(USER_CONTENT_ADMIN, METHOD.GET, {
+        source: "integrated_object",
+      }),
+      ATLAS_WITH_MISC_SOURCE_STUDIES.id,
+    );
+
+    expect(atlas.classes.dataset).toEqual({
+      completion: 1,
+      entityCount: 1,
+      filledSlots: 1,
+      totalSlots: 1,
+    });
+    expect(atlas.classes.donor).toEqual({
+      completion: 15 / 20,
+      entityCount: 20,
+      filledSlots: 15,
+      totalSlots: 20,
+    });
+    expect(atlas.classes.sample).toEqual({
+      completion: 6 / 8,
+      entityCount: 8,
+      filledSlots: 6,
+      totalSlots: 8,
+    });
+    expect(atlas.total).toEqual((1 + 15 / 20 + 6 / 8) / 3);
+  });
+
+  it("returns empty classes and zero total for atlases with no files of the requested source", async () => {
+    const atlas = await getAtlasFromResponse(
+      await doRequest(USER_CONTENT_ADMIN, METHOD.GET, {}),
+      ATLAS_WITH_MISC_SOURCE_STUDIES_B.id,
+    );
+    for (const className of ["dataset", "donor", "sample"] as const) {
+      expect(atlas.classes[className]).toEqual({
+        completion: null,
+        entityCount: 0,
+        filledSlots: 0,
+        totalSlots: 0,
+      });
+    }
+    expect(atlas.total).toEqual(0);
+  });
+});
+
+function fieldCoverage(
+  entityClass: FileMetadataCoverage["fieldCoverage"][number]["entityClass"],
+  field: string,
+  complete: number,
+  missing: number,
+  inconsistent: number,
+): FileMetadataCoverage["fieldCoverage"][number] {
+  return { complete, entityClass, field, inconsistent, missing };
+}
+
+async function setFileMetadataCoverage(
+  fileId: string,
+  coverage: FileMetadataCoverage,
+): Promise<void> {
+  await query("UPDATE hat.files SET metadata_coverage = $1 WHERE id = $2", [
+    JSON.stringify(coverage),
+    fileId,
+  ]);
+}
+
+async function getAtlasFromResponse(
+  res: httpMocks.MockResponse<NextApiResponse>,
+  atlasId: string,
+): Promise<AtlasMetadataCoverage> {
+  expect(res._getStatusCode()).toEqual(200);
+  const rollup = res._getJSONData() as AtlasMetadataCoverageRollup;
+  const atlases = rollup.atlases.filter((a) => a.atlasId === atlasId);
+  expect(atlases).toHaveLength(1);
+  return atlases[0];
+}
+
+async function doRequest(
+  user?: TestUser,
+  method = METHOD.GET,
+  query: Record<string, string> = {},
+  hideConsoleError = false,
+): Promise<httpMocks.MockResponse<NextApiResponse>> {
+  const { req, res } = httpMocks.createMocks<NextApiRequest, NextApiResponse>({
+    headers: { authorization: user?.authorization },
+    method,
+    query,
+  });
+  await withConsoleErrorHiding(
+    () => metadataCoverageAtlasesHandler(req, res),
+    hideConsoleError,
+  );
+  return res;
+}

--- a/__tests__/api-metadata-coverage-atlases.test.ts
+++ b/__tests__/api-metadata-coverage-atlases.test.ts
@@ -304,6 +304,13 @@ describe(TEST_ROUTE, () => {
   }
 
   it("aggregates source dataset coverage for the required tier by default", async () => {
+    // ATLAS_WITH_MISC_SOURCE_STUDIES links many source dataset files, but
+    // coverage was set only on SOURCE_DATASET_FOO and SOURCE_DATASET_BAR.
+    // Its other linked files (e.g. SOURCE_DATASET_BAZ) are seeded with no
+    // metadata coverage; the query's `metadata_coverage IS NOT NULL` filter
+    // drops them before aggregation. A successful response whose counts
+    // reflect only FOO + BAR therefore confirms that linked files without
+    // coverage are skipped without erroring.
     const atlas = await getAtlasFromResponse(
       await doRequest(USER_CONTENT_ADMIN, METHOD.GET, {}),
       ATLAS_WITH_MISC_SOURCE_STUDIES.id,
@@ -369,6 +376,10 @@ describe(TEST_ROUTE, () => {
   });
 
   it("aggregates integrated object coverage when source is integrated_object", async () => {
+    // As with the source dataset case, the atlas links integrated object files
+    // with no coverage (COMPONENT_ATLAS_MISC_BAR and COMPONENT_ATLAS_MISC_BAZ);
+    // counts reflecting only COMPONENT_ATLAS_MISC_FOO confirm those null-coverage
+    // files are excluded without erroring.
     const atlas = await getAtlasFromResponse(
       await doRequest(USER_CONTENT_ADMIN, METHOD.GET, {
         source: "integrated_object",

--- a/__tests__/api-metadata-coverage-atlases.test.ts
+++ b/__tests__/api-metadata-coverage-atlases.test.ts
@@ -178,11 +178,11 @@ describe(TEST_ROUTE, () => {
       ATLAS_WITH_MISC_SOURCE_STUDIES.id,
     );
 
-    expect(atlas.name).toEqual(ATLAS_WITH_MISC_SOURCE_STUDIES.shortName);
-    expect(atlas.version).toEqual("2.3");
+    expect(atlas.shortName).toEqual(ATLAS_WITH_MISC_SOURCE_STUDIES.shortName);
     expect(atlas.generation).toEqual(2);
-    expect(atlas.bionetwork).toEqual("adipose");
-    expect(atlas.integrationLeads).toEqual([
+    expect(atlas.revision).toEqual(3);
+    expect(atlas.network).toEqual("adipose");
+    expect(atlas.integrationLead).toEqual([
       {
         email: INTEGRATION_LEAD_BAZ_BAZ.email,
         name: INTEGRATION_LEAD_BAZ_BAZ.name,

--- a/__tests__/api-metadata-coverage-atlases.test.ts
+++ b/__tests__/api-metadata-coverage-atlases.test.ts
@@ -11,10 +11,17 @@ import metadataCoverageAtlasesHandler from "../pages/api/metadata-coverage/atlas
 import {
   ATLAS_WITH_MISC_SOURCE_STUDIES,
   ATLAS_WITH_MISC_SOURCE_STUDIES_B,
+  ATLAS_WITH_NON_LATEST_METADATA_ENTITIES,
   COMPONENT_ATLAS_MISC_FOO,
+  COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAR_W2,
+  COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ_W1,
+  COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_FOO_W2,
   INTEGRATION_LEAD_BAZ_BAZ,
   SOURCE_DATASET_BAR,
   SOURCE_DATASET_FOO,
+  SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_BAR_W2,
+  SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_BAZ_W1,
+  SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_FOO_W2,
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
   USER_UNREGISTERED,
@@ -94,6 +101,106 @@ const COVERAGE_INTEGRATED_OBJECT_FOO: FileMetadataCoverage = {
   schemaVersion: "1.0.0",
 };
 
+// Coverage blobs set on the source dataset files linked to
+// ATLAS_WITH_NON_LATEST_METADATA_ENTITIES. FOO_W2's file is the latest version,
+// while BAR_W2's and BAZ_W1's are non-latest versions linked via the atlas's
+// `source_datasets` array; all three must contribute to the rollup.
+const COVERAGE_NON_LATEST_SOURCE_DATASET_FOO: FileMetadataCoverage = {
+  entities: {
+    dataset: { recordCount: 2 },
+    donor: { recordCount: 4 },
+    obs: { recordCount: 40 },
+    sample: { recordCount: 3 },
+  },
+  fieldCoverage: [
+    fieldCoverage("dataset", "alignment_software", 2, 0, 0),
+    fieldCoverage("donor", "donor_id", 3, 1, 0),
+    fieldCoverage("sample", "cell_enrichment", 2, 1, 0),
+  ],
+  schemaName: "test-schema",
+  schemaVersion: "1.0.0",
+};
+const COVERAGE_NON_LATEST_SOURCE_DATASET_BAR: FileMetadataCoverage = {
+  entities: {
+    dataset: { recordCount: 1 },
+    donor: { recordCount: 2 },
+    obs: { recordCount: 20 },
+    sample: { recordCount: 1 },
+  },
+  fieldCoverage: [
+    fieldCoverage("dataset", "alignment_software", 1, 0, 0),
+    fieldCoverage("donor", "donor_id", 1, 1, 0),
+    fieldCoverage("sample", "cell_enrichment", 0, 1, 0),
+  ],
+  schemaName: "test-schema",
+  schemaVersion: "1.0.0",
+};
+const COVERAGE_NON_LATEST_SOURCE_DATASET_BAZ: FileMetadataCoverage = {
+  entities: {
+    dataset: { recordCount: 3 },
+    donor: { recordCount: 5 },
+    obs: { recordCount: 50 },
+    sample: { recordCount: 2 },
+  },
+  fieldCoverage: [
+    fieldCoverage("dataset", "alignment_software", 1, 1, 1),
+    fieldCoverage("donor", "donor_id", 4, 1, 0),
+    fieldCoverage("sample", "cell_enrichment", 2, 0, 0),
+  ],
+  schemaName: "test-schema",
+  schemaVersion: "1.0.0",
+};
+
+// Coverage blobs set on the integrated object files linked to
+// ATLAS_WITH_NON_LATEST_METADATA_ENTITIES. BAR_W2's file is the latest version,
+// while FOO_W2's and BAZ_W1's are non-latest versions linked via the atlas's
+// `component_atlases` array; all three must contribute to the rollup.
+const COVERAGE_NON_LATEST_INTEGRATED_OBJECT_FOO: FileMetadataCoverage = {
+  entities: {
+    dataset: { recordCount: 1 },
+    donor: { recordCount: 10 },
+    obs: { recordCount: 100 },
+    sample: { recordCount: 4 },
+  },
+  fieldCoverage: [
+    fieldCoverage("dataset", "alignment_software", 1, 0, 0),
+    fieldCoverage("donor", "donor_id", 6, 4, 0),
+    fieldCoverage("sample", "cell_enrichment", 3, 1, 0),
+  ],
+  schemaName: "test-schema",
+  schemaVersion: "1.0.0",
+};
+const COVERAGE_NON_LATEST_INTEGRATED_OBJECT_BAR: FileMetadataCoverage = {
+  entities: {
+    dataset: { recordCount: 2 },
+    donor: { recordCount: 5 },
+    obs: { recordCount: 50 },
+    sample: { recordCount: 2 },
+  },
+  fieldCoverage: [
+    fieldCoverage("dataset", "alignment_software", 1, 1, 0),
+    fieldCoverage("donor", "donor_id", 5, 0, 0),
+    fieldCoverage("sample", "cell_enrichment", 1, 1, 0),
+  ],
+  schemaName: "test-schema",
+  schemaVersion: "1.0.0",
+};
+const COVERAGE_NON_LATEST_INTEGRATED_OBJECT_BAZ: FileMetadataCoverage = {
+  entities: {
+    dataset: { recordCount: 1 },
+    donor: { recordCount: 3 },
+    obs: { recordCount: 30 },
+    sample: { recordCount: 1 },
+  },
+  fieldCoverage: [
+    fieldCoverage("dataset", "alignment_software", 0, 1, 0),
+    fieldCoverage("donor", "donor_id", 2, 1, 0),
+    fieldCoverage("sample", "cell_enrichment", 1, 0, 0),
+  ],
+  schemaName: "test-schema",
+  schemaVersion: "1.0.0",
+};
+
 beforeAll(async () => {
   await resetDatabase();
   await setFileMetadataCoverage(
@@ -107,6 +214,30 @@ beforeAll(async () => {
   await setFileMetadataCoverage(
     COMPONENT_ATLAS_MISC_FOO.file.id,
     COVERAGE_INTEGRATED_OBJECT_FOO,
+  );
+  await setFileMetadataCoverage(
+    SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_FOO_W2.file.id,
+    COVERAGE_NON_LATEST_SOURCE_DATASET_FOO,
+  );
+  await setFileMetadataCoverage(
+    SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_BAR_W2.file.id,
+    COVERAGE_NON_LATEST_SOURCE_DATASET_BAR,
+  );
+  await setFileMetadataCoverage(
+    SOURCE_DATASET_NON_LATEST_METADATA_ENTITIES_BAZ_W1.file.id,
+    COVERAGE_NON_LATEST_SOURCE_DATASET_BAZ,
+  );
+  await setFileMetadataCoverage(
+    COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_FOO_W2.file.id,
+    COVERAGE_NON_LATEST_INTEGRATED_OBJECT_FOO,
+  );
+  await setFileMetadataCoverage(
+    COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAR_W2.file.id,
+    COVERAGE_NON_LATEST_INTEGRATED_OBJECT_BAR,
+  );
+  await setFileMetadataCoverage(
+    COMPONENT_ATLAS_NON_LATEST_METADATA_ENTITIES_BAZ_W1.file.id,
+    COVERAGE_NON_LATEST_INTEGRATED_OBJECT_BAZ,
   );
 });
 
@@ -280,6 +411,68 @@ describe(TEST_ROUTE, () => {
       });
     }
     expect(atlas.total).toEqual(0);
+  });
+
+  it("aggregates source dataset coverage across files linked via non-latest versions", async () => {
+    const atlas = await getAtlasFromResponse(
+      await doRequest(USER_CONTENT_ADMIN, METHOD.GET, {}),
+      ATLAS_WITH_NON_LATEST_METADATA_ENTITIES.id,
+    );
+
+    // dataset: alignment_software FOO 2/2 + BAR 1/1 + BAZ 1/3
+    expect(atlas.classes.dataset).toEqual({
+      completion: 4 / 6,
+      entityCount: 6,
+      filledSlots: 4,
+      totalSlots: 6,
+    });
+    // donor: donor_id FOO 3/4 + BAR 1/2 + BAZ 4/5
+    expect(atlas.classes.donor).toEqual({
+      completion: 8 / 11,
+      entityCount: 11,
+      filledSlots: 8,
+      totalSlots: 11,
+    });
+    // sample: cell_enrichment FOO 2/3 + BAR 0/1 + BAZ 2/2
+    expect(atlas.classes.sample).toEqual({
+      completion: 4 / 6,
+      entityCount: 6,
+      filledSlots: 4,
+      totalSlots: 6,
+    });
+    expect(atlas.total).toEqual((4 / 6 + 8 / 11 + 4 / 6) / 3);
+  });
+
+  it("aggregates integrated object coverage across files linked via non-latest versions", async () => {
+    const atlas = await getAtlasFromResponse(
+      await doRequest(USER_CONTENT_ADMIN, METHOD.GET, {
+        source: "integrated_object",
+      }),
+      ATLAS_WITH_NON_LATEST_METADATA_ENTITIES.id,
+    );
+
+    // dataset: alignment_software FOO 1/1 + BAR 1/2 + BAZ 0/1
+    expect(atlas.classes.dataset).toEqual({
+      completion: 2 / 4,
+      entityCount: 4,
+      filledSlots: 2,
+      totalSlots: 4,
+    });
+    // donor: donor_id FOO 6/10 + BAR 5/5 + BAZ 2/3
+    expect(atlas.classes.donor).toEqual({
+      completion: 13 / 18,
+      entityCount: 18,
+      filledSlots: 13,
+      totalSlots: 18,
+    });
+    // sample: cell_enrichment FOO 3/4 + BAR 1/2 + BAZ 1/1
+    expect(atlas.classes.sample).toEqual({
+      completion: 5 / 7,
+      entityCount: 7,
+      filledSlots: 5,
+      totalSlots: 7,
+    });
+    expect(atlas.total).toEqual((2 / 4 + 13 / 18 + 5 / 7) / 3);
   });
 });
 

--- a/app/apis/catalog/hca-atlas-tracker/common/constants.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/constants.ts
@@ -230,6 +230,20 @@ export const FILE_METADATA_COVERAGE_ENTITY_TYPES = [
   "sample",
 ] as const;
 
+// Entity classes rolled up by the metadata completeness API. These are the
+// data-dictionary classes that carry fields; the blob's `obs` entity (the
+// dictionary's empty `cell` class) is intentionally excluded.
+export const METADATA_COVERAGE_CLASSES = [
+  "dataset",
+  "donor",
+  "sample",
+] as const;
+
+// Field requirement tiers selectable via the metadata completeness API's
+// `required` query parameter. The schema only carries `required: true/false`
+// today, mapping to `required` and `recommended` respectively.
+export const METADATA_COVERAGE_TIERS = ["recommended", "required"] as const;
+
 export const FILE_VALIDATOR_NAME_LABEL: Record<FileValidatorName, string> = {
   cap: "CAP Upload",
   cellxgene: "CELLxGENE",

--- a/app/apis/catalog/hca-atlas-tracker/common/constants.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/constants.ts
@@ -233,7 +233,7 @@ export const FILE_METADATA_COVERAGE_ENTITY_TYPES = [
 // Entity classes rolled up by the metadata completeness API. These are the
 // data-dictionary classes that carry fields; the blob's `obs` entity (the
 // dictionary's empty `cell` class) is intentionally excluded.
-export const METADATA_COVERAGE_CLASSES = [
+export const METADATA_COVERAGE_REPORT_CLASSES = [
   "dataset",
   "donor",
   "sample",
@@ -242,7 +242,10 @@ export const METADATA_COVERAGE_CLASSES = [
 // Field requirement tiers selectable via the metadata completeness API's
 // `required` query parameter. The schema only carries `required: true/false`
 // today, mapping to `required` and `recommended` respectively.
-export const METADATA_COVERAGE_TIERS = ["recommended", "required"] as const;
+export const METADATA_COVERAGE_REPORT_TIERS = [
+  "recommended",
+  "required",
+] as const;
 
 export const FILE_VALIDATOR_NAME_LABEL: Record<FileValidatorName, string> = {
   cap: "CAP Upload",

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -7,6 +7,8 @@ import { API } from "./api";
 import {
   FILE_METADATA_COVERAGE_ENTITY_TYPES,
   FILE_VALIDATOR_NAMES,
+  METADATA_COVERAGE_CLASSES,
+  METADATA_COVERAGE_TIERS,
   NETWORK_KEYS,
   WAVES,
 } from "./constants";
@@ -911,6 +913,42 @@ export interface FileMetadataFieldCoverage {
   field: string;
   inconsistent: number;
   missing: number;
+}
+
+export type MetadataCoverageClass = (typeof METADATA_COVERAGE_CLASSES)[number];
+
+export type MetadataCoverageTier = (typeof METADATA_COVERAGE_TIERS)[number];
+
+export interface AtlasMetadataCoverageRollup {
+  atlases: AtlasMetadataCoverage[];
+}
+
+export interface AtlasMetadataCoverage {
+  atlasId: string;
+  bionetwork: AtlasMetadataCoverageBioNetwork;
+  classes: Record<MetadataCoverageClass, AtlasMetadataCoverageClass>;
+  generation: number;
+  integrationLeads: AtlasMetadataCoverageIntegrationLead[];
+  name: string;
+  total: number;
+  version: string;
+}
+
+export interface AtlasMetadataCoverageBioNetwork {
+  id: NetworkKey;
+  label: string;
+}
+
+export interface AtlasMetadataCoverageIntegrationLead {
+  id: string;
+  name: string;
+}
+
+export interface AtlasMetadataCoverageClass {
+  completion: number | null;
+  entityCount: number;
+  filledSlots: number;
+  totalSlots: number;
 }
 
 export type FileValidationReports = Partial<

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -932,13 +932,13 @@ export interface AtlasMetadataCoverageRollup {
 
 export interface AtlasMetadataCoverage {
   atlasId: string;
-  bionetwork: NetworkKey;
   classes: Record<MetadataCoverageClass, AtlasMetadataCoverageClass>;
   generation: number;
-  integrationLeads: IntegrationLead[];
-  name: string;
+  integrationLead: IntegrationLead[];
+  network: NetworkKey;
+  revision: number;
+  shortName: string;
   total: number;
-  version: string;
 }
 
 export interface AtlasMetadataCoverageClass {

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -7,8 +7,8 @@ import { API } from "./api";
 import {
   FILE_METADATA_COVERAGE_ENTITY_TYPES,
   FILE_VALIDATOR_NAMES,
-  METADATA_COVERAGE_CLASSES,
-  METADATA_COVERAGE_TIERS,
+  METADATA_COVERAGE_REPORT_CLASSES,
+  METADATA_COVERAGE_REPORT_TIERS,
   NETWORK_KEYS,
   WAVES,
 } from "./constants";
@@ -922,9 +922,11 @@ export interface FileMetadataFieldCoverage {
   missing: number;
 }
 
-export type MetadataCoverageClass = (typeof METADATA_COVERAGE_CLASSES)[number];
+export type MetadataCoverageReportClass =
+  (typeof METADATA_COVERAGE_REPORT_CLASSES)[number];
 
-export type MetadataCoverageTier = (typeof METADATA_COVERAGE_TIERS)[number];
+export type MetadataCoverageReportTier =
+  (typeof METADATA_COVERAGE_REPORT_TIERS)[number];
 
 export interface AtlasMetadataCoverageRollup {
   atlases: AtlasMetadataCoverage[];
@@ -932,7 +934,7 @@ export interface AtlasMetadataCoverageRollup {
 
 export interface AtlasMetadataCoverage {
   atlasId: string;
-  classes: Record<MetadataCoverageClass, AtlasMetadataCoverageClass>;
+  classes: Record<MetadataCoverageReportClass, AtlasMetadataCoverageClass>;
   generation: number;
   integrationLead: IntegrationLead[];
   network: NetworkKey;

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -932,23 +932,13 @@ export interface AtlasMetadataCoverageRollup {
 
 export interface AtlasMetadataCoverage {
   atlasId: string;
-  bionetwork: AtlasMetadataCoverageBioNetwork;
+  bionetwork: NetworkKey;
   classes: Record<MetadataCoverageClass, AtlasMetadataCoverageClass>;
   generation: number;
-  integrationLeads: AtlasMetadataCoverageIntegrationLead[];
+  integrationLeads: IntegrationLead[];
   name: string;
   total: number;
   version: string;
-}
-
-export interface AtlasMetadataCoverageBioNetwork {
-  id: NetworkKey;
-  label: string;
-}
-
-export interface AtlasMetadataCoverageIntegrationLead {
-  id: string;
-  name: string;
 }
 
 export interface AtlasMetadataCoverageClass {

--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -391,6 +391,13 @@ export type HCAAtlasTrackerDBSourceStudyForStatusSummary = Pick<
   "doi"
 >;
 
+export interface HCAAtlasTrackerDBAtlasForMetadataCoverage extends Pick<
+  HCAAtlasTrackerDBAtlas,
+  "id" | "generation" | "revision" | "overview"
+> {
+  metadata_coverages: FileMetadataCoverage[];
+}
+
 export interface HCAAtlasTrackerDBComponentAtlas {
   component_info: HCAAtlasTrackerDBComponentAtlasInfo;
   created_at: Date;

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -10,7 +10,7 @@ import {
   string,
 } from "yup";
 import { isDoi, normalizeDoi } from "../../../../utils/doi";
-import { NETWORK_KEYS, WAVES } from "./constants";
+import { METADATA_COVERAGE_TIERS, NETWORK_KEYS, WAVES } from "./constants";
 import {
   ATLAS_STATUS,
   PUBLICATION_STATUS,
@@ -400,6 +400,22 @@ export const filesSetIsArchivedSchema = object({
 }).strict();
 
 export type FilesSetIsArchivedData = InferType<typeof filesSetIsArchivedSchema>;
+
+/**
+ * Schema for list of tiers provided to the metadata coverage API.
+ */
+export const metadataCoverageTiersSchema = array()
+  .of(
+    string()
+      .required()
+      .min(1, '"required" parameter must not be empty')
+      .oneOf(
+        METADATA_COVERAGE_TIERS,
+        `"required" parameter values must be among: ${METADATA_COVERAGE_TIERS.join(", ")}`,
+      ),
+  )
+  .required()
+  .strict();
 
 /**
  * Schema for data used to create a comment.

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -412,12 +412,12 @@ export const metadataCoverageTiersSchema = array()
   .of(
     string()
       .required()
-      .min(1, '"required" parameter must not be empty')
       .oneOf(
         METADATA_COVERAGE_REPORT_TIERS,
         `"required" parameter values must be among: ${METADATA_COVERAGE_REPORT_TIERS.join(", ")}`,
       ),
   )
+  .min(1, '"required" parameter must not be empty')
   .required()
   .strict();
 

--- a/app/apis/catalog/hca-atlas-tracker/common/schema.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/schema.ts
@@ -10,7 +10,11 @@ import {
   string,
 } from "yup";
 import { isDoi, normalizeDoi } from "../../../../utils/doi";
-import { METADATA_COVERAGE_TIERS, NETWORK_KEYS, WAVES } from "./constants";
+import {
+  METADATA_COVERAGE_REPORT_TIERS,
+  NETWORK_KEYS,
+  WAVES,
+} from "./constants";
 import {
   ATLAS_STATUS,
   PUBLICATION_STATUS,
@@ -410,8 +414,8 @@ export const metadataCoverageTiersSchema = array()
       .required()
       .min(1, '"required" parameter must not be empty')
       .oneOf(
-        METADATA_COVERAGE_TIERS,
-        `"required" parameter values must be among: ${METADATA_COVERAGE_TIERS.join(", ")}`,
+        METADATA_COVERAGE_REPORT_TIERS,
+        `"required" parameter values must be among: ${METADATA_COVERAGE_REPORT_TIERS.join(", ")}`,
       ),
   )
   .required()

--- a/app/data/metadata-coverage.ts
+++ b/app/data/metadata-coverage.ts
@@ -27,7 +27,6 @@ export async function getAtlasComponentAtlasMetadataCoverage(
       LEFT JOIN hat.component_atlases e ON e.version_id = ANY(a.component_atlases)
       LEFT JOIN hat.files f
         ON f.id = e.file_id
-        AND f.is_latest
         AND NOT f.is_archived
       GROUP BY a.id
     `,
@@ -62,7 +61,6 @@ export async function getAtlasSourceDatasetMetadataCoverage(
       LEFT JOIN hat.source_datasets e ON e.version_id = ANY(a.source_datasets)
       LEFT JOIN hat.files f
         ON f.id = e.file_id
-        AND f.is_latest
         AND NOT f.is_archived
       GROUP BY a.id
     `,

--- a/app/data/metadata-coverage.ts
+++ b/app/data/metadata-coverage.ts
@@ -1,0 +1,84 @@
+import pg from "pg";
+import {
+  FileMetadataCoverage,
+  HCAAtlasTrackerDBAtlasOverview,
+} from "../apis/catalog/hca-atlas-tracker/common/entities";
+import { query } from "../services/database";
+
+export interface AtlasMetadataCoverageDBRow {
+  generation: number;
+  id: string;
+  metadata_coverages: FileMetadataCoverage[];
+  overview: HCAAtlasTrackerDBAtlasOverview;
+  revision: number;
+}
+
+/**
+ * Get every atlas along with the `metadata_coverage` blobs of its latest,
+ * non-archived integrated object files. Atlases with no such files are included
+ * with an empty array.
+ * @param client - Optional database client for transaction support.
+ * @returns one row per atlas, each with its files' metadata coverage blobs.
+ */
+export async function getAtlasComponentAtlasMetadataCoverage(
+  client?: pg.PoolClient,
+): Promise<AtlasMetadataCoverageDBRow[]> {
+  const { rows } = await query<AtlasMetadataCoverageDBRow>(
+    `
+      SELECT
+        a.id,
+        a.generation,
+        a.revision,
+        a.overview,
+        COALESCE(
+          ARRAY_AGG(f.metadata_coverage) FILTER (WHERE f.metadata_coverage IS NOT NULL),
+          '{}'
+        ) AS metadata_coverages
+      FROM hat.atlases a
+      LEFT JOIN hat.component_atlases e ON e.version_id = ANY(a.component_atlases)
+      LEFT JOIN hat.files f
+        ON f.id = e.file_id
+        AND f.is_latest
+        AND NOT f.is_archived
+      GROUP BY a.id
+    `,
+    undefined,
+    client,
+  );
+  return rows;
+}
+
+/**
+ * Get every atlas along with the `metadata_coverage` blobs of its latest,
+ * non-archived source dataset files. Atlases with no such files are included
+ * with an empty array.
+ * @param client - Optional database client for transaction support.
+ * @returns one row per atlas, each with its files' metadata coverage blobs.
+ */
+export async function getAtlasSourceDatasetMetadataCoverage(
+  client?: pg.PoolClient,
+): Promise<AtlasMetadataCoverageDBRow[]> {
+  const { rows } = await query<AtlasMetadataCoverageDBRow>(
+    `
+      SELECT
+        a.id,
+        a.generation,
+        a.revision,
+        a.overview,
+        COALESCE(
+          ARRAY_AGG(f.metadata_coverage) FILTER (WHERE f.metadata_coverage IS NOT NULL),
+          '{}'
+        ) AS metadata_coverages
+      FROM hat.atlases a
+      LEFT JOIN hat.source_datasets e ON e.version_id = ANY(a.source_datasets)
+      LEFT JOIN hat.files f
+        ON f.id = e.file_id
+        AND f.is_latest
+        AND NOT f.is_archived
+      GROUP BY a.id
+    `,
+    undefined,
+    client,
+  );
+  return rows;
+}

--- a/app/data/metadata-coverage.ts
+++ b/app/data/metadata-coverage.ts
@@ -1,17 +1,6 @@
 import pg from "pg";
-import {
-  FileMetadataCoverage,
-  HCAAtlasTrackerDBAtlasOverview,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
+import { HCAAtlasTrackerDBAtlasForMetadataCoverage } from "../apis/catalog/hca-atlas-tracker/common/entities";
 import { query } from "../services/database";
-
-export interface AtlasMetadataCoverageDBRow {
-  generation: number;
-  id: string;
-  metadata_coverages: FileMetadataCoverage[];
-  overview: HCAAtlasTrackerDBAtlasOverview;
-  revision: number;
-}
 
 /**
  * Get every atlas along with the `metadata_coverage` blobs of its latest,
@@ -22,8 +11,8 @@ export interface AtlasMetadataCoverageDBRow {
  */
 export async function getAtlasComponentAtlasMetadataCoverage(
   client?: pg.PoolClient,
-): Promise<AtlasMetadataCoverageDBRow[]> {
-  const { rows } = await query<AtlasMetadataCoverageDBRow>(
+): Promise<HCAAtlasTrackerDBAtlasForMetadataCoverage[]> {
+  const { rows } = await query<HCAAtlasTrackerDBAtlasForMetadataCoverage>(
     `
       SELECT
         a.id,
@@ -57,8 +46,8 @@ export async function getAtlasComponentAtlasMetadataCoverage(
  */
 export async function getAtlasSourceDatasetMetadataCoverage(
   client?: pg.PoolClient,
-): Promise<AtlasMetadataCoverageDBRow[]> {
-  const { rows } = await query<AtlasMetadataCoverageDBRow>(
+): Promise<HCAAtlasTrackerDBAtlasForMetadataCoverage[]> {
+  const { rows } = await query<HCAAtlasTrackerDBAtlasForMetadataCoverage>(
     `
       SELECT
         a.id,

--- a/app/data/metadata-coverage.ts
+++ b/app/data/metadata-coverage.ts
@@ -3,7 +3,7 @@ import { HCAAtlasTrackerDBAtlasForMetadataCoverage } from "../apis/catalog/hca-a
 import { query } from "../services/database";
 
 /**
- * Get every atlas along with the `metadata_coverage` blobs of its latest,
+ * Get every atlas along with the `metadata_coverage` blobs of its
  * non-archived integrated object files. Atlases with no such files are included
  * with an empty array.
  * @param client - Optional database client for transaction support.
@@ -37,7 +37,7 @@ export async function getAtlasComponentAtlasMetadataCoverage(
 }
 
 /**
- * Get every atlas along with the `metadata_coverage` blobs of its latest,
+ * Get every atlas along with the `metadata_coverage` blobs of its
  * non-archived source dataset files. Atlases with no such files are included
  * with an empty array.
  * @param client - Optional database client for transaction support.

--- a/app/services/heatmaps.ts
+++ b/app/services/heatmaps.ts
@@ -1,9 +1,9 @@
 import { Class } from "@databiosphere/findable-ui/lib/common/entities";
-import dataDictionary from "../../catalog/downloaded/data-dictionary.json";
 import {
   HCAAtlasTrackerDBEntrySheetValidation,
   Heatmap,
 } from "../apis/catalog/hca-atlas-tracker/common/entities";
+import { getDataDictionaryClass } from "../utils/data-dictionary";
 import { EntrySheetValidationErrorInfo } from "../utils/hca-validation-tools/hca-validation-tools";
 import { getBaseModelAtlasEntrySheetValidations } from "./entry-sheets";
 
@@ -16,8 +16,7 @@ export async function getAtlasHeatmap(atlasId: string): Promise<Heatmap> {
     await getBaseModelAtlasEntrySheetValidations(atlasId);
   return {
     classes: ENTITY_TYPES.map((entityType) => {
-      const ddClass = dataDictionary.classes.find((c) => c.name === entityType);
-      if (!ddClass) throw new Error(`Class not found for ${entityType}`);
+      const ddClass = getDataDictionaryClass(entityType);
       return getClassHeatmap(entityType, ddClass, entrySheetValidations);
     }),
   };

--- a/app/services/metadata-coverage.ts
+++ b/app/services/metadata-coverage.ts
@@ -1,5 +1,4 @@
 import pg from "pg";
-import dataDictionary from "../../catalog/downloaded/data-dictionary.json";
 import { METADATA_COVERAGE_REPORT_CLASSES } from "../apis/catalog/hca-atlas-tracker/common/constants";
 import {
   AtlasMetadataCoverage,
@@ -14,6 +13,7 @@ import {
   getAtlasComponentAtlasMetadataCoverage,
   getAtlasSourceDatasetMetadataCoverage,
 } from "../data/metadata-coverage";
+import { getDataDictionaryClass } from "../utils/data-dictionary";
 
 type FieldCatalog = Record<MetadataCoverageReportClass, Set<string>>;
 
@@ -68,9 +68,7 @@ function getFieldCatalog(tiers: Set<MetadataCoverageReportTier>): FieldCatalog {
     sample: new Set(),
   };
   for (const className of METADATA_COVERAGE_REPORT_CLASSES) {
-    const ddClass = dataDictionary.classes.find((c) => c.name === className);
-    if (!ddClass)
-      throw new Error(`Data dictionary class not found: ${className}`);
+    const ddClass = getDataDictionaryClass(className);
     for (const attribute of ddClass.attributes) {
       const tier: MetadataCoverageReportTier = attribute.required
         ? "required"

--- a/app/services/metadata-coverage.ts
+++ b/app/services/metadata-coverage.ts
@@ -62,19 +62,21 @@ async function getAtlasMetadataCoverage(
  * @returns map of class name to in-scope field names.
  */
 function getFieldCatalog(tiers: Set<MetadataCoverageTier>): FieldCatalog {
-  const catalog = {} as FieldCatalog;
+  const catalog: FieldCatalog = {
+    dataset: new Set(),
+    donor: new Set(),
+    sample: new Set(),
+  };
   for (const className of METADATA_COVERAGE_CLASSES) {
     const ddClass = dataDictionary.classes.find((c) => c.name === className);
     if (!ddClass)
       throw new Error(`Data dictionary class not found: ${className}`);
-    const fields = new Set<string>();
     for (const attribute of ddClass.attributes) {
       const tier: MetadataCoverageTier = attribute.required
         ? "required"
         : "recommended";
-      if (tiers.has(tier)) fields.add(attribute.name);
+      if (tiers.has(tier)) catalog[className].add(attribute.name);
     }
-    catalog[className] = fields;
   }
   return catalog;
 }

--- a/app/services/metadata-coverage.ts
+++ b/app/services/metadata-coverage.ts
@@ -1,0 +1,176 @@
+import pg from "pg";
+import dataDictionary from "../../catalog/downloaded/data-dictionary.json";
+import {
+  METADATA_COVERAGE_CLASSES,
+  NETWORKS,
+} from "../apis/catalog/hca-atlas-tracker/common/constants";
+import {
+  AtlasMetadataCoverage,
+  AtlasMetadataCoverageBioNetwork,
+  AtlasMetadataCoverageClass,
+  FILE_TYPE,
+  FileMetadataCoverage,
+  MetadataCoverageClass,
+  MetadataCoverageTier,
+  NetworkKey,
+} from "../apis/catalog/hca-atlas-tracker/common/entities";
+import {
+  AtlasMetadataCoverageDBRow,
+  getAtlasComponentAtlasMetadataCoverage,
+  getAtlasSourceDatasetMetadataCoverage,
+} from "../data/metadata-coverage";
+
+type FieldCatalog = Record<MetadataCoverageClass, Set<string>>;
+
+/**
+ * Get the per-atlas, per-entity-class metadata completeness rollup that backs
+ * the corpus-wide metadata completeness heatmap.
+ * @param source - File type contributing coverage (source dataset or integrated object).
+ * @param tiers - Field requirement tiers to include in the slot math.
+ * @param client - Optional database client for transaction support.
+ * @returns one entry per atlas, including atlases with no files of the requested source.
+ */
+export async function getAtlasCompletenessRollup(
+  source: FILE_TYPE.INTEGRATED_OBJECT | FILE_TYPE.SOURCE_DATASET,
+  tiers: MetadataCoverageTier[],
+  client?: pg.PoolClient,
+): Promise<AtlasMetadataCoverage[]> {
+  const fieldCatalog = getFieldCatalog(new Set(tiers));
+  const atlasRows = await getAtlasMetadataCoverage(source, client);
+  return atlasRows.map((row) => buildAtlasCoverage(row, fieldCatalog));
+}
+
+/**
+ * Get metadata coverage for files of the given type for each atlas.
+ * @param source - File type to get metadata coverage for.
+ * @param client - Optional Postgres client to use.
+ * @returns per-atlas metadata coverage info for the given file type.
+ */
+async function getAtlasMetadataCoverage(
+  source: FILE_TYPE.INTEGRATED_OBJECT | FILE_TYPE.SOURCE_DATASET,
+  client?: pg.PoolClient,
+): Promise<AtlasMetadataCoverageDBRow[]> {
+  switch (source) {
+    case FILE_TYPE.INTEGRATED_OBJECT: {
+      return await getAtlasComponentAtlasMetadataCoverage(client);
+    }
+    case FILE_TYPE.SOURCE_DATASET: {
+      return await getAtlasSourceDatasetMetadataCoverage(client);
+    }
+  }
+}
+
+/**
+ * Build the set of in-scope field names per class from the data dictionary,
+ * limited to the requested requirement tiers.
+ * @param tiers - Requirement tiers to include.
+ * @returns map of class name to in-scope field names.
+ */
+function getFieldCatalog(tiers: Set<MetadataCoverageTier>): FieldCatalog {
+  const catalog = {} as FieldCatalog;
+  for (const className of METADATA_COVERAGE_CLASSES) {
+    const ddClass = dataDictionary.classes.find((c) => c.name === className);
+    if (!ddClass)
+      throw new Error(`Data dictionary class not found: ${className}`);
+    const fields = new Set<string>();
+    for (const attribute of ddClass.attributes) {
+      const tier: MetadataCoverageTier = attribute.required
+        ? "required"
+        : "recommended";
+      if (tiers.has(tier)) fields.add(attribute.name);
+    }
+    catalog[className] = fields;
+  }
+  return catalog;
+}
+
+/**
+ * Build the rollup entry for a single atlas.
+ * @param row - Atlas row with its files' metadata coverage blobs.
+ * @param fieldCatalog - In-scope field names per class.
+ * @returns atlas completeness entry.
+ */
+function buildAtlasCoverage(
+  row: AtlasMetadataCoverageDBRow,
+  fieldCatalog: FieldCatalog,
+): AtlasMetadataCoverage {
+  const classes = {} as Record<
+    MetadataCoverageClass,
+    AtlasMetadataCoverageClass
+  >;
+  for (const className of METADATA_COVERAGE_CLASSES) {
+    classes[className] = buildClassCoverage(
+      className,
+      row.metadata_coverages,
+      fieldCatalog[className],
+    );
+  }
+  const total =
+    METADATA_COVERAGE_CLASSES.reduce(
+      (sum, className) => sum + (classes[className].completion ?? 0),
+      0,
+    ) / METADATA_COVERAGE_CLASSES.length;
+  return {
+    atlasId: row.id,
+    bionetwork: getBioNetwork(row.overview.network),
+    classes,
+    generation: row.generation,
+    integrationLeads: row.overview.integrationLead.map((lead) => ({
+      id: lead.email,
+      name: lead.name,
+    })),
+    name: row.overview.shortName,
+    total,
+    version: `${row.generation}.${row.revision}`,
+  };
+}
+
+/**
+ * Aggregate the slot math for a single (atlas, entity class) across all of the
+ * atlas's coverage blobs.
+ * @param className - Entity class being aggregated.
+ * @param coverages - Metadata coverage blobs of the atlas's files.
+ * @param inScopeFields - In-scope field names for the class.
+ * @returns aggregated class coverage.
+ */
+function buildClassCoverage(
+  className: MetadataCoverageClass,
+  coverages: FileMetadataCoverage[],
+  inScopeFields: Set<string>,
+): AtlasMetadataCoverageClass {
+  let entityCount = 0;
+  let filledSlots = 0;
+  let totalSlots = 0;
+  for (const coverage of coverages) {
+    entityCount += coverage.entities[className].recordCount;
+    for (const fieldInfo of coverage.fieldCoverage) {
+      if (
+        fieldInfo.entityClass !== className ||
+        !inScopeFields.has(fieldInfo.field)
+      )
+        continue;
+      filledSlots += fieldInfo.complete;
+      totalSlots +=
+        fieldInfo.complete + fieldInfo.missing + fieldInfo.inconsistent;
+    }
+  }
+  return {
+    completion: totalSlots === 0 ? null : filledSlots / totalSlots,
+    entityCount,
+    filledSlots,
+    totalSlots,
+  };
+}
+
+/**
+ * Get the bionetwork identifier and display label for an atlas's network key.
+ * @param networkKey - Network key.
+ * @returns bionetwork id and label.
+ */
+function getBioNetwork(
+  networkKey: NetworkKey,
+): AtlasMetadataCoverageBioNetwork {
+  const network = NETWORKS.find((n) => n.key === networkKey);
+  const label = (network?.name ?? networkKey).replace(/\sNetwork.*/i, "");
+  return { id: networkKey, label };
+}

--- a/app/services/metadata-coverage.ts
+++ b/app/services/metadata-coverage.ts
@@ -89,17 +89,11 @@ function buildAtlasCoverage(
   row: HCAAtlasTrackerDBAtlasForMetadataCoverage,
   fieldCatalog: FieldCatalog,
 ): AtlasMetadataCoverage {
-  const classes = {} as Record<
-    MetadataCoverageClass,
-    AtlasMetadataCoverageClass
-  >;
-  for (const className of METADATA_COVERAGE_CLASSES) {
-    classes[className] = buildClassCoverage(
-      className,
-      row.metadata_coverages,
-      fieldCatalog[className],
-    );
-  }
+  const classes: Record<MetadataCoverageClass, AtlasMetadataCoverageClass> = {
+    dataset: buildCoverageForClass("dataset"),
+    donor: buildCoverageForClass("donor"),
+    sample: buildCoverageForClass("sample"),
+  };
   const total =
     METADATA_COVERAGE_CLASSES.reduce(
       (sum, className) => sum + (classes[className].completion ?? 0),
@@ -115,6 +109,16 @@ function buildAtlasCoverage(
     shortName: row.overview.shortName,
     total,
   };
+
+  function buildCoverageForClass(
+    className: MetadataCoverageClass,
+  ): AtlasMetadataCoverageClass {
+    return buildClassCoverage(
+      className,
+      row.metadata_coverages,
+      fieldCatalog[className],
+    );
+  }
 }
 
 /**

--- a/app/services/metadata-coverage.ts
+++ b/app/services/metadata-coverage.ts
@@ -107,13 +107,13 @@ function buildAtlasCoverage(
     ) / METADATA_COVERAGE_CLASSES.length;
   return {
     atlasId: row.id,
-    bionetwork: row.overview.network,
     classes,
     generation: row.generation,
-    integrationLeads: row.overview.integrationLead,
-    name: row.overview.shortName,
+    integrationLead: row.overview.integrationLead,
+    network: row.overview.network,
+    revision: row.revision,
+    shortName: row.overview.shortName,
     total,
-    version: `${row.generation}.${row.revision}`,
   };
 }
 

--- a/app/services/metadata-coverage.ts
+++ b/app/services/metadata-coverage.ts
@@ -1,19 +1,14 @@
 import pg from "pg";
 import dataDictionary from "../../catalog/downloaded/data-dictionary.json";
-import {
-  METADATA_COVERAGE_CLASSES,
-  NETWORKS,
-} from "../apis/catalog/hca-atlas-tracker/common/constants";
+import { METADATA_COVERAGE_CLASSES } from "../apis/catalog/hca-atlas-tracker/common/constants";
 import {
   AtlasMetadataCoverage,
-  AtlasMetadataCoverageBioNetwork,
   AtlasMetadataCoverageClass,
   FILE_TYPE,
   FileMetadataCoverage,
   HCAAtlasTrackerDBAtlasForMetadataCoverage,
   MetadataCoverageClass,
   MetadataCoverageTier,
-  NetworkKey,
 } from "../apis/catalog/hca-atlas-tracker/common/entities";
 import {
   getAtlasComponentAtlasMetadataCoverage,
@@ -112,13 +107,10 @@ function buildAtlasCoverage(
     ) / METADATA_COVERAGE_CLASSES.length;
   return {
     atlasId: row.id,
-    bionetwork: getBioNetwork(row.overview.network),
+    bionetwork: row.overview.network,
     classes,
     generation: row.generation,
-    integrationLeads: row.overview.integrationLead.map((lead) => ({
-      id: lead.email,
-      name: lead.name,
-    })),
+    integrationLeads: row.overview.integrationLead,
     name: row.overview.shortName,
     total,
     version: `${row.generation}.${row.revision}`,
@@ -160,17 +152,4 @@ function buildClassCoverage(
     filledSlots,
     totalSlots,
   };
-}
-
-/**
- * Get the bionetwork identifier and display label for an atlas's network key.
- * @param networkKey - Network key.
- * @returns bionetwork id and label.
- */
-function getBioNetwork(
-  networkKey: NetworkKey,
-): AtlasMetadataCoverageBioNetwork {
-  const network = NETWORKS.find((n) => n.key === networkKey);
-  const label = (network?.name ?? networkKey).replace(/\sNetwork.*/i, "");
-  return { id: networkKey, label };
 }

--- a/app/services/metadata-coverage.ts
+++ b/app/services/metadata-coverage.ts
@@ -10,12 +10,12 @@ import {
   AtlasMetadataCoverageClass,
   FILE_TYPE,
   FileMetadataCoverage,
+  HCAAtlasTrackerDBAtlasForMetadataCoverage,
   MetadataCoverageClass,
   MetadataCoverageTier,
   NetworkKey,
 } from "../apis/catalog/hca-atlas-tracker/common/entities";
 import {
-  AtlasMetadataCoverageDBRow,
   getAtlasComponentAtlasMetadataCoverage,
   getAtlasSourceDatasetMetadataCoverage,
 } from "../data/metadata-coverage";
@@ -49,7 +49,7 @@ export async function getAtlasCompletenessRollup(
 async function getAtlasMetadataCoverage(
   source: FILE_TYPE.INTEGRATED_OBJECT | FILE_TYPE.SOURCE_DATASET,
   client?: pg.PoolClient,
-): Promise<AtlasMetadataCoverageDBRow[]> {
+): Promise<HCAAtlasTrackerDBAtlasForMetadataCoverage[]> {
   switch (source) {
     case FILE_TYPE.INTEGRATED_OBJECT: {
       return await getAtlasComponentAtlasMetadataCoverage(client);
@@ -91,7 +91,7 @@ function getFieldCatalog(tiers: Set<MetadataCoverageTier>): FieldCatalog {
  * @returns atlas completeness entry.
  */
 function buildAtlasCoverage(
-  row: AtlasMetadataCoverageDBRow,
+  row: HCAAtlasTrackerDBAtlasForMetadataCoverage,
   fieldCatalog: FieldCatalog,
 ): AtlasMetadataCoverage {
   const classes = {} as Record<

--- a/app/services/metadata-coverage.ts
+++ b/app/services/metadata-coverage.ts
@@ -1,21 +1,21 @@
 import pg from "pg";
 import dataDictionary from "../../catalog/downloaded/data-dictionary.json";
-import { METADATA_COVERAGE_CLASSES } from "../apis/catalog/hca-atlas-tracker/common/constants";
+import { METADATA_COVERAGE_REPORT_CLASSES } from "../apis/catalog/hca-atlas-tracker/common/constants";
 import {
   AtlasMetadataCoverage,
   AtlasMetadataCoverageClass,
   FILE_TYPE,
   FileMetadataCoverage,
   HCAAtlasTrackerDBAtlasForMetadataCoverage,
-  MetadataCoverageClass,
-  MetadataCoverageTier,
+  MetadataCoverageReportClass,
+  MetadataCoverageReportTier,
 } from "../apis/catalog/hca-atlas-tracker/common/entities";
 import {
   getAtlasComponentAtlasMetadataCoverage,
   getAtlasSourceDatasetMetadataCoverage,
 } from "../data/metadata-coverage";
 
-type FieldCatalog = Record<MetadataCoverageClass, Set<string>>;
+type FieldCatalog = Record<MetadataCoverageReportClass, Set<string>>;
 
 /**
  * Get the per-atlas, per-entity-class metadata completeness rollup that backs
@@ -27,7 +27,7 @@ type FieldCatalog = Record<MetadataCoverageClass, Set<string>>;
  */
 export async function getAtlasCompletenessRollup(
   source: FILE_TYPE.INTEGRATED_OBJECT | FILE_TYPE.SOURCE_DATASET,
-  tiers: MetadataCoverageTier[],
+  tiers: MetadataCoverageReportTier[],
   client?: pg.PoolClient,
 ): Promise<AtlasMetadataCoverage[]> {
   const fieldCatalog = getFieldCatalog(new Set(tiers));
@@ -61,18 +61,18 @@ async function getAtlasMetadataCoverage(
  * @param tiers - Requirement tiers to include.
  * @returns map of class name to in-scope field names.
  */
-function getFieldCatalog(tiers: Set<MetadataCoverageTier>): FieldCatalog {
+function getFieldCatalog(tiers: Set<MetadataCoverageReportTier>): FieldCatalog {
   const catalog: FieldCatalog = {
     dataset: new Set(),
     donor: new Set(),
     sample: new Set(),
   };
-  for (const className of METADATA_COVERAGE_CLASSES) {
+  for (const className of METADATA_COVERAGE_REPORT_CLASSES) {
     const ddClass = dataDictionary.classes.find((c) => c.name === className);
     if (!ddClass)
       throw new Error(`Data dictionary class not found: ${className}`);
     for (const attribute of ddClass.attributes) {
-      const tier: MetadataCoverageTier = attribute.required
+      const tier: MetadataCoverageReportTier = attribute.required
         ? "required"
         : "recommended";
       if (tiers.has(tier)) catalog[className].add(attribute.name);
@@ -91,16 +91,19 @@ function buildAtlasCoverage(
   row: HCAAtlasTrackerDBAtlasForMetadataCoverage,
   fieldCatalog: FieldCatalog,
 ): AtlasMetadataCoverage {
-  const classes: Record<MetadataCoverageClass, AtlasMetadataCoverageClass> = {
+  const classes: Record<
+    MetadataCoverageReportClass,
+    AtlasMetadataCoverageClass
+  > = {
     dataset: buildCoverageForClass("dataset"),
     donor: buildCoverageForClass("donor"),
     sample: buildCoverageForClass("sample"),
   };
   const total =
-    METADATA_COVERAGE_CLASSES.reduce(
+    METADATA_COVERAGE_REPORT_CLASSES.reduce(
       (sum, className) => sum + (classes[className].completion ?? 0),
       0,
-    ) / METADATA_COVERAGE_CLASSES.length;
+    ) / METADATA_COVERAGE_REPORT_CLASSES.length;
   return {
     atlasId: row.id,
     classes,
@@ -113,7 +116,7 @@ function buildAtlasCoverage(
   };
 
   function buildCoverageForClass(
-    className: MetadataCoverageClass,
+    className: MetadataCoverageReportClass,
   ): AtlasMetadataCoverageClass {
     return buildClassCoverage(
       className,
@@ -132,7 +135,7 @@ function buildAtlasCoverage(
  * @returns aggregated class coverage.
  */
 function buildClassCoverage(
-  className: MetadataCoverageClass,
+  className: MetadataCoverageReportClass,
   coverages: FileMetadataCoverage[],
   inScopeFields: Set<string>,
 ): AtlasMetadataCoverageClass {

--- a/app/utils/api-handler.ts
+++ b/app/utils/api-handler.ts
@@ -16,6 +16,7 @@ import { query } from "../services/database";
 import {
   ApiError,
   ForbiddenError,
+  InvalidOperationError,
   NotFoundError,
   UnauthenticatedError,
 } from "./api-errors";
@@ -213,7 +214,9 @@ export function handleRequiredParam(
   );
   if (responseSent) return null;
   if (param === undefined) {
-    res.status(400).json({ message: `Missing ${paramName} parameter` });
+    res
+      .status(400)
+      .json({ message: `Missing ${JSON.stringify(paramName)} parameter` });
     return null;
   }
   return param;
@@ -233,15 +236,72 @@ export function handleOptionalParam(
   paramName: string,
   paramRegExp?: RegExp,
 ): { param: string | undefined; responseSent: boolean } {
-  const param = req.query[paramName];
-  if (param === undefined) return { param, responseSent: false };
-  if (typeof param !== "string" || (paramRegExp && !paramRegExp.test(param))) {
+  const result = handleMappedOptionalParam(req, res, paramName, (v) => v);
+  if (result.responseSent) return result;
+  if (
+    paramRegExp &&
+    result.param !== undefined &&
+    !paramRegExp.test(result.param)
+  ) {
     res.status(400).json({
-      message: `${paramName} parameter must be a string matching ${paramRegExp}`,
+      message: `${JSON.stringify(paramName)} parameter must match ${paramRegExp}`,
     });
     return { param: undefined, responseSent: true };
   }
-  return { param, responseSent: false };
+  return result;
+}
+
+/**
+ * Retrieves an optional string-valued query parameter from a request and applies a mapping function to it, sending an error response if the parameter is not provided as a string.
+ * @param req - Next API request.
+ * @param res - Next API response.
+ * @param paramName - Parameter name to get.
+ * @param mapParamValue - Function to apply to the parameter value.
+ * @returns object containing mapped parameter value and boolean for whether an error response was sent.
+ */
+export function handleMappedOptionalParam<T>(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  paramName: string,
+  mapParamValue: (v: string, p: string) => T,
+): { param: T | undefined; responseSent: boolean } {
+  const param = req.query[paramName];
+  if (param === undefined) return { param, responseSent: false };
+  if (typeof param !== "string") {
+    res.status(400).json({
+      message: `${JSON.stringify(paramName)} parameter must be a string`,
+    });
+    return { param: undefined, responseSent: true };
+  }
+  return { param: mapParamValue(param, paramName), responseSent: false };
+}
+
+/**
+ * Create a query parameter parsing function that restricts the parameter value to being one of a list of allowed values, and throws an error if it's not.
+ * @param allowedValues - Allowed values for the query parameter.
+ * @returns function to be used to parse the query parameter.
+ */
+export function paramParserForOneOf<T extends string>(
+  allowedValues: readonly T[],
+): (v: string, p: string) => T {
+  return (value, paramName) => {
+    if (allowedValues.includes(value as T)) return value as T;
+    throw new InvalidOperationError(
+      `Parameter ${JSON.stringify(paramName)} must be one of: ${allowedValues.join(", ")}`,
+    );
+  };
+}
+
+/**
+ * Parse a query parameter value representing a comma-separated list, trimming whitespace from each item and dropping empty items.
+ * @param value - Query parameter value to parse.
+ * @returns array of strings representing the parsed list.
+ */
+export function parseListParam(value: string): string[] {
+  return value
+    .split(",")
+    .map((tier) => tier.trim())
+    .filter(Boolean);
 }
 
 /**

--- a/app/utils/data-dictionary.ts
+++ b/app/utils/data-dictionary.ts
@@ -1,0 +1,9 @@
+import { Class } from "@databiosphere/findable-ui/lib/common/entities";
+import dataDictionary from "../../catalog/downloaded/data-dictionary.json";
+
+export function getDataDictionaryClass(className: string): Class {
+  const ddClass = dataDictionary.classes.find((c) => c.name === className);
+  if (!ddClass)
+    throw new Error(`Data dictionary class not found: ${className}`);
+  return ddClass;
+}

--- a/pages/api/metadata-coverage/atlases.ts
+++ b/pages/api/metadata-coverage/atlases.ts
@@ -2,7 +2,7 @@ import { metadataCoverageTiersSchema } from "app/apis/catalog/hca-atlas-tracker/
 import {
   AtlasMetadataCoverageRollup,
   FILE_TYPE,
-  MetadataCoverageTier,
+  MetadataCoverageReportTier,
 } from "../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD } from "../../../app/common/entities";
 import { getAtlasCompletenessRollup } from "../../../app/services/metadata-coverage";
@@ -22,7 +22,7 @@ const ALLOWED_SOURCES = [
 
 const DEFAULT_SOURCE = FILE_TYPE.SOURCE_DATASET;
 
-const DEFAULT_TIERS: MetadataCoverageTier[] = ["required"];
+const DEFAULT_TIERS: MetadataCoverageReportTier[] = ["required"];
 
 /**
  * API route to get the per-atlas, per-entity-class metadata completeness

--- a/pages/api/metadata-coverage/atlases.ts
+++ b/pages/api/metadata-coverage/atlases.ts
@@ -1,4 +1,4 @@
-import { METADATA_COVERAGE_TIERS } from "../../../app/apis/catalog/hca-atlas-tracker/common/constants";
+import { metadataCoverageTiersSchema } from "app/apis/catalog/hca-atlas-tracker/common/schema";
 import {
   AtlasMetadataCoverageRollup,
   FILE_TYPE,
@@ -6,81 +6,51 @@ import {
 } from "../../../app/apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD } from "../../../app/common/entities";
 import { getAtlasCompletenessRollup } from "../../../app/services/metadata-coverage";
-import { InvalidOperationError } from "../../../app/utils/api-errors";
 import {
+  handleMappedOptionalParam,
   handler,
   method,
+  paramParserForOneOf,
+  parseListParam,
   registeredUser,
 } from "../../../app/utils/api-handler";
+
+const ALLOWED_SOURCES = [
+  FILE_TYPE.INTEGRATED_OBJECT,
+  FILE_TYPE.SOURCE_DATASET,
+] as const;
+
+const DEFAULT_SOURCE = FILE_TYPE.SOURCE_DATASET;
+
+const DEFAULT_TIERS: MetadataCoverageTier[] = ["required"];
 
 /**
  * API route to get the per-atlas, per-entity-class metadata completeness
  * rollup that backs the corpus-wide metadata completeness heatmap.
  */
 export default handler(method(METHOD.GET), registeredUser, async (req, res) => {
-  const source = parseSource(req.query.source);
-  const tiers = parseTiers(req.query.required);
+  const sourceResult = handleMappedOptionalParam(
+    req,
+    res,
+    "source",
+    paramParserForOneOf(ALLOWED_SOURCES),
+  );
+  if (sourceResult.responseSent) return;
+  const source = sourceResult.param ?? DEFAULT_SOURCE;
+
+  const tiersResult = handleMappedOptionalParam(
+    req,
+    res,
+    "required",
+    parseListParam,
+  );
+  if (tiersResult.responseSent) return;
+  const tiers = await metadataCoverageTiersSchema.validate(
+    tiersResult.param ?? DEFAULT_TIERS,
+  );
+
   const rollup: AtlasMetadataCoverageRollup = {
     atlases: await getAtlasCompletenessRollup(source, tiers),
   };
   res.status(200).json(rollup);
 });
-
-/**
- * Parse the `source` query parameter, defaulting to source datasets.
- * @param value - Raw query parameter value.
- * @returns file type contributing coverage.
- * @throws InvalidOperationError - When the value isn't a recognized source.
- */
-function parseSource(
-  value: string | string[] | undefined,
-): FILE_TYPE.INTEGRATED_OBJECT | FILE_TYPE.SOURCE_DATASET {
-  if (value === undefined) return FILE_TYPE.SOURCE_DATASET;
-  if (
-    value === FILE_TYPE.SOURCE_DATASET ||
-    value === FILE_TYPE.INTEGRATED_OBJECT
-  )
-    return value;
-  throw new InvalidOperationError(
-    `source parameter must be "${FILE_TYPE.SOURCE_DATASET}" or "${FILE_TYPE.INTEGRATED_OBJECT}"`,
-  );
-}
-
-/**
- * Parse the comma-separated `required` query parameter, defaulting to the
- * required tier.
- * @param value - Raw query parameter value.
- * @returns deduplicated list of requirement tiers.
- * @throws InvalidOperationError - When the value contains an unrecognized tier.
- */
-function parseTiers(
-  value: string | string[] | undefined,
-): MetadataCoverageTier[] {
-  const raw = value === undefined ? "required" : value;
-  if (typeof raw !== "string")
-    throw new InvalidOperationError("required parameter must be a string");
-  const rawTiers = raw
-    .split(",")
-    .map((tier) => tier.trim())
-    .filter(Boolean);
-  if (rawTiers.length === 0)
-    throw new InvalidOperationError("required parameter must not be empty");
-  const tiers = new Set<MetadataCoverageTier>();
-  for (const tier of rawTiers) {
-    if (!isMetadataCoverageTier(tier))
-      throw new InvalidOperationError(
-        `required parameter values must be among: ${METADATA_COVERAGE_TIERS.join(", ")}`,
-      );
-    tiers.add(tier);
-  }
-  return Array.from(tiers);
-}
-
-/**
- * Type guard for requirement tier values.
- * @param value - Value to check.
- * @returns whether the value is a requirement tier.
- */
-function isMetadataCoverageTier(value: string): value is MetadataCoverageTier {
-  return (METADATA_COVERAGE_TIERS as readonly string[]).includes(value);
-}

--- a/pages/api/metadata-coverage/atlases.ts
+++ b/pages/api/metadata-coverage/atlases.ts
@@ -1,0 +1,86 @@
+import { METADATA_COVERAGE_TIERS } from "../../../app/apis/catalog/hca-atlas-tracker/common/constants";
+import {
+  AtlasMetadataCoverageRollup,
+  FILE_TYPE,
+  MetadataCoverageTier,
+} from "../../../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "../../../app/common/entities";
+import { getAtlasCompletenessRollup } from "../../../app/services/metadata-coverage";
+import { InvalidOperationError } from "../../../app/utils/api-errors";
+import {
+  handler,
+  method,
+  registeredUser,
+} from "../../../app/utils/api-handler";
+
+/**
+ * API route to get the per-atlas, per-entity-class metadata completeness
+ * rollup that backs the corpus-wide metadata completeness heatmap.
+ */
+export default handler(method(METHOD.GET), registeredUser, async (req, res) => {
+  const source = parseSource(req.query.source);
+  const tiers = parseTiers(req.query.required);
+  const rollup: AtlasMetadataCoverageRollup = {
+    atlases: await getAtlasCompletenessRollup(source, tiers),
+  };
+  res.status(200).json(rollup);
+});
+
+/**
+ * Parse the `source` query parameter, defaulting to source datasets.
+ * @param value - Raw query parameter value.
+ * @returns file type contributing coverage.
+ * @throws InvalidOperationError - When the value isn't a recognized source.
+ */
+function parseSource(
+  value: string | string[] | undefined,
+): FILE_TYPE.INTEGRATED_OBJECT | FILE_TYPE.SOURCE_DATASET {
+  if (value === undefined) return FILE_TYPE.SOURCE_DATASET;
+  if (
+    value === FILE_TYPE.SOURCE_DATASET ||
+    value === FILE_TYPE.INTEGRATED_OBJECT
+  )
+    return value;
+  throw new InvalidOperationError(
+    `source parameter must be "${FILE_TYPE.SOURCE_DATASET}" or "${FILE_TYPE.INTEGRATED_OBJECT}"`,
+  );
+}
+
+/**
+ * Parse the comma-separated `required` query parameter, defaulting to the
+ * required tier.
+ * @param value - Raw query parameter value.
+ * @returns deduplicated list of requirement tiers.
+ * @throws InvalidOperationError - When the value contains an unrecognized tier.
+ */
+function parseTiers(
+  value: string | string[] | undefined,
+): MetadataCoverageTier[] {
+  const raw = value === undefined ? "required" : value;
+  if (typeof raw !== "string")
+    throw new InvalidOperationError("required parameter must be a string");
+  const rawTiers = raw
+    .split(",")
+    .map((tier) => tier.trim())
+    .filter(Boolean);
+  if (rawTiers.length === 0)
+    throw new InvalidOperationError("required parameter must not be empty");
+  const tiers = new Set<MetadataCoverageTier>();
+  for (const tier of rawTiers) {
+    if (!isMetadataCoverageTier(tier))
+      throw new InvalidOperationError(
+        `required parameter values must be among: ${METADATA_COVERAGE_TIERS.join(", ")}`,
+      );
+    tiers.add(tier);
+  }
+  return Array.from(tiers);
+}
+
+/**
+ * Type guard for requirement tier values.
+ * @param value - Value to check.
+ * @returns whether the value is a requirement tier.
+ */
+function isMetadataCoverageTier(value: string): value is MetadataCoverageTier {
+  return (METADATA_COVERAGE_TIERS as readonly string[]).includes(value);
+}


### PR DESCRIPTION
Closes #1274

Notes:
- I made some adjustments from what was previously specified; see my comment on the ticket
- The API currently returns all versions of each atlas; if nothing else, this has implications for how the frontend would need to handle calculating a combined score across atlases
- I've opened a few tickets to address things that came up that I don't think need to block this PR but could do with being addressed: #1394, #1393, #1396