### PR TITLE
ci: run unit tests in ci (#1463)

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -8,7 +8,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22.13.0"
+          node-version-file: ".nvmrc"
+          cache: "npm"
       - run: |
           npm ci
           npm run check-format
@@ -18,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
+        # Matches the Postgres major version used for development (see schema.sql)
         image: postgres:14
         env:
           POSTGRES_USER: postgres
@@ -26,15 +28,16 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -h 127.0.0.1"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22.13.0"
+          node-version-file: ".nvmrc"
+          cache: "npm"
       - run: npm ci
       - run: npm test
         env:

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -14,3 +14,30 @@ jobs:
           npm run check-format
           npm run lint
           npx tsc --noEmit
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: atlas-tracker-test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "22.13.0"
+      - run: npm ci
+      - run: npm test
+        env:
+          PGPASSWORD: postgres
+          PGUSER: postgres
+          TZ: UTC

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -1,6 +1,9 @@
 name: Run checks
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #1463

## What changed

Added a `test` job to the `Run checks` workflow so the Jest suite (79 suites, 1181 tests) runs on every PR, in parallel with the existing format/lint/typecheck job. The job provisions a `postgres:14` service container with the `atlas-tracker-test` database and runs `npm test`. A follow-up review commit updated both jobs to the SHA-pinned `actions/checkout` / `actions/setup-node` v7.0.0 per the convention from #1455 (adopted during rebase), switched them to read the Node version from `.nvmrc`, enabled npm caching, made the Postgres health check probe TCP, and documented the Postgres version pin.

## Why

Until now the unit tests only ran when a developer remembered to run `npm test` locally — CI checked formatting, lint, and types but never executed the suite, because it needs a real PostgreSQL database. A service container closes that gap. (e2e tests remain out of scope; they're blocked on standing up a temporary app instance.)

## Assumptions I made

- **No code changes were needed**: the Jest mock `app/utils/__mocks__/pg-app-connect-config.ts` targets `atlas-tracker-test` on localhost and deliberately leaves user/password unset, so the workflow supplies them via the standard `PGUSER`/`PGPASSWORD` env vars. If that mock ever hardcodes credentials, the workflow env becomes dead config.
- **No migration step in the workflow**: `resetDatabase()` in `testing/db-utils.ts` creates the `hat` schema and runs migrations itself.
- **`postgres:14` matches development** (schema.sql is dumped from 14.x); no Postgres version is pinned anywhere else in the repo, so CI now effectively asserts the supported major version.
- **`TZ: UTC` is a stopgap** for the timezone-sensitive s3-sync test tracked in #1464; once that's fixed the pin is belt-and-suspenders but harmless.
- **Failing tests do not yet block merges**: branch protection has no required status checks — tracked separately in #1466.

## How to verify

Issue #1463 has no explicit definition-of-done checklist; the acceptance criterion is "unit tests run automatically on every PR and failures are visible."

1. Open this PR's Checks tab — a `test` check should be present alongside `build`, green, having run ~1181 tests (see the "Run npm test" step log; runtime ~2-3 min).
2. Confirm the run used the service container: the job log's "Initialize containers" section shows `postgres:14` starting and passing its health check.
3. Optional negative test: push a commit that breaks any assertion (or temporarily edit one) and confirm the `test` check goes red on the PR.
4. Note for reviewers: merging a red PR is still possible until #1466 (branch protection) is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
