### PR TITLE
feat: update validation results generator to draw from data dictionary and support pinning probabilities (#1394)

### DIFF
--- a/app/apis/catalog/hca-atlas-tracker/common/utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/utils.ts
@@ -1,5 +1,6 @@
 import { GREATEST_UNIX_TIME } from "../../../../utils/date-fns";
 import {
+  FILE_METADATA_COVERAGE_ENTITY_TYPES,
   FILE_VALIDATOR_NAMES_HIDDEN_WHEN_REPROCESSED,
   NETWORK_KEYS,
   STATUS_LABEL,
@@ -10,6 +11,7 @@ import {
   CAP_INGEST_STATUS,
   DOI_STATUS,
   DoiPublicationInfo,
+  FileMetadataCoverageEntityType,
   FileValidationSummary,
   FileValidatorName,
   HCA_TIER1_VALIDATION_STATUS,
@@ -437,6 +439,22 @@ export function getLinkedAtlasFieldArrays(atlases: LinkedAtlasSummary[]): {
 export function isNetworkKey(key: unknown): key is NetworkKey {
   return (
     typeof key === "string" && (NETWORK_KEYS as readonly string[]).includes(key)
+  );
+}
+
+/**
+ * Returns true if the given value is a valid file metadata coverage entity type.
+ * @param value - Value.
+ * @returns true if the value is a valid file metadata coverage entity type.
+ */
+export function isFileMetadataCoverageEntityType(
+  value: unknown,
+): value is FileMetadataCoverageEntityType {
+  return (
+    typeof value === "string" &&
+    FILE_METADATA_COVERAGE_ENTITY_TYPES.includes(
+      value as FileMetadataCoverageEntityType,
+    )
   );
 }
 

--- a/db_scripts/generate-test-validation-results.ts
+++ b/db_scripts/generate-test-validation-results.ts
@@ -3,10 +3,7 @@ import {
   DatasetValidatorToolReport,
   DatasetValidatorToolReports,
 } from "../app/apis/catalog/hca-atlas-tracker/aws/schemas";
-import {
-  FILE_METADATA_COVERAGE_ENTITY_TYPES,
-  FILE_VALIDATOR_NAMES,
-} from "../app/apis/catalog/hca-atlas-tracker/common/constants";
+import { FILE_METADATA_COVERAGE_ENTITY_TYPES } from "../app/apis/catalog/hca-atlas-tracker/common/constants";
 import {
   FILE_VALIDATION_STATUS,
   FileMetadataCoverage,
@@ -36,27 +33,78 @@ import dataDictionary from "../catalog/downloaded/data-dictionary.json";
  * added to them.
  */
 
-// Probability of all fields listed by metadata coverage being forced to be entirely complete
-const METADATA_COVERAGE_ALL_COMPLETE_PROBABILITY = 0.3;
+enum PROBABILITY {
+  CLAIM_CHECK_ERROR = "CLAIM_CHECK_ERROR",
+  COVERAGE_COMPLETE = "COVERAGE_COMPLETE",
+  COVERAGE_FIELD_COMPLETE = "COVERAGE_FIELD_COMPLETE",
+  FAILED_REQUEST = "FAILED_REQUEST",
+  FAILED_VALIDATION = "FAILED_VALIDATION",
+  INTEGRITY_ERROR = "INTEGRITY_ERROR",
+  JOB_ERROR = "JOB_ERROR",
+  OVERALL_VALID = "OVERALL_VALID",
+  TOOL_VALID = "TOOL_VALID",
+}
 
-// Probability of an individual field in metadata coverage being forced to be entirely complete
-const METADATA_COVERAGE_FIELD_ALL_COMPLETE_PROBABILITY = 0.2;
+const PROBABILITY_DEFS = [
+  {
+    // Probability of all fields listed by metadata coverage being forced to be entirely complete
+    default: 0.3,
+    flagBase: "coverage-complete",
+    id: PROBABILITY.COVERAGE_COMPLETE,
+  },
+  {
+    // Probability of an individual field in metadata coverage being forced to be entirely complete
+    default: 0.2,
+    flagBase: "coverage-field-complete",
+    id: PROBABILITY.COVERAGE_FIELD_COMPLETE,
+  },
 
-// Probability of failed validation (of various types) vs. successful validation containing tool reports etc.
-const FAILED_VALIDATION_PROBABILITY = 0.5;
+  {
+    // Probability of failed validation (of various types) vs. successful validation containing tool reports etc.
+    default: 0.5,
+    flagBase: "failed-validation",
+    id: PROBABILITY.FAILED_VALIDATION,
+  },
 
-// Probabilities of failure types, with the remaining possibility being an integrity failure
-const JOB_ERROR_PROBABILITY = 0.4;
-const CLAIM_CHECK_ERROR_PROBABILITY = 0.3;
+  {
+    // Probability of a failed validation being a job error
+    default: 0.4,
+    flagBase: "job-error",
+    id: PROBABILITY.JOB_ERROR,
+  },
+  {
+    // Probability of a failed validation that's not a job error being a claim check error (with the remaining possibility being integrity failure)
+    default: 0.5,
+    flagBase: "claim-check-error",
+    id: PROBABILITY.CLAIM_CHECK_ERROR,
+  },
+  {
+    // Probability of an integrity failure being an error vs. invalid
+    default: 0.5,
+    flagBase: "integrity-error",
+    id: PROBABILITY.INTEGRITY_ERROR,
+  },
 
-// Probability of an integrity failure being an error vs. invalid
-const INTEGRITY_ERROR_PROBABILITY = 0.5;
+  {
+    // Probability of successful results having a failed request on top of them
+    default: 0.2,
+    flagBase: "failed-request",
+    id: PROBABILITY.FAILED_REQUEST,
+  },
 
-// Probability of successful results having a failed request on top of them
-const FAILED_REQUEST_PROBABILITY = 0.2;
-
-// Probability of all tool reports being valid
-const OVERALL_VALID_PROBABILITY = 0.5;
+  {
+    // Probability of tool reports being forced to all be valid
+    default: 0.5,
+    flagBase: "overall-valid",
+    id: PROBABILITY.OVERALL_VALID,
+  },
+  {
+    // Probability of an individual tool report being valid
+    default: 0.5,
+    flagBase: "tool-valid",
+    id: PROBABILITY.TOOL_VALID,
+  },
+];
 
 // (Below use uninclusive max)
 
@@ -87,10 +135,30 @@ interface SuccessRelatedFields {
   validationSummary: FileValidationSummary | null;
 }
 
+const probabilityDefaults: Partial<Record<PROBABILITY, number>> =
+  Object.fromEntries(PROBABILITY_DEFS.map((p) => [p.id, p.default]));
+
+const params = process.argv.slice(2);
+
+const probabilityFlagValues: Partial<Record<PROBABILITY, boolean>> = {};
+for (const param of params) {
+  if (!isFlagParam(param)) continue;
+  for (const { flagBase, id } of PROBABILITY_DEFS) {
+    if (param === `--${flagBase}`) {
+      probabilityFlagValues[id] = true;
+      break;
+    } else if (param === `--not-${flagBase}`) {
+      probabilityFlagValues[id] = false;
+      break;
+    }
+  }
+  throw new Error(`Unknown flag: ${param}`);
+}
+
 generateAndAddValidationResults();
 
 async function generateAndAddValidationResults(): Promise<void> {
-  const entityKeywords = process.argv.slice(2);
+  const entityKeywords = params.filter((p) => !isFlagParam(p));
 
   let fileKeysById: Map<string, string> = new Map(); // Initial value is overwritten and is only here because TS can't tell that the callback below will run
 
@@ -116,8 +184,7 @@ async function addValidationResultsToFiles(
   for (const fileId of fileIds) {
     const validatedAt = new Date();
     let successRelatedFields: SuccessRelatedFields;
-    // eslint-disable-next-line sonarjs/pseudo-random -- track via #1386
-    if (Math.random() < FAILED_VALIDATION_PROBABILITY) {
+    if (probabilityPasses(PROBABILITY.FAILED_VALIDATION)) {
       successRelatedFields = getFailedValidationFields();
     } else {
       successRelatedFields = getSuccessfulValidationFields(
@@ -147,10 +214,7 @@ async function addValidationResultsToFiles(
 }
 
 function getFailedValidationFields(): SuccessRelatedFields {
-  // eslint-disable-next-line sonarjs/pseudo-random -- track via #1386
-  let errorTypeSource = Math.random();
-
-  if (errorTypeSource < JOB_ERROR_PROBABILITY) {
+  if (probabilityPasses(PROBABILITY.JOB_ERROR)) {
     return {
       datasetInfo: null,
       errorMessage: "Error in dataset validator",
@@ -161,9 +225,8 @@ function getFailedValidationFields(): SuccessRelatedFields {
       validationSummary: null,
     };
   }
-  errorTypeSource -= JOB_ERROR_PROBABILITY;
 
-  if (errorTypeSource < CLAIM_CHECK_ERROR_PROBABILITY) {
+  if (probabilityPasses(PROBABILITY.CLAIM_CHECK_ERROR)) {
     return {
       datasetInfo: null,
       errorMessage: "Error while reading claim check",
@@ -175,8 +238,7 @@ function getFailedValidationFields(): SuccessRelatedFields {
     };
   }
 
-  // eslint-disable-next-line sonarjs/pseudo-random -- track via #1386
-  if (Math.random() < INTEGRITY_ERROR_PROBABILITY) {
+  if (probabilityPasses(PROBABILITY.INTEGRITY_ERROR)) {
     return {
       datasetInfo: null,
       errorMessage:
@@ -225,11 +287,9 @@ function getSuccessfulValidationFields(
     integrityStatus: INTEGRITY_STATUS.VALID,
     metadataCoverage: makeMetadataCoverage(),
     validationReports: validationReports,
-    validationStatus:
-      // eslint-disable-next-line sonarjs/pseudo-random -- track via #1386
-      Math.random() < FAILED_REQUEST_PROBABILITY
-        ? FILE_VALIDATION_STATUS.REQUEST_FAILED
-        : FILE_VALIDATION_STATUS.COMPLETED,
+    validationStatus: probabilityPasses(PROBABILITY.FAILED_REQUEST)
+      ? FILE_VALIDATION_STATUS.REQUEST_FAILED
+      : FILE_VALIDATION_STATUS.COMPLETED,
     validationSummary: validationSummary,
   };
 }
@@ -248,9 +308,7 @@ function makeMetadataCoverage(): FileMetadataCoverage {
     MAX_FIELD_COVERAGE_ENTRIES,
   );
 
-  const allComplete =
-    // eslint-disable-next-line sonarjs/pseudo-random -- track via #1386
-    Math.random() < METADATA_COVERAGE_ALL_COMPLETE_PROBABILITY;
+  const allComplete = probabilityPasses(PROBABILITY.COVERAGE_COMPLETE);
 
   const fieldCoverage = fields.map((fieldName): FileMetadataFieldCoverage => {
     const entityType =
@@ -262,9 +320,7 @@ function makeMetadataCoverage(): FileMetadataCoverage {
     const { recordCount } = entities[entityType];
 
     const fieldAllComplete =
-      allComplete ||
-      // eslint-disable-next-line sonarjs/pseudo-random -- track via #1386
-      Math.random() < METADATA_COVERAGE_FIELD_ALL_COMPLETE_PROBABILITY;
+      allComplete || probabilityPasses(PROBABILITY.COVERAGE_FIELD_COMPLETE);
 
     const completeCount = fieldAllComplete
       ? recordCount
@@ -308,24 +364,20 @@ function makeValidationReports(): [
   FileValidationReports,
   FileValidationSummary,
 ] {
-  const validatorValidProbability =
-    OVERALL_VALID_PROBABILITY ** (1 / FILE_VALIDATOR_NAMES.length);
+  const forceValid = probabilityPasses(PROBABILITY.OVERALL_VALID);
 
   const toolReports: DatasetValidatorToolReports = {
-    cap: generateToolReport(validatorValidProbability),
-    cellxgene: generateToolReport(validatorValidProbability),
-    hcaCellAnnotation: generateToolReport(validatorValidProbability),
-    hcaSchema: generateToolReport(validatorValidProbability),
+    cap: generateToolReport(forceValid),
+    cellxgene: generateToolReport(forceValid),
+    hcaCellAnnotation: generateToolReport(forceValid),
+    hcaSchema: generateToolReport(forceValid),
   };
 
   return toolReportsToValidationReportsAndSummary(toolReports);
 }
 
-function generateToolReport(
-  validatorValidProbability: number,
-): DatasetValidatorToolReport {
-  // eslint-disable-next-line sonarjs/pseudo-random -- track via #1386
-  const valid = Math.random() < validatorValidProbability;
+function generateToolReport(forceValid: boolean): DatasetValidatorToolReport {
+  const valid = forceValid || probabilityPasses(PROBABILITY.TOOL_VALID);
   const errors = valid
     ? []
     : generateArrayVia((l) => `Error ${l.toUpperCase()}`);
@@ -520,4 +572,18 @@ async function findEntityOfTypeForKeyword<TIdKey extends string>(
     }
   }
   return foundEntity;
+}
+
+function probabilityPasses(probability: PROBABILITY): boolean {
+  const flagValue = probabilityFlagValues[probability];
+  if (flagValue !== undefined) return flagValue;
+  const defaultValue = probabilityDefaults[probability];
+  if (defaultValue === undefined)
+    throw new Error(`No definition found for ${probability} probability`);
+  // eslint-disable-next-line sonarjs/pseudo-random -- track via #1386
+  return Math.random() < defaultValue;
+}
+
+function isFlagParam(param: string): boolean {
+  return param.startsWith("--");
 }

--- a/db_scripts/generate-test-validation-results.ts
+++ b/db_scripts/generate-test-validation-results.ts
@@ -39,10 +39,10 @@ enum PROBABILITY {
   COVERAGE_COMPLETE = "COVERAGE_COMPLETE",
   COVERAGE_FIELD_COMPLETE = "COVERAGE_FIELD_COMPLETE",
   FAILED_REQUEST = "FAILED_REQUEST",
-  FAILED_VALIDATION = "FAILED_VALIDATION",
   INTEGRITY_ERROR = "INTEGRITY_ERROR",
   JOB_ERROR = "JOB_ERROR",
   OVERALL_VALID = "OVERALL_VALID",
+  SUCCESSFUL_VALIDATION = "SUCCESSFUL_VALIDATION",
   TOOL_VALID = "TOOL_VALID",
 }
 
@@ -61,10 +61,10 @@ const PROBABILITY_DEFS = [
   },
 
   {
-    // Probability of failed validation (of various types) vs. successful validation containing tool reports etc.
+    // Probability of successful validation containing tool reports etc. vs failed validation (of various types)
     default: 0.5,
-    flagBase: "failed-validation",
-    id: PROBABILITY.FAILED_VALIDATION,
+    flagBase: "successful-validation",
+    id: PROBABILITY.SUCCESSFUL_VALIDATION,
   },
 
   {
@@ -185,13 +185,13 @@ async function addValidationResultsToFiles(
   for (const fileId of fileIds) {
     const validatedAt = new Date();
     let successRelatedFields: SuccessRelatedFields;
-    if (probabilityPasses(PROBABILITY.FAILED_VALIDATION)) {
-      successRelatedFields = getFailedValidationFields();
-    } else {
+    if (probabilityPasses(PROBABILITY.SUCCESSFUL_VALIDATION)) {
       successRelatedFields = getSuccessfulValidationFields(
         fileKeysById,
         fileId,
       );
+    } else {
+      successRelatedFields = getFailedValidationFields();
     }
     const validationInfo: HCAAtlasTrackerDBFileValidationInfo = {
       batchJobId: `test-batch-job-${crypto.randomUUID()}`,

--- a/db_scripts/generate-test-validation-results.ts
+++ b/db_scripts/generate-test-validation-results.ts
@@ -24,6 +24,7 @@ import {
 import { addValidationResultsToFile } from "../app/data/files";
 import { doTransaction, endPgPool } from "../app/services/database";
 import { toolReportsToValidationReportsAndSummary } from "../app/services/validation-results-notification";
+import dataDictionary from "../catalog/downloaded/data-dictionary.json";
 
 /**
  * Usage: `npx tsx db_scripts/generate-test-validation-results.ts <keyword ...>`
@@ -287,7 +288,7 @@ function makeMetadataCoverage(): FileMetadataCoverage {
   return {
     entities,
     fieldCoverage,
-    schemaName: "test",
+    schemaName: dataDictionary.name,
     schemaVersion: "1.0-test",
   };
 

--- a/db_scripts/generate-test-validation-results.ts
+++ b/db_scripts/generate-test-validation-results.ts
@@ -141,16 +141,19 @@ const params = process.argv.slice(2);
 const probabilityFlagValues: Partial<Record<PROBABILITY, boolean>> = {};
 for (const param of params) {
   if (!isFlagParam(param)) continue;
+  let matched = false;
   for (const { flagBase, id } of PROBABILITY_DEFS) {
     if (param === `--${flagBase}`) {
       probabilityFlagValues[id] = true;
+      matched = true;
       break;
     } else if (param === `--not-${flagBase}`) {
       probabilityFlagValues[id] = false;
+      matched = true;
       break;
     }
   }
-  throw new Error(`Unknown flag: ${param}`);
+  if (!matched) throw new Error(`Unknown flag: ${param}`);
 }
 
 generateAndAddValidationResults();

--- a/db_scripts/generate-test-validation-results.ts
+++ b/db_scripts/generate-test-validation-results.ts
@@ -25,13 +25,22 @@ import { toolReportsToValidationReportsAndSummary } from "../app/services/valida
 import dataDictionary from "../catalog/downloaded/data-dictionary.json";
 
 /**
- * Usage: `npx tsx db_scripts/generate-test-validation-results.ts <keyword ...>`
+ * Usage: `npx tsx db_scripts/generate-test-validation-results.ts <keyword/flag ...>`
+ *
  * Each keyword can be an atlas ID, and atlas short name, an atlas name with version,
  * a component atlas ID, a source dataset ID, a file ID, a file key, or a file name.
  * An atlas represents files of that atlas's component atlases and source datasets,
  * a component atlas or source dataset represents the corresponding file, and a file
  * represent the file itself. All matched files will have random validation results
  * added to them.
+ *
+ * Flags can be used to pin certain probabilities to 100% or 0%. The available
+ * probabilities are defined below in `PROBABILITY_DEFS`; the defined `flagBase` can
+ * be prefixed with `--` to pin the probability at 100%, or with `--not-` to pin the
+ * probability to 0%. For example, passing `--successful-validation --coverage-complete`
+ * to the script will ensure that all generated validation results are successful and
+ * have fully complete metadata coverage, and passing `--not-successful-validation` will
+ * ensure that all validation results are unsuccessful.
  */
 
 enum PROBABILITY {

--- a/db_scripts/generate-test-validation-results.ts
+++ b/db_scripts/generate-test-validation-results.ts
@@ -18,6 +18,7 @@ import {
   HCAAtlasTrackerDBSourceDataset,
   INTEGRITY_STATUS,
 } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+import { isFileMetadataCoverageEntityType } from "../app/apis/catalog/hca-atlas-tracker/common/utils";
 import { addValidationResultsToFile } from "../app/data/files";
 import { doTransaction, endPgPool } from "../app/services/database";
 import { toolReportsToValidationReportsAndSummary } from "../app/services/validation-results-notification";
@@ -110,9 +111,6 @@ const PROBABILITY_DEFS = [
 
 const MIN_METADATA_RECORD_COUNT = 100;
 const MAX_METADATA_RECORD_COUNT = 1000;
-
-const MIN_FIELD_COVERAGE_ENTRIES = 10;
-const MAX_FIELD_COVERAGE_ENTRIES = 50;
 
 const MIN_CELL_COUNT = 100;
 const MAX_CELL_COUNT = 10000;
@@ -302,44 +300,40 @@ function makeMetadataCoverage(): FileMetadataCoverage {
     sample: generateEntity(),
   };
 
-  const fields = generateArrayVia(
-    (l) => "field_" + l,
-    MIN_FIELD_COVERAGE_ENTRIES,
-    MAX_FIELD_COVERAGE_ENTRIES,
-  );
-
   const allComplete = probabilityPasses(PROBABILITY.COVERAGE_COMPLETE);
 
-  const fieldCoverage = fields.map((fieldName): FileMetadataFieldCoverage => {
-    const entityType =
-      FILE_METADATA_COVERAGE_ENTITY_TYPES[
+  const fieldCoverage: FileMetadataFieldCoverage[] = [];
+  for (const entityClass of dataDictionary.classes) {
+    const entityType = entityClass.name;
+    if (!isFileMetadataCoverageEntityType(entityType)) continue;
+
+    for (const field of entityClass.attributes) {
+      if (shouldOmitMetadataCoverageField(field)) continue;
+
+      const { recordCount } = entities[entityType];
+
+      const fieldAllComplete =
+        allComplete || probabilityPasses(PROBABILITY.COVERAGE_FIELD_COMPLETE);
+
+      const completeCount = fieldAllComplete
+        ? recordCount
+        : // eslint-disable-next-line sonarjs/pseudo-random -- track via #1386
+          Math.floor(Math.random() * (recordCount + 1));
+
+      const missingCount = Math.floor(
         // eslint-disable-next-line sonarjs/pseudo-random -- track via #1386
-        Math.floor(Math.random() * FILE_METADATA_COVERAGE_ENTITY_TYPES.length)
-      ];
+        Math.random() * (recordCount - completeCount + 1),
+      );
 
-    const { recordCount } = entities[entityType];
-
-    const fieldAllComplete =
-      allComplete || probabilityPasses(PROBABILITY.COVERAGE_FIELD_COMPLETE);
-
-    const completeCount = fieldAllComplete
-      ? recordCount
-      : // eslint-disable-next-line sonarjs/pseudo-random -- track via #1386
-        Math.floor(Math.random() * (recordCount + 1));
-
-    const missingCount = Math.floor(
-      // eslint-disable-next-line sonarjs/pseudo-random -- track via #1386
-      Math.random() * (recordCount - completeCount + 1),
-    );
-
-    return {
-      complete: completeCount,
-      entityClass: entityType,
-      field: fieldName,
-      inconsistent: recordCount - completeCount - missingCount,
-      missing: missingCount,
-    };
-  });
+      fieldCoverage.push({
+        complete: completeCount,
+        entityClass: entityType,
+        field: field.name,
+        inconsistent: recordCount - completeCount - missingCount,
+        missing: missingCount,
+      });
+    }
+  }
 
   return {
     entities,
@@ -358,6 +352,17 @@ function makeMetadataCoverage(): FileMetadataCoverage {
         ) + MIN_METADATA_RECORD_COUNT,
     };
   }
+}
+
+function shouldOmitMetadataCoverageField(field: {
+  name: string;
+  description: string;
+}): boolean {
+  // Very rough analog to how the dataset validator filters fields for metadata coverage
+  return (
+    FILE_METADATA_COVERAGE_ENTITY_TYPES.some((t) => field.name === `${t}_id`) ||
+    /deprecated/i.test(field.description)
+  );
 }
 
 function makeValidationReports(): [


### PR DESCRIPTION
Closes #1394

In addition to updating metadata coverage generation to use actual fields from the data dictionary, this also adds arguments for the script to allow pinning probabilities used by the script, which will make it possible to e.g. force full metadata coverage and potentially make it easier to generate useful test cases