### PR TITLE
feat: bump findable-ui to 55.0.0 for login mobile ux (#1437)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@aws-sdk/client-batch": "^3.896.0",
         "@aws-sdk/client-s3": "^3.896.0",
         "@aws-sdk/s3-request-presigner": "^3.896.0",
-        "@databiosphere/findable-ui": "^54.1.0",
+        "@databiosphere/findable-ui": "^55.0.0",
         "@emotion/react": "^11",
         "@emotion/server": "^11",
         "@emotion/styled": "^11",
@@ -1606,9 +1606,9 @@
       }
     },
     "node_modules/@databiosphere/findable-ui": {
-      "version": "54.1.0",
-      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-54.1.0.tgz",
-      "integrity": "sha512-zN1hqsrPHc5gT6orAVUDWw7clGua5lISA/r3dkK2oyCL+XfIUqTh4TiTamHuK77NbJKraW7XRFejViY1imzP/w==",
+      "version": "55.0.0",
+      "resolved": "https://registry.npmjs.org/@databiosphere/findable-ui/-/findable-ui-55.0.0.tgz",
+      "integrity": "sha512-BkzNX1R76mdY8hvdLGFaDNhi1+H7iq7PwRnGNqTYH82YaRBmQOWPozojkLqsesu8Nlg9JL6V+59cqFX1941iuQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": "22.13.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@aws-sdk/client-batch": "^3.896.0",
     "@aws-sdk/client-s3": "^3.896.0",
     "@aws-sdk/s3-request-presigner": "^3.896.0",
-    "@databiosphere/findable-ui": "^54.1.0",
+    "@databiosphere/findable-ui": "^55.0.0",
     "@emotion/react": "^11",
     "@emotion/server": "^11",
     "@emotion/styled": "^11",


### PR DESCRIPTION
## Summary

Bumps `@databiosphere/findable-ui` `^54.1.0` → `^55.0.0`, which brings in the login page mobile-UX changes (findable-ui [#965](https://github.com/DataBiosphere/findable-ui/pull/965) / #964): a larger privacy-policy checkbox tap target and a sign-in button loading indicator. The tracker consumes these purely via the version bump — no tracker code changes.

Closes #1437

### Testing

- `npm run build:local` — succeeds
- `npm test` — 1173/1173 pass

### Note

The pre-existing `next-auth@4` / React 19 peer-dependency conflict is unrelated and unaffected by this bump — it only surfaces under `npm audit fix` (a clean resolution needs next-auth 5, still in beta; see DataBiosphere/findable-ui#943). Install, build, and tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
