### PR TITLE
fix: status page: metric card progress bar is empty when valid count is 0 (#1442)

### DIFF
--- a/__tests__/atlas-status-dashboard.test.tsx
+++ b/__tests__/atlas-status-dashboard.test.tsx
@@ -319,6 +319,20 @@ describe("StatusDashboard", () => {
       expect(progress).toBeCloseTo(((56 - 9) / 56) * 100);
       expect(progress).toBeGreaterThan(0);
     });
+
+    it("is empty when nothing has been validated (0 valid, 0 invalid)", () => {
+      const summary: AtlasStatusSummary = {
+        ...SUMMARY,
+        sourceDatasets: {
+          ...SUMMARY.sourceDatasets,
+          tier1Invalid: 0,
+          tier1Valid: 0,
+          total: 2,
+        },
+      };
+      // All pending → 0, not (2 - 0) / 2 = 100%.
+      expect(buildSourceDatasetsCard(summary).progress).toBe(0);
+    });
   });
 
   // The integrated objects progress bar fill is (total - invalid) / total, where

--- a/__tests__/atlas-status-dashboard.test.tsx
+++ b/__tests__/atlas-status-dashboard.test.tsx
@@ -13,6 +13,7 @@ import {
 import {
   buildIntegratedObjectsCard,
   buildSourceDatasetsCard,
+  buildSourceStudiesCard,
   getCapStatus,
   getMinValidBadge,
   getValidationStatus,
@@ -358,6 +359,39 @@ describe("StatusDashboard", () => {
       };
       // sectionValids = [3, 0, 0] → invalid 3 → (3 - 3) / 3 = 0.
       expect(buildIntegratedObjectsCard(summary).progress).toBe(0);
+    });
+
+    it("clamps to 0 and caps the badge count for inconsistent data (capInvalid > total)", () => {
+      const summary: AtlasStatusSummary = {
+        ...SUMMARY,
+        integratedObjects: {
+          ...SUMMARY.integratedObjects,
+          capInvalid: 6,
+          cellAnnotationValid: 0,
+          tier1Valid: 0,
+          total: 4,
+        },
+      };
+      const card = buildIntegratedObjectsCard(summary);
+      // fullyValid clamps to 0 → progress 0 (not negative), badge invalid capped
+      // at total (4), never "6 invalid".
+      expect(card.progress).toBe(0);
+      expect(card.badge?.label).toBe("4 invalid");
+    });
+  });
+
+  // Source studies progress fill is (total - unpublished) / total, matching the
+  // "N unpublished" badge.
+  describe("source studies progress bar", () => {
+    it("derives progress from total - unpublished", () => {
+      // total 9, unpublished 6 → (9 - 6) / 9.
+      expect(buildSourceStudiesCard(SUMMARY).progress).toBeCloseTo(
+        ((9 - 6) / 9) * 100,
+      );
+    });
+
+    it("is 0 when there are no studies", () => {
+      expect(buildSourceStudiesCard(ZERO_SUMMARY).progress).toBe(0);
     });
   });
 });

