### PR TITLE
fix: no-nested-assignment in viewsourcestudies (#1364)

### DIFF
--- a/app/components/Detail/components/ViewSourceStudies/viewSourceStudies.tsx
+++ b/app/components/Detail/components/ViewSourceStudies/viewSourceStudies.tsx
@@ -54,9 +54,10 @@ export const ViewSourceStudies = ({
         );
         if (linkedDataset) {
           let studyDatasets = datasets.get(sourceDataset.sourceStudyId);
-          if (!studyDatasets)
-            // eslint-disable-next-line sonarjs/no-nested-assignment -- track via #1364
-            datasets.set(sourceDataset.sourceStudyId, (studyDatasets = []));
+          if (!studyDatasets) {
+            studyDatasets = [];
+            datasets.set(sourceDataset.sourceStudyId, studyDatasets);
+          }
           studyDatasets.push(sourceDataset);
         }
         return datasets;


### PR DESCRIPTION
## Summary

Resolves `sonarjs/no-nested-assignment` in `ViewSourceStudies` by extracting the inline `studyDatasets` assignment out of the `Map.set()` call.

```ts
// before
let studyDatasets = datasets.get(sourceDataset.sourceStudyId);
if (!studyDatasets)
  // eslint-disable-next-line sonarjs/no-nested-assignment -- track via #1364
  datasets.set(sourceDataset.sourceStudyId, (studyDatasets = []));
studyDatasets.push(sourceDataset);

// after
let studyDatasets = datasets.get(sourceDataset.sourceStudyId);
if (!studyDatasets) {
  studyDatasets = [];
  datasets.set(sourceDataset.sourceStudyId, studyDatasets);
}
studyDatasets.push(sourceDataset);
```

Behavior is identical (same get-or-create-and-push); the eslint-disable directive is removed.

Closes #1364

Parent epic: #1360 (sonarjs + react-hooks v7 lint cleanup)

## Verification
- `npm run lint` passes for the file (no `no-nested-assignment`).
- Code review (high effort) — no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)