### PR TITLE
refactor: resolve `sonarjs/no-nested-conditional` errors (#1447)

### DIFF
--- a/app/components/Forms/components/CellxGeneInProgress/cellxgeneInProgress.tsx
+++ b/app/components/Forms/components/CellxGeneInProgress/cellxgeneInProgress.tsx
@@ -74,12 +74,7 @@ export const CellxGeneInProgressForm = (): JSX.Element => {
       {responseErrors || updateResult ? (
         <>
           <h2>Result</h2>
-          {responseErrors
-            ? buildResponseErrors(responseErrors)
-            : // eslint-disable-next-line sonarjs/no-nested-conditional -- track via #1367
-              updateResult
-              ? buildUpdateResult(updateResult)
-              : ""}
+          {buildResult(responseErrors, updateResult)}
         </>
       ) : (
         ""
@@ -87,6 +82,15 @@ export const CellxGeneInProgressForm = (): JSX.Element => {
     </>
   );
 };
+
+function buildResult(
+  responseErrors: FormResponseErrors | undefined,
+  updateResult: TaskStatusesUpdatedByDOIResult | undefined,
+): JSX.Element | string {
+  if (responseErrors) return buildResponseErrors(responseErrors);
+  if (updateResult) return buildUpdateResult(updateResult);
+  return "";
+}
 
 function buildResponseErrors(responseErrors: FormResponseErrors): JSX.Element {
   return "message" in responseErrors ? (

--- a/app/components/Forms/components/IntegrationLeadsFromAtlases/integrationLeadsFromAtlases.tsx
+++ b/app/components/Forms/components/IntegrationLeadsFromAtlases/integrationLeadsFromAtlases.tsx
@@ -53,12 +53,7 @@ export const IntegrationLeadsFromAtlasesForm = (): JSX.Element => {
       </div>
       {responseErrors || didUpdate ? (
         <div style={{ marginTop: "1em" }}>
-          {responseErrors
-            ? buildResponseErrors(responseErrors)
-            : // eslint-disable-next-line sonarjs/no-nested-conditional -- track via #1368
-              didUpdate
-              ? "Updated"
-              : ""}
+          {responseErrors ? buildResponseErrors(responseErrors) : "Updated"}
         </div>
       ) : (
         ""

--- a/app/components/Forms/components/Refresh/refresh.tsx
+++ b/app/components/Forms/components/Refresh/refresh.tsx
@@ -44,12 +44,7 @@ export const RefreshForm = (): JSX.Element => {
 
   return (
     <>
-      {statusResponseErrors
-        ? buildResponseErrors(statusResponseErrors)
-        : // eslint-disable-next-line sonarjs/no-nested-conditional -- track via #1369
-          statuses
-          ? buildStatuses(statuses)
-          : ""}
+      {buildStatusResult(statusResponseErrors, statuses)}
       <div style={{ marginBottom: "1em", marginTop: "1em" }}>
         <Button
           color={BUTTON_PROPS.COLOR.PRIMARY}
@@ -71,17 +66,28 @@ export const RefreshForm = (): JSX.Element => {
           Start Refresh
         </Button>
       </div>
-      {refreshResponseErrors ? (
-        buildResponseErrors(refreshResponseErrors)
-      ) : // eslint-disable-next-line sonarjs/no-nested-conditional -- track via #1369
-      refreshStarted ? (
-        <div>Refresh started</div>
-      ) : (
-        ""
-      )}
+      {buildRefreshResult(refreshResponseErrors, refreshStarted)}
     </>
   );
 };
+
+function buildStatusResult(
+  statusResponseErrors: FormResponseErrors | undefined,
+  statuses: RefreshServicesStatuses | undefined,
+): JSX.Element | string {
+  if (statusResponseErrors) return buildResponseErrors(statusResponseErrors);
+  if (statuses) return buildStatuses(statuses);
+  return "";
+}
+
+function buildRefreshResult(
+  refreshResponseErrors: FormResponseErrors | undefined,
+  refreshStarted: boolean,
+): JSX.Element | string {
+  if (refreshResponseErrors) return buildResponseErrors(refreshResponseErrors);
+  if (refreshStarted) return <div>Refresh started</div>;
+  return "";
+}
 
 function buildStatuses(statuses: RefreshServicesStatuses): JSX.Element {
   return (

--- a/app/components/common/AdminForm/components/AdminFormResults/adminFormResults.tsx
+++ b/app/components/common/AdminForm/components/AdminFormResults/adminFormResults.tsx
@@ -13,17 +13,19 @@ export const AdminFormResults = ({
   success,
   wrapResult = defaultWrapResult,
 }: Props): JSX.Element => {
-  return (
-    <>
-      {errors === null
-        ? // eslint-disable-next-line sonarjs/no-nested-conditional -- track via #1372
-          success === null
-          ? ""
-          : applyResultWrapper(success, wrapResult)
-        : applyResultWrapper(<AdminFormErrors errors={errors} />, wrapResult)}
-    </>
-  );
+  return <>{buildResults(errors, success, wrapResult)}</>;
 };
+
+function buildResults(
+  errors: FormResponseErrors | null,
+  success: React.ReactNode | null,
+  wrapResult: ((result: React.ReactNode) => React.ReactNode) | null,
+): React.ReactNode {
+  if (errors !== null)
+    return applyResultWrapper(<AdminFormErrors errors={errors} />, wrapResult);
+  if (success !== null) return applyResultWrapper(success, wrapResult);
+  return "";
+}
 
 function applyResultWrapper(
   result: React.ReactNode,

--- a/app/services/common/refresh-service.ts
+++ b/app/services/common/refresh-service.ts
@@ -138,12 +138,7 @@ export function makeRefreshService<TData, TRefreshParams>(
     },
     getStatus(): RefreshStatus {
       return {
-        currentActivity: info.refreshing
-          ? REFRESH_ACTIVITY.REFRESHING
-          : // eslint-disable-next-line sonarjs/no-nested-conditional -- track via #1378
-            info.attemptingRefresh
-            ? REFRESH_ACTIVITY.ATTEMPTING_REFRESH
-            : REFRESH_ACTIVITY.NOT_REFRESHING,
+        currentActivity: getCurrentActivity(info),
         errorMessage: info.errorMessage ?? null,
         lastAttemptedAt: info.lastAttemptedAt?.toISOString() ?? null,
         lastResolvedAt: info.lastResolvedAt?.toISOString() ?? null,
@@ -157,6 +152,14 @@ export function makeRefreshService<TData, TRefreshParams>(
       startRefreshIfNeeded(params, info);
     },
   };
+}
+
+function getCurrentActivity<TData, TRefreshParams>(
+  info: RefreshInfo<TData, TRefreshParams>,
+): REFRESH_ACTIVITY {
+  if (info.refreshing) return REFRESH_ACTIVITY.REFRESHING;
+  if (info.attemptingRefresh) return REFRESH_ACTIVITY.ATTEMPTING_REFRESH;
+  return REFRESH_ACTIVITY.NOT_REFRESHING;
 }
 
 function startRefreshIfNeeded<TData, TRefreshParams>(

--- a/app/services/validation-results-notification.ts
+++ b/app/services/validation-results-notification.ts
@@ -89,13 +89,12 @@ export async function processValidationResultsMessage(
     snsMessage,
     validationResults.error_message,
   );
+  // An invalid integrity status is also counted as completed, since the dataset validator currently sets the status as "failure" when the integrity check doesn't pass.
   const validationStatus =
-    validationResults.status === "success"
+    validationResults.status === "success" ||
+    validationResults.integrity_status === INTEGRITY_STATUS.INVALID
       ? FILE_VALIDATION_STATUS.COMPLETED
-      : // eslint-disable-next-line sonarjs/no-nested-conditional -- track via #1381
-        validationResults.integrity_status === INTEGRITY_STATUS.INVALID // Currently, the dataset validator sets the status as "failure" when the integrity check doesn't pass
-        ? FILE_VALIDATION_STATUS.COMPLETED
-        : FILE_VALIDATION_STATUS.JOB_FAILED;
+      : FILE_VALIDATION_STATUS.JOB_FAILED;
   const [validationReports, validationSummary] =
     getValidationReportsAndSummary(validationResults);
 

--- a/app/services/validation-results-notification.ts
+++ b/app/services/validation-results-notification.ts
@@ -89,7 +89,8 @@ export async function processValidationResultsMessage(
     snsMessage,
     validationResults.error_message,
   );
-  // An invalid integrity status is also counted as completed, since the dataset validator currently sets the status as "failure" when the integrity check doesn't pass.
+  // An invalid integrity status is also counted as completed, since the dataset validator
+  // currently sets the status as "failure" when the integrity check doesn't pass.
   const validationStatus =
     validationResults.status === "success" ||
     validationResults.integrity_status === INTEGRITY_STATUS.INVALID

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -309,17 +309,7 @@ export function fillTestFileDefaults(file: TestFile): NormalizedTestFile {
     ...restFields
   } = file;
   const resolvedAtlas = typeof atlas === "function" ? atlas() : atlas;
-  const validationInfo: HCAAtlasTrackerDBFileValidationInfo | null =
-    file.validationInfo !== undefined
-      ? file.validationInfo
-      : // eslint-disable-next-line sonarjs/no-nested-conditional -- track via #1387
-        integrityCheckedAt === null
-        ? null
-        : {
-            batchJobId: `batch-job-${file.id}`,
-            snsMessageId: `sns-message-${file.id}`,
-            snsMessageTime: integrityCheckedAt,
-          };
+  const validationInfo = getTestFileValidationInfo(file, integrityCheckedAt);
   return {
     atlas,
     datasetInfo,
@@ -337,6 +327,19 @@ export function fillTestFileDefaults(file: TestFile): NormalizedTestFile {
     validationStatus,
     validationSummary,
     ...restFields,
+  };
+}
+
+function getTestFileValidationInfo(
+  file: TestFile,
+  integrityCheckedAt: string | null,
+): HCAAtlasTrackerDBFileValidationInfo | null {
+  if (file.validationInfo !== undefined) return file.validationInfo;
+  if (integrityCheckedAt === null) return null;
+  return {
+    batchJobId: `batch-job-${file.id}`,
+    snsMessageId: `sns-message-${file.id}`,
+    snsMessageTime: integrityCheckedAt,
   };
 }
 


### PR DESCRIPTION
Removes nested ternary operators, either by factoring them out into functions with if/else blocks, or by reducing them to single conditionals if one of the conditions is redundant or can be combined with the other

Closes #1447

And the individual tickets:
Closes #1367
Closes #1368
Closes #1369
Closes #1372
Closes #1378
Closes #1381
Closes #1387
