### PR TITLE
ci: run dev deploy after release-please to fix version race

### DIFF
--- a/.github/workflows/cc-dev-build-and-push-nextjs-container.yml
+++ b/.github/workflows/cc-dev-build-and-push-nextjs-container.yml
@@ -24,7 +24,7 @@ jobs:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
       - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-      - run: echo "🍏 This job's run number is${{ env.IMAGE_TAG }}"
+      - run: echo "🍏 This job is building commit ${{ env.IMAGE_TAG }}"
 
       - name: Check out repository code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/cc-dev-build-and-push-nextjs-container.yml
+++ b/.github/workflows/cc-dev-build-and-push-nextjs-container.yml
@@ -1,7 +1,9 @@
 name: HCA Atlas Tracker Dev Deploy
 run-name: 🚀 HCA Atlas Tracker Dev Deploy 🚀
 on:
-  push:
+  workflow_run:
+    workflows: ["release-please"]
+    types: [completed]
     branches: [main]
 
 concurrency:
@@ -10,12 +12,13 @@ concurrency:
 
 env:
   AWS_REGION: ${{ secrets.DEV_AWS_REGION }}
-  IMAGE_TAG: ${{ github.sha }}
+  IMAGE_TAG: ${{ github.event.workflow_run.head_sha }}
 permissions:
   id-token: write
   contents: read
 jobs:
   Build-and-Push-Docker-Image:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
@@ -26,6 +29,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch: # Enable manual triggering
 
 concurrency:
-  group: release-please
+  group: release-please-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,10 @@ on:
       - main
   workflow_dispatch: # Enable manual triggering
 
+concurrency:
+  group: release-please
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
Closes #1167

## What changed

- `cc-dev-build-and-push-nextjs-container.yml` (dev deploy) now triggers via `workflow_run` after the `release-please` workflow completes on `main`, instead of racing it on `push`. The job is gated on `conclusion == 'success'`, and both `IMAGE_TAG` and the checkout `ref` use `github.event.workflow_run.head_sha` so the built commit, the ECR image tag, and the commit release-please tags are the same SHA.
- `release-please.yml` gains a `concurrency` group (`cancel-in-progress: false`) so release-please runs execute in commit order — this keeps downstream deploy completions in commit order too (without it, two quick pushes could deploy the older commit last, rolling dev back).

## Why

Both workflows previously triggered on push to `main` simultaneously. `scripts/set-version.sh` runs `git tag --points-at HEAD` during the build, but release-please hadn't created the tag yet — so release merges deployed with an empty `NEXT_PUBLIC_VERSION` and the dev footer showed no/stale version until a manual re-deploy. Sequencing the deploy after release-please guarantees the tag exists when the build reads it. Same pattern as anvil-portal's `dev-deploy.yml`.

## Assumptions I made

- Every push to main should still produce a dev deploy (release or not) — release-please runs on every push, and its completion fires the build; non-release merges just build without a version tag, as before.
- The `conclusion == 'success'` gate is intentional: if release-please fails, the deploy is skipped (visible as a skipped run in Actions, no separate alert). Deploy liveness is now coupled to release-please health — accepted trade-off for the ordering guarantee.
- Manually dispatching release-please (`workflow_dispatch`) now triggers a dev deploy of main's tip as a side effect. This is treated as a feature: it becomes the manual re-deploy path that previously required re-running the deploy workflow.
- Checkout keeps `fetch-depth: 0`, which fetches all tags — required for `git tag --points-at HEAD`. Checking out `head_sha` (not `main`) was chosen so the image tag always matches the built commit even if pushes queue.
- Prod deploy (`on: push: [prod]`) is untouched; by the time main merges to prod the tag already exists.

## How to verify

Definition of done from #1167: every merge to `main` yields exactly one dev deploy that runs after release-please, with the version tag present on release merges; no deploys skipped for non-release merges; prod unaffected.

1. Merge this PR. In the Actions tab, confirm `release-please` runs first and `HCA Atlas Tracker Dev Deploy` starts only after it completes (it will appear under "workflow_run" rather than alongside the push). → covers "deploy runs after release-please".
2. When the next release PR (version bump) is merged to main: after the dev deploy finishes, open the dev site footer and confirm it shows the new version number without any manual re-deploy. → covers "version tag present on release merges" (the original bug).
3. Merge any non-release PR to main and confirm a dev deploy still runs (skipped only if release-please itself failed). → covers "no deploys skipped".
4. Confirm the ECR image pushed by step 2/3 is tagged with the merge commit's SHA (matches the commit release-please tagged). → covers image/commit consistency.
5. Prod: no action — its workflow is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
