### PR TITLE
content: tweak home/landing page copy (hero + sign-in card) (#1405)

### DIFF
--- a/app/components/common/MDXContent/index.tsx
+++ b/app/components/common/MDXContent/index.tsx
@@ -1,2 +1,1 @@
 export { default as LoginTermsOfService } from "./loginTermsOfService.mdx";
-export { default as LoginText } from "./loginText.mdx";

--- a/app/components/common/MDXContent/loginText.mdx
+++ b/app/components/common/MDXContent/loginText.mdx
@@ -1,1 +1,0 @@
-Please sign in to your Atlas Tracker account

--- a/app/views/HomeView/homeView.styles.ts
+++ b/app/views/HomeView/homeView.styles.ts
@@ -64,7 +64,6 @@ export const StyledStack = styled(Stack)`
     font-style: normal;
     font-weight: 700;
     line-height: 48px;
-    max-width: 366px;
     letter-spacing: -0.4px;
   }
 `;

--- a/app/views/HomeView/homeView.tsx
+++ b/app/views/HomeView/homeView.tsx
@@ -21,9 +21,13 @@ export const HomeView = ({ providers }: Props): JSX.Element => {
         <StyledLoginView providers={providers} />
         <StyledStack spacing={2} useFlexGap>
           <Typography component="h1">HCA Atlas Tracker</Typography>
-          <Typography component="h2">Atlas Ingest and Validation</Typography>
+          <Typography component="h2">
+            Atlas Ingest, Validation,
+            <br />
+            and Publishing
+          </Typography>
           <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_LARGE_400}>
-            Community generated, multi-omic, open data
+            The entry point for atlas data into the HCA ecosystem
           </Typography>
         </StyledStack>
       </StyledSection>

--- a/site-config/hca-atlas-tracker/local/authentication/authentication.ts
+++ b/site-config/hca-atlas-tracker/local/authentication/authentication.ts
@@ -3,6 +3,6 @@ import * as MDX from "../../../../app/components/common/MDXContent";
 
 export const authenticationConfig: AuthenticationConfig = {
   termsOfService: MDX.LoginTermsOfService({}),
-  text: MDX.LoginText({}),
-  title: "Sign in to your account",
+  text: "Please sign in to access the Atlas Tracker",
+  title: "Sign in",
 };

--- a/site-config/hca-atlas-tracker/prod/authentication/authentication.ts
+++ b/site-config/hca-atlas-tracker/prod/authentication/authentication.ts
@@ -3,6 +3,6 @@ import * as MDX from "../../../../app/components/common/MDXContent";
 
 export const authenticationConfig: AuthenticationConfig = {
   termsOfService: MDX.LoginTermsOfService({}),
-  text: MDX.LoginText({}),
-  title: "Sign in to your account",
+  text: "Please sign in to access the Atlas Tracker",
+  title: "Sign in",
 };


### PR DESCRIPTION
## Summary

Copy changes per #1405:

| Element | New copy |
|---|---|
| Hero (`h2`) | Atlas Ingest, Validation,`<br />`and Publishing (rendered as JSX) |
| Sub-hero | The entry point for atlas data into the HCA ecosystem |
| Sign-in card heading | Sign in |
| Sign-in card subtext | Please sign in to access the Atlas Tracker |

Eyebrow (`h1`) unchanged. The card subtext is now an inline string in the local and prod `authentication.ts` configs (the shared `loginText.mdx` and its barrel export are removed — findable-ui's `Login` wraps the `text` prop in `Typography` either way, so rendering is unchanged). The `max-width: 366px` on the hero `h2` is dropped since the explicit `<br />` now controls the line break. Dev inherits local's authentication config via `makeConfig()`, so the new title reaches dev builds — verified there's no dev-side override.

Closes #1405

## Review notes

- The `h2` keeps 40px at all breakpoints, so on narrow phones the first hero line wraps naturally above the forced break (inherent to the copy at this size, not introduced here) — flagging in case design wants a `bpDownSm` font-size follow-up.
- local/prod `authentication.ts` are now byte-identical; the copy could be hoisted to `site-config/.../common/` if we want a single source again.

## Test plan

- [x] `npx tsc --noEmit`, `npm run lint`, `npm run check-format` clean
- [x] `npm run build:local` compiles, 15/15 pages generated
- [x] `npm test` — 77 suites, 1157 tests passing
- [x] Visual check of the landing hero on a narrow viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<img width="1257" height="1288" alt="image" src="https://github.com/user-attachments/assets/99b12961-be1d-44a5-97af-b0648234b836" />

<img width="377" height="812" alt="image" src="https://github.com/user-attachments/assets/b39ce474-3dfb-41c4-896a-bb38d6c2f311" />
