### PR TITLE
ci: generate next types before doing typechecking but exclude dev types (#1459)

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -17,7 +17,7 @@ jobs:
           npm ci
           npm run check-format
           npm run lint
-          npx tsc --noEmit
+          npm run typecheck
   test:
     runs-on: ubuntu-latest
     services:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -18,7 +18,7 @@ npm run lint ||
 )
 
 # Check TypeScript
-npx tsc --noEmit ||
+npm run typecheck ||
 (
 	echo 'TypeScript compile failed';
 	false;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:prod": "./scripts/build.sh hca-atlas-tracker prod && ./scripts/set-version.sh && next build --webpack",
     "start": "next start",
     "lint": "eslint .",
+    "typecheck": "next typegen && tsc --noEmit",
     "check-format": "prettier --check .",
     "prepare": "husky install .husky",
     "test": "jest --runInBand",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,5 +31,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", ".next/dev/types"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,5 +31,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules", ".next"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Closes #1459

I'm not 100% certain I'm happy with excluding the dev types from typechecking (see ticket for context), but I do at least personally prefer that option (with its, AFAIK, minimal consequences) over hard-to-predict commit failures

---

## Summary (Claude-generated)

- Adds a `typecheck` npm script — `next typegen && tsc --noEmit` — so Next's route types are regenerated immediately before every typecheck.
- Replaces the bare `npx tsc --noEmit` with `npm run typecheck` in both the `run-checks` GitHub workflow and the Husky pre-commit hook.
- Narrows the tsconfig `exclude` from `.next` to `.next/dev/types`: the build-time types under `.next/types` (including `validator.ts`, which validates page exports) are now part of the checked program, while the dev-server-only types stay excluded per the tradeoff described in #1459.
