### PR TITLE
fix: redundant-type-aliases in viewmodelbuilders entities (#1383)

### DIFF
--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/entities.ts
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/entities.ts
@@ -30,6 +30,3 @@ export enum DISEASE {
 }
 
 export type ExtraPropsByComponentName = Map<COMPONENT_NAME, ExtraProps>;
-
-// eslint-disable-next-line sonarjs/redundant-type-aliases -- track via #1383
-export type Unused = unknown;

--- a/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.tsx
+++ b/app/viewModelBuilders/catalog/hca-atlas-tracker/common/viewModelBuilders.tsx
@@ -71,7 +71,6 @@ import {
   DISEASE,
   ExtraPropsByComponentName,
   METADATA_KEY,
-  Unused,
 } from "./entities";
 import {
   getPluralizedMetadataLabel,
@@ -1004,7 +1003,7 @@ export const buildTaskNetworks = (
  * @returns Props to be used for the RowDrawer component.
  */
 export const buildTaskRowPreview = (
-  _: Unused,
+  _: unknown,
   viewContext: ViewContext<HCAAtlasTrackerListValidationRecord>,
 ): ComponentProps<typeof C.RowDrawer<HCAAtlasTrackerListValidationRecord>> => {
   const { tableInstance } = viewContext;


### PR DESCRIPTION
## Summary

Resolves `sonarjs/redundant-type-aliases` in `viewModelBuilders/.../entities.ts` by inlining the redundant `Unused = unknown` alias.

`Unused` was used in exactly one place — the intentionally-ignored first parameter of `buildTaskRowPreview` — so it's replaced with the idiomatic `_: unknown` (the `_` name + JSDoc already convey 'unused').

```tsx
// before
// eslint-disable-next-line sonarjs/redundant-type-aliases -- track via #1383
export type Unused = unknown;
...
export const buildTaskRowPreview = (_: Unused, viewContext: ...) => { ... }

// after
export const buildTaskRowPreview = (_: unknown, viewContext: ...) => { ... }
```

The alias, its export, and the import in `viewModelBuilders.tsx` are removed. Type-only, no behavior change.

Closes #1383

Parent epic: #1360 (sonarjs + react-hooks v7 lint cleanup)

## Verification
- `npm run lint` passes (no `redundant-type-aliases`); `tsc --noEmit` clean.
- No remaining `Unused` type references (only the descriptive `@param _ - Unused.` JSDoc remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)