### PR TITLE
fix: no-nested-conditional in inputcontroller (#1373)

### DIFF
--- a/app/components/common/Form/components/Controllers/components/InputController/inputController.tsx
+++ b/app/components/common/Form/components/Controllers/components/InputController/inputController.tsx
@@ -59,16 +59,7 @@ export const InputController = <
           error={invalid}
           helperText={error?.message || renderHelperText?.(formMethod.data)}
           isFilled={Boolean(field.value)}
-          label={
-            labelLink
-              ? getLabelWithLink(
-                  label,
-                  // eslint-disable-next-line sonarjs/no-nested-conditional -- track via #1373
-                  labelLink === true ? {} : labelLink,
-                  field.value,
-                )
-              : label
-          }
+          label={getInputLabel(label, labelLink, field.value)}
           readOnly={isReadOnly}
           viewBuilder={viewBuilder}
           {...inputProps}
@@ -78,6 +69,23 @@ export const InputController = <
     />
   );
 };
+
+/**
+ * Get the input label, optionally augmented with a value-derived link.
+ * @param label - Primary label.
+ * @param labelLink - Link config, `true` for defaults, or undefined for no link.
+ * @param value - Input value.
+ * @returns Input label, with a link when `labelLink` is set.
+ */
+function getInputLabel(
+  label: ReactNode,
+  labelLink: LabelLinkConfig | true | undefined,
+  value: unknown,
+): ReactNode {
+  if (!labelLink) return label;
+  const linkConfig = labelLink === true ? {} : labelLink;
+  return getLabelWithLink(label, linkConfig, value);
+}
 
 /**
  * Get input label including a link derived from the input value.


### PR DESCRIPTION
## Summary

Resolves `sonarjs/no-nested-conditional` in `InputController` by extracting the label-with-link logic (which nested `labelLink === true ? {} : labelLink` inside the outer `labelLink ? … : label` ternary) into a small typed helper.

```tsx
// before (nested ternary in JSX)
label={
  labelLink
    ? getLabelWithLink(
        label,
        // eslint-disable-next-line sonarjs/no-nested-conditional -- track via #1373
        labelLink === true ? {} : labelLink,
        field.value,
      )
    : label
}

// after
label={getInputLabel(label, labelLink, field.value)}
```

New helper (alongside the existing `getLabelWithLink` in this file):

```tsx
function getInputLabel(
  label: ReactNode,
  labelLink: LabelLinkConfig | true | undefined,
  value: unknown,
): ReactNode {
  if (!labelLink) return label;
  const linkConfig = labelLink === true ? {} : labelLink;
  return getLabelWithLink(label, linkConfig, value);
}
```

The early-return guard narrows `labelLink` so the remaining single ternary is type-safe — extracting the inner ternary to a bare statement otherwise loses the `LabelLinkConfig | true | undefined` correlation. Behavior is identical; the eslint-disable directive is removed.

Closes #1373

Parent epic: #1360 (sonarjs + react-hooks v7 lint cleanup)

## Verification
- `npm run lint` passes for the file (no `no-nested-conditional`).
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)