### PR TITLE
fix: react-hooks/set-state-in-effect in useform (#1376)

### DIFF
--- a/app/hooks/useForm/useForm.ts
+++ b/app/hooks/useForm/useForm.ts
@@ -1,5 +1,5 @@
 import { yupResolver } from "@hookform/resolvers/yup";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   FieldValues,
   Path,
@@ -52,8 +52,20 @@ export const useForm = <T extends FieldValues, R = undefined>(
     values,
     ...options,
   });
-  const [data, setData] = useState<R | undefined>();
+  const [data, setData] = useState<R | undefined>(apiData);
+  const [prevApiData, setPrevApiData] = useState(apiData);
   const { reset, setError } = formMethod;
+
+  // Re-initialize data when the API response (apiData) changes — mirrors the
+  // previous effect keyed on [apiData]: track every reference change, but only
+  // overwrite data when apiData is truthy. apiData must be referentially stable
+  // across renders (it is — it comes from useFetchData's state); a caller
+  // passing a freshly-built apiData each render would loop ("Too many
+  // re-renders"), just as the prior effect would have looped on [apiData].
+  if (prevApiData !== apiData) {
+    setPrevApiData(apiData);
+    if (apiData) setData(apiData);
+  }
 
   const onError = useCallback(
     (errors: FormResponseErrors) => {
@@ -113,13 +125,6 @@ export const useForm = <T extends FieldValues, R = undefined>(
     },
     [mapApiValues, mapSchemaValues, onError, schema],
   );
-
-  // Initialize data with given API response.
-  useEffect(() => {
-    if (!apiData) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- track via #1376
-    setData(apiData);
-  }, [apiData]);
 
   return {
     ...formMethod,

--- a/app/hooks/useForm/useForm.ts
+++ b/app/hooks/useForm/useForm.ts
@@ -57,12 +57,13 @@ export const useForm = <T extends FieldValues, R = undefined>(
   const { reset, setError } = formMethod;
 
   // Re-initialize data when the API response (apiData) changes — mirrors the
-  // previous effect keyed on [apiData]: track every reference change, but only
-  // overwrite data when apiData is truthy. apiData must be referentially stable
-  // across renders (it is — it comes from useFetchData's state); a caller
-  // passing a freshly-built apiData each render would loop ("Too many
-  // re-renders"), just as the prior effect would have looped on [apiData].
-  if (prevApiData !== apiData) {
+  // previous effect keyed on [apiData]: track every reference change (compared
+  // with Object.is, matching React's dependency semantics) but only overwrite
+  // data when apiData is truthy. apiData must be referentially stable across
+  // renders (it is — it comes from useFetchData's state); a caller passing a
+  // freshly-built apiData each render would loop here, just as the prior
+  // [apiData] effect would have.
+  if (!Object.is(prevApiData, apiData)) {
     setPrevApiData(apiData);
     if (apiData) setData(apiData);
   }

--- a/app/hooks/useForm/useForm.ts
+++ b/app/hooks/useForm/useForm.ts
@@ -52,8 +52,8 @@ export const useForm = <T extends FieldValues, R = undefined>(
     values,
     ...options,
   });
-  const [data, setData] = useState<R | undefined>(apiData);
-  const [prevApiData, setPrevApiData] = useState(apiData);
+  const [data, setData] = useState<R | undefined>();
+  const [prevApiData, setPrevApiData] = useState<R | undefined>();
   const { reset, setError } = formMethod;
 
   // Re-initialize data when the API response (apiData) changes — mirrors the


### PR DESCRIPTION
## Summary

Removes the `react-hooks/set-state-in-effect` suppression in `useForm` by replacing the prop-into-state init effect with React's "adjust state during render" pattern.

The flagged effect was a **true positive** — a synchronous `setData(apiData)` in an effect (the classic "copy a prop into state" anti-pattern), causing a cascading render (mount commits `data=undefined` → effect → `setData` → re-render).

```ts
// before
const [data, setData] = useState<R | undefined>();
useEffect(() => {
  if (!apiData) return;
  // eslint-disable-next-line react-hooks/set-state-in-effect -- track via #1376
  setData(apiData);
}, [apiData]);

// after
const [data, setData] = useState<R | undefined>();
const [prevApiData, setPrevApiData] = useState<R | undefined>();
if (!Object.is(prevApiData, apiData)) {
  setPrevApiData(apiData);
  if (apiData) setData(apiData);
}
```

This mirrors the original `[apiData]` effect's trigger semantics exactly: track every reference change, overwrite `data` only when `apiData` is truthy. `data` is still also updated locally by `onSubmit`. No suppression needed.

Closes #1376

Parent epic: #1360 (sonarjs + react-hooks v7 lint cleanup)

## Notes (from code review)
- `prevApiData` is updated on **every** reference change (not only the truthy branch) so a `value → undefined → same-value` round-trip resets `data` exactly as the old effect did.
- `apiData` must be referentially stable across renders (it is — sourced from `useFetchData`'s state); documented inline. This is the same implicit contract the prior effect had.
- Behavior preserved: stale-data-on-`apiData`-falsy matches the prior `if (!apiData) return`; the only change is the (intended) removal of the one-render `undefined` tick — no consumer relies on it.

## Verification
- `npm run lint` passes for the file (no `set-state-in-effect`; directive removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
