### PR TITLE
fix: react-hooks/refs anti-pattern in usebackpath hook (#1370)

### DIFF
--- a/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook.ts
+++ b/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook.ts
@@ -1,6 +1,6 @@
 import { useRouter } from "next/router";
 import { useState } from "react";
-import { PathParameter } from "../../../../../../../../../../common/entities";
+import type { PathParameter } from "../../../../../../../../../../common/entities";
 import { parseBackOrigin, resolveBackPath } from "./utils";
 
 /**

--- a/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook.ts
+++ b/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook.ts
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { useRef } from "react";
+import { useState } from "react";
 import { PathParameter } from "../../../../../../../../../../common/entities";
 import { parseBackOrigin, resolveBackPath } from "./utils";
 
@@ -15,9 +15,7 @@ import { parseBackOrigin, resolveBackPath } from "./utils";
 export function useBackPath(pathParameter: PathParameter): string | undefined {
   const { query } = useRouter();
   const { from } = query;
-  const originRef = useRef(parseBackOrigin(from));
-  // eslint-disable-next-line react-hooks/refs -- track via #1370
-  const origin = originRef.current;
+  const [origin] = useState(() => parseBackOrigin(from));
 
   return resolveBackPath({ origin, pathParameter });
 }

--- a/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook.ts
+++ b/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook.ts
@@ -6,8 +6,9 @@ import { parseBackOrigin, resolveBackPath } from "./utils";
 /**
  * Captures the back-arrow origin from `useRouter().query.from` once at first
  * render and resolves the back path for the current detail view. The snapshot
- * survives tab navigation (the ref locks at mount) so a tab switch within
- * the detail view doesn't repoint the back arrow.
+ * survives tab navigation (captured once at mount via a lazy state
+ * initializer) so a tab switch within the detail view doesn't repoint the
+ * back arrow.
  * @param pathParameter - Path parameter of the current detail view.
  * @returns Resolved back path, or undefined for deep links / direct entry
  *   (in which case `BackButton` falls back to its URL-segment trim).


### PR DESCRIPTION
## Summary

Removes the `react-hooks/refs` lint suppression in the `useBackPath` hook by replacing the `useRef` snapshot (read during render) with a `useState` lazy initializer.

react-hooks v7 flags reading `ref.current` during render. A lazy state initializer runs once at mount and reading state during render is fine — preserving the exact "capture the back-arrow origin once at mount, survive tab navigation" semantics without the anti-pattern.

```ts
// before
const originRef = useRef(parseBackOrigin(from));
// eslint-disable-next-line react-hooks/refs -- track via #1370
const origin = originRef.current;

// after
const [origin] = useState(() => parseBackOrigin(from));
```

Closes #1370

Parent epic: #1360 (sonarjs + react-hooks v7 lint cleanup)

## Verification
- `npm run lint` passes for the file (no `react-hooks/refs`; disable directive removed).
- Existing `use-back-path.test.ts` / `back-button-utils.test.ts` pass (23 tests), including the snapshot-survives-rerender case that confirms unchanged behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)