### PR TITLE
chore: exclude `.next` from type checking (#1412)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,5 +31,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", ".next"]
 }


### PR DESCRIPTION
Closes #1412