--- a/__tests__/atlas-status-dashboard.test.tsx
+++ b/__tests__/atlas-status-dashboard.test.tsx
@@ -12,6 +12,7 @@ import {
 } from "../app/views/AtlasStatusView/components/StatusDashboard/types";
 import {
   buildIntegratedObjectsCard,
+  buildSourceDatasetsCard,
   getCapStatus,
   getMinValidBadge,
   getValidationStatus,
@@ -235,31 +236,31 @@ describe("StatusDashboard", () => {
   // smallest per-section valid (an object must pass every section to be valid),
   // shown red only when there are known invalids, amber when only pending.
   describe("getMinValidBadge", () => {
-    it("is red with the shortfall when there are known invalids", () => {
-      // total 5, smallest valid 1 → 4 short, and there are known invalids.
-      expect(getMinValidBadge(5, [4, 2, 1], 3, "empty")).toEqual({
+    it("is red with the invalid count when there are known invalids", () => {
+      // total 5, 4 not-fully-valid, and there are known invalids.
+      expect(getMinValidBadge(5, 4, 3, "empty")).toEqual({
         label: "4 invalid",
         variant: BADGE_VARIANT.ERROR,
       });
     });
 
     it("is amber (pending) when the shortfall is only unvalidated sections", () => {
-      // total 5, a section is unvalidated (valid 0) but nothing has failed.
-      expect(getMinValidBadge(5, [5, 0, 0], 0, "empty")).toEqual({
+      // total 5, 5 not-fully-valid but nothing has failed.
+      expect(getMinValidBadge(5, 5, 0, "empty")).toEqual({
         label: "5 pending",
         variant: BADGE_VARIANT.CAUTION,
       });
     });
 
-    it("is green when every section is fully valid", () => {
-      expect(getMinValidBadge(5, [5, 5, 5], 0, "empty")).toEqual({
+    it("is green when every item is fully valid", () => {
+      expect(getMinValidBadge(5, 0, 0, "empty")).toEqual({
         label: "5 valid",
         variant: BADGE_VARIANT.SUCCESS,
       });
     });
 
     it("uses the neutral empty label when the column is empty", () => {
-      expect(getMinValidBadge(0, [0, 0, 0], 0, "empty")).toEqual({
+      expect(getMinValidBadge(0, 0, 0, "empty")).toEqual({
         label: "empty",
         variant: BADGE_VARIANT.DEFAULT,
       });
@@ -290,6 +291,59 @@ describe("StatusDashboard", () => {
       );
       expect(invalidRows.length).toBeGreaterThan(0);
       for (const row of invalidRows) expect(row.highlight).toBe(false);
+    });
+  });
+
+  // The source datasets progress bar fill is (total - invalid) / total, matching
+  // the "N invalid" badge — so pending datasets (not yet valid) still fill it.
+  describe("source datasets progress bar", () => {
+    it("derives progress from total - invalid", () => {
+      // total 62, tier1Invalid 3 → (62 - 3) / 62.
+      expect(buildSourceDatasetsCard(SUMMARY).progress).toBeCloseTo(
+        ((62 - 3) / 62) * 100,
+      );
+    });
+
+    it("fills even when valid is 0 but not everything is invalid", () => {
+      const summary: AtlasStatusSummary = {
+        ...SUMMARY,
+        sourceDatasets: {
+          ...SUMMARY.sourceDatasets,
+          tier1Invalid: 9,
+          tier1Valid: 0,
+          total: 56,
+        },
+      };
+      const { progress } = buildSourceDatasetsCard(summary);
+      // (56 - 9) / 56 ≈ 83.9%, not 0.
+      expect(progress).toBeCloseTo(((56 - 9) / 56) * 100);
+      expect(progress).toBeGreaterThan(0);
+    });
+  });
+
+  // The integrated objects progress bar fill is (total - invalid) / total, where
+  // invalid is the same not-fully-valid count shown in the badge.
+  describe("integrated objects progress bar", () => {
+    it("derives progress from total - invalid (smallest section valid)", () => {
+      // total 4, smallest section valid 2 (Cell Annotation) → invalid 2 → (4-2)/4.
+      expect(buildIntegratedObjectsCard(SUMMARY).progress).toBeCloseTo(
+        ((4 - 2) / 4) * 100,
+      );
+    });
+
+    it("is 0 when the smallest section valid is 0", () => {
+      const summary: AtlasStatusSummary = {
+        ...SUMMARY,
+        integratedObjects: {
+          ...SUMMARY.integratedObjects,
+          capInvalid: 0,
+          cellAnnotationValid: 0,
+          tier1Valid: 0,
+          total: 3,
+        },
+      };
+      // sectionValids = [3, 0, 0] → invalid 3 → (3 - 3) / 3 = 0.
+      expect(buildIntegratedObjectsCard(summary).progress).toBe(0);
     });
   });
 });

--- a/app/views/AtlasStatusView/components/StatusDashboard/utils.ts
+++ b/app/views/AtlasStatusView/components/StatusDashboard/utils.ts
@@ -72,18 +72,16 @@ export function buildIntegratedObjectsCard(
 ): MetricCardModel {
   const { integratedObjects } = summary;
   // An integrated object must pass every section to be valid, so the fully valid
-  // count is bounded by the weakest section: the smallest valid across CAP
-  // (total - capInvalid), Tier-1, and Cell Annotation. `invalid` = total minus
-  // that, and the badge and progress bar share this one count.
+  // count is the smallest valid across CAP (total - capInvalid), Tier-1, and Cell
+  // Annotation, clamped to 0..total (guarding against inconsistent counts). The
+  // badge and progress bar share it: invalid = total - fullyValid.
   const sectionValids = [
     integratedObjects.total - integratedObjects.capInvalid,
     integratedObjects.tier1Valid,
     integratedObjects.cellAnnotationValid,
   ];
-  const invalid = Math.max(
-    0,
-    integratedObjects.total - Math.min(...sectionValids),
-  );
+  const fullyValid = Math.max(0, Math.min(...sectionValids));
+  const invalid = integratedObjects.total - fullyValid;
   return {
     badge: getMinValidBadge(
       integratedObjects.total,
@@ -93,12 +91,9 @@ export function buildIntegratedObjectsCard(
         integratedObjects.cellAnnotationInvalid,
       "0 valid integrated objects",
     ),
-    // Fill = (total - invalid) / total, matching the badge below it (so the
-    // unfilled portion is invalid / total).
-    progress: getProgress(
-      integratedObjects.total - invalid,
-      integratedObjects.total,
-    ),
+    // Fill = fully-valid / total (= (total - invalid) / total), matching the
+    // badge below it (so the unfilled portion is invalid / total).
+    progress: getProgress(fullyValid, integratedObjects.total),
     sections: [
       // All integrated objects are required for CAP, so there is no "Required"
       // row here (required = total).
@@ -351,14 +346,16 @@ export function getMinValidBadge(
 }
 
 /**
- * Returns the progress percentage (0-100) for a numerator over a total.
+ * Returns the progress percentage clamped to 0-100 for a numerator over a total.
+ * Clamping guards against inconsistent summary counts (e.g. an invalid count
+ * exceeding the total) producing an out-of-range value for the progress bar.
  * @param numerator - Subset count.
  * @param total - Total count.
  * @returns percentage between 0 and 100.
  */
 function getProgress(numerator: number, total: number): number {
   if (total === 0) return 0;
-  return (numerator / total) * 100;
+  return Math.max(0, Math.min(100, (numerator / total) * 100));
 }
 
 /**

--- a/app/views/AtlasStatusView/components/StatusDashboard/utils.ts
+++ b/app/views/AtlasStatusView/components/StatusDashboard/utils.ts
@@ -73,24 +73,32 @@ export function buildIntegratedObjectsCard(
   const { integratedObjects } = summary;
   // An integrated object must pass every section to be valid, so the fully valid
   // count is bounded by the weakest section: the smallest valid across CAP
-  // (total - capInvalid), Tier-1, and Cell Annotation. invalid = total - this.
+  // (total - capInvalid), Tier-1, and Cell Annotation. `invalid` = total minus
+  // that, and the badge and progress bar share this one count.
   const sectionValids = [
     integratedObjects.total - integratedObjects.capInvalid,
     integratedObjects.tier1Valid,
     integratedObjects.cellAnnotationValid,
   ];
-  const fullyValid = Math.max(0, Math.min(...sectionValids));
+  const invalid = Math.max(
+    0,
+    integratedObjects.total - Math.min(...sectionValids),
+  );
   return {
     badge: getMinValidBadge(
       integratedObjects.total,
-      sectionValids,
+      invalid,
       integratedObjects.capInvalid +
         integratedObjects.tier1Invalid +
         integratedObjects.cellAnnotationInvalid,
       "0 valid integrated objects",
     ),
-    // Fill reflects fully-valid / total, so the unfilled portion is invalid / total.
-    progress: getProgress(fullyValid, integratedObjects.total),
+    // Fill = (total - invalid) / total, matching the badge below it (so the
+    // unfilled portion is invalid / total).
+    progress: getProgress(
+      integratedObjects.total - invalid,
+      integratedObjects.total,
+    ),
     sections: [
       // All integrated objects are required for CAP, so there is no "Required"
       // row here (required = total).
@@ -129,19 +137,17 @@ export function buildSourceDatasetsCard(
     0,
     sourceDatasets.total - sourceDatasets.original - sourceDatasets.reprocessed,
   );
+  // Source datasets validate Tier-1 only, so invalid is the Tier-1 invalid count
+  // — shared by the badge and the progress bar.
+  const invalid = sourceDatasets.tier1Invalid;
   return {
-    // Source datasets validate Tier-1 only, so the badge rolls up that single
-    // dimension.
     badge: getColumnBadge(
-      [
-        {
-          invalid: sourceDatasets.tier1Invalid,
-          valid: sourceDatasets.tier1Valid,
-        },
-      ],
+      [{ invalid, valid: sourceDatasets.tier1Valid }],
       "0 valid source datasets",
     ),
-    progress: getProgress(sourceDatasets.tier1Valid, sourceDatasets.total),
+    // Fill = (total - invalid) / total so the bar matches the "N invalid" badge
+    // below it (pending datasets count towards the bar, not against it).
+    progress: getProgress(sourceDatasets.total - invalid, sourceDatasets.total),
     sections: [
       {
         heading: SECTION_HEADING.PROCESSING,
@@ -202,8 +208,12 @@ export function buildSourceStudiesCard(
       sourceStudies.published,
       sourceStudies.unpublished,
     ),
-    // Progress reflects the published proportion of the total.
-    progress: getProgress(sourceStudies.published, sourceStudies.total),
+    // Fill = (total - invalid) / total so the bar matches the "N unpublished"
+    // badge below it, consistent with the other cards.
+    progress: getProgress(
+      sourceStudies.total - sourceStudies.unpublished,
+      sourceStudies.total,
+    ),
     sections: [
       {
         heading: SECTION_HEADING.PUBLICATION_STATUS,
@@ -306,35 +316,33 @@ function getColumnBadge(
 
 /**
  * Returns the column badge for a column whose sections all validate the full
- * population (e.g. integrated objects). An item must pass every section to be
- * valid, so the not-fully-valid count is bounded by the smallest per-section
- * valid count (`total - min`). The chip is: neutral when the column is empty,
- * green when every item is fully valid, red ("N invalid") when there are known
- * failures, and amber ("N pending") when the shortfall is only due to sections
- * that haven't been validated yet (no known invalids).
+ * population (e.g. integrated objects). `invalid` is the not-fully-valid count
+ * (total minus the smallest per-section valid — an item must pass every section
+ * to be valid). The chip is: neutral when the column is empty, green when every
+ * item is fully valid, red ("N invalid") when there are known failures, and
+ * amber ("N pending") when the shortfall is only sections not yet validated.
  * @param total - Total item count.
- * @param sectionValids - Valid count per section.
+ * @param invalid - Not-fully-valid count (total - smallest per-section valid).
  * @param invalidTotal - Combined known-invalid count across sections.
  * @param emptyLabel - Label for the neutral (empty column) chip.
  * @returns column badge model.
  */
 export function getMinValidBadge(
   total: number,
-  sectionValids: number[],
+  invalid: number,
   invalidTotal: number,
   emptyLabel: string,
 ): MetricBadgeModel {
   if (total === 0) {
     return { label: emptyLabel, variant: BADGE_VARIANT.DEFAULT };
   }
-  const notValid = Math.max(0, total - Math.min(...sectionValids));
-  if (notValid === 0) {
+  if (invalid === 0) {
     return { label: `${total} valid`, variant: BADGE_VARIANT.SUCCESS };
   }
   if (invalidTotal > 0) {
-    return { label: `${notValid} invalid`, variant: BADGE_VARIANT.ERROR };
+    return { label: `${invalid} invalid`, variant: BADGE_VARIANT.ERROR };
   }
-  return { label: `${notValid} pending`, variant: BADGE_VARIANT.CAUTION };
+  return { label: `${invalid} pending`, variant: BADGE_VARIANT.CAUTION };
 }
 
 /**

--- a/app/views/AtlasStatusView/components/StatusDashboard/utils.ts
+++ b/app/views/AtlasStatusView/components/StatusDashboard/utils.ts
@@ -145,9 +145,14 @@ export function buildSourceDatasetsCard(
       [{ invalid, valid: sourceDatasets.tier1Valid }],
       "0 valid source datasets",
     ),
-    // Fill = (total - invalid) / total so the bar matches the "N invalid" badge
-    // below it (pending datasets count towards the bar, not against it).
-    progress: getProgress(sourceDatasets.total - invalid, sourceDatasets.total),
+    // Fill = (total - invalid) / total to match the "N invalid" badge below it
+    // (pending datasets count towards the bar). But when nothing has been
+    // validated yet (no valid and no invalid), show an empty bar rather than a
+    // full one.
+    progress:
+      sourceDatasets.tier1Valid + invalid === 0
+        ? 0
+        : getProgress(sourceDatasets.total - invalid, sourceDatasets.total),
     sections: [
       {
         heading: SECTION_HEADING.PROCESSING,

--- a/app/views/AtlasStatusView/components/StatusDashboard/utils.ts
+++ b/app/views/AtlasStatusView/components/StatusDashboard/utils.ts
@@ -80,7 +80,10 @@ export function buildIntegratedObjectsCard(
     integratedObjects.tier1Valid,
     integratedObjects.cellAnnotationValid,
   ];
-  const fullyValid = Math.max(0, Math.min(...sectionValids));
+  const fullyValid = Math.max(
+    0,
+    Math.min(integratedObjects.total, ...sectionValids),
+  );
   const invalid = integratedObjects.total - fullyValid;
   return {
     badge: getMinValidBadge(


### PR DESCRIPTION
## Summary

On the atlas **Status** page, the metric-card progress bar rendered **empty** for Source Datasets and Integrated Objects when the valid count was `0` (all invalid, or pending/unvalidated), even though the cards had data. It now fills to **`(total − invalid) / total`**, where `invalid` is the count shown in the badge below the bar — so the unfilled portion mirrors the chip, and pending items still register as progress.

Closes #1442

### Changes

- **Source Datasets:** fill = `(total − tier1Invalid) / total` (was `tier1Valid / total`, which showed 0% whenever nothing had passed Tier-1 yet). The invalid count is shared between the badge and the bar.
- **Integrated Objects:** fill = `(total − invalid) / total`, where `invalid = total − smallest per-section valid` — the same count fed to the badge (refactored so badge and bar can't drift). An all-invalid column is correctly 0%.
- **Source Studies:** fill = `(total − unpublished) / total` (was `published / total`). Equivalent today, but expresses the same rule as the other cards and is robust if a third study state is ever added.

All three cards now express one uniform rule: `getProgress(total − invalid, total)`.

### Testing

- `npm test -- atlas-status-dashboard` — 30/30 pass (added Source Datasets and Integrated Objects progress regression tests, incl. valid 0 / invalid 9 / total 56 → ~84% fill).
- `npm run build:local`, lint, prettier — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
