### PR TITLE
fix: no-nested-conditional in atlasmetadataentrysheetvalidationview alert (#1384)

### DIFF
--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.tsx
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.tsx
@@ -77,10 +77,12 @@ export const Alert = ({
 
 /**
  * Get the location detail for a validation report, preferring the cell
- * reference and falling back to the (1-based) row number.
- * @param cell - Cell reference, if any.
- * @param row - Zero-based row index, if any.
- * @returns Location detail element, or null when neither is present.
+ * reference and otherwise showing the row number. Mirrors the prior inline
+ * logic exactly: falsy `cell`/`row` (including a `row` of 0) are treated as
+ * absent.
+ * @param cell - Cell reference, shown when truthy.
+ * @param row - Row index, shown (as `row + 1`) when truthy.
+ * @returns Location detail element, or null when neither is set.
  */
 function getCellOrRowDetail(
   cell: string | null,

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.tsx
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert.tsx
@@ -70,18 +70,35 @@ export const Alert = ({
           <Typography noWrap>{message}</Typography>
         </Tooltip>
       </Fragment>
-      {cell ? (
-        <Fragment>
-          <StyledDot />
-          <code>{cell}</code>
-        </Fragment>
-      ) : // eslint-disable-next-line sonarjs/no-nested-conditional -- track via #1384
-      row ? (
-        <Fragment>
-          <StyledDot />
-          <code>row {row + 1}</code>
-        </Fragment>
-      ) : null}
+      {getCellOrRowDetail(cell, row)}
     </StyledAlert>
   );
 };
+
+/**
+ * Get the location detail for a validation report, preferring the cell
+ * reference and falling back to the (1-based) row number.
+ * @param cell - Cell reference, if any.
+ * @param row - Zero-based row index, if any.
+ * @returns Location detail element, or null when neither is present.
+ */
+function getCellOrRowDetail(
+  cell: string | null,
+  row: number | null,
+): JSX.Element | null {
+  if (cell)
+    return (
+      <Fragment>
+        <StyledDot />
+        <code>{cell}</code>
+      </Fragment>
+    );
+  if (row)
+    return (
+      <Fragment>
+        <StyledDot />
+        <code>row {row + 1}</code>
+      </Fragment>
+    );
+  return null;
+}


### PR DESCRIPTION
## Summary

Resolves `sonarjs/no-nested-conditional` in the validation-report `Alert` by extracting the nested `cell ? … : (row ? … : null)` ternary into a small render helper.

```tsx
// before (nested ternary in JSX)
{cell ? (
  <Fragment><StyledDot /><code>{cell}</code></Fragment>
) : // eslint-disable-next-line sonarjs/no-nested-conditional -- track via #1384
row ? (
  <Fragment><StyledDot /><code>row {row + 1}</code></Fragment>
) : null}

// after
{getCellOrRowDetail(cell, row)}
```

New helper (module-level, like the existing pattern in these components):

```tsx
function getCellOrRowDetail(cell: string | null, row: number | null): JSX.Element | null {
  if (cell) return <Fragment><StyledDot /><code>{cell}</code></Fragment>;
  if (row) return <Fragment><StyledDot /><code>row {row + 1}</code></Fragment>;
  return null;
}
```

Behavior is identical, including the edge cases: `cell` is `string | null` and `row` is `number | null`, so a naive `&&` rewrite would render a literal `0` when `row === 0` — the explicit `if` guards preserve the original `row ? … : null` semantics (`row === 0` and `cell === ""` behave exactly as before). The eslint-disable directive is removed.

Closes #1384

Parent epic: #1360 (sonarjs + react-hooks v7 lint cleanup)

## Verification
- `npm run lint` passes for the file (no `no-nested-conditional`); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)