### PR TITLE
docs: justify redundant-type-aliases disable in updatearchived (#1366)

### DIFF
--- a/app/components/Entity/providers/archived/actions/updateArchived/entities.ts
+++ b/app/components/Entity/providers/archived/actions/updateArchived/entities.ts
@@ -5,5 +5,5 @@ export type UpdateArchivedAction = {
   type: ArchivedActionKind.UpdateArchived;
 };
 
-// eslint-disable-next-line sonarjs/redundant-type-aliases -- track via #1366
+// eslint-disable-next-line sonarjs/redundant-type-aliases -- intentional named action-payload type; kept for the Redux action convention and as a single change-point if the payload grows beyond boolean
 export type UpdateArchivedPayload = boolean;


### PR DESCRIPTION
## Summary

Resolves `sonarjs/redundant-type-aliases` in `updateArchived/entities.ts` by replacing the temporary `-- track via #1366` directive with a **permanent, justified** suppression.

`UpdateArchivedPayload = boolean` is kept intentionally: it's a **named Redux action-payload type**, used by both `UpdateArchivedAction` and the `updateArchived` action creator. The name documents intent and provides a single change-point if the payload ever grows beyond `boolean`. Inlining `boolean` — what the rule wants — would lose that, so we keep the alias with a documented suppression.

No behavior change (type-only).

Closes #1366

Parent epic: #1360 (sonarjs + react-hooks v7 lint cleanup)

## Verification
- `npm run lint` passes for the file (no `redundant-type-aliases`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)