### PR TITLE
feat: restrict randomness in test data generators to two utility functions (#1385, #1386)

### DIFF
--- a/db_scripts/generate-test-files.ts
+++ b/db_scripts/generate-test-files.ts
@@ -39,6 +39,7 @@ import { createComponentAtlas } from "../app/services/component-atlases";
 import { getOrCreateConceptId } from "../app/services/concepts";
 import { doTransaction, endPgPool } from "../app/services/database";
 import { createSourceDataset } from "../app/services/source-datasets";
+import { randomTestValueInRange } from "./utils";
 
 /**
  * Usage: `npx tsx db_scripts/generate-test-files.ts`
@@ -239,17 +240,17 @@ async function generateAndAddFilesForAtlas(
   client: pg.PoolClient,
   atlas: HCAAtlasTrackerDBAtlas,
 ): Promise<[number, number]> {
-  const integratedObjectAmount = randomInRange(
+  const integratedObjectAmount = randomTestValueInRange(
     GENERATED_INTEGRATED_OBJECT_AMOUNT_MIN,
     GENERATED_INTEGRATED_OBJECT_AMOUNT_MAX,
   );
-  const sourceDatasetAmount = randomInRange(
+  const sourceDatasetAmount = randomTestValueInRange(
     GENERATED_SOURCE_DATASET_AMOUNT_MIN,
     GENERATED_SOURCE_DATASET_AMOUNT_MAX,
   );
 
-  const bucketName = `test-${randomInRange(0, 99999)}`;
-  const versioned = Boolean(randomInRange(0, 1));
+  const bucketName = `test-${randomTestValueInRange(0, 99999)}`;
+  const versioned = Boolean(randomTestValueInRange(0, 1));
 
   // Generate integrated object files linked to component atlases
   for (let i = 0; i < integratedObjectAmount; i++) {
@@ -290,7 +291,7 @@ async function generateAndAddVersionsForFile(
     throw new Error(`Missing concept ID for file ${file.id}`);
   const conceptId = file.concept_id;
 
-  const numVersions = randomInRange(
+  const numVersions = randomTestValueInRange(
     GENERATED_FILE_VERSION_AMOUNT_MIN,
     GENERATED_FILE_VERSION_AMOUNT_MAX,
   );
@@ -427,12 +428,14 @@ async function generateAndAddFileVersion(
   conceptId: string,
 ): Promise<string> {
   const versionId = versioned
-    ? randomInRange(0, 999999).toString().padStart(6, "0")
+    ? randomTestValueInRange(0, 999999).toString().padStart(6, "0")
     : null;
   const eTag = crypto.randomUUID().replaceAll("-", "");
   const eventInfo: FileEventInfo = {
     eventName: "ObjectCreated:*",
-    eventTime: new Date(randomInRange(1755755554042, Date.now())).toISOString(),
+    eventTime: new Date(
+      randomTestValueInRange(1755755554042, Date.now()),
+    ).toISOString(),
   };
   const snsMessageId = crypto.randomUUID();
 
@@ -446,7 +449,7 @@ async function generateAndAddFileVersion(
       integrityStatus: INTEGRITY_STATUS.PENDING,
       key,
       sha256Client: null,
-      sizeBytes: randomInRange(1e3, 1e12),
+      sizeBytes: randomTestValueInRange(1e3, 1e12),
       snsMessageId,
       validationStatus: FILE_VALIDATION_STATUS.PENDING,
       versionId,
@@ -469,11 +472,11 @@ async function generateAndAddAtlas(client: pg.PoolClient): Promise<string> {
   const network = chooseRandom(networkOptions);
   // Create a random sequence of letters to name the atlas with
   const shortNameDiscriminator = Array.from({ length: 5 }, () =>
-    String.fromCodePoint(65 + randomInRange(0, 25)),
+    String.fromCodePoint(65 + randomTestValueInRange(0, 25)),
   ).join("");
   const shortName = `Files Test ${shortNameDiscriminator}`;
-  const generation = randomInRange(0, 9);
-  const revision = randomInRange(0, 9);
+  const generation = randomTestValueInRange(0, 9);
+  const revision = randomTestValueInRange(0, 9);
   const wave = chooseRandom(waveOptions);
   const status = chooseRandom(atlasStatusOptions);
   const integrationLead = chooseRandom(integrationLeadOptions);
@@ -499,10 +502,5 @@ async function generateAndAddAtlas(client: pg.PoolClient): Promise<string> {
 }
 
 function chooseRandom<T>(arr: T[]): T {
-  return arr[randomInRange(0, arr.length - 1)];
-}
-
-function randomInRange(min: number, max: number): number {
-  // eslint-disable-next-line sonarjs/pseudo-random -- track via #1385
-  return min + Math.floor(Math.random() * (max - min + 1));
+  return arr[randomTestValueInRange(0, arr.length - 1)];
 }

--- a/db_scripts/generate-test-validation-results.ts
+++ b/db_scripts/generate-test-validation-results.ts
@@ -23,6 +23,7 @@ import { addValidationResultsToFile } from "../app/data/files";
 import { doTransaction, endPgPool } from "../app/services/database";
 import { toolReportsToValidationReportsAndSummary } from "../app/services/validation-results-notification";
 import dataDictionary from "../catalog/downloaded/data-dictionary.json";
+import { randomTestProbabilityPasses, randomTestValueInRange } from "./utils";
 
 /**
  * Usage: `npx tsx db_scripts/generate-test-validation-results.ts <keyword/flag ...>`
@@ -115,8 +116,6 @@ const PROBABILITY_DEFS = [
     id: PROBABILITY.TOOL_VALID,
   },
 ];
-
-// (Below use uninclusive max)
 
 const MIN_METADATA_RECORD_COUNT = 100;
 const MAX_METADATA_RECORD_COUNT = 1000;
@@ -281,15 +280,9 @@ function getSuccessfulValidationFields(
   return {
     datasetInfo: {
       assay: generateArray("assay"),
-      cellCount:
-        // eslint-disable-next-line sonarjs/pseudo-random -- track via #1386
-        Math.floor(Math.random() * (MAX_CELL_COUNT - MIN_CELL_COUNT)) +
-        MIN_CELL_COUNT,
+      cellCount: randomTestValueInRange(MIN_CELL_COUNT, MAX_CELL_COUNT),
       disease: generateArray("disease"),
-      geneCount:
-        // eslint-disable-next-line sonarjs/pseudo-random -- track via #1386
-        Math.floor(Math.random() * (MAX_GENE_COUNT - MIN_GENE_COUNT)) +
-        MIN_GENE_COUNT,
+      geneCount: randomTestValueInRange(MIN_GENE_COUNT, MAX_GENE_COUNT),
       suspensionType: generateArray("suspension-type"),
       tissue: generateArray("tissue"),
       title: `Test ${(key && key.split("/").pop()) || fileId}`,
@@ -329,12 +322,11 @@ function makeMetadataCoverage(): FileMetadataCoverage {
 
       const completeCount = fieldAllComplete
         ? recordCount
-        : // eslint-disable-next-line sonarjs/pseudo-random -- track via #1386
-          Math.floor(Math.random() * (recordCount + 1));
+        : randomTestValueInRange(0, recordCount);
 
-      const missingCount = Math.floor(
-        // eslint-disable-next-line sonarjs/pseudo-random -- track via #1386
-        Math.random() * (recordCount - completeCount + 1),
+      const missingCount = randomTestValueInRange(
+        0,
+        recordCount - completeCount,
       );
 
       fieldCoverage.push({
@@ -356,12 +348,10 @@ function makeMetadataCoverage(): FileMetadataCoverage {
 
   function generateEntity(): FileMetadataCoverageEntity {
     return {
-      recordCount:
-        Math.floor(
-          // eslint-disable-next-line sonarjs/pseudo-random -- track via #1386
-          Math.random() *
-            (MAX_METADATA_RECORD_COUNT - MIN_METADATA_RECORD_COUNT),
-        ) + MIN_METADATA_RECORD_COUNT,
+      recordCount: randomTestValueInRange(
+        MIN_METADATA_RECORD_COUNT,
+        MAX_METADATA_RECORD_COUNT,
+      ),
     };
   }
 }
@@ -398,11 +388,9 @@ function generateToolReport(forceValid: boolean): DatasetValidatorToolReport {
   const errors = valid
     ? []
     : generateArrayVia((l) => `Error ${l.toUpperCase()}`);
-  const warnings =
-    // eslint-disable-next-line sonarjs/pseudo-random -- track via #1386
-    Math.random() < 0.5
-      ? []
-      : generateArrayVia((l) => `Warning ${l.toUpperCase()}`);
+  const warnings = randomTestProbabilityPasses(0.5)
+    ? []
+    : generateArrayVia((l) => `Warning ${l.toUpperCase()}`);
   const timestamp = new Date().toISOString();
   return {
     errors,
@@ -424,9 +412,7 @@ function generateArrayVia(
 ): string[] {
   let prevLetters = Array.from(LETTERS);
   let lettersLeft = prevLetters.slice();
-  const amount =
-    // eslint-disable-next-line sonarjs/pseudo-random -- track via #1386
-    Math.floor(Math.random() * (maxLength - minLength)) + minLength;
+  const amount = randomTestValueInRange(minLength, maxLength);
   const result: string[] = [];
   for (let i = 0; i < amount; i++) {
     if (lettersLeft.length === 0) {
@@ -435,8 +421,7 @@ function generateArrayVia(
         .flat();
       lettersLeft = prevLetters.slice();
     }
-    // eslint-disable-next-line sonarjs/pseudo-random -- track via #1386
-    const j = Math.floor(Math.random() * lettersLeft.length);
+    const j = randomTestValueInRange(0, lettersLeft.length - 1);
     result.push(makeItem(lettersLeft[j]));
     lettersLeft.splice(j, 1);
   }
@@ -597,8 +582,7 @@ function probabilityPasses(probability: PROBABILITY): boolean {
   const defaultValue = probabilityDefaults[probability];
   if (defaultValue === undefined)
     throw new Error(`No definition found for ${probability} probability`);
-  // eslint-disable-next-line sonarjs/pseudo-random -- track via #1386
-  return Math.random() < defaultValue;
+  return randomTestProbabilityPasses(defaultValue);
 }
 
 function isFlagParam(param: string): boolean {

--- a/db_scripts/utils.ts
+++ b/db_scripts/utils.ts
@@ -1,0 +1,20 @@
+/**
+ * Get a boolean that is randomly true according the given probability, to be used to generate data for manual testing.
+ * @param probability - Probability (0 to 1) to check against.
+ * @returns boolean to use for test data, corresponding to the provided probability.
+ */
+export function randomTestProbabilityPasses(probability: number): boolean {
+  // eslint-disable-next-line sonarjs/pseudo-random -- Used only for persistent test data.
+  return Math.random() < probability;
+}
+
+/**
+ * Get a random integer in the given range, to be used to generate data for manual testing.
+ * @param min - Inclusive minimum value.
+ * @param max - Inclusive maximum value.
+ * @returns random integer for test data.
+ */
+export function randomTestValueInRange(min: number, max: number): number {
+  // eslint-disable-next-line sonarjs/pseudo-random -- Used only for persistent test data.
+  return min + Math.floor(Math.random() * (max - min + 1));
+}

--- a/db_scripts/utils.ts
+++ b/db_scripts/utils.ts
@@ -1,5 +1,5 @@
 /**
- * Get a boolean that is randomly true according the given probability, to be used to generate data for manual testing.
+ * Get a boolean that is randomly true according to the given probability, to be used to generate data for manual testing.
  * @param probability - Probability (0 to 1) to check against.
  * @returns boolean to use for test data, corresponding to the provided probability.
  */


### PR DESCRIPTION
Closes #1385
Closes #1386

Resolves the `sonarjs/pseudo-random` linting errors by disabling the rule only for two clearly-marked test-data-specific utility functions

Due to how the `randomTestValueInRange` function works, certain constant ranges now use an inclusive maximum rather than exclusive, which is fine because the exact maximum values don't really matter, and I think it's good to keep things simple. Places where inclusive vs. exclusive matters *are* updated