### PR TITLE
build: add Dependabot to keep the pinned Node base image current (#1063)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Keeps the pinned Node base image in Dockerfile.node current.
+#
+# The base image is pinned to an exact version (node:22.13.0) to remove the
+# unpinned `n` installer (#1063). An exact pin does not passively pick up newer
+# Node patch releases or OS-security rebuilds, so Dependabot opens a PR when a
+# newer image is published — keeping updates deliberate and reviewable rather
+# than silent (a floating tag) or never (a manual-only pin).
+#
+# Dependabot's docker ecosystem detects any file whose name contains
+# "dockerfile" (case-insensitive), so the non-standard `Dockerfile.node` name is
+# picked up at the repo root.
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "build"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Follow-up to #1420 (which pinned the Node base image to `node:22.13.0` and removed the unpinned `n` installer per #1063).

## Why
An exact pin is great for supply-chain safety and reproducibility, but it has one downside: it won't passively pick up newer Node patch releases or rebuilt-with-OS-security-patches images. Without automation a pinned base image slowly accumulates CVEs. Dependabot neutralizes that — it opens a reviewable PR when a newer image is published, so updates are **deliberate and visible** rather than silent (a floating tag) or never (manual-only).

## What
Adds `.github/dependabot.yml` with the `docker` ecosystem watching the repo root weekly.

## Will it find `Dockerfile.node`?
Yes. Dependabot's docker ecosystem matches any filename containing `dockerfile` (case-insensitive) — current dependabot-core uses `DOCKER_REGEXP = /dockerfile|containerfile/i` — so the non-standard `Dockerfile.node` name is detected at `/`. (The older "non-standard Dockerfile name" limitation has since been fixed.)

## Scope
Docker base image only, to keep PR noise low. Happy to add the `npm` ecosystem in a separate change if you want app-dependency updates too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)