### PR TITLE
fix: no-nested-conditional in backend-utils (#1362)

### DIFF
--- a/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/backend-utils.ts
@@ -477,16 +477,14 @@ export function getDbSourceStudyTierOneMetadataStatus(
   sourceStudy: HCAAtlasTrackerDBSourceStudy,
 ): TIER_ONE_METADATA_STATUS {
   const collectionId = sourceStudy.study_info.cellxgeneCollectionId;
-  return collectionId
-    ? // eslint-disable-next-line sonarjs/no-nested-conditional -- track via #1362
-      Object.hasOwn(savedCellxgeneInfo.collections, collectionId)
-      ? getCompositeTierOneMetadataStatus(
-          savedCellxgeneInfo.collections[collectionId].datasets.map(
-            getCellxGeneDatasetTierOneMetadataStatus,
-          ),
-        )
-      : TIER_ONE_METADATA_STATUS.NEEDS_VALIDATION
-    : TIER_ONE_METADATA_STATUS.NA;
+  if (!collectionId) return TIER_ONE_METADATA_STATUS.NA;
+  if (!Object.hasOwn(savedCellxgeneInfo.collections, collectionId))
+    return TIER_ONE_METADATA_STATUS.NEEDS_VALIDATION;
+  return getCompositeTierOneMetadataStatus(
+    savedCellxgeneInfo.collections[collectionId].datasets.map(
+      getCellxGeneDatasetTierOneMetadataStatus,
+    ),
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Resolves `sonarjs/no-nested-conditional` in `getDbSourceStudyTierOneMetadataStatus` by extracting the nested ternary into early-return guards.

```ts
// before
return collectionId
  ? // eslint-disable-next-line sonarjs/no-nested-conditional -- track via #1362
    Object.hasOwn(savedCellxgeneInfo.collections, collectionId)
    ? getCompositeTierOneMetadataStatus(...)
    : TIER_ONE_METADATA_STATUS.NEEDS_VALIDATION
  : TIER_ONE_METADATA_STATUS.NA;

// after
if (!collectionId) return TIER_ONE_METADATA_STATUS.NA;
if (!Object.hasOwn(savedCellxgeneInfo.collections, collectionId))
  return TIER_ONE_METADATA_STATUS.NEEDS_VALIDATION;
return getCompositeTierOneMetadataStatus(...);
```

Behavior is identical; the eslint-disable directive is removed.

Closes #1362

Parent epic: #1360 (sonarjs + react-hooks v7 lint cleanup)

## Verification
- `npm run lint` passes for the file (no `no-nested-conditional`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)