### PR TITLE
feat: add various potentially-useful indexes to database and update queries to benefit (#1458)

### DIFF
--- a/app/data/component-atlases.ts
+++ b/app/data/component-atlases.ts
@@ -74,7 +74,11 @@ export async function updateSourceDatasetVersionInComponentAtlases(
   client: pg.PoolClient,
 ): Promise<void> {
   await client.query(
-    "UPDATE hat.component_atlases SET source_datasets = ARRAY_REPLACE(source_datasets, $1, $2) WHERE is_latest",
+    `
+      UPDATE hat.component_atlases
+      SET source_datasets = ARRAY_REPLACE(source_datasets, $1, $2)
+      WHERE is_latest AND source_datasets @> ARRAY[$1::uuid]
+    `,
     [existingVersionId, newVersionId],
   );
 }

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -521,7 +521,7 @@ export async function updateTaskCounts(client?: pg.PoolClient): Promise<void> {
         FROM
           hat.atlases a
         LEFT JOIN
-          hat.validations v ON a.id = ANY(v.atlas_ids)
+          hat.validations v ON v.atlas_ids @> ARRAY[a.id]
         GROUP BY
           a.id
       ) AS counts

--- a/app/services/validations.ts
+++ b/app/services/validations.ts
@@ -366,7 +366,7 @@ export async function getValidationRecords(
             ARRAY_AGG(DISTINCT a.overview->>'network') AS networks,
             ARRAY_AGG(DISTINCT a.overview->>'wave') AS waves
           FROM hat.validations v
-          LEFT JOIN hat.atlases a ON a.id = ANY(v.atlas_ids)
+          LEFT JOIN hat.atlases a ON v.atlas_ids @> ARRAY[a.id]
           WHERE v.id=ANY($1)
           GROUP BY v.entity_id, v.validation_id;
         `,
@@ -383,7 +383,7 @@ export async function getValidationRecords(
             ARRAY_AGG(DISTINCT a.overview->>'network') AS networks,
             ARRAY_AGG(DISTINCT a.overview->>'wave') AS waves
           FROM hat.validations v
-          LEFT JOIN hat.atlases a ON a.id = ANY(v.atlas_ids)
+          LEFT JOIN hat.atlases a ON v.atlas_ids @> ARRAY[a.id]
           GROUP BY v.entity_id, v.validation_id;
         `,
         undefined,

--- a/app/services/validations.ts
+++ b/app/services/validations.ts
@@ -366,7 +366,7 @@ export async function getValidationRecords(
             ARRAY_AGG(DISTINCT a.overview->>'network') AS networks,
             ARRAY_AGG(DISTINCT a.overview->>'wave') AS waves
           FROM hat.validations v
-          LEFT JOIN hat.atlases a ON v.atlas_ids @> ARRAY[a.id]
+          LEFT JOIN hat.atlases a ON a.id = ANY(v.atlas_ids)
           WHERE v.id=ANY($1)
           GROUP BY v.entity_id, v.validation_id;
         `,
@@ -383,7 +383,7 @@ export async function getValidationRecords(
             ARRAY_AGG(DISTINCT a.overview->>'network') AS networks,
             ARRAY_AGG(DISTINCT a.overview->>'wave') AS waves
           FROM hat.validations v
-          LEFT JOIN hat.atlases a ON v.atlas_ids @> ARRAY[a.id]
+          LEFT JOIN hat.atlases a ON a.id = ANY(v.atlas_ids)
           GROUP BY v.entity_id, v.validation_id;
         `,
         undefined,

--- a/migrations/1785126937994_access-pattern-indexes.ts
+++ b/migrations/1785126937994_access-pattern-indexes.ts
@@ -56,8 +56,7 @@ export function up(pgm: MigrationBuilder): void {
   // GIN indexes for the array/jsonb containment relationships. These can't use
   // B-trees, and the joins below currently scan the whole referencing table.
 
-  // `JOIN ... ON v.atlas_ids @> ARRAY[a.id]` in `updateTaskCounts` and
-  // `getValidationRecords` (the tasks/reports page).
+  // `JOIN ... ON v.atlas_ids @> ARRAY[a.id]` in `updateTaskCounts`.
   pgm.createIndex(VALIDATIONS, ["atlas_ids"], { method: "gin" });
 
   // `a.source_studies` is jsonb queried with both `?` and `@>`, so the default

--- a/migrations/1785126937994_access-pattern-indexes.ts
+++ b/migrations/1785126937994_access-pattern-indexes.ts
@@ -56,17 +56,15 @@ export function up(pgm: MigrationBuilder): void {
   // GIN indexes for the array/jsonb containment relationships. These can't use
   // B-trees, and the joins below currently scan the whole referencing table.
 
-  // `JOIN ... ON a.id = ANY(v.atlas_ids)` in `updateTaskCounts` and
-  // `getValidationRecords` (the tasks/reports page). Queries need updating to
-  // use `@>`.
+  // `JOIN ... ON v.atlas_ids @> ARRAY[a.id]` in `updateTaskCounts` and
+  // `getValidationRecords` (the tasks/reports page).
   pgm.createIndex(VALIDATIONS, ["atlas_ids"], { method: "gin" });
 
   // `a.source_studies` is jsonb queried with both `?` and `@>`, so the default
   // `jsonb_ops` opclass is required (`jsonb_path_ops` doesn't support `?`).
   pgm.createIndex(ATLASES, ["source_studies"], { method: "gin" });
 
-  // `updateSourceDatasetVersionInComponentAtlases` could make use of this but
-  // needs to be updated to filter by existing ID.
+  // `WHERE ... source_datasets @> ARRAY[$1]` in `updateSourceDatasetVersionInComponentAtlases`.
   pgm.createIndex(COMPONENT_ATLASES, ["source_datasets"], { method: "gin" });
 
   // `getExistingStudyId` and `getSourceStudiesByDois` match a DOI against `doi`

--- a/migrations/1785126937994_access-pattern-indexes.ts
+++ b/migrations/1785126937994_access-pattern-indexes.ts
@@ -1,0 +1,85 @@
+import { MigrationBuilder } from "node-pg-migrate";
+
+const COMMENTS = { name: "comments", schema: "hat" };
+const COMPONENT_ATLASES = { name: "component_atlases", schema: "hat" };
+const ENTRY_SHEET_VALIDATIONS = {
+  name: "entry_sheet_validations",
+  schema: "hat",
+};
+const FILES = { name: "files", schema: "hat" };
+const SOURCE_DATASETS = { name: "source_datasets", schema: "hat" };
+const SOURCE_STUDIES = { name: "source_studies", schema: "hat" };
+const VALIDATIONS = { name: "validations", schema: "hat" };
+const ATLASES = { name: "atlases", schema: "hat" };
+
+/**
+ * Add indexes for the access patterns identified in the schema/query review (#1458).
+ * `down` is omitted so that node-pg-migrate infers it by reversing these operations.
+ * @param pgm - Migration builder instance.
+ */
+export function up(pgm: MigrationBuilder): void {
+  // Unindexed foreign keys, all joined or filtered on in hot read paths, and all
+  // requiring a full scan of the referencing table to enforce the constraint on
+  // parent deletes/key updates.
+
+  // Joined `ON f.id = d.file_id` in every source dataset read, and filtered on
+  // directly by `getSourceDatasetForAtlasFile`.
+  pgm.createIndex(SOURCE_DATASETS, ["file_id"]);
+
+  // Joined `ON f.id = ca.file_id` in every component atlas read, and filtered on
+  // directly by `getComponentAtlasForAtlasFile`.
+  pgm.createIndex(COMPONENT_ATLASES, ["file_id"]);
+
+  // Source dataset and component atlas `id` is the per-concept identity shared
+  // across versions, not the primary key (which is `version_id`). It backs the
+  // by-ID route resolvers `getSourceDatasetVersionsPresentOnAtlas` and
+  // `getComponentAtlasVersionForAtlas`, the `mark*AsNotLatest` updates on the S3
+  // ingest path, and the `JOIN hat.concepts con ON con.id = d.id` in list reads.
+  pgm.createIndex(SOURCE_DATASETS, ["id"]);
+  pgm.createIndex(COMPONENT_ATLASES, ["id"]);
+
+  // `markPreviousVersionsAsNotLatest` and `getLatestNotificationInfo` both filter
+  // on `concept_id` on every S3 notification.
+  pgm.createIndex(FILES, ["concept_id"]);
+
+  // `source_dataset_counts` groups by it; source study replacement/unlinking
+  // updates filter on it.
+  pgm.createIndex(SOURCE_DATASETS, ["source_study_id"]);
+
+  // Filtered with `= $n` / `= ANY(...)` throughout the entry sheet services.
+  pgm.createIndex(ENTRY_SHEET_VALIDATIONS, ["source_study_id"]);
+
+  // `WHERE thread_id = $1` throughout the comment services, including a
+  // correlated `MIN(created_at)` subquery.
+  pgm.createIndex(COMMENTS, ["thread_id"]);
+
+  // GIN indexes for the array/jsonb containment relationships. These can't use
+  // B-trees, and the joins below currently scan the whole referencing table.
+
+  // `JOIN ... ON a.id = ANY(v.atlas_ids)` in `updateTaskCounts` and
+  // `getValidationRecords` (the tasks/reports page). Queries need updating to
+  // use `@>`.
+  pgm.createIndex(VALIDATIONS, ["atlas_ids"], { method: "gin" });
+
+  // `a.source_studies` is jsonb queried with both `?` and `@>`, so the default
+  // `jsonb_ops` opclass is required (`jsonb_path_ops` doesn't support `?`).
+  pgm.createIndex(ATLASES, ["source_studies"], { method: "gin" });
+
+  // `updateSourceDatasetVersionInComponentAtlases` could make use of this but
+  // needs to be updated to filter by existing ID.
+  pgm.createIndex(COMPONENT_ATLASES, ["source_datasets"], { method: "gin" });
+
+  // `getExistingStudyId` and `getSourceStudiesByDois` match a DOI against `doi`
+  // OR either of these jsonb paths; the unique index on `doi` can't be used
+  // while the other two branches of the OR are unindexed.
+  pgm.createIndex(
+    SOURCE_STUDIES,
+    ["(study_info->'publication'->>'preprintOfDoi')"],
+    { name: "source_studies_preprint_of_doi_index" },
+  );
+  pgm.createIndex(
+    SOURCE_STUDIES,
+    ["(study_info->'publication'->>'hasPreprintDoi')"],
+    { name: "source_studies_has_preprint_doi_index" },
+  );
+}

--- a/schema.sql
+++ b/schema.sql
@@ -509,10 +509,59 @@ ALTER TABLE ONLY hat.validations
 
 
 --
+-- Name: atlases_source_studies_index; Type: INDEX; Schema: hat; Owner: -
+--
+
+CREATE INDEX atlases_source_studies_index ON hat.atlases USING gin (source_studies);
+
+
+--
+-- Name: comments_thread_id_index; Type: INDEX; Schema: hat; Owner: -
+--
+
+CREATE INDEX comments_thread_id_index ON hat.comments USING btree (thread_id);
+
+
+--
+-- Name: component_atlases_file_id_index; Type: INDEX; Schema: hat; Owner: -
+--
+
+CREATE INDEX component_atlases_file_id_index ON hat.component_atlases USING btree (file_id);
+
+
+--
+-- Name: component_atlases_id_index; Type: INDEX; Schema: hat; Owner: -
+--
+
+CREATE INDEX component_atlases_id_index ON hat.component_atlases USING btree (id);
+
+
+--
+-- Name: component_atlases_source_datasets_index; Type: INDEX; Schema: hat; Owner: -
+--
+
+CREATE INDEX component_atlases_source_datasets_index ON hat.component_atlases USING gin (source_datasets);
+
+
+--
+-- Name: entry_sheet_validations_source_study_id_index; Type: INDEX; Schema: hat; Owner: -
+--
+
+CREATE INDEX entry_sheet_validations_source_study_id_index ON hat.entry_sheet_validations USING btree (source_study_id);
+
+
+--
 -- Name: files_bucket_key_index; Type: INDEX; Schema: hat; Owner: -
 --
 
 CREATE INDEX files_bucket_key_index ON hat.files USING btree (bucket, key);
+
+
+--
+-- Name: files_concept_id_index; Type: INDEX; Schema: hat; Owner: -
+--
+
+CREATE INDEX files_concept_id_index ON hat.files USING btree (concept_id);
 
 
 --
@@ -548,6 +597,48 @@ CREATE INDEX files_status_index ON hat.files USING btree (validation_status);
 --
 
 CREATE UNIQUE INDEX idx_concepts_identity_fields ON hat.concepts USING btree (atlas_short_name, base_filename, file_type, generation, network);
+
+
+--
+-- Name: source_datasets_file_id_index; Type: INDEX; Schema: hat; Owner: -
+--
+
+CREATE INDEX source_datasets_file_id_index ON hat.source_datasets USING btree (file_id);
+
+
+--
+-- Name: source_datasets_id_index; Type: INDEX; Schema: hat; Owner: -
+--
+
+CREATE INDEX source_datasets_id_index ON hat.source_datasets USING btree (id);
+
+
+--
+-- Name: source_datasets_source_study_id_index; Type: INDEX; Schema: hat; Owner: -
+--
+
+CREATE INDEX source_datasets_source_study_id_index ON hat.source_datasets USING btree (source_study_id);
+
+
+--
+-- Name: source_studies_has_preprint_doi_index; Type: INDEX; Schema: hat; Owner: -
+--
+
+CREATE INDEX source_studies_has_preprint_doi_index ON hat.source_studies USING btree ((((study_info -> 'publication'::text) ->> 'hasPreprintDoi'::text)));
+
+
+--
+-- Name: source_studies_preprint_of_doi_index; Type: INDEX; Schema: hat; Owner: -
+--
+
+CREATE INDEX source_studies_preprint_of_doi_index ON hat.source_studies USING btree ((((study_info -> 'publication'::text) ->> 'preprintOfDoi'::text)));
+
+
+--
+-- Name: validations_atlas_ids_index; Type: INDEX; Schema: hat; Owner: -
+--
+
+CREATE INDEX validations_atlas_ids_index ON hat.validations USING gin (atlas_ids);
 
 
 --


### PR DESCRIPTION
Closes #1458

- All of the implemented indexes seem like they may be used in practice based on my local experimentation
  - (Well, aside from comment thread ID, technically, since we're not using comments in practice)
- The indexes are mostly the same as the ones proposed in the ticket's thread
- Omitted indexes:
  - Partial `is_latest AND NOT is_archived` on `hat.files` -- Unclear whether this would apply to a small enough portion of rows to be useful; we might need to look at the prod data to come to a solid judgement
  - GINs on `source_datasets` and `component_atlases` for `hat.atlases` -- Not used in any queries in the app where they would be applicable (the queries that filter by them seem to all be either filtering something other than atlases or already filtered by atlas ID)
- Additional indexes:
  - B-trees on `id` for `hat.source_datasets` and `hat.component_atlases` -- These are previously-unindexed foreign keys
- Updated a couple queries to make two of the indexes actually beneficial:
  - Updated atlas join in `updateTaskCounts` to use `@>` (which is applicable to the GIN) rather than `ANY` (which is not)
  - Updated `updateSourceDatasetVersionInComponentAtlases` to filter by the version ID that's being replaced, which is beneficial on its own and should further benefit from the index

Follow-ups (from review of this PR and from the non-index-related notes on the ticket):

- #1486
- #1489
- #1490
- #1491
- #1492
- (No ticket for the join by `role_associated_resource_ids` because I don't anticipate that being an issue)