### PR TITLE
ci: pin github actions by commit sha at current versions

### DIFF
--- a/.github/workflows/cc-dev-build-and-push-nextjs-container.yml
+++ b/.github/workflows/cc-dev-build-and-push-nextjs-container.yml
@@ -24,14 +24,14 @@ jobs:
       - run: echo "🍏 This job's run number is${{ env.IMAGE_TAG }}"
 
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ROLE_NAME }}
           role-session-name: ${{ secrets.DEV_ROLE_SESSION_NAME }}
@@ -39,7 +39,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
 
       - name: Build Docker container
         id: build-image

--- a/.github/workflows/cc-prod-build-and-push-prod.yml
+++ b/.github/workflows/cc-prod-build-and-push-prod.yml
@@ -24,14 +24,14 @@ jobs:
       - run: echo "🍏 This job's run number is${{ env.IMAGE_TAG }}"
 
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.PROD_AWS_ACCOUNT_ID }}:role/${{ secrets.PROD_AWS_ROLE_NAME }}
           role-session-name: ${{ secrets.PROD_ROLE_SESSION_NAME }}
@@ -39,7 +39,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
 
       - name: Build Docker container
         id: build-image

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -5,8 +5,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22.13.0"
       - run: |


### PR DESCRIPTION
Closes #1453

Upgrades every action reference in the workflows to its current version and converts all tag pins to commit SHA pins with version comments, exactly per the table in #1453. Each SHA was resolved and verified against the upstream tag. Same change already merged and green in anvilproject/anvil-portal#4040.

## Test plan

- Workflows that trigger on pull requests validate the new pins on this PR itself.
- Workflows that only run on push to the default branch or on dispatch complete a green run after merge, via the next natural trigger or a manual dispatch, with no Node deprecation annotations.
- This PR is the prerequisite for the explicit Actions allowlist in #1454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)