### PR TITLE
build: pin Node base image to 22.13.0 and drop unpinned 'n' installer (#1063)

### DIFF
--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -2,7 +2,7 @@
 # docker run -p 3000:3000 tracker-node
 
 # Base stage
-FROM --platform=linux/amd64 node:22 AS base
+FROM --platform=linux/amd64 node:22.13.0 AS base
 
 # Deps stage
 FROM base AS deps
@@ -10,9 +10,6 @@ WORKDIR /app
 ARG ENVIRONMENT
 ENV ENVIRONMENT ${ENVIRONMENT}
 COPY ./package*.json ./
-RUN node --version
-RUN npm install -g n
-RUN n 22.13.0
 RUN node --version
 RUN npm ci
 


### PR DESCRIPTION
Closes #1063. Clean reimplementation that supersedes #1064 (which targeted the now-outdated Node 20.10.0 and is in merge conflict).

## Problem
`Dockerfile.node` installs the third-party `n` tool **unpinned** (`npm install -g n`) to force an exact Node version on top of the floating `node:22` base — the supply-chain risk described in #1063. A compromised `n` release could run arbitrary code during the build.

## Change
```diff
-FROM --platform=linux/amd64 node:22 AS base
+FROM --platform=linux/amd64 node:22.13.0 AS base
 ...
 COPY ./package*.json ./
 RUN node --version
-RUN npm install -g n
-RUN n 22.13.0
-RUN node --version
 RUN npm ci
```
Pin the base image directly to `node:22.13.0` — the exact version already required by `package.json` engines and `.nvmrc` — and drop the `n` install plus the redundant version echo. Same Debian variant as `node:22`, exact version, no third-party installer.

## Why a rewrite instead of #1064
#1064 was authored when `main` was on Node 20, so it pins to `node:20.10.0`. Merging it now would **downgrade** the image below the `22.13.0` required by `engines`/`.nvmrc`. This PR uses the current required version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)