### PR TITLE
feat: add styled 404 and 500 error pages (#1404)

### DIFF
--- a/app/views/NotFoundView/notFoundView.tsx
+++ b/app/views/NotFoundView/notFoundView.tsx
@@ -11,7 +11,6 @@ import {
   ErrorSection,
   SectionContent,
 } from "@databiosphere/findable-ui/lib/components/Error/error.styles";
-import { useLayoutDimensions } from "@databiosphere/findable-ui/lib/providers/layoutDimensions/hook";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { Typography } from "@mui/material";
 import Link from "next/link";
@@ -19,9 +18,8 @@ import { JSX } from "react";
 import { ROUTE } from "../../routes/constants";
 
 export const NotFoundView = (): JSX.Element => {
-  const { dimensions } = useLayoutDimensions();
   return (
-    <ErrorLayout offset={dimensions.header.height}>
+    <ErrorLayout offset={0}>
       <ErrorContent>
         <ErrorSection>
           <StatusIcon priority={PRIORITY.HIGH} StatusIcon={AlertIcon} />

--- a/app/views/NotFoundView/notFoundView.tsx
+++ b/app/views/NotFoundView/notFoundView.tsx
@@ -1,0 +1,48 @@
+import { ButtonPrimary } from "@databiosphere/findable-ui/lib/components/common/Button/components/ButtonPrimary/buttonPrimary";
+import { AlertIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/AlertIcon/alertIcon";
+import { SectionActions } from "@databiosphere/findable-ui/lib/components/common/Section/section.styles";
+import {
+  PRIORITY,
+  StatusIcon,
+} from "@databiosphere/findable-ui/lib/components/common/StatusIcon/statusIcon";
+import {
+  Error as ErrorContent,
+  ErrorLayout,
+  ErrorSection,
+  SectionContent,
+} from "@databiosphere/findable-ui/lib/components/Error/error.styles";
+import { useLayoutDimensions } from "@databiosphere/findable-ui/lib/providers/layoutDimensions/hook";
+import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
+import { Typography } from "@mui/material";
+import Link from "next/link";
+import { JSX } from "react";
+import { ROUTE } from "../../routes/constants";
+
+export const NotFoundView = (): JSX.Element => {
+  const { dimensions } = useLayoutDimensions();
+  return (
+    <ErrorLayout offset={dimensions.header.height}>
+      <ErrorContent>
+        <ErrorSection>
+          <StatusIcon priority={PRIORITY.HIGH} StatusIcon={AlertIcon} />
+          <SectionContent>
+            <Typography
+              component="h1"
+              variant={TYPOGRAPHY_PROPS.VARIANT.HEADING_XLARGE}
+            >
+              Page not found
+            </Typography>
+            <Typography variant={TYPOGRAPHY_PROPS.VARIANT.BODY_LARGE_400}>
+              This page doesn&apos;t exist
+            </Typography>
+          </SectionContent>
+          <SectionActions>
+            <ButtonPrimary component={Link} href={ROUTE.ATLASES}>
+              Go to Atlases
+            </ButtonPrimary>
+          </SectionActions>
+        </ErrorSection>
+      </ErrorContent>
+    </ErrorLayout>
+  );
+};

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,8 @@
+import { JSX } from "react";
+import { NotFoundView } from "../app/views/NotFoundView/notFoundView";
+
+const NotFoundPage = (): JSX.Element => {
+  return <NotFoundView />;
+};
+
+export default NotFoundPage;

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -1,10 +1,9 @@
 import { Error } from "@databiosphere/findable-ui/lib/components/Error/error";
-import { config } from "app/config/config";
+import { ROUTE } from "app/routes/constants";
 import { JSX } from "react";
 
 const ServerErrorPage = (): JSX.Element => {
-  const { redirectRootToPath } = config();
-  return <Error rootPath={redirectRootToPath} />;
+  return <Error rootPath={ROUTE.ATLASES} />;
 };
 
 export default ServerErrorPage;

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -1,0 +1,10 @@
+import { Error } from "@databiosphere/findable-ui/lib/components/Error/error";
+import { config } from "app/config/config";
+import { JSX } from "react";
+
+const ServerErrorPage = (): JSX.Element => {
+  const { redirectRootToPath } = config();
+  return <Error rootPath={redirectRootToPath} />;
+};
+
+export default ServerErrorPage;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -21,6 +21,7 @@ import { AppCacheProvider } from "@mui/material-nextjs/v16-pagesRouter";
 import { createBreakpoints } from "@mui/system";
 import { deepmerge } from "@mui/utils";
 import { config } from "app/config/config";
+import { ROUTE } from "app/routes/constants";
 import { NextPage } from "next";
 import { Session } from "next-auth";
 import type { AppProps } from "next/app";
@@ -52,7 +53,7 @@ function MyApp(props: AppPropsWithComponent): JSX.Element {
   const { Component, pageProps } = props;
   // Set up the site configuration, layout and theme.
   const appConfig = config();
-  const { layout, redirectRootToPath, themeOptions } = appConfig;
+  const { layout, themeOptions } = appConfig;
   const { floating, footer, header } = layout || {};
   const defaultTheme = createAppTheme(themeOptions);
   const appTheme = mergeAppTheme(defaultTheme);
@@ -101,9 +102,9 @@ function MyApp(props: AppPropsWithComponent): JSX.Element {
                               }): JSX.Element => (
                                 <Error
                                   errorMessage={error.message}
-                                  requestUrlMessage={error.requestUrlMessage}
-                                  rootPath={redirectRootToPath}
                                   onReset={reset}
+                                  requestUrlMessage={error.requestUrlMessage}
+                                  rootPath={ROUTE.ATLASES}
                                 />
                               )}
                             >


### PR DESCRIPTION
## Summary

Adds custom, on-brand `pages/404.tsx` and `pages/500.tsx` so users no longer hit Next.js's bare unstyled default error page. Both render inside the app shell (header/footer) using findable-ui's existing styled `Error` component — no new design.

Closes #1404

## Changes
- **`pages/404.tsx`** → renders a new `NotFoundView`.
- **`app/views/NotFoundView/notFoundView.tsx`** → mirrors the findable-ui `Error` layout (reusing its `error.styles` primitives + `StatusIcon`/`AlertIcon`/`ButtonPrimary`) with not-found copy ("Page not found" / "This page doesn't exist") and a **Go to Atlases** button → `ROUTE.ATLASES`. The `Error` component has no props to override its hardcoded "Error" heading, so the 404 reuses its styled primitives rather than the component itself.
- **`pages/500.tsx`** → renders findable-ui's `Error` directly (its generic "Error" copy + "To Homepage" button is appropriate for a real server error), with `rootPath` from config.

## Verification
Confirmed end-to-end against a production server (`next start`) through the real `proxy.ts` middleware gate:
- `/fark` (and other 404 routes) **unauthenticated** → `307` to login (deny-by-default gate).
- `/fark` **authenticated** → `HTTP 404` rendering the styled "Page not found" page inside the app shell (header + footer).
- Built `500.html` verified to contain the styled "Error" / "To Homepage" content.

Note: `next dev` serves Next's built-in 404 (bypassing the shell); the custom static 404/500 are emitted by `next build` and served by all built environments — to see them locally run `npm run build:local && npx next start`.

## Out of scope
No middleware/gating changes; no design work; no `_error.tsx` catch-all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1240" height="1262" alt="image" src="https://github.com/user-attachments/assets/11504bd1-39df-4e11-ab1b-1037f38c6463" />
