### PR TITLE
docs: justify set-state-in-effect disable in usefetchsourcestudiessourcedatasets (#1375)

### DIFF
--- a/app/hooks/useFetchSourceStudiesSourceDatasets.ts
+++ b/app/hooks/useFetchSourceStudiesSourceDatasets.ts
@@ -44,7 +44,7 @@ export const useFetchSourceStudiesSourceDatasets = (
 
   useEffect(() => {
     if (!sourceStudies) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- track via #1375
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- false positive: fetchData sets state after await (async fetch completion), not a synchronous cascading render; the rule flags the useCallback call site because it can't see the await boundary
     fetchData(
       sourceStudies.map(({ id }) => id),
       pathParameter,


### PR DESCRIPTION
## Summary

Resolves the `react-hooks/set-state-in-effect` flag in `useFetchSourceStudiesSourceDatasets` by replacing the temporary `-- track via #1375` directive with a **permanent, justified** suppression.

After investigation this is a **false positive**: the `setState` runs after `await Promise.all(...)` inside `fetchData` — it is asynchronous (one render when the data lands), not the synchronous cascading render the rule targets. The rule fires only because its analysis traces the synchronous `fetchData(...)` call into the `useCallback` and can't see the `await` boundary. (Confirmed: inlining the same logic so the `await` is visible makes the rule pass — but trips the `sonarjs` 4-level-nesting rule instead, indicating the current `useCallback` structure is the reasonable shape.)

No behavior change.

Closes #1375

Parent epic: #1360 (sonarjs + react-hooks v7 lint cleanup)

## Verification
- `npm run lint` passes for the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)