### PR TITLE
fix: redundant-type-aliases in summary entities (#1365)

### DIFF
--- a/app/components/Entity/components/EntityView/components/Summary/entities.ts
+++ b/app/components/Entity/components/EntityView/components/Summary/entities.ts
@@ -1,7 +1,4 @@
-// eslint-disable-next-line sonarjs/redundant-type-aliases -- track via #1365
-type SummaryKey = string;
-
 export interface SummaryProps {
-  summary: Record<SummaryKey, number>;
-  summaryKeyValues: [SummaryKey, string][];
+  summary: Record<string, number>;
+  summaryKeyValues: [string, string][];
 }


### PR DESCRIPTION
## Summary

Resolves `sonarjs/redundant-type-aliases` in `EntityView/Summary/entities.ts` by inlining the redundant `SummaryKey = string` alias.

`SummaryKey` was a **local, non-exported** alias used in only two spots in one interface — unlike the exported domain-ID aliases in #1363 (kept intentionally), it carries no shared domain meaning, so inlining `string` is the cleaner resolution.

```ts
// before
// eslint-disable-next-line sonarjs/redundant-type-aliases -- track via #1365
type SummaryKey = string;
export interface SummaryProps {
  summary: Record<SummaryKey, number>;
  summaryKeyValues: [SummaryKey, string][];
}

// after
export interface SummaryProps {
  summary: Record<string, number>;
  summaryKeyValues: [string, string][];
}
```

No behavior change (type-only); the alias and its eslint-disable directive are removed.

Closes #1365

Parent epic: #1360 (sonarjs + react-hooks v7 lint cleanup)

## Verification
- `npm run lint` passes for the file (no `redundant-type-aliases`).
- No remaining `SummaryKey` references in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)