### PR TITLE
fix: no-clear-text-protocols in backbutton utils (#1371)

### DIFF
--- a/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/utils.ts
+++ b/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/utils.ts
@@ -1,9 +1,9 @@
 import { BackOrigin } from "./constants";
 
 // Dummy base for parsing relative URLs through the URL API; never appears
-// in the output. We always return `pathname + search + hash`.
-// eslint-disable-next-line sonarjs/no-clear-text-protocols -- track via #1371
-const DUMMY_BASE = "http://x";
+// in the output (we always return `pathname + search + hash`), so the scheme
+// is irrelevant — https avoids the cleartext-protocol lint.
+const DUMMY_BASE = "https://x";
 
 /**
  * Adds a `from=<origin>` query parameter to a URL so the target view can


### PR DESCRIPTION
## Summary

Resolves `sonarjs/no-clear-text-protocols` in `BackButton/utils.ts` by switching the dummy URL-parsing base from `http://x` to `https://x`.

`DUMMY_BASE` is only a placeholder for parsing relative URLs via the `URL` API — its scheme **never appears in output** (`withBackOrigin` returns `pathname + search + hash` only). So the scheme is irrelevant to behavior, and using `https` removes the suppression entirely (the rule only flags cleartext schemes).

```ts
// before
// eslint-disable-next-line sonarjs/no-clear-text-protocols -- track via #1371
const DUMMY_BASE = "http://x";

// after
const DUMMY_BASE = "https://x";
```

No behavior change; the eslint-disable directive is removed.

Closes #1371

Parent epic: #1360 (sonarjs + react-hooks v7 lint cleanup)

## Verification
- `npm run lint` passes for the file (no `no-clear-text-protocols`).
- `back-button-utils.test.ts` — 18/18 pass (output unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)