### PR TITLE
docs: justify redundant-type-aliases disables in entities (#1363)

### DIFF
--- a/app/apis/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/apis/catalog/hca-atlas-tracker/common/entities.ts
@@ -795,7 +795,7 @@ export interface HeatmapEntrySheet {
 
 export type AtlasId = HCAAtlasTrackerAtlas["id"];
 
-// eslint-disable-next-line sonarjs/redundant-type-aliases -- track via #1363
+// eslint-disable-next-line sonarjs/redundant-type-aliases -- intentional domain-semantic alias; kept for self-documenting call sites and to allow future tightening (e.g. branding) without touching usages
 export type ComponentAtlasId = string;
 
 export type EntrySheetValidationId = HCAAtlasTrackerEntrySheetValidation["id"];
@@ -881,10 +881,10 @@ export interface GoogleSheetInfo {
   title: string | null;
 }
 
-// eslint-disable-next-line sonarjs/redundant-type-aliases -- track via #1363
+// eslint-disable-next-line sonarjs/redundant-type-aliases -- intentional domain-semantic alias; kept for self-documenting call sites and to allow future tightening (e.g. branding) without touching usages
 export type SourceDatasetId = string;
 
-// eslint-disable-next-line sonarjs/redundant-type-aliases -- track via #1363
+// eslint-disable-next-line sonarjs/redundant-type-aliases -- intentional domain-semantic alias; kept for self-documenting call sites and to allow future tightening (e.g. branding) without touching usages
 export type SourceStudyId = string;
 
 export enum TIER_ONE_METADATA_STATUS {
@@ -986,10 +986,10 @@ export interface PresignedUrlInfo {
   url: string;
 }
 
-// eslint-disable-next-line sonarjs/redundant-type-aliases -- track via #1363
+// eslint-disable-next-line sonarjs/redundant-type-aliases -- intentional domain-semantic alias; kept for self-documenting call sites and to allow future tightening (e.g. branding) without touching usages
 export type UserId = number;
 
-// eslint-disable-next-line sonarjs/redundant-type-aliases -- track via #1363
+// eslint-disable-next-line sonarjs/redundant-type-aliases -- intentional domain-semantic alias; kept for self-documenting call sites and to allow future tightening (e.g. branding) without touching usages
 export type ValidatorName = FileValidatorName;
 
 export interface ValidationDifference {


### PR DESCRIPTION
## Summary

Resolves `sonarjs/redundant-type-aliases` in `apis/catalog/.../entities.ts` by replacing the temporary `-- track via #1363` directives with **permanent, justified** suppressions.

The flagged aliases are **intentional domain-semantic types** we want to keep:

- `ComponentAtlasId = string`
- `SourceDatasetId = string`
- `SourceStudyId = string`
- `UserId = number`
- `ValidatorName = FileValidatorName`

They make call sites self-documenting (`ComponentAtlasId` reads better than bare `string`) and leave room to tighten to branded types later without touching usages. Inlining the primitives — what the rule wants — would lose that intent, so we keep the aliases with a documented suppression instead.

No behavior change (type aliases only).

Closes #1363

Parent epic: #1360 (sonarjs + react-hooks v7 lint cleanup)

## Verification
- `npm run lint` passes for the file (no `redundant-type-aliases`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)