### PR TITLE
chore: enforce @/ alias import convention — ban all ../ relative imports (#1507)

### DIFF
--- a/@types/global.d.ts
+++ b/@types/global.d.ts
@@ -2,10 +2,10 @@
 
 declare var hcaAtlasTrackerProjectsInfoCache:
   | undefined
-  | import("../app/services/hca-projects").ProjectsInfo;
+  | import("@/app/services/hca-projects").ProjectsInfo;
 
 declare var hcaAtlasTrackerCellxGeneInfoCache:
   | undefined
-  | import("../app/services/cellxgene").CellxGeneInfo;
+  | import("@/app/services/cellxgene").CellxGeneInfo;
 
 /* eslint-enable no-var -- Paired enable for above disable */

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,7 @@ The database uses schema `hat` (Human Atlas Tracker). See `docs/entity-relations
 
 - **JSDoc**: JSDoc comments are encouraged for functions
 - **Explicit return types**: Functions generally require return types (with some exceptions for typed function expressions)
+- **Imports**: Reach outside a file's own directory through the `@/` alias (repo root); relative imports (`./`) are only for the same directory and its descendants. No `../`, and no bare `baseUrl` paths (e.g. `app/foo`) — both are banned by `no-restricted-imports`. This keeps a module's internal and external references to the same string, so one `grep` finds every consumer.
 - **Sorted keys**: Object keys, destructuring, interfaces, and string enums must be alphabetically sorted
 - **SonarJS**: Code quality and complexity checks
 - **React hooks**: Exhaustive dependencies required

--- a/__mocks__/googleapis.ts
+++ b/__mocks__/googleapis.ts
@@ -1,9 +1,9 @@
-import { GaxiosError, GaxiosResponse } from "gaxios";
-import { sheets_v4 } from "googleapis";
 import {
   TEST_GOOGLE_SHEET_TITLES_BY_ID,
   TEST_UNSHARED_GOOGLE_SHEET_IDS,
-} from "../testing/constants";
+} from "@/testing/constants";
+import { GaxiosError, GaxiosResponse } from "gaxios";
+import { sheets_v4 } from "googleapis";
 
 type TestGaxiosPromise<T> = Promise<Pick<GaxiosResponse<T>, "data">>;
 

--- a/__mocks__/next-auth.ts
+++ b/__mocks__/next-auth.ts
@@ -1,6 +1,6 @@
+import { TEST_USERS } from "@/testing/constants";
 import { NextApiRequest } from "next";
 import { Session } from "next-auth";
-import { TEST_USERS } from "../testing/constants";
 
 export async function getServerSession(
   req: NextApiRequest,

--- a/__tests__/action-button.test.tsx
+++ b/__tests__/action-button.test.tsx
@@ -1,11 +1,11 @@
 import { render, screen } from "@testing-library/react";
 
-jest.mock("../app/hooks/useFormManager/useFormManager", () => ({
+jest.mock("@/app/hooks/useFormManager/useFormManager", () => ({
   useFormManager: jest.fn(),
 }));
 
-import { useFormManager } from "../app/hooks/useFormManager/useFormManager";
-import { ActionButton } from "../app/views/EntitiesView/components/ActionButton/actionButton";
+import { useFormManager } from "@/app/hooks/useFormManager/useFormManager";
+import { ActionButton } from "@/app/views/EntitiesView/components/ActionButton/actionButton";
 
 const mockUseFormManager = useFormManager as jest.MockedFunction<
   typeof useFormManager

--- a/__tests__/active-user-query.test.ts
+++ b/__tests__/active-user-query.test.ts
@@ -1,8 +1,8 @@
+import { ACTIVE_USER } from "@/app/hooks/UseFetchActiveUser/query/constants";
+import { useQuery } from "@/app/hooks/UseFetchActiveUser/query/useQuery";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import { createElement, FunctionComponent, PropsWithChildren } from "react";
-import { ACTIVE_USER } from "../app/hooks/UseFetchActiveUser/query/constants";
-import { useQuery } from "../app/hooks/UseFetchActiveUser/query/useQuery";
 
 /**
  * Wraps a rendered hook in a QueryClientProvider with retries disabled.

--- a/__tests__/admin-page-guard.test.ts
+++ b/__tests__/admin-page-guard.test.ts
@@ -4,14 +4,14 @@ jest.mock("next-auth", () => ({
   getServerSession: jest.fn(),
 }));
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
   () => ({ nextAuthOptions: {} }),
 );
 
+import { ROLE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { getAdminPageRedirect } from "@/app/routes/adminPageGuard";
+import { ROUTE } from "@/app/routes/constants";
 import { getServerSession } from "next-auth";
-import { ROLE } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { getAdminPageRedirect } from "../app/routes/adminPageGuard";
-import { ROUTE } from "../app/routes/constants";
 
 const mockGetServerSession = getServerSession as jest.Mock;
 

--- a/__tests__/api-atlases-create.test.ts
+++ b/__tests__/api-atlases-create.test.ts
@@ -1,18 +1,16 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   ATLAS_STATUS,
   HCAAtlasTrackerAtlas,
   HCAAtlasTrackerDBAtlas,
   PublicationInfo,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { NewAtlasData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { METHOD } from "../app/common/entities";
-import { FormResponseErrors } from "../app/hooks/useForm/common/entities";
-import { endPgPool, query } from "../app/services/database";
-import { slugifyAtlasShortName } from "../app/utils/atlases";
-import { getSheetTitleForApi } from "../app/utils/google-sheets-api";
-import createHandler from "../pages/api/atlases/create";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { NewAtlasData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { METHOD } from "@/app/common/entities";
+import { FormResponseErrors } from "@/app/hooks/useForm/common/entities";
+import { endPgPool, query } from "@/app/services/database";
+import { slugifyAtlasShortName } from "@/app/utils/atlases";
+import { getSheetTitleForApi } from "@/app/utils/google-sheets-api";
+import createHandler from "@/pages/api/atlases/create";
 import {
   DOI_NONEXISTENT,
   DOI_PREPRINT_NO_JOURNAL,
@@ -21,31 +19,33 @@ import {
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
 import {
   expectDbAtlasToMatchApi,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 jest.mock("googleapis");
 
 const getSheetTitleMock = getSheetTitleForApi as jest.Mock;
 
-jest.mock("../app/utils/google-sheets-api", () => {
-  const googleSheetsApi: typeof import("../app/utils/google-sheets-api") =
-    jest.requireActual("../app/utils/google-sheets-api");
+jest.mock("@/app/utils/google-sheets-api", () => {
+  const googleSheetsApi: typeof import("@/app/utils/google-sheets-api") =
+    jest.requireActual("@/app/utils/google-sheets-api");
 
   return {
     getSheetTitleForApi: jest.fn(googleSheetsApi.getSheetTitleForApi),

--- a/__tests__/api-atlases-id-component-atlases-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id-source-datasets.test.ts
@@ -1,17 +1,15 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   HCAAtlasTrackerDBComponentAtlas,
   HCAAtlasTrackerLocalListSourceDataset,
   HCAAtlasTrackerSourceDataset,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import {
   ComponentAtlasAddSourceDatasetsData,
   ComponentAtlasDeleteSourceDatasetsData,
-} from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { METHOD } from "../app/common/entities";
-import { endPgPool, query } from "../app/services/database";
-import sourceDatasetsHandler from "../pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId]/source-datasets";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool, query } from "@/app/services/database";
+import sourceDatasetsHandler from "@/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId]/source-datasets";
 import {
   ATLAS_DRAFT,
   ATLAS_PUBLIC,
@@ -57,14 +55,14 @@ import {
   USER_INTEGRATION_LEAD_DRAFT,
   USER_INTEGRATION_LEAD_PUBLIC,
   USER_UNREGISTERED,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   expectComponentAtlasToHaveSourceDatasets,
   getComponentAtlasSourceDatasets,
   resetDatabase,
   setComponentAtlasDatasets,
-} from "../testing/db-utils";
-import { TestComponentAtlas, TestUser } from "../testing/entities";
+} from "@/testing/db-utils";
+import { TestComponentAtlas, TestUser } from "@/testing/entities";
 import {
   assertExpectDefined,
   expectApiSourceDatasetsToHaveComponentAtlases,
@@ -72,14 +70,16 @@ import {
   getTestEntityDownloadName,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-atlases-id-component-atlases-id.test.ts
+++ b/__tests__/api-atlases-id-component-atlases-id.test.ts
@@ -1,14 +1,12 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   FileValidationSummary,
   HCAAtlasTrackerDetailComponentAtlas,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { ComponentAtlasEditData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { METHOD } from "../app/common/entities";
-import { FormResponseErrors } from "../app/hooks/useForm/common/entities";
-import { endPgPool } from "../app/services/database";
-import componentAtlasHandler from "../pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId]";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { ComponentAtlasEditData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { METHOD } from "@/app/common/entities";
+import { FormResponseErrors } from "@/app/hooks/useForm/common/entities";
+import { endPgPool } from "@/app/services/database";
+import componentAtlasHandler from "@/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId]";
 import {
   ATLAS_DRAFT,
   ATLAS_PUBLIC,
@@ -40,9 +38,9 @@ import {
   USER_INTEGRATION_LEAD_PUBLIC,
   USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { getConceptFromDatabase, resetDatabase } from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
+} from "@/testing/constants";
+import { getConceptFromDatabase, resetDatabase } from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
 import {
   assertExpectDefined,
   delay,
@@ -50,14 +48,16 @@ import {
   getTestEntityDownloadName,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-atlases-id-component-atlases.test.ts
+++ b/__tests__/api-atlases-id-component-atlases.test.ts
@@ -1,9 +1,7 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { HCAAtlasTrackerComponentAtlas } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import componentAtlasesHandler from "../pages/api/atlases/[atlasId]/component-atlases";
+import { HCAAtlasTrackerComponentAtlas } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import componentAtlasesHandler from "@/pages/api/atlases/[atlasId]/component-atlases";
 import {
   ATLAS_DRAFT,
   ATLAS_PUBLISHED,
@@ -30,9 +28,9 @@ import {
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestComponentAtlas, TestUser } from "../testing/entities";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestComponentAtlas, TestUser } from "@/testing/entities";
 import {
   assertExpectDefined,
   expectApiComponentAtlasToMatchTest,
@@ -40,14 +38,16 @@ import {
   getTestAtlasShortNameSlug,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-atlases-id-entry-sheet-validations-id-sync.test.ts
+++ b/__tests__/api-atlases-id-entry-sheet-validations-id-sync.test.ts
@@ -1,9 +1,7 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import { startUpdateForEntrySheetValidation } from "../app/services/entry-sheets";
-import syncHandler from "../pages/api/atlases/[atlasId]/entry-sheet-validations/[entrySheetValidationId]/sync";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import { startUpdateForEntrySheetValidation } from "@/app/services/entry-sheets";
+import syncHandler from "@/pages/api/atlases/[atlasId]/entry-sheet-validations/[entrySheetValidationId]/sync";
 import {
   ATLAS_NONEXISTENT,
   ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A,
@@ -15,35 +13,37 @@ import {
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   deleteEntrySheetValidationFromDatabase,
   getEntrySheetValidationFromDatabase,
   initEntrySheetValidation,
   resetDatabase,
-} from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
+} from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
 import {
   expectIsDefined,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
-jest.mock("../app/utils/hca-validation-tools/hca-validation-tools-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/hca-validation-tools/hca-validation-tools-api");
 
 jest.mock("next-auth");
 
 const updateMock = startUpdateForEntrySheetValidation as jest.Mock;
 
-jest.mock("../app/services/entry-sheets", () => {
+jest.mock("@/app/services/entry-sheets", () => {
   const hcaValidationTools = jest.requireActual<
-    typeof import("../app/services/entry-sheets")
+    typeof import("@/app/services/entry-sheets")
   >("../app/services/entry-sheets");
   return {
     startUpdateForEntrySheetValidation: jest.fn(

--- a/__tests__/api-atlases-id-entry-sheet-validations-id-sync.test.ts
+++ b/__tests__/api-atlases-id-entry-sheet-validations-id-sync.test.ts
@@ -44,7 +44,7 @@ const updateMock = startUpdateForEntrySheetValidation as jest.Mock;
 jest.mock("@/app/services/entry-sheets", () => {
   const hcaValidationTools = jest.requireActual<
     typeof import("@/app/services/entry-sheets")
-  >("../app/services/entry-sheets");
+  >("@/app/services/entry-sheets");
   return {
     startUpdateForEntrySheetValidation: jest.fn(
       hcaValidationTools.startUpdateForEntrySheetValidation,

--- a/__tests__/api-atlases-id-entry-sheet-validations-id.test.ts
+++ b/__tests__/api-atlases-id-entry-sheet-validations-id.test.ts
@@ -1,9 +1,7 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { HCAAtlasTrackerEntrySheetValidation } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import entrySheetValidationHandler from "../pages/api/atlases/[atlasId]/entry-sheet-validations/[entrySheetValidationId]";
+import { HCAAtlasTrackerEntrySheetValidation } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import entrySheetValidationHandler from "@/pages/api/atlases/[atlasId]/entry-sheet-validations/[entrySheetValidationId]";
 import {
   ATLAS_NONEXISTENT,
   ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A,
@@ -15,26 +13,28 @@ import {
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
 import {
   TestEntrySheetValidation,
   TestSourceStudy,
   TestUser,
-} from "../testing/entities";
+} from "@/testing/entities";
 import {
   getTestSourceStudyCitation,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
-jest.mock("../app/utils/hca-validation-tools/hca-validation-tools-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/hca-validation-tools/hca-validation-tools-api");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-atlases-id-entry-sheet-validations-sync.test.ts
+++ b/__tests__/api-atlases-id-entry-sheet-validations-sync.test.ts
@@ -58,7 +58,7 @@ const updateMock = startAtlasEntrySheetValidationsUpdate as jest.Mock;
 jest.mock("@/app/services/entry-sheets", () => {
   const hcaValidationTools = jest.requireActual<
     typeof import("@/app/services/entry-sheets")
-  >("../app/services/entry-sheets");
+  >("@/app/services/entry-sheets");
   return {
     startAtlasEntrySheetValidationsUpdate: jest.fn(
       hcaValidationTools.startAtlasEntrySheetValidationsUpdate,

--- a/__tests__/api-atlases-id-entry-sheet-validations-sync.test.ts
+++ b/__tests__/api-atlases-id-entry-sheet-validations-sync.test.ts
@@ -1,14 +1,11 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { ValidationError } from "yup";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import { startAtlasEntrySheetValidationsUpdate } from "../app/services/entry-sheets";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import { startAtlasEntrySheetValidationsUpdate } from "@/app/services/entry-sheets";
 import {
   EntrySheetValidationErrorInfo,
   EntrySheetValidationSummary,
-} from "../app/utils/hca-validation-tools/hca-validation-tools";
-import syncHandler from "../pages/api/atlases/[atlasId]/entry-sheet-validations/sync";
+} from "@/app/utils/hca-validation-tools/hca-validation-tools";
+import syncHandler from "@/pages/api/atlases/[atlasId]/entry-sheet-validations/sync";
 import {
   ATLAS_NONEXISTENT,
   ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A,
@@ -28,36 +25,39 @@ import {
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   deleteEntrySheetValidationBySheetId,
   getEntrySheetValidationBySheetId,
   getEntrySheetValidationFromDatabase,
   resetDatabase,
-} from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
+} from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
 import {
   expectIsDefined,
   expectIsInstanceOf,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
+import { ValidationError } from "yup";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
-jest.mock("../app/utils/hca-validation-tools/hca-validation-tools-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/hca-validation-tools/hca-validation-tools-api");
 
 jest.mock("next-auth");
 
 const updateMock = startAtlasEntrySheetValidationsUpdate as jest.Mock;
 
-jest.mock("../app/services/entry-sheets", () => {
+jest.mock("@/app/services/entry-sheets", () => {
   const hcaValidationTools = jest.requireActual<
-    typeof import("../app/services/entry-sheets")
+    typeof import("@/app/services/entry-sheets")
   >("../app/services/entry-sheets");
   return {
     startAtlasEntrySheetValidationsUpdate: jest.fn(

--- a/__tests__/api-atlases-id-entry-sheet-validations.test.ts
+++ b/__tests__/api-atlases-id-entry-sheet-validations.test.ts
@@ -1,9 +1,6 @@
-import { HCAAtlasTrackerListEntrySheetValidation } from "app/apis/catalog/hca-atlas-tracker/common/entities";
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import entrySheetValidationsHandler from "../pages/api/atlases/[atlasId]/entry-sheet-validations";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import entrySheetValidationsHandler from "@/pages/api/atlases/[atlasId]/entry-sheet-validations";
 import {
   ATLAS_NONEXISTENT,
   ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A,
@@ -16,27 +13,30 @@ import {
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
 import {
   TestEntrySheetValidation,
   TestSourceStudy,
   TestUser,
-} from "../testing/entities";
+} from "@/testing/entities";
 import {
   expectIsDefined,
   getTestSourceStudyCitation,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { HCAAtlasTrackerListEntrySheetValidation } from "app/apis/catalog/hca-atlas-tracker/common/entities";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
-jest.mock("../app/utils/hca-validation-tools/hca-validation-tools-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/hca-validation-tools/hca-validation-tools-api");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-atlases-id-entry-sheet-validations.test.ts
+++ b/__tests__/api-atlases-id-entry-sheet-validations.test.ts
@@ -1,3 +1,4 @@
+import { HCAAtlasTrackerListEntrySheetValidation } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD } from "@/app/common/entities";
 import { endPgPool } from "@/app/services/database";
 import entrySheetValidationsHandler from "@/pages/api/atlases/[atlasId]/entry-sheet-validations";
@@ -26,7 +27,6 @@ import {
   testApiRole,
   withConsoleErrorHiding,
 } from "@/testing/utils";
-import { HCAAtlasTrackerListEntrySheetValidation } from "app/apis/catalog/hca-atlas-tracker/common/entities";
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
 

--- a/__tests__/api-atlases-id-files-archive.test.ts
+++ b/__tests__/api-atlases-id-files-archive.test.ts
@@ -1,9 +1,7 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { FilesSetIsArchivedData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import archiveHandler from "../pages/api/atlases/[atlasId]/files/archive";
+import { FilesSetIsArchivedData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import archiveHandler from "@/pages/api/atlases/[atlasId]/files/archive";
 import {
   ATLAS_NONEXISTENT,
   ATLAS_WITH_LINKED_PUBLISH_STATUSES,
@@ -37,22 +35,24 @@ import {
   USER_INTEGRATION_LEAD_PUBLIC,
   USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
   USER_UNREGISTERED,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   expectFilesToHaveArchiveStatus,
   resetDatabase,
-} from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
-import { testApiRole, withConsoleErrorHiding } from "../testing/utils";
+} from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
+import { testApiRole, withConsoleErrorHiding } from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
-jest.mock("../app/services/s3-operations");
+jest.mock("@/app/services/s3-operations");
 
 jest.mock("googleapis");
 jest.mock("next-auth");

--- a/__tests__/api-atlases-id-files-id-presigned-url.test.ts
+++ b/__tests__/api-atlases-id-files-id-presigned-url.test.ts
@@ -1,9 +1,7 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { PresignedUrlInfo } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import presignedUrlHandler from "../pages/api/atlases/[atlasId]/files/[fileId]/presigned-url";
+import { PresignedUrlInfo } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import presignedUrlHandler from "@/pages/api/atlases/[atlasId]/files/[fileId]/presigned-url";
 import {
   ATLAS_DRAFT,
   ATLAS_NONEXISTENT,
@@ -20,19 +18,21 @@ import {
   USER_INTEGRATION_LEAD_PUBLIC,
   USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestFile, TestUser } from "../testing/entities";
-import { testApiRole, withConsoleErrorHiding } from "../testing/utils";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestFile, TestUser } from "@/testing/entities";
+import { testApiRole, withConsoleErrorHiding } from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
-jest.mock("../app/services/s3-operations");
+jest.mock("@/app/services/s3-operations");
 
 jest.mock("googleapis");
 jest.mock("next-auth");

--- a/__tests__/api-atlases-id-files-unarchive.test.ts
+++ b/__tests__/api-atlases-id-files-unarchive.test.ts
@@ -1,9 +1,7 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { FilesSetIsArchivedData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import unarchiveHandler from "../pages/api/atlases/[atlasId]/files/unarchive";
+import { FilesSetIsArchivedData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import unarchiveHandler from "@/pages/api/atlases/[atlasId]/files/unarchive";
 import {
   ATLAS_NONEXISTENT,
   ATLAS_WITH_MISC_SOURCE_STUDIES,
@@ -26,22 +24,24 @@ import {
   USER_INTEGRATION_LEAD_PUBLIC,
   USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES_B,
   USER_UNREGISTERED,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   expectFilesToHaveArchiveStatus,
   resetDatabase,
-} from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
-import { testApiRole, withConsoleErrorHiding } from "../testing/utils";
+} from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
+import { testApiRole, withConsoleErrorHiding } from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
-jest.mock("../app/services/s3-operations");
+jest.mock("@/app/services/s3-operations");
 
 jest.mock("googleapis");
 jest.mock("next-auth");

--- a/__tests__/api-atlases-id-heatmap.test.ts
+++ b/__tests__/api-atlases-id-heatmap.test.ts
@@ -1,14 +1,12 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   Heatmap,
   HeatmapClass,
   HeatmapEntrySheet,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import dataDictionary from "../catalog/downloaded/data-dictionary.json";
-import heatmapHandler from "../pages/api/atlases/[atlasId]/heatmap";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import dataDictionary from "@/catalog/downloaded/data-dictionary.json";
+import heatmapHandler from "@/pages/api/atlases/[atlasId]/heatmap";
 import {
   ATLAS_HEATMAP_TEST,
   ATLAS_NONEXISTENT,
@@ -20,21 +18,23 @@ import {
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
 import {
   expectIsDefined,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-atlases-id-publish.test.ts
+++ b/__tests__/api-atlases-id-publish.test.ts
@@ -1,13 +1,11 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   HCAAtlasTrackerAtlas,
   HCAAtlasTrackerDBComponentAtlas,
   HCAAtlasTrackerDBSourceDataset,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import publishHandler from "../pages/api/atlases/[atlasId]/publish";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import publishHandler from "@/pages/api/atlases/[atlasId]/publish";
 import {
   ATLAS_PUBLISHED,
   ATLAS_WITH_LINKED_PUBLISH_STATUSES,
@@ -25,27 +23,29 @@ import {
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   getExistingAtlasFromDatabase,
   getExistingComponentAtlasFromDatabase,
   getExistingSourceDatasetFromDatabase,
   resetDatabase,
-} from "../testing/db-utils";
+} from "@/testing/db-utils";
 import {
   TestComponentAtlas,
   TestSourceDataset,
   TestUser,
-} from "../testing/entities";
-import { testApiRole, withConsoleErrorHiding } from "../testing/utils";
+} from "@/testing/entities";
+import { testApiRole, withConsoleErrorHiding } from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("googleapis");
 jest.mock("next-auth");

--- a/__tests__/api-atlases-id-source-datasets-id.test.ts
+++ b/__tests__/api-atlases-id-source-datasets-id.test.ts
@@ -1,16 +1,14 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   FileValidationSummary,
   HCAAtlasTrackerDetailSourceDataset,
   HCAAtlasTrackerSourceDataset,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { AtlasSourceDatasetEditData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { METHOD } from "../app/common/entities";
-import { FormResponseErrors } from "../app/hooks/useForm/common/entities";
-import { endPgPool } from "../app/services/database";
-import { getSheetTitleForApi } from "../app/utils/google-sheets-api";
-import sourceDatasetHandler from "../pages/api/atlases/[atlasId]/source-datasets/[sourceDatasetId]";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { AtlasSourceDatasetEditData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { METHOD } from "@/app/common/entities";
+import { FormResponseErrors } from "@/app/hooks/useForm/common/entities";
+import { endPgPool } from "@/app/services/database";
+import { getSheetTitleForApi } from "@/app/utils/google-sheets-api";
+import sourceDatasetHandler from "@/pages/api/atlases/[atlasId]/source-datasets/[sourceDatasetId]";
 import {
   ATLAS_WITH_MISC_SOURCE_STUDIES,
   ATLAS_WITH_MISC_SOURCE_STUDIES_B,
@@ -40,13 +38,13 @@ import {
   USER_INTEGRATION_LEAD_PUBLIC,
   USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
   USER_UNREGISTERED,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   expectSourceDatasetToBeUnchanged,
   getConceptFromDatabase,
   resetDatabase,
-} from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
+} from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
 import {
   assertExpectDefined,
   delay,
@@ -54,23 +52,25 @@ import {
   getTestEntityDownloadName,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("googleapis");
 jest.mock("next-auth");
 
 const getSheetTitleMock = getSheetTitleForApi as jest.Mock;
 
-jest.mock("../app/utils/google-sheets-api", () => {
-  const googleSheetsApi: typeof import("../app/utils/google-sheets-api") =
-    jest.requireActual("../app/utils/google-sheets-api");
+jest.mock("@/app/utils/google-sheets-api", () => {
+  const googleSheetsApi: typeof import("@/app/utils/google-sheets-api") =
+    jest.requireActual("@/app/utils/google-sheets-api");
 
   return {
     getSheetTitleForApi: jest.fn(googleSheetsApi.getSheetTitleForApi),

--- a/__tests__/api-atlases-id-source-datasets-publication-status.test.ts
+++ b/__tests__/api-atlases-id-source-datasets-publication-status.test.ts
@@ -1,10 +1,8 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { PUBLICATION_STATUS } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { SourceDatasetsSetPublicationStatusData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { METHOD } from "../app/common/entities";
-import { endPgPool, query } from "../app/services/database";
-import publicationStatusHandler from "../pages/api/atlases/[atlasId]/source-datasets/publication-status";
+import { PUBLICATION_STATUS } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { SourceDatasetsSetPublicationStatusData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool, query } from "@/app/services/database";
+import publicationStatusHandler from "@/pages/api/atlases/[atlasId]/source-datasets/publication-status";
 import {
   ATLAS_WITH_MISC_SOURCE_STUDIES,
   ATLAS_WITH_MISC_SOURCE_STUDIES_B,
@@ -26,26 +24,28 @@ import {
   USER_INTEGRATION_LEAD_PUBLIC,
   USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
   USER_UNREGISTERED,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   expectSourceDatasetToBeUnchanged,
   getAtlasSourceDatasetsFromDatabase,
   resetDatabase,
-} from "../testing/db-utils";
-import { TestSourceDataset, TestUser } from "../testing/entities";
+} from "@/testing/db-utils";
+import { TestSourceDataset, TestUser } from "@/testing/entities";
 import {
   expectDbSourceDatasetToMatchTest,
   expectIsDefined,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("googleapis");
 jest.mock("next-auth");

--- a/__tests__/api-atlases-id-source-datasets-reprocessed-status.test.ts
+++ b/__tests__/api-atlases-id-source-datasets-reprocessed-status.test.ts
@@ -1,10 +1,8 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { REPROCESSED_STATUS } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { SourceDatasetsSetReprocessedStatusData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { METHOD } from "../app/common/entities";
-import { endPgPool, query } from "../app/services/database";
-import reprocessedStatusHandler from "../pages/api/atlases/[atlasId]/source-datasets/reprocessed-status";
+import { REPROCESSED_STATUS } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { SourceDatasetsSetReprocessedStatusData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool, query } from "@/app/services/database";
+import reprocessedStatusHandler from "@/pages/api/atlases/[atlasId]/source-datasets/reprocessed-status";
 import {
   ATLAS_WITH_MISC_SOURCE_STUDIES,
   ATLAS_WITH_MISC_SOURCE_STUDIES_B,
@@ -26,33 +24,35 @@ import {
   USER_INTEGRATION_LEAD_PUBLIC,
   USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
   USER_UNREGISTERED,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   expectSourceDatasetToBeUnchanged,
   getAtlasSourceDatasetsFromDatabase,
   resetDatabase,
-} from "../testing/db-utils";
-import { TestSourceDataset, TestUser } from "../testing/entities";
+} from "@/testing/db-utils";
+import { TestSourceDataset, TestUser } from "@/testing/entities";
 import {
   expectDbSourceDatasetToMatchTest,
   expectIsDefined,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("googleapis");
 jest.mock("next-auth");
 
-jest.mock("../app/utils/google-sheets-api", () => {
-  const googleSheetsApi: typeof import("../app/utils/google-sheets-api") =
-    jest.requireActual("../app/utils/google-sheets-api");
+jest.mock("@/app/utils/google-sheets-api", () => {
+  const googleSheetsApi: typeof import("@/app/utils/google-sheets-api") =
+    jest.requireActual("@/app/utils/google-sheets-api");
 
   return {
     getSheetTitleForApi: jest.fn(googleSheetsApi.getSheetTitleForApi),

--- a/__tests__/api-atlases-id-source-datasets-source-study.test.ts
+++ b/__tests__/api-atlases-id-source-datasets-source-study.test.ts
@@ -1,9 +1,7 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { SourceDatasetsSetSourceStudyData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { METHOD } from "../app/common/entities";
-import { endPgPool, query } from "../app/services/database";
-import sourceStudyHandler from "../pages/api/atlases/[atlasId]/source-datasets/source-study";
+import { SourceDatasetsSetSourceStudyData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool, query } from "@/app/services/database";
+import sourceStudyHandler from "@/pages/api/atlases/[atlasId]/source-datasets/source-study";
 import {
   ATLAS_WITH_MISC_SOURCE_STUDIES_C,
   ATLAS_WITH_NON_LATEST_METADATA_ENTITIES,
@@ -23,26 +21,28 @@ import {
   USER_INTEGRATION_LEAD_PUBLIC,
   USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES_C,
   USER_UNREGISTERED,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   expectSourceDatasetToBeUnchanged,
   getAtlasSourceDatasetsFromDatabase,
   resetDatabase,
-} from "../testing/db-utils";
-import { TestSourceDataset, TestUser } from "../testing/entities";
+} from "@/testing/db-utils";
+import { TestSourceDataset, TestUser } from "@/testing/entities";
 import {
   expectDbSourceDatasetToMatchTest,
   expectIsDefined,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("googleapis");
 jest.mock("next-auth");

--- a/__tests__/api-atlases-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-source-datasets.test.ts
@@ -1,12 +1,10 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   HCAAtlasTrackerLocalListSourceDataset,
   HCAAtlasTrackerSourceDataset,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import sourceDatasetsHandler from "../pages/api/atlases/[atlasId]/source-datasets";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import sourceDatasetsHandler from "@/pages/api/atlases/[atlasId]/source-datasets";
 import {
   ATLAS_PUBLISHED,
   ATLAS_WITH_MISC_SOURCE_STUDIES,
@@ -54,9 +52,9 @@ import {
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
 import {
   assertExpectDefined,
   expectApiSourceDatasetsToHaveComponentAtlases,
@@ -67,14 +65,16 @@ import {
   getTestEntityDownloadName,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-atlases-id-source-studies-create.test.ts
+++ b/__tests__/api-atlases-id-source-studies-create.test.ts
@@ -1,14 +1,12 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   HCAAtlasTrackerDBAtlas,
   HCAAtlasTrackerDBSourceStudy,
   HCAAtlasTrackerSourceStudy,
   PublicationInfo,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool, query } from "../app/services/database";
-import createHandler from "../pages/api/atlases/[atlasId]/source-studies/create";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool, query } from "@/app/services/database";
+import createHandler from "@/pages/api/atlases/[atlasId]/source-studies/create";
 import {
   ATLAS_DRAFT,
   ATLAS_NONEXISTENT,
@@ -44,28 +42,30 @@ import {
   USER_DISABLED_CONTENT_ADMIN,
   USER_INTEGRATION_LEAD_DRAFT,
   USER_UNREGISTERED,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   getAllSourceDatasetsFromDatabase,
   getStudySourceDatasets,
   getValidationsByEntityId,
   resetDatabase,
-} from "../testing/db-utils";
-import { TestAtlas, TestUser } from "../testing/entities";
+} from "@/testing/db-utils";
+import { TestAtlas, TestUser } from "@/testing/entities";
 import {
   expectApiValidationsToMatchDb,
   expectSourceStudyToMatch,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/pg-app-connect-config");
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-atlases-id-source-studies-id-source-datasets.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id-source-datasets.test.ts
@@ -1,12 +1,10 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   HCAAtlasTrackerLocalListSourceDataset,
   HCAAtlasTrackerSourceDataset,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import sourceDatasetsHandler from "../pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import sourceDatasetsHandler from "@/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]/source-datasets";
 import {
   ATLAS_WITH_MISC_SOURCE_STUDIES,
   ATLAS_WITH_MISC_SOURCE_STUDIES_B,
@@ -39,9 +37,9 @@ import {
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
 import {
   assertExpectDefined,
   expectApiSourceDatasetsToHaveComponentAtlases,
@@ -50,14 +48,16 @@ import {
   getTestEntityDownloadName,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-atlases-id-source-studies-id.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id.test.ts
@@ -203,7 +203,7 @@ const SOURCE_STUDY_UNPUBLISHED_WITH_CELLXGENE_EDIT: SourceStudyEditData = {
 beforeAll(async () => {
   actualEntrySheetsModule = jest.requireActual<
     typeof import("@/app/services/entry-sheets")
-  >("../app/services/entry-sheets");
+  >("@/app/services/entry-sheets");
 
   await resetDatabase();
 });

--- a/__tests__/api-atlases-id-source-studies-id.test.ts
+++ b/__tests__/api-atlases-id-source-studies-id.test.ts
@@ -1,21 +1,19 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   DOI_STATUS,
   HCAAtlasTrackerDBSourceStudy,
   HCAAtlasTrackerDBValidation,
   HCAAtlasTrackerSourceStudy,
   VALIDATION_ID,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import {
   SourceStudyEditData,
   UnpublishedSourceStudyEditData,
-} from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { METHOD } from "../app/common/entities";
-import { endPgPool, query } from "../app/services/database";
-import { startEntrySheetValidationsUpdate } from "../app/services/entry-sheets";
-import { getSpreadsheetIdFromUrl } from "../app/utils/google-sheets";
-import studyHandler from "../pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool, query } from "@/app/services/database";
+import { startEntrySheetValidationsUpdate } from "@/app/services/entry-sheets";
+import { getSpreadsheetIdFromUrl } from "@/app/utils/google-sheets";
+import studyHandler from "@/pages/api/atlases/[atlasId]/source-studies/[sourceStudyId]";
 import {
   ATLAS_DRAFT,
   ATLAS_PUBLIC,
@@ -70,7 +68,7 @@ import {
   USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
   USER_STAKEHOLDER,
   USER_UNREGISTERED,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   expectApiSourceStudyToHaveMatchingDbValidations,
   expectSourceDatasetsToHaveSourceStudy,
@@ -87,31 +85,33 @@ import {
   getStudySourceDatasets,
   getValidationsByEntityId,
   resetDatabase,
-} from "../testing/db-utils";
-import { TestSourceStudy, TestUser } from "../testing/entities";
+} from "@/testing/db-utils";
+import { TestSourceStudy, TestUser } from "@/testing/entities";
 import {
   expectApiValidationsToMatchDb,
   expectSourceStudyToMatch,
   makeTestSourceStudyOverview,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/pg-app-connect-config");
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
 
 jest.mock("next-auth");
 
 const entrySheetsUpdateMock = startEntrySheetValidationsUpdate as jest.Mock;
-let actualEntrySheetsModule: typeof import("../app/services/entry-sheets");
+let actualEntrySheetsModule: typeof import("@/app/services/entry-sheets");
 
-jest.mock("../app/services/entry-sheets", () => {
-  const unchangedItems: Partial<typeof import("../app/services/entry-sheets")> =
+jest.mock("@/app/services/entry-sheets", () => {
+  const unchangedItems: Partial<typeof import("@/app/services/entry-sheets")> =
     {
       deleteEntrySheetValidationsBySpreadsheet(...args) {
         return actualEntrySheetsModule.deleteEntrySheetValidationsBySpreadsheet(
@@ -202,7 +202,7 @@ const SOURCE_STUDY_UNPUBLISHED_WITH_CELLXGENE_EDIT: SourceStudyEditData = {
 
 beforeAll(async () => {
   actualEntrySheetsModule = jest.requireActual<
-    typeof import("../app/services/entry-sheets")
+    typeof import("@/app/services/entry-sheets")
   >("../app/services/entry-sheets");
 
   await resetDatabase();

--- a/__tests__/api-atlases-id-source-studies.test.ts
+++ b/__tests__/api-atlases-id-source-studies.test.ts
@@ -1,9 +1,7 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { HCAAtlasTrackerSourceStudy } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import studiesHandler from "../pages/api/atlases/[atlasId]/source-studies";
+import { HCAAtlasTrackerSourceStudy } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import studiesHandler from "@/pages/api/atlases/[atlasId]/source-studies";
 import {
   ATLAS_DRAFT,
   ATLAS_PUBLIC,
@@ -19,26 +17,28 @@ import {
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   expectApiSourceStudyToHaveMatchingDbValidations,
   resetDatabase,
-} from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
+} from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
 import {
   expectApiSourceStudyToMatchPublishedTest,
   expectApiSourceStudyToMatchUnpublishedTest,
   getTestAtlasShortNameSlug,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-atlases-id-status.test.ts
+++ b/__tests__/api-atlases-id-status.test.ts
@@ -1,6 +1,4 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { FILE_VALIDATOR_NAMES } from "../app/apis/catalog/hca-atlas-tracker/common/constants";
+import { FILE_VALIDATOR_NAMES } from "@/app/apis/catalog/hca-atlas-tracker/common/constants";
 import {
   ATLAS_STATUS,
   AtlasStatusSummary,
@@ -11,10 +9,10 @@ import {
   FileValidatorName,
   REPROCESSED_STATUS,
   ROLE,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { doTransaction, endPgPool } from "../app/services/database";
-import statusHandler from "../pages/api/atlases/[atlasId]/status";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { doTransaction, endPgPool } from "@/app/services/database";
+import statusHandler from "@/pages/api/atlases/[atlasId]/status";
 import {
   ATLAS_NONEXISTENT,
   STAKEHOLDER_ANALOGOUS_ROLES,
@@ -22,7 +20,7 @@ import {
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   initAtlases,
   initComponentAtlases,
@@ -31,26 +29,28 @@ import {
   initSourceStudies,
   initUsers,
   resetDatabase,
-} from "../testing/db-utils";
+} from "@/testing/db-utils";
 import {
   TestAtlas,
   TestComponentAtlas,
   TestSourceDataset,
   TestSourceStudy,
   TestUser,
-} from "../testing/entities";
+} from "@/testing/entities";
 import {
   makeTestUser,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-atlases-id-versions.test.ts
+++ b/__tests__/api-atlases-id-versions.test.ts
@@ -1,9 +1,7 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { HCAAtlasTrackerAtlas } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import versionsHandler from "../pages/api/atlases/[atlasId]/versions";
+import { HCAAtlasTrackerAtlas } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import versionsHandler from "@/pages/api/atlases/[atlasId]/versions";
 import {
   ATLAS_PUBLISHED,
   ATLAS_PUBLISHED_R6,
@@ -15,14 +13,14 @@ import {
   USER_DISABLED_CONTENT_ADMIN,
   USER_INTEGRATION_LEAD_PUBLISHED,
   USER_UNREGISTERED,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   getExistingAtlasFromDatabase,
   getUserFromDatabaseByEmail,
   getValidationsByEntityId,
   resetDatabase,
-} from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
+} from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
 import {
   assertExpectDefined,
   delay,
@@ -30,15 +28,17 @@ import {
   expectDbAtlasToMatchApi,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("googleapis");
 jest.mock("next-auth");

--- a/__tests__/api-atlases-id.test.ts
+++ b/__tests__/api-atlases-id.test.ts
@@ -1,18 +1,16 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   ATLAS_STATUS,
   HCAAtlasTrackerAtlas,
   HCAAtlasTrackerDBAtlas,
   PublicationInfo,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { AtlasEditData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { METHOD } from "../app/common/entities";
-import { FormResponseErrors } from "../app/hooks/useForm/common/entities";
-import { endPgPool, query } from "../app/services/database";
-import { slugifyAtlasShortName } from "../app/utils/atlases";
-import { getSheetTitleForApi } from "../app/utils/google-sheets-api";
-import atlasHandler from "../pages/api/atlases/[atlasId]";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { AtlasEditData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { METHOD } from "@/app/common/entities";
+import { FormResponseErrors } from "@/app/hooks/useForm/common/entities";
+import { endPgPool, query } from "@/app/services/database";
+import { slugifyAtlasShortName } from "@/app/utils/atlases";
+import { getSheetTitleForApi } from "@/app/utils/google-sheets-api";
+import atlasHandler from "@/pages/api/atlases/[atlasId]";
 import {
   ATLAS_DRAFT,
   ATLAS_PUBLIC,
@@ -36,9 +34,9 @@ import {
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestAtlas, TestUser } from "../testing/entities";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestAtlas, TestUser } from "@/testing/entities";
 import {
   expectApiAtlasToMatchTest,
   expectDbAtlasToMatchApi,
@@ -46,24 +44,26 @@ import {
   makeTestAtlasOverview,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("googleapis");
 jest.mock("next-auth");
 
 const getSheetTitleMock = getSheetTitleForApi as jest.Mock;
 
-jest.mock("../app/utils/google-sheets-api", () => {
-  const googleSheetsApi: typeof import("../app/utils/google-sheets-api") =
-    jest.requireActual("../app/utils/google-sheets-api");
+jest.mock("@/app/utils/google-sheets-api", () => {
+  const googleSheetsApi: typeof import("@/app/utils/google-sheets-api") =
+    jest.requireActual("@/app/utils/google-sheets-api");
 
   return {
     getSheetTitleForApi: jest.fn(googleSheetsApi.getSheetTitleForApi),

--- a/__tests__/api-atlases.test.ts
+++ b/__tests__/api-atlases.test.ts
@@ -1,9 +1,7 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { HCAAtlasTrackerAtlas } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import atlasesHandler from "../pages/api/atlases";
+import { HCAAtlasTrackerAtlas } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import atlasesHandler from "@/pages/api/atlases";
 import {
   ATLAS_DRAFT,
   ATLAS_WITH_DRAFT_LATEST_R0,
@@ -16,23 +14,25 @@ import {
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestAtlas, TestUser } from "../testing/entities";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestAtlas, TestUser } from "@/testing/entities";
 import {
   expectApiAtlasToMatchTest,
   expectIsDefined,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-comments-thread-id-comments-comment-id.test.ts
+++ b/__tests__/api-comments-thread-id-comments-comment-id.test.ts
@@ -1,14 +1,12 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   HCAAtlasTrackerComment,
   HCAAtlasTrackerDBComment,
   HCAAtlasTrackerDBUser,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { CommentEditData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { METHOD } from "../app/common/entities";
-import { endPgPool, query } from "../app/services/database";
-import commentHandler from "../pages/api/comments/[threadId]/comments/[commentId]";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { CommentEditData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool, query } from "@/app/services/database";
+import commentHandler from "@/pages/api/comments/[threadId]/comments/[commentId]";
 import {
   COMMENT_BY_CELLXGENE_ADMIN_REPLY2_CELLXGENE_ADMIN,
   COMMENT_BY_CELLXGENE_ADMIN_ROOT,
@@ -41,17 +39,19 @@ import {
   USER_STAKEHOLDER,
   USER_STAKEHOLDER2,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { getDbUsersByEmail, resetDatabase } from "../testing/db-utils";
-import { TestComment, TestUser } from "../testing/entities";
-import { withConsoleErrorHiding } from "../testing/utils";
+} from "@/testing/constants";
+import { getDbUsersByEmail, resetDatabase } from "@/testing/db-utils";
+import { TestComment, TestUser } from "@/testing/entities";
+import { withConsoleErrorHiding } from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-comments-thread-id-comments.test.ts
+++ b/__tests__/api-comments-thread-id-comments.test.ts
@@ -1,14 +1,11 @@
-import { METHOD } from "app/common/entities";
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   HCAAtlasTrackerComment,
   HCAAtlasTrackerDBComment,
   HCAAtlasTrackerDBUser,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { NewCommentData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { endPgPool, query } from "../app/services/database";
-import commentsHandler from "../pages/api/comments/[threadId]/comments";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { NewCommentData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { endPgPool, query } from "@/app/services/database";
+import commentsHandler from "@/pages/api/comments/[threadId]/comments";
 import {
   TEST_COMMENTS_BY_THREAD_ID,
   THREAD_ID_BY_CONTENT_ADMIN,
@@ -21,17 +18,20 @@ import {
   USER_INTEGRATION_LEAD_DRAFT,
   USER_STAKEHOLDER,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { getDbUsersByEmail, resetDatabase } from "../testing/db-utils";
-import { TestComment, TestUser } from "../testing/entities";
-import { withConsoleErrorHiding } from "../testing/utils";
+} from "@/testing/constants";
+import { getDbUsersByEmail, resetDatabase } from "@/testing/db-utils";
+import { TestComment, TestUser } from "@/testing/entities";
+import { withConsoleErrorHiding } from "@/testing/utils";
+import { METHOD } from "app/common/entities";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-comments-thread-id-comments.test.ts
+++ b/__tests__/api-comments-thread-id-comments.test.ts
@@ -4,6 +4,7 @@ import {
   HCAAtlasTrackerDBUser,
 } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { NewCommentData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { METHOD } from "@/app/common/entities";
 import { endPgPool, query } from "@/app/services/database";
 import commentsHandler from "@/pages/api/comments/[threadId]/comments";
 import {
@@ -22,7 +23,6 @@ import {
 import { getDbUsersByEmail, resetDatabase } from "@/testing/db-utils";
 import { TestComment, TestUser } from "@/testing/entities";
 import { withConsoleErrorHiding } from "@/testing/utils";
-import { METHOD } from "app/common/entities";
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
 

--- a/__tests__/api-comments.test.ts
+++ b/__tests__/api-comments.test.ts
@@ -3,6 +3,7 @@ import {
   HCAAtlasTrackerDBComment,
 } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { NewCommentThreadData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { METHOD } from "@/app/common/entities";
 import { endPgPool, query } from "@/app/services/database";
 import commentsHandler from "@/pages/api/comments";
 import {
@@ -16,7 +17,6 @@ import {
 import { resetDatabase } from "@/testing/db-utils";
 import { TestUser } from "@/testing/entities";
 import { withConsoleErrorHiding } from "@/testing/utils";
-import { METHOD } from "app/common/entities";
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
 

--- a/__tests__/api-comments.test.ts
+++ b/__tests__/api-comments.test.ts
@@ -1,13 +1,10 @@
-import { METHOD } from "app/common/entities";
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   HCAAtlasTrackerComment,
   HCAAtlasTrackerDBComment,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { NewCommentThreadData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { endPgPool, query } from "../app/services/database";
-import commentsHandler from "../pages/api/comments";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { NewCommentThreadData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { endPgPool, query } from "@/app/services/database";
+import commentsHandler from "@/pages/api/comments";
 import {
   USER_CELLXGENE_ADMIN,
   USER_CONTENT_ADMIN,
@@ -15,17 +12,20 @@ import {
   USER_INTEGRATION_LEAD_DRAFT,
   USER_STAKEHOLDER,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
-import { withConsoleErrorHiding } from "../testing/utils";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
+import { withConsoleErrorHiding } from "@/testing/utils";
+import { METHOD } from "app/common/entities";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-component-atlases.test.ts
+++ b/__tests__/api-component-atlases.test.ts
@@ -1,9 +1,7 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { HCAAtlasTrackerGlobalComponentAtlas } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import componentAtlasesHandler from "../pages/api/component-atlases";
+import { HCAAtlasTrackerGlobalComponentAtlas } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import componentAtlasesHandler from "@/pages/api/component-atlases";
 import {
   ATLAS_PUBLISHED,
   ATLAS_PUBLISHED_R6,
@@ -30,22 +28,24 @@ import {
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestAtlas, TestComponentAtlas, TestUser } from "../testing/entities";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestAtlas, TestComponentAtlas, TestUser } from "@/testing/entities";
 import {
   expectApiComponentAtlasToMatchTest,
   expectApiEntityToMatchLinkedAtlases,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-me.test.ts
+++ b/__tests__/api-me.test.ts
@@ -1,34 +1,34 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   HCAAtlasTrackerActiveUser,
   HCAAtlasTrackerDBUser,
   ROLE,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool, query } from "../app/services/database";
-import meHandler from "../pages/api/me";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool, query } from "@/app/services/database";
+import meHandler from "@/pages/api/me";
 import {
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
   USER_STAKEHOLDER,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
 import {
   expectIsDefined,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-metadata-coverage-atlases.test.ts
+++ b/__tests__/api-metadata-coverage-atlases.test.ts
@@ -1,13 +1,11 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   AtlasMetadataCoverage,
   AtlasMetadataCoverageRollup,
   FileMetadataCoverage,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool, query } from "../app/services/database";
-import metadataCoverageAtlasesHandler from "../pages/api/metadata-coverage/atlases";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool, query } from "@/app/services/database";
+import metadataCoverageAtlasesHandler from "@/pages/api/metadata-coverage/atlases";
 import {
   ATLAS_WITH_MISC_SOURCE_STUDIES,
   ATLAS_WITH_MISC_SOURCE_STUDIES_B,
@@ -25,17 +23,19 @@ import {
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
-import { testApiRole, withConsoleErrorHiding } from "../testing/utils";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
+import { testApiRole, withConsoleErrorHiding } from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-published-atlases.test.ts
+++ b/__tests__/api-published-atlases.test.ts
@@ -1,30 +1,30 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { HCAAtlasTrackerAtlasSummary } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import publishedAtlasesHandler from "../pages/api/published-atlases";
+import { HCAAtlasTrackerAtlasSummary } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import publishedAtlasesHandler from "@/pages/api/published-atlases";
 import {
   INITIAL_TEST_ATLASES,
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestAtlas, TestUser } from "../testing/entities";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestAtlas, TestUser } from "@/testing/entities";
 import {
   expectAtlasSummaryToMatchTestAtlas,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-refresh.test.ts
+++ b/__tests__/api-refresh.test.ts
@@ -1,14 +1,12 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { ProjectsResponse } from "../app/apis/azul/hca-dcp/common/responses";
-import { METHOD } from "../app/common/entities";
+import { ProjectsResponse } from "@/app/apis/azul/hca-dcp/common/responses";
+import { METHOD } from "@/app/common/entities";
 import {
   REFRESH_ACTIVITY,
   REFRESH_OUTCOME,
   RefreshServicesStatuses,
-} from "../app/services/common/entities";
-import { endPgPool } from "../app/services/database";
-import { Handler } from "../app/utils/api-handler";
+} from "@/app/services/common/entities";
+import { endPgPool } from "@/app/services/database";
+import { Handler } from "@/app/utils/api-handler";
 import {
   HCA_CATALOG_TEST1,
   STAKEHOLDER_ANALOGOUS_ROLES,
@@ -17,34 +15,36 @@ import {
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { FunctionMocked, TestUser } from "../testing/entities";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { FunctionMocked, TestUser } from "@/testing/entities";
 import {
   delay,
   promiseWithResolvers,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
-jest.mock("../app/services/component-atlases");
+jest.mock("@/app/services/component-atlases");
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/utils/pg-app-connect-config");
-jest.mock("../app/services/source-studies", () => ({
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/utils/pg-app-connect-config");
+jest.mock("@/app/services/source-studies", () => ({
   updateSourceStudyExternalIds: jest.fn(),
   updateSourceStudyValidationsByEntityId: jest.fn(),
 }));
-jest.mock("../app/services/source-datasets", () => ({
+jest.mock("@/app/services/source-datasets", () => ({
   updateCellxGeneSourceDatasets: jest.fn(),
 }));
 
 jest.mock("next-auth");
 
 const refreshValidations = jest.fn();
-jest.mock("../app/services/validations", () => {
+jest.mock("@/app/services/validations", () => {
   const refreshValidationsProxy: FunctionMocked<
     typeof refreshValidations
   > = () => refreshValidations();
@@ -59,7 +59,7 @@ const getCellxGeneCollections = jest.fn(async () => {
   await getCollectionsBlock;
   return TEST_CELLXGENE_COLLECTIONS_A;
 });
-jest.mock("../app/utils/cellxgene-api", () => {
+jest.mock("@/app/utils/cellxgene-api", () => {
   const getCellxGeneCollectionsProxy: FunctionMocked<
     typeof getCellxGeneCollections
   > = () => getCellxGeneCollections();
@@ -73,7 +73,7 @@ const getAllProjects = jest.fn(
   async (catalog: string): Promise<ProjectsResponse[]> =>
     TEST_HCA_CATALOGS[catalog],
 );
-jest.mock("../app/utils/hca-api", () => {
+jest.mock("@/app/utils/hca-api", () => {
   const getAllProjectsProxy: FunctionMocked<typeof getAllProjects> = (
     catalog,
   ) => getAllProjects(catalog);
@@ -91,7 +91,7 @@ let refreshHandler: Handler;
 beforeAll(async () => {
   await resetDatabase();
   consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
-  refreshHandler = (await import("../pages/api/refresh")).default;
+  refreshHandler = (await import("@/pages/api/refresh")).default;
   await delay();
 });
 

--- a/__tests__/api-sns-with-s3-event.test.ts
+++ b/__tests__/api-sns-with-s3-event.test.ts
@@ -92,7 +92,7 @@ jest.mock("sns-validator", () => {
 
 const mockSubmitJob = jest.requireMock<
   typeof import("@/app/services/__mocks__/validator-batch")
->("../app/services/validator-batch").submitDatasetValidationJob;
+>("@/app/services/validator-batch").submitDatasetValidationJob;
 
 const TEST_ROUTE = "/api/sns";
 

--- a/__tests__/api-sns-with-s3-event.test.ts
+++ b/__tests__/api-sns-with-s3-event.test.ts
@@ -26,15 +26,13 @@ import {
   TEST_TIMESTAMP_PLUS_1H,
   TEST_VERSION_IDS,
   validateTestSnsMessage,
-} from "../testing/sns-testing";
+} from "@/testing/sns-testing";
 
 // Set up AWS resource configuration BEFORE any other imports
 setUpAwsConfig();
 
 // Imports
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { SNSMessage } from "../app/apis/catalog/hca-atlas-tracker/aws/schemas";
+import { SNSMessage } from "@/app/apis/catalog/hca-atlas-tracker/aws/schemas";
 import {
   FILE_TYPE,
   FILE_VALIDATION_STATUS,
@@ -45,11 +43,11 @@ import {
   HCAAtlasTrackerDBSourceDatasetInfo,
   INTEGRITY_STATUS,
   PUBLICATION_STATUS,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { resetConfigCache } from "../app/config/aws-resources";
-import { endPgPool, query } from "../app/services/database";
-import { parseNormalizedInfoFromS3Key } from "../app/utils/files";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { resetConfigCache } from "@/app/config/aws-resources";
+import { endPgPool, query } from "@/app/services/database";
+import { parseNormalizedInfoFromS3Key } from "@/app/utils/files";
 import {
   expectSourceDatasetFileToBeConsistentWith,
   getAtlasFromDatabase,
@@ -60,21 +58,23 @@ import {
   getFileComponentAtlas,
   getFileSourceDataset,
   resetDatabase,
-} from "../testing/db-utils";
+} from "@/testing/db-utils";
 import {
   assertExpectDefined,
   expectIsDefined,
   withConsoleMessageHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
-jest.mock("../app/services/validator-batch");
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
+jest.mock("@/app/services/validator-batch");
 
 jest.mock("next-auth");
 
@@ -91,12 +91,12 @@ jest.mock("sns-validator", () => {
 });
 
 const mockSubmitJob = jest.requireMock<
-  typeof import("../app/services/__mocks__/validator-batch")
+  typeof import("@/app/services/__mocks__/validator-batch")
 >("../app/services/validator-batch").submitDatasetValidationJob;
 
 const TEST_ROUTE = "/api/sns";
 
-import snsHandler from "../pages/api/sns";
+import snsHandler from "@/pages/api/sns";
 
 beforeEach(async () => {
   await resetDatabase(false);
@@ -662,7 +662,7 @@ describe(`${TEST_ROUTE} (S3 event)`, () => {
       })),
     }));
 
-    const { default: snsHandler } = await import("../pages/api/sns");
+    const { default: snsHandler } = await import("@/pages/api/sns");
 
     const errorMessages: unknown[][] = [];
 
@@ -2570,7 +2570,7 @@ describe(`${TEST_ROUTE} (S3 event)`, () => {
       },
     );
 
-    const handler = (await import("../pages/api/sns")).default;
+    const handler = (await import("@/pages/api/sns")).default;
     await withConsoleMessageHiding(async () => {
       await handler(req, res);
     });

--- a/__tests__/api-sns-with-validation-results.test.ts
+++ b/__tests__/api-sns-with-validation-results.test.ts
@@ -15,12 +15,44 @@ import {
   validateTestSnsMessage,
   ValidationResultsMetadataOptions,
   ValidationResultsOptions,
-} from "../testing/sns-testing";
+} from "@/testing/sns-testing";
 
 // Set up AWS resource configuration BEFORE any other imports
 setUpAwsConfig();
 
 // Imports
+import {
+  DatasetValidatorMetadataCoverage,
+  DatasetValidatorMetadataCoverageEntity,
+  DatasetValidatorResults,
+  DatasetValidatorResultsMetadata,
+  DatasetValidatorToolReports,
+  SNSMessage,
+} from "@/app/apis/catalog/hca-atlas-tracker/aws/schemas";
+import {
+  FILE_VALIDATION_STATUS,
+  FileValidationSummary,
+  HCAAtlasTrackerDBFileDatasetInfo,
+  INTEGRITY_STATUS,
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { resetConfigCache } from "@/app/config/aws-resources";
+import { endPgPool } from "@/app/services/database";
+import {
+  COMPONENT_ATLAS_DRAFT_FOO,
+  SOURCE_DATASET_BAR,
+  SOURCE_DATASET_BAZ,
+  SOURCE_DATASET_FOO,
+  SOURCE_DATASET_FOOBAR,
+  SOURCE_DATASET_FOOFOO,
+} from "@/testing/constants";
+import { getFileFromDatabase, resetDatabase } from "@/testing/db-utils";
+import {
+  ConsoleMessageOutputArrays,
+  fillTestFileDefaults,
+  getTestFileKey,
+  withConsoleMessageHiding,
+} from "@/testing/utils";
 import {
   DeleteObjectCommand,
   GetObjectCommand,
@@ -33,46 +65,14 @@ import { mockClient } from "aws-sdk-client-mock";
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
 import { Readable } from "stream";
-import {
-  DatasetValidatorMetadataCoverage,
-  DatasetValidatorMetadataCoverageEntity,
-  DatasetValidatorResults,
-  DatasetValidatorResultsMetadata,
-  DatasetValidatorToolReports,
-  SNSMessage,
-} from "../app/apis/catalog/hca-atlas-tracker/aws/schemas";
-import {
-  FILE_VALIDATION_STATUS,
-  FileValidationSummary,
-  HCAAtlasTrackerDBFileDatasetInfo,
-  INTEGRITY_STATUS,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { resetConfigCache } from "../app/config/aws-resources";
-import { endPgPool } from "../app/services/database";
-import {
-  COMPONENT_ATLAS_DRAFT_FOO,
-  SOURCE_DATASET_BAR,
-  SOURCE_DATASET_BAZ,
-  SOURCE_DATASET_FOO,
-  SOURCE_DATASET_FOOBAR,
-  SOURCE_DATASET_FOOFOO,
-} from "../testing/constants";
-import { getFileFromDatabase, resetDatabase } from "../testing/db-utils";
-import {
-  ConsoleMessageOutputArrays,
-  fillTestFileDefaults,
-  getTestFileKey,
-  withConsoleMessageHiding,
-} from "../testing/utils";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 
@@ -108,7 +108,7 @@ jest.mock("sns-validator", () => {
 
 const TEST_ROUTE = "/api/sns";
 
-import snsHandler from "../pages/api/sns";
+import snsHandler from "@/pages/api/sns";
 
 const FILE_SOURCE_DATASET_FOO = fillTestFileDefaults(SOURCE_DATASET_FOO.file);
 const FILE_SOURCE_DATASET_BAR = fillTestFileDefaults(SOURCE_DATASET_BAR.file);

--- a/__tests__/api-sns.test.ts
+++ b/__tests__/api-sns.test.ts
@@ -1,5 +1,5 @@
 // Mock HTTP wrapper for outbound requests BEFORE any imports
-jest.mock("../app/utils/http", () => {
+jest.mock("@/app/utils/http", () => {
   return { httpGet: jest.fn() };
 });
 
@@ -22,22 +22,22 @@ import {
   TEST_TIMESTAMP_ALT,
   TEST_VERSION_IDS,
   validateTestSnsMessage,
-} from "../testing/sns-testing";
+} from "@/testing/sns-testing";
 
 // Set up AWS resource configuration BEFORE any other imports
 setUpAwsConfig();
 
 // Imports
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { METHOD } from "../app/common/entities";
-import { resetConfigCache } from "../app/config/aws-resources";
-import { endPgPool, query } from "../app/services/database";
-import { resetDatabase } from "../testing/db-utils";
+import { METHOD } from "@/app/common/entities";
+import { resetConfigCache } from "@/app/config/aws-resources";
+import { endPgPool, query } from "@/app/services/database";
+import { resetDatabase } from "@/testing/db-utils";
 import {
   withConsoleErrorHiding,
   withConsoleMessageHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 // Retrieve the mock function created in the jest.mock factory above
 const { httpGet } = jest.requireMock("../app/utils/http") as {
@@ -46,12 +46,12 @@ const { httpGet } = jest.requireMock("../app/utils/http") as {
 const mockHttpGet = httpGet as jest.Mock;
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 
@@ -69,7 +69,7 @@ jest.mock("sns-validator", () => {
 
 const TEST_ROUTE = "/api/sns";
 
-import snsHandler from "../pages/api/sns";
+import snsHandler from "@/pages/api/sns";
 
 beforeEach(async () => {
   await resetDatabase();
@@ -261,7 +261,7 @@ describe(TEST_ROUTE, () => {
         method: METHOD.POST,
       });
 
-      const handler = (await import("../pages/api/sns")).default;
+      const handler = (await import("@/pages/api/sns")).default;
       await handler(req, res);
 
       expect(res._getStatusCode()).toBe(403);
@@ -317,7 +317,7 @@ describe(TEST_ROUTE, () => {
           method: METHOD.POST,
         });
 
-        const handler = (await import("../pages/api/sns")).default;
+        const handler = (await import("@/pages/api/sns")).default;
         await withConsoleMessageHiding(async () => {
           await handler(req, res);
         });
@@ -348,7 +348,7 @@ describe(TEST_ROUTE, () => {
           method: METHOD.POST,
         });
 
-        const handler = (await import("../pages/api/sns")).default;
+        const handler = (await import("@/pages/api/sns")).default;
         await withConsoleMessageHiding(async () => {
           await handler(req, res);
         });
@@ -381,7 +381,7 @@ describe(TEST_ROUTE, () => {
           method: METHOD.POST,
         });
 
-        const handler = (await import("../pages/api/sns")).default;
+        const handler = (await import("@/pages/api/sns")).default;
         await withConsoleMessageHiding(async () => {
           await handler(req, res);
         });
@@ -415,7 +415,7 @@ describe(TEST_ROUTE, () => {
           method: METHOD.POST,
         });
 
-        const handler = (await import("../pages/api/sns")).default;
+        const handler = (await import("@/pages/api/sns")).default;
         await withConsoleMessageHiding(async () => {
           await handler(req, res);
         });
@@ -444,7 +444,7 @@ describe(TEST_ROUTE, () => {
           method: METHOD.POST,
         });
 
-        const handler = (await import("../pages/api/sns")).default;
+        const handler = (await import("@/pages/api/sns")).default;
         await withConsoleMessageHiding(async () => {
           await handler(req, res);
         });
@@ -476,7 +476,7 @@ describe(TEST_ROUTE, () => {
           method: METHOD.POST,
         });
 
-        const handler = (await import("../pages/api/sns")).default;
+        const handler = (await import("@/pages/api/sns")).default;
         await withConsoleMessageHiding(async () => {
           await handler(req, res);
         });

--- a/__tests__/api-sns.test.ts
+++ b/__tests__/api-sns.test.ts
@@ -40,7 +40,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
 
 // Retrieve the mock function created in the jest.mock factory above
-const { httpGet } = jest.requireMock("../app/utils/http") as {
+const { httpGet } = jest.requireMock("@/app/utils/http") as {
   httpGet: jest.Mock;
 };
 const mockHttpGet = httpGet as jest.Mock;

--- a/__tests__/api-source-datasets.test.ts
+++ b/__tests__/api-source-datasets.test.ts
@@ -1,9 +1,7 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { HCAAtlasTrackerGlobalSourceDataset } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import sourceDatasetsHandler from "../pages/api/source-datasets";
+import { HCAAtlasTrackerGlobalSourceDataset } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import sourceDatasetsHandler from "@/pages/api/source-datasets";
 import {
   ATLAS_PUBLISHED,
   ATLAS_PUBLISHED_R6,
@@ -28,22 +26,24 @@ import {
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestAtlas, TestSourceDataset, TestUser } from "../testing/entities";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestAtlas, TestSourceDataset, TestUser } from "@/testing/entities";
 import {
   expectApiEntityToMatchLinkedAtlases,
   expectApiSourceDatasetToMatchTest,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-source-studies.test.ts
+++ b/__tests__/api-source-studies.test.ts
@@ -1,9 +1,7 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { HCAAtlasTrackerGlobalSourceStudy } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import sourceStudiesHandler from "../pages/api/source-studies";
+import { HCAAtlasTrackerGlobalSourceStudy } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import sourceStudiesHandler from "@/pages/api/source-studies";
 import {
   ATLAS_DRAFT,
   ATLAS_PUBLISHED,
@@ -24,25 +22,27 @@ import {
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   expectApiSourceStudyToHaveMatchingDbValidations,
   resetDatabase,
-} from "../testing/db-utils";
-import { TestAtlas, TestSourceStudy, TestUser } from "../testing/entities";
+} from "@/testing/db-utils";
+import { TestAtlas, TestSourceStudy, TestUser } from "@/testing/entities";
 import {
   expectApiEntityToMatchLinkedAtlases,
   expectApiSourceStudyToMatchTest,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-source-study-cellxgene-ids.test.ts
+++ b/__tests__/api-source-study-cellxgene-ids.test.ts
@@ -1,3 +1,4 @@
+import { METHOD } from "@/app/common/entities";
 import { endPgPool } from "@/app/services/database";
 import cellxgeneIdsHandler from "@/pages/api/source-study-cellxgene-ids";
 import {
@@ -13,7 +14,6 @@ import {
 import { resetDatabase } from "@/testing/db-utils";
 import { TestUser } from "@/testing/entities";
 import { withConsoleErrorHiding } from "@/testing/utils";
-import { METHOD } from "app/common/entities";
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
 

--- a/__tests__/api-source-study-cellxgene-ids.test.ts
+++ b/__tests__/api-source-study-cellxgene-ids.test.ts
@@ -1,8 +1,5 @@
-import { METHOD } from "app/common/entities";
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { endPgPool } from "../app/services/database";
-import cellxgeneIdsHandler from "../pages/api/source-study-cellxgene-ids";
+import { endPgPool } from "@/app/services/database";
+import cellxgeneIdsHandler from "@/pages/api/source-study-cellxgene-ids";
 import {
   TEST_CELLXGENE_COLLECTIONS_BY_DOI,
   TEST_SOURCE_STUDIES,
@@ -12,17 +9,20 @@ import {
   USER_INTEGRATION_LEAD_DRAFT,
   USER_STAKEHOLDER,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
-import { withConsoleErrorHiding } from "../testing/utils";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
+import { withConsoleErrorHiding } from "@/testing/utils";
+import { METHOD } from "app/common/entities";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-sync-files.test.ts
+++ b/__tests__/api-sync-files.test.ts
@@ -1,24 +1,24 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import { syncFilesFromS3 } from "../app/services/s3-sync";
-import syncFilesHandler from "../pages/api/sync-files";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import { syncFilesFromS3 } from "@/app/services/s3-sync";
+import syncFilesHandler from "@/pages/api/sync-files";
 import {
   USER_CONTENT_ADMIN,
   USER_STAKEHOLDER,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { TestUser } from "../testing/entities";
-import { withConsoleErrorHiding } from "../testing/utils";
+} from "@/testing/constants";
+import { TestUser } from "@/testing/entities";
+import { withConsoleErrorHiding } from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
-jest.mock("../app/services/s3-sync");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
+jest.mock("@/app/services/s3-sync");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-tasks-cellxgene-in-progress.test.ts
+++ b/__tests__/api-tasks-cellxgene-in-progress.test.ts
@@ -1,15 +1,13 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   HCAAtlasTrackerDBValidation,
   ROLE,
   TASK_STATUS,
   TaskStatusesUpdatedByDOIResult,
   VALIDATION_ID,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool, query } from "../app/services/database";
-import cellxgeneInProgressHandler from "../pages/api/tasks/cellxgene-in-progress";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool, query } from "@/app/services/database";
+import cellxgeneInProgressHandler from "@/pages/api/tasks/cellxgene-in-progress";
 import {
   DOI_DRAFT_OK,
   DOI_PUBLIC_WITH_PREPRINT_PREPRINT,
@@ -27,17 +25,19 @@ import {
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
-import { testApiRole, withConsoleErrorHiding } from "../testing/utils";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
+import { testApiRole, withConsoleErrorHiding } from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/pg-app-connect-config");
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-tasks-completion-dates.test.ts
+++ b/__tests__/api-tasks-completion-dates.test.ts
@@ -1,12 +1,10 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   HCAAtlasTrackerDBValidation,
   HCAAtlasTrackerValidationRecord,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool, query } from "../app/services/database";
-import completionDatesHandler from "../pages/api/tasks/completion-dates";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool, query } from "@/app/services/database";
+import completionDatesHandler from "@/pages/api/tasks/completion-dates";
 import {
   ATLAS_WITH_IL,
   ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_A,
@@ -15,17 +13,19 @@ import {
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
-import { testApiRole, withConsoleErrorHiding } from "../testing/utils";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
+import { testApiRole, withConsoleErrorHiding } from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-tasks-validation-id-comment.test.ts
+++ b/__tests__/api-tasks-validation-id-comment.test.ts
@@ -1,15 +1,13 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   HCAAtlasTrackerComment,
   HCAAtlasTrackerDBComment,
   HCAAtlasTrackerDBUser,
   HCAAtlasTrackerDBValidation,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { NewCommentThreadData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { METHOD } from "../app/common/entities";
-import { endPgPool, query } from "../app/services/database";
-import commentHandler from "../pages/api/tasks/[validationId]/comment";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { NewCommentThreadData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool, query } from "@/app/services/database";
+import commentHandler from "@/pages/api/tasks/[validationId]/comment";
 import {
   COMMENT_BY_STAKEHOLDER2_ROOT,
   TEST_COMMENTS_BY_THREAD_ID,
@@ -20,17 +18,19 @@ import {
   USER_INTEGRATION_LEAD_DRAFT,
   USER_STAKEHOLDER,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { getDbUsersByEmail, resetDatabase } from "../testing/db-utils";
-import { TestComment, TestUser } from "../testing/entities";
-import { withConsoleErrorHiding } from "../testing/utils";
+} from "@/testing/constants";
+import { getDbUsersByEmail, resetDatabase } from "@/testing/db-utils";
+import { TestComment, TestUser } from "@/testing/entities";
+import { withConsoleErrorHiding } from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-tasks.test.ts
+++ b/__tests__/api-tasks.test.ts
@@ -1,10 +1,8 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { ProjectsResponse } from "../app/apis/azul/hca-dcp/common/responses";
-import { HCAAtlasTrackerValidationRecord } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import tasksHandler from "../pages/api/tasks";
+import { ProjectsResponse } from "@/app/apis/azul/hca-dcp/common/responses";
+import { HCAAtlasTrackerValidationRecord } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import tasksHandler from "@/pages/api/tasks";
 import {
   INITIAL_TEST_ATLASES_BY_SOURCE_STUDY,
   INITIAL_TEST_SOURCE_STUDIES,
@@ -17,17 +15,19 @@ import {
   USER_DISABLED_CONTENT_ADMIN,
   USER_STAKEHOLDER,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestSourceStudy, TestUser } from "../testing/entities";
-import { testApiRole, withConsoleErrorHiding } from "../testing/utils";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestSourceStudy, TestUser } from "@/testing/entities";
+import { testApiRole, withConsoleErrorHiding } from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/pg-app-connect-config");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-users-create.test.ts
+++ b/__tests__/api-users-create.test.ts
@@ -1,36 +1,36 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   HCAAtlasTrackerDBUser,
   HCAAtlasTrackerUser,
   ROLE,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { NewUserData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { METHOD } from "../app/common/entities";
-import { endPgPool, query } from "../app/services/database";
-import createHandler from "../pages/api/users/create";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { NewUserData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool, query } from "@/app/services/database";
+import createHandler from "@/pages/api/users/create";
 import {
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_NEW,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
 import {
   expectDbUserToMatchInputData,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-users-id-disable.test.ts
+++ b/__tests__/api-users-id-disable.test.ts
@@ -1,26 +1,26 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { METHOD } from "../app/common/entities";
-import { endPgPool, query } from "../app/services/database";
-import disableHandler from "../pages/api/users/[id]/disable";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool, query } from "@/app/services/database";
+import disableHandler from "@/pages/api/users/[id]/disable";
 import {
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_STAKEHOLDER,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
-import { testApiRole, withConsoleErrorHiding } from "../testing/utils";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
+import { testApiRole, withConsoleErrorHiding } from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-users-id-enable.test.ts
+++ b/__tests__/api-users-id-enable.test.ts
@@ -1,26 +1,26 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { METHOD } from "../app/common/entities";
-import { endPgPool, query } from "../app/services/database";
-import enableHandler from "../pages/api/users/[id]/enable";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool, query } from "@/app/services/database";
+import enableHandler from "@/pages/api/users/[id]/enable";
 import {
   STAKEHOLDER_ANALOGOUS_ROLES,
   USER_CONTENT_ADMIN,
   USER_DISABLED,
   USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
-import { testApiRole, withConsoleErrorHiding } from "../testing/utils";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
+import { testApiRole, withConsoleErrorHiding } from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-users-id.test.ts
+++ b/__tests__/api-users-id.test.ts
@@ -1,14 +1,12 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   HCAAtlasTrackerDBUser,
   HCAAtlasTrackerUser,
   ROLE,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { UserEditData } from "../app/apis/catalog/hca-atlas-tracker/common/schema";
-import { METHOD } from "../app/common/entities";
-import { endPgPool, query } from "../app/services/database";
-import userHandler from "../pages/api/users/[id]";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { UserEditData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool, query } from "@/app/services/database";
+import userHandler from "@/pages/api/users/[id]";
 import {
   INITIAL_TEST_USERS,
   STAKEHOLDER_ANALOGOUS_ROLES,
@@ -17,22 +15,24 @@ import {
   USER_NONEXISTENT,
   USER_STAKEHOLDER,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
 import {
   expectApiUserToMatchTest,
   expectDbUserToMatchInputData,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-users-integration-leads-from-atlases.test.ts
+++ b/__tests__/api-users-integration-leads-from-atlases.test.ts
@@ -1,9 +1,6 @@
-import { HCAAtlasTrackerDBUser } from "app/apis/catalog/hca-atlas-tracker/common/entities";
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { METHOD } from "../app/common/entities";
-import { endPgPool, query } from "../app/services/database";
-import integrationLeadsFromAtlasesHandler from "../pages/api/users/integration-leads-from-atlases";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool, query } from "@/app/services/database";
+import integrationLeadsFromAtlasesHandler from "@/pages/api/users/integration-leads-from-atlases";
 import {
   ATLAS_DRAFT,
   ATLAS_PUBLIC,
@@ -19,21 +16,24 @@ import {
   USER_INTEGRATION_LEAD_WITH_MISC_SOURCE_STUDIES,
   USER_INTEGRATION_LEAD_WITH_NEW_ATLAS,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
 import {
   expectIsDefined,
   testApiRole,
   withConsoleErrorHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { HCAAtlasTrackerDBUser } from "app/apis/catalog/hca-atlas-tracker/common/entities";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/pg-app-connect-config");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-users-integration-leads-from-atlases.test.ts
+++ b/__tests__/api-users-integration-leads-from-atlases.test.ts
@@ -1,3 +1,4 @@
+import { HCAAtlasTrackerDBUser } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD } from "@/app/common/entities";
 import { endPgPool, query } from "@/app/services/database";
 import integrationLeadsFromAtlasesHandler from "@/pages/api/users/integration-leads-from-atlases";
@@ -24,7 +25,6 @@ import {
   testApiRole,
   withConsoleErrorHiding,
 } from "@/testing/utils";
-import { HCAAtlasTrackerDBUser } from "app/apis/catalog/hca-atlas-tracker/common/entities";
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
 

--- a/__tests__/api-users.test.ts
+++ b/__tests__/api-users.test.ts
@@ -13,14 +13,14 @@ import {
 } from "@/testing/constants";
 import { resetDatabase } from "@/testing/db-utils";
 import { TestUser } from "@/testing/entities";
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   expectApiUserToMatchTest,
   expectIsDefined,
   testApiRole,
   withConsoleErrorHiding,
-} from "testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 
 jest.mock(
   "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",

--- a/__tests__/api-users.test.ts
+++ b/__tests__/api-users.test.ts
@@ -1,15 +1,7 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import {
-  expectApiUserToMatchTest,
-  expectIsDefined,
-  testApiRole,
-  withConsoleErrorHiding,
-} from "testing/utils";
-import { HCAAtlasTrackerUser } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import usersHandler from "../pages/api/users";
+import { HCAAtlasTrackerUser } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import usersHandler from "@/pages/api/users";
 import {
   INITIAL_TEST_USERS,
   STAKEHOLDER_ANALOGOUS_ROLES,
@@ -18,17 +10,25 @@ import {
   USER_NONEXISTENT,
   USER_STAKEHOLDER,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestUser } from "../testing/entities";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestUser } from "@/testing/entities";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
+import {
+  expectApiUserToMatchTest,
+  expectIsDefined,
+  testApiRole,
+  withConsoleErrorHiding,
+} from "testing/utils";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 jest.mock("next-auth");
 

--- a/__tests__/api-validate-files.test.ts
+++ b/__tests__/api-validate-files.test.ts
@@ -1,11 +1,8 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { resetDatabase } from "testing/db-utils";
-import { FILE_TYPE } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../app/common/entities";
-import { endPgPool } from "../app/services/database";
-import { validateAllFiles } from "../app/services/files";
-import validateFilesHandler from "../pages/api/validate-files";
+import { FILE_TYPE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { endPgPool } from "@/app/services/database";
+import { validateAllFiles } from "@/app/services/files";
+import validateFilesHandler from "@/pages/api/validate-files";
 import {
   FILE_A_SOURCE_DATASET_WITH_MULTIPLE_FILES,
   FILE_B_COMPONENT_ATLAS_WITH_ARCHIVED_LATEST,
@@ -14,30 +11,33 @@ import {
   USER_CONTENT_ADMIN,
   USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
-} from "../testing/constants";
-import { TestFile, TestUser } from "../testing/entities";
+} from "@/testing/constants";
+import { TestFile, TestUser } from "@/testing/entities";
 import {
   getAllTestFiles,
   testApiRole,
   withConsoleErrorHiding,
   withConsoleMessageHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
+import { resetDatabase } from "testing/db-utils";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
-jest.mock("../app/services/validator-batch");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
+jest.mock("@/app/services/validator-batch");
 
 jest.mock("next-auth");
 
 const validateMock = validateAllFiles as jest.Mock;
 
-jest.mock("../app/services/files", () => {
+jest.mock("@/app/services/files", () => {
   const filesServices = jest.requireActual<
-    typeof import("../app/services/files")
+    typeof import("@/app/services/files")
   >("../app/services/files");
   return {
     validateAllFiles: jest.fn(filesServices.validateAllFiles),
@@ -45,7 +45,7 @@ jest.mock("../app/services/files", () => {
 });
 
 const mockSubmitJob = jest.requireMock<
-  typeof import("../app/services/__mocks__/validator-batch")
+  typeof import("@/app/services/__mocks__/validator-batch")
 >("../app/services/validator-batch").submitDatasetValidationJob;
 
 beforeAll(async () => {

--- a/__tests__/api-validate-files.test.ts
+++ b/__tests__/api-validate-files.test.ts
@@ -12,6 +12,7 @@ import {
   USER_DISABLED_CONTENT_ADMIN,
   USER_UNREGISTERED,
 } from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
 import { TestFile, TestUser } from "@/testing/entities";
 import {
   getAllTestFiles,
@@ -21,7 +22,6 @@ import {
 } from "@/testing/utils";
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
-import { resetDatabase } from "testing/db-utils";
 
 jest.mock(
   "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
@@ -38,7 +38,7 @@ const validateMock = validateAllFiles as jest.Mock;
 jest.mock("@/app/services/files", () => {
   const filesServices = jest.requireActual<
     typeof import("@/app/services/files")
-  >("../app/services/files");
+  >("@/app/services/files");
   return {
     validateAllFiles: jest.fn(filesServices.validateAllFiles),
   };
@@ -46,7 +46,7 @@ jest.mock("@/app/services/files", () => {
 
 const mockSubmitJob = jest.requireMock<
   typeof import("@/app/services/__mocks__/validator-batch")
->("../app/services/validator-batch").submitDatasetValidationJob;
+>("@/app/services/validator-batch").submitDatasetValidationJob;
 
 beforeAll(async () => {
   await resetDatabase();

--- a/__tests__/atlas-status-dashboard.test.tsx
+++ b/__tests__/atlas-status-dashboard.test.tsx
@@ -1,15 +1,10 @@
-import { createAppTheme } from "@databiosphere/findable-ui/lib/theme/theme";
-import { ThemeProvider } from "@mui/material";
-import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
-import { JSX, ReactNode } from "react";
-import { AtlasStatusSummary } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { mergeAppTheme } from "../app/theme/theme";
-import { StatusDashboard } from "../app/views/AtlasStatusView/components/StatusDashboard/statusDashboard";
+import { AtlasStatusSummary } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { mergeAppTheme } from "@/app/theme/theme";
+import { StatusDashboard } from "@/app/views/AtlasStatusView/components/StatusDashboard/statusDashboard";
 import {
   BADGE_VARIANT,
   SECTION_STATUS,
-} from "../app/views/AtlasStatusView/components/StatusDashboard/types";
+} from "@/app/views/AtlasStatusView/components/StatusDashboard/types";
 import {
   buildIntegratedObjectsCard,
   buildSourceDatasetsCard,
@@ -18,7 +13,12 @@ import {
   getMinValidBadge,
   getValidationStatus,
   getWarningStatus,
-} from "../app/views/AtlasStatusView/components/StatusDashboard/utils";
+} from "@/app/views/AtlasStatusView/components/StatusDashboard/utils";
+import { createAppTheme } from "@databiosphere/findable-ui/lib/theme/theme";
+import { ThemeProvider } from "@mui/material";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { JSX, ReactNode } from "react";
 
 // Theme must include the app-only "caution" palette because mergeAppTheme's
 // MuiChip override reads theme.palette.caution when the theme is built.

--- a/__tests__/authed-query.test.ts
+++ b/__tests__/authed-query.test.ts
@@ -2,11 +2,11 @@ jest.mock("@databiosphere/findable-ui/lib/auth/hooks/useAuth", () => ({
   useAuth: jest.fn(),
 }));
 
+import { useAuthedQuery } from "@/app/query/useAuthedQuery";
 import { useAuth } from "@databiosphere/findable-ui/lib/auth/hooks/useAuth";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import { createElement, FunctionComponent, PropsWithChildren } from "react";
-import { useAuthedQuery } from "../app/query/useAuthedQuery";
 
 const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 

--- a/__tests__/authorization-provider.test.tsx
+++ b/__tests__/authorization-provider.test.tsx
@@ -5,14 +5,14 @@ import { JSX, ReactNode } from "react";
 jest.mock("@databiosphere/findable-ui/lib/auth/hooks/useAuth", () => ({
   useAuth: jest.fn(),
 }));
-jest.mock("../app/hooks/UseFetchActiveUser/hook", () => ({
+jest.mock("@/app/hooks/UseFetchActiveUser/hook", () => ({
   useFetchActiveUser: jest.fn(),
 }));
 
+import { HCAAtlasTrackerActiveUser } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { useFetchActiveUser } from "@/app/hooks/UseFetchActiveUser/hook";
+import { AuthorizationProvider } from "@/app/providers/authorization";
 import { useAuth } from "@databiosphere/findable-ui/lib/auth/hooks/useAuth";
-import { HCAAtlasTrackerActiveUser } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { useFetchActiveUser } from "../app/hooks/UseFetchActiveUser/hook";
-import { AuthorizationProvider } from "../app/providers/authorization";
 
 const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 const mockUseFetchActiveUser = useFetchActiveUser as jest.MockedFunction<

--- a/__tests__/back-button-utils.test.ts
+++ b/__tests__/back-button-utils.test.ts
@@ -1,8 +1,8 @@
 import {
   parseBackOrigin,
   resolveBackPath,
-} from "../app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/utils";
-import { withBackOrigin } from "../app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/utils";
+} from "@/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/utils";
+import { withBackOrigin } from "@/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/utils";
 
 describe("parseBackOrigin", () => {
   it("returns undefined for undefined", () => {

--- a/__tests__/cap-ingest-status.utils.test.ts
+++ b/__tests__/cap-ingest-status.utils.test.ts
@@ -4,8 +4,8 @@ import {
   HCAAtlasTrackerComponentAtlas,
   HCAAtlasTrackerSourceDataset,
   REPROCESSED_STATUS,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { getCapIngestStatus } from "../app/apis/catalog/hca-atlas-tracker/common/utils";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { getCapIngestStatus } from "@/app/apis/catalog/hca-atlas-tracker/common/utils";
 
 describe("getCapIngestStatus", () => {
   it("returns NOT_REQUIRED for reprocessed source datasets", () => {

--- a/__tests__/cellxgene.test.ts
+++ b/__tests__/cellxgene.test.ts
@@ -1,4 +1,4 @@
-import { CellxGeneCollection } from "../app/utils/cellxgene-api";
+import { CellxGeneCollection } from "@/app/utils/cellxgene-api";
 import {
   CELLXGENE_ID_NORMAL,
   CELLXGENE_ID_NORMAL2,
@@ -6,16 +6,16 @@ import {
   DOI_NORMAL2,
   TEST_CELLXGENE_COLLECTIONS_A,
   TEST_CELLXGENE_COLLECTIONS_B,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   delay,
   promiseWithResolvers,
   withConsoleMessageHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
 
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/utils/pg-app-connect-config");
-jest.mock("../app/services/refresh-services", () => ({
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/utils/pg-app-connect-config");
+jest.mock("@/app/services/refresh-services", () => ({
   doUpdatesIfRefreshesComplete: jest.fn(),
 }));
 
@@ -33,17 +33,17 @@ const getCellxGeneCollections = jest
     return cellxgeneCollections;
   });
 
-jest.mock("../app/utils/cellxgene-api", () => ({
+jest.mock("@/app/utils/cellxgene-api", () => ({
   getCellxGeneCollections,
 }));
 
-let getCellxGeneIdByDoi: typeof import("../app/services/cellxgene").getCellxGeneIdByDoi;
+let getCellxGeneIdByDoi: typeof import("@/app/services/cellxgene").getCellxGeneIdByDoi;
 
 let consoleLogSpy: jest.SpyInstance;
 
 beforeAll(async () => {
   consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
-  getCellxGeneIdByDoi = (await import("../app/services/cellxgene"))
+  getCellxGeneIdByDoi = (await import("@/app/services/cellxgene"))
     .getCellxGeneIdByDoi;
 });
 

--- a/__tests__/component-atlases.test.ts
+++ b/__tests__/component-atlases.test.ts
@@ -1,21 +1,21 @@
-import { FILE_TYPE } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { createComponentAtlas } from "../app/services/component-atlases";
-import { doTransaction, endPgPool, query } from "../app/services/database";
-import { ATLAS_DRAFT, EMPTY_COMPONENT_INFO } from "../testing/constants";
+import { FILE_TYPE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { createComponentAtlas } from "@/app/services/component-atlases";
+import { doTransaction, endPgPool, query } from "@/app/services/database";
+import { ATLAS_DRAFT, EMPTY_COMPONENT_INFO } from "@/testing/constants";
 import {
   createTestFile,
   getAtlasFromDatabase,
   getComponentAtlasVersionsFromDatabase,
   resetDatabase,
-} from "../testing/db-utils";
-import { expectIsDefined } from "../testing/utils";
+} from "@/testing/db-utils";
+import { expectIsDefined } from "@/testing/utils";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 const ATLAS_ID_NONEXISTENT = "ea885ef9-54ae-42c7-8a7a-75c32e4703a6";
 

--- a/__tests__/data-files.test.ts
+++ b/__tests__/data-files.test.ts
@@ -1,16 +1,16 @@
-import { ETagMismatchError } from "../app/apis/catalog/hca-atlas-tracker/aws/errors";
+import { ETagMismatchError } from "@/app/apis/catalog/hca-atlas-tracker/aws/errors";
 import {
   FILE_TYPE,
   FILE_VALIDATION_STATUS,
   INTEGRITY_STATUS,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import {
   confirmLatestFilesExistOnAtlas,
   markPreviousVersionsAsNotLatest,
   upsertFileRecord,
-} from "../app/data/files";
-import { doTransaction, endPgPool, query } from "../app/services/database";
-import { NotFoundError } from "../app/utils/api-errors";
+} from "@/app/data/files";
+import { doTransaction, endPgPool, query } from "@/app/services/database";
+import { NotFoundError } from "@/app/utils/api-errors";
 import {
   ATLAS_DRAFT,
   ATLAS_WITH_MISC_SOURCE_STUDIES,
@@ -22,12 +22,12 @@ import {
   SOURCE_DATASET_BAR,
   SOURCE_DATASET_DRAFT_OK_FOO,
   SOURCE_DATASET_FOO,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   createTestConceptFromS3Key,
   createTestFile,
   resetDatabase,
-} from "../testing/db-utils";
+} from "@/testing/db-utils";
 
 // Shared test constants
 const TEST_EVENT_INFO = JSON.stringify({
@@ -37,12 +37,12 @@ const TEST_EVENT_INFO = JSON.stringify({
 
 // Mock external dependencies
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 jest.mock("next-auth");
 
 beforeEach(async () => {

--- a/__tests__/format-iso-to-utc-date-time.test.ts
+++ b/__tests__/format-iso-to-utc-date-time.test.ts
@@ -1,4 +1,4 @@
-import { formatISOToUTCDateTime } from "../app/utils/date-fns";
+import { formatISOToUTCDateTime } from "@/app/utils/date-fns";
 
 describe("formatISOToUTCDateTime", () => {
   it("formats a valid ISO string into date and time parts", () => {

--- a/__tests__/get-sheet-title.test.ts
+++ b/__tests__/get-sheet-title.test.ts
@@ -1,6 +1,6 @@
-import { InvalidSheetError } from "app/utils/google-sheets";
-import { getSheetTitle } from "app/utils/google-sheets-api";
-import { withConsoleErrorHiding } from "testing/utils";
+import { InvalidSheetError } from "@/app/utils/google-sheets";
+import { getSheetTitle } from "@/app/utils/google-sheets-api";
+import { withConsoleErrorHiding } from "@/testing/utils";
 
 jest.mock("googleapis");
 

--- a/__tests__/hca-projects.test.ts
+++ b/__tests__/hca-projects.test.ts
@@ -1,5 +1,5 @@
-import { ProjectsResponse } from "../app/apis/azul/hca-dcp/common/responses";
-import { endPgPool } from "../app/services/database";
+import { ProjectsResponse } from "@/app/apis/azul/hca-dcp/common/responses";
+import { endPgPool } from "@/app/services/database";
 import {
   DOI_NORMAL,
   DOI_NORMAL2,
@@ -8,19 +8,19 @@ import {
   HCA_ID_NORMAL,
   HCA_ID_NORMAL2,
   TEST_HCA_CATALOGS,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   delay,
   promiseWithResolvers,
   withConsoleMessageHiding,
-} from "../testing/utils";
+} from "@/testing/utils";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
-jest.mock("../app/services/validations", () => ({
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
+jest.mock("@/app/services/validations", () => ({
   refreshValidations: jest.fn(),
 }));
 
@@ -40,18 +40,18 @@ const getAllProjects = jest
 
 const getLatestCatalog = jest.fn().mockResolvedValue(HCA_CATALOG_TEST1);
 
-jest.mock("../app/utils/hca-api", () => ({
+jest.mock("@/app/utils/hca-api", () => ({
   getAllProjects,
   getLatestCatalog,
 }));
 
-let getProjectIdByDoi: typeof import("../app/services/hca-projects").getProjectIdByDoi;
+let getProjectIdByDoi: typeof import("@/app/services/hca-projects").getProjectIdByDoi;
 
 let consoleLogSpy: jest.SpyInstance;
 
 beforeAll(async () => {
   consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
-  getProjectIdByDoi = (await import("../app/services/hca-projects"))
+  getProjectIdByDoi = (await import("@/app/services/hca-projects"))
     .getProjectIdByDoi;
 });
 

--- a/__tests__/hca-tier1-validation-status.utils.test.ts
+++ b/__tests__/hca-tier1-validation-status.utils.test.ts
@@ -3,8 +3,8 @@ import {
   HCA_TIER1_VALIDATION_STATUS,
   HCAAtlasTrackerComponentAtlas,
   HCAAtlasTrackerSourceDataset,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { getHcaTier1ValidationStatus } from "../app/apis/catalog/hca-atlas-tracker/common/utils";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { getHcaTier1ValidationStatus } from "@/app/apis/catalog/hca-atlas-tracker/common/utils";
 
 describe("getHcaTier1ValidationStatus", () => {
   it("returns UNKNOWN when validation status is pending with no existing summary", () => {

--- a/__tests__/integrated-object-source-datasets.test.ts
+++ b/__tests__/integrated-object-source-datasets.test.ts
@@ -6,27 +6,27 @@ import { createElement, FunctionComponent, PropsWithChildren } from "react";
 jest.mock("@databiosphere/findable-ui/lib/auth/hooks/useAuth", () => ({
   useAuth: jest.fn(),
 }));
-jest.mock("../app/hooks/useDeleteData");
-jest.mock("../app/providers/entity/hook");
-jest.mock("../app/common/utils", () => ({
-  ...jest.requireActual("../app/common/utils"),
+jest.mock("@/app/hooks/useDeleteData");
+jest.mock("@/app/providers/entity/hook");
+jest.mock("@/app/common/utils", () => ({
+  ...jest.requireActual("@/app/common/utils"),
   fetchResource: jest.fn(),
 }));
 
-import { useAuth } from "@databiosphere/findable-ui/lib/auth/hooks/useAuth";
-import { HCAAtlasTrackerSourceDataset } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { fetchResource } from "../app/common/utils";
-import { useDeleteData } from "../app/hooks/useDeleteData";
-import { useEntity } from "../app/providers/entity/hook";
-import { INTEGRATED_OBJECT } from "../app/views/ComponentAtlasView/hooks/UseFetchComponentAtlas/query/constants";
+import { HCAAtlasTrackerSourceDataset } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { fetchResource } from "@/app/common/utils";
+import { useDeleteData } from "@/app/hooks/useDeleteData";
+import { useEntity } from "@/app/providers/entity/hook";
+import { INTEGRATED_OBJECT } from "@/app/views/ComponentAtlasView/hooks/UseFetchComponentAtlas/query/constants";
 import {
   renderFileName,
   renderPublicationString,
-} from "../app/views/IntegratedObjectSourceDatasetsView/components/Table/viewBuilders";
-import { IntegratedObjectSourceDataset } from "../app/views/IntegratedObjectSourceDatasetsView/entities";
-import { useEditIntegratedObjectSourceDatasets } from "../app/views/IntegratedObjectSourceDatasetsView/hooks/useEditIntegratedObjectSourceDatasets";
-import { useFetchIntegratedObjectSourceDatasets } from "../app/views/IntegratedObjectSourceDatasetsView/hooks/UseFetchIntegratedObjectSourceDatasets/hook";
-import { INTEGRATED_OBJECT_SOURCE_DATASETS } from "../app/views/IntegratedObjectSourceDatasetsView/hooks/UseFetchIntegratedObjectSourceDatasets/query/constants";
+} from "@/app/views/IntegratedObjectSourceDatasetsView/components/Table/viewBuilders";
+import { IntegratedObjectSourceDataset } from "@/app/views/IntegratedObjectSourceDatasetsView/entities";
+import { useEditIntegratedObjectSourceDatasets } from "@/app/views/IntegratedObjectSourceDatasetsView/hooks/useEditIntegratedObjectSourceDatasets";
+import { useFetchIntegratedObjectSourceDatasets } from "@/app/views/IntegratedObjectSourceDatasetsView/hooks/UseFetchIntegratedObjectSourceDatasets/hook";
+import { INTEGRATED_OBJECT_SOURCE_DATASETS } from "@/app/views/IntegratedObjectSourceDatasetsView/hooks/UseFetchIntegratedObjectSourceDatasets/query/constants";
+import { useAuth } from "@databiosphere/findable-ui/lib/auth/hooks/useAuth";
 
 // Type mocks
 const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
@@ -312,7 +312,7 @@ describe("useIntegratedObjectSourceDatasetsTable", () => {
     );
 
     const { useIntegratedObjectSourceDatasetsTable } =
-      await import("../app/views/IntegratedObjectSourceDatasetsView/components/Table/hooks/UseIntegratedObjectSourceDatasetsTable/hook");
+      await import("@/app/views/IntegratedObjectSourceDatasetsView/components/Table/hooks/UseIntegratedObjectSourceDatasetsTable/hook");
 
     const { result } = renderHook(() =>
       useIntegratedObjectSourceDatasetsTable(),
@@ -337,7 +337,7 @@ describe("useIntegratedObjectSourceDatasetsTable", () => {
     );
 
     const { useIntegratedObjectSourceDatasetsTable } =
-      await import("../app/views/IntegratedObjectSourceDatasetsView/components/Table/hooks/UseIntegratedObjectSourceDatasetsTable/hook");
+      await import("@/app/views/IntegratedObjectSourceDatasetsView/components/Table/hooks/UseIntegratedObjectSourceDatasetsTable/hook");
 
     const { result } = renderHook(() =>
       useIntegratedObjectSourceDatasetsTable(),
@@ -360,7 +360,7 @@ describe("useIntegratedObjectSourceDatasetsTable", () => {
     );
 
     const { useIntegratedObjectSourceDatasetsTable } =
-      await import("../app/views/IntegratedObjectSourceDatasetsView/components/Table/hooks/UseIntegratedObjectSourceDatasetsTable/hook");
+      await import("@/app/views/IntegratedObjectSourceDatasetsView/components/Table/hooks/UseIntegratedObjectSourceDatasetsTable/hook");
 
     const { result } = renderHook(() =>
       useIntegratedObjectSourceDatasetsTable(),
@@ -388,7 +388,7 @@ describe("useIntegratedObjectSourceDatasetsTable", () => {
     );
 
     const { useIntegratedObjectSourceDatasetsTable } =
-      await import("../app/views/IntegratedObjectSourceDatasetsView/components/Table/hooks/UseIntegratedObjectSourceDatasetsTable/hook");
+      await import("@/app/views/IntegratedObjectSourceDatasetsView/components/Table/hooks/UseIntegratedObjectSourceDatasetsTable/hook");
 
     const { result } = renderHook(() =>
       useIntegratedObjectSourceDatasetsTable(),
@@ -408,7 +408,7 @@ describe("useIntegratedObjectSourceDatasetsTable", () => {
     );
 
     const { useIntegratedObjectSourceDatasetsTable } =
-      await import("../app/views/IntegratedObjectSourceDatasetsView/components/Table/hooks/UseIntegratedObjectSourceDatasetsTable/hook");
+      await import("@/app/views/IntegratedObjectSourceDatasetsView/components/Table/hooks/UseIntegratedObjectSourceDatasetsTable/hook");
 
     const { result } = renderHook(() =>
       useIntegratedObjectSourceDatasetsTable(),

--- a/__tests__/migration-down-guard.test.ts
+++ b/__tests__/migration-down-guard.test.ts
@@ -1,4 +1,4 @@
-import { assertMigrationDownAllowed } from "../scripts/migration-down-guard";
+import { assertMigrationDownAllowed } from "@/scripts/migration-down-guard";
 
 const DISABLED_MESSAGE = "migrate:down is disabled in deployed environments.";
 

--- a/__tests__/query-fn.test.ts
+++ b/__tests__/query-fn.test.ts
@@ -1,12 +1,12 @@
-jest.mock("../app/common/utils", () => ({
-  ...jest.requireActual("../app/common/utils"),
+jest.mock("@/app/common/utils", () => ({
+  ...jest.requireActual("@/app/common/utils"),
   fetchResource: jest.fn(),
 }));
 
+import { METHOD } from "@/app/common/entities";
+import { fetchResource } from "@/app/common/utils";
+import { queryFn } from "@/app/query/queryFn";
 import { QueryFunctionContext } from "@tanstack/react-query";
-import { METHOD } from "../app/common/entities";
-import { fetchResource } from "../app/common/utils";
-import { queryFn } from "../app/query/queryFn";
 
 const mockFetchResource = fetchResource as jest.MockedFunction<
   typeof fetchResource

--- a/__tests__/refresh-validations.test.ts
+++ b/__tests__/refresh-validations.test.ts
@@ -1,29 +1,29 @@
-import { refreshValidations } from "app/services/validations";
 import {
   HCAAtlasTrackerDBAtlas,
   HCAAtlasTrackerDBAtlasOverview,
   HCAAtlasTrackerDBValidation,
   VALIDATION_ID,
   VALIDATION_STATUS,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { endPgPool, query } from "../app/services/database";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { endPgPool, query } from "@/app/services/database";
 import {
   ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_A,
   ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_B,
   SOURCE_STUDY_PUBLISHED_WITH_HCA,
   SOURCE_STUDY_PUBLISHED_WITH_HCA_TITLE_MISMATCH,
   SOURCE_STUDY_UNPUBLISHED_WITH_CELLXGENE,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestAtlas, TestSourceStudy } from "../testing/entities";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestAtlas, TestSourceStudy } from "@/testing/entities";
+import { refreshValidations } from "app/services/validations";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 beforeAll(async () => {
   await resetDatabase();

--- a/__tests__/refresh-validations.test.ts
+++ b/__tests__/refresh-validations.test.ts
@@ -6,6 +6,7 @@ import {
   VALIDATION_STATUS,
 } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { endPgPool, query } from "@/app/services/database";
+import { refreshValidations } from "@/app/services/validations";
 import {
   ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_A,
   ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_B,
@@ -15,7 +16,6 @@ import {
 } from "@/testing/constants";
 import { resetDatabase } from "@/testing/db-utils";
 import { TestAtlas, TestSourceStudy } from "@/testing/entities";
-import { refreshValidations } from "app/services/validations";
 
 jest.mock(
   "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",

--- a/__tests__/register-user.test.ts
+++ b/__tests__/register-user.test.ts
@@ -1,20 +1,20 @@
 import {
   HCAAtlasTrackerDBUser,
   ROLE,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { endPgPool, query } from "../app/services/database";
-import { registerUser } from "../app/services/users";
-import { USER_CONTENT_ADMIN, USER_UNREGISTERED } from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { expectIsDefined } from "../testing/utils";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { endPgPool, query } from "@/app/services/database";
+import { registerUser } from "@/app/services/users";
+import { USER_CONTENT_ADMIN, USER_UNREGISTERED } from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { expectIsDefined } from "@/testing/utils";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 beforeAll(async () => {
   await resetDatabase();

--- a/__tests__/revalidate-on-refresh.test.ts
+++ b/__tests__/revalidate-on-refresh.test.ts
@@ -1,23 +1,23 @@
-import { delay, promiseWithResolvers } from "testing/utils";
-import { ProjectsResponse } from "../app/apis/azul/hca-dcp/common/responses";
-import { CellxGeneCollection } from "../app/utils/cellxgene-api";
+import { ProjectsResponse } from "@/app/apis/azul/hca-dcp/common/responses";
+import { CellxGeneCollection } from "@/app/utils/cellxgene-api";
 import {
   HCA_CATALOG_TEST1,
   HCA_CATALOG_TEST2,
   TEST_CELLXGENE_COLLECTIONS_A,
   TEST_HCA_CATALOGS,
-} from "../testing/constants";
+} from "@/testing/constants";
+import { delay, promiseWithResolvers } from "testing/utils";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/source-studies");
-jest.mock("../app/services/source-datasets");
-jest.mock("../app/services/component-atlases");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/source-studies");
+jest.mock("@/app/services/source-datasets");
+jest.mock("@/app/services/component-atlases");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 const refreshValidations = jest.fn();
-jest.mock("../app/services/validations", () => ({
+jest.mock("@/app/services/validations", () => ({
   refreshValidations,
 }));
 
@@ -32,12 +32,12 @@ const getAllProjects = jest
 
 const getLatestCatalog = jest.fn().mockResolvedValue(HCA_CATALOG_TEST1);
 
-jest.mock("../app/utils/hca-api", () => ({
+jest.mock("@/app/utils/hca-api", () => ({
   getAllProjects,
   getLatestCatalog,
 }));
 
-let hcaService: typeof import("../app/services/hca-projects");
+let hcaService: typeof import("@/app/services/hca-projects");
 
 jest.useFakeTimers({
   doNotFake: ["setTimeout"],
@@ -52,20 +52,20 @@ const getCellxGeneCollections = jest
     return TEST_CELLXGENE_COLLECTIONS_A;
   });
 
-jest.mock("../app/utils/cellxgene-api", () => ({
+jest.mock("@/app/utils/cellxgene-api", () => ({
   getCellxGeneCollections,
   getCellxGeneDatasets: jest.fn().mockResolvedValue([]),
 }));
 
-let cellxgeneService: typeof import("../app/services/cellxgene");
+let cellxgeneService: typeof import("@/app/services/cellxgene");
 
 let consoleLogSpy: jest.SpyInstance;
 
 beforeAll(async () => {
   consoleLogSpy = jest.spyOn(console, "log").mockImplementation();
 
-  hcaService = await import("../app/services/hca-projects");
-  cellxgeneService = await import("../app/services/cellxgene");
+  hcaService = await import("@/app/services/hca-projects");
+  cellxgeneService = await import("@/app/services/cellxgene");
 
   hcaService.forceProjectsRefresh();
   cellxgeneService.forceCellxGeneRefresh();

--- a/__tests__/revalidate-on-refresh.test.ts
+++ b/__tests__/revalidate-on-refresh.test.ts
@@ -6,7 +6,7 @@ import {
   TEST_CELLXGENE_COLLECTIONS_A,
   TEST_HCA_CATALOGS,
 } from "@/testing/constants";
-import { delay, promiseWithResolvers } from "testing/utils";
+import { delay, promiseWithResolvers } from "@/testing/utils";
 
 jest.mock(
   "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",

--- a/__tests__/route-authorization.test.ts
+++ b/__tests__/route-authorization.test.ts
@@ -1,6 +1,6 @@
-import { ROLE } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { isAdminPath, isRequestAuthorized } from "../app/routes/authorization";
-import { ROUTE } from "../app/routes/constants";
+import { ROLE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { isAdminPath, isRequestAuthorized } from "@/app/routes/authorization";
+import { ROUTE } from "@/app/routes/constants";
 
 describe("isAdminPath", () => {
   it("flags the admin-only paths", () => {

--- a/__tests__/s3-sync.test.ts
+++ b/__tests__/s3-sync.test.ts
@@ -3,20 +3,12 @@ import {
   HCAAtlasTrackerDBFile,
 } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { endPgPool, query } from "@/app/services/database";
-import { setTestRandomUuids } from "@/testing/setup";
-import {
-  HeadObjectCommand,
-  HeadObjectCommandOutput,
-  ListObjectsV2Command,
-  S3Client,
-} from "@aws-sdk/client-s3";
-import { getBucketFileKeys, syncFilesFromS3 } from "app/services/s3-sync";
-import { mockClient } from "aws-sdk-client-mock";
+import { getBucketFileKeys, syncFilesFromS3 } from "@/app/services/s3-sync";
 import {
   ATLAS_DRAFT,
   EMPTY_COMPONENT_INFO,
   TEST_S3_BUCKET,
-} from "testing/constants";
+} from "@/testing/constants";
 import {
   createTestComponentAtlas,
   createTestFile,
@@ -25,12 +17,20 @@ import {
   getFileComponentAtlas,
   getFileFromDatabase,
   resetDatabase,
-} from "testing/db-utils";
+} from "@/testing/db-utils";
+import { setTestRandomUuids } from "@/testing/setup";
 import {
   delay,
   expectIsDefined,
   withConsoleMessageHiding,
-} from "testing/utils";
+} from "@/testing/utils";
+import {
+  HeadObjectCommand,
+  HeadObjectCommandOutput,
+  ListObjectsV2Command,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { mockClient } from "aws-sdk-client-mock";
 
 jest.mock("@/app/services/hca-projects");
 jest.mock("@/app/services/cellxgene");
@@ -41,7 +41,7 @@ const s3Mock = mockClient(S3Client);
 
 const mockSubmitJob = jest.requireMock<
   typeof import("@/app/services/__mocks__/validator-batch")
->("../app/services/validator-batch").submitDatasetValidationJob;
+>("@/app/services/validator-batch").submitDatasetValidationJob;
 
 const TEST_UUID_COMPLETE_FOO = "9ac2e257-76ae-4220-bcb4-31709533e00d";
 const TEST_UUID_COMPLETE_BAR = "135d67d9-2a56-42f5-886f-a4c50c239aea";

--- a/__tests__/s3-sync.test.ts
+++ b/__tests__/s3-sync.test.ts
@@ -1,4 +1,10 @@
 import {
+  FILE_TYPE,
+  HCAAtlasTrackerDBFile,
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { endPgPool, query } from "@/app/services/database";
+import { setTestRandomUuids } from "@/testing/setup";
+import {
   HeadObjectCommand,
   HeadObjectCommandOutput,
   ListObjectsV2Command,
@@ -25,22 +31,16 @@ import {
   expectIsDefined,
   withConsoleMessageHiding,
 } from "testing/utils";
-import {
-  FILE_TYPE,
-  HCAAtlasTrackerDBFile,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { endPgPool, query } from "../app/services/database";
-import { setTestRandomUuids } from "../testing/setup";
 
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
-jest.mock("../app/services/validator-batch");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
+jest.mock("@/app/services/validator-batch");
 
 const s3Mock = mockClient(S3Client);
 
 const mockSubmitJob = jest.requireMock<
-  typeof import("../app/services/__mocks__/validator-batch")
+  typeof import("@/app/services/__mocks__/validator-batch")
 >("../app/services/validator-batch").submitDatasetValidationJob;
 
 const TEST_UUID_COMPLETE_FOO = "9ac2e257-76ae-4220-bcb4-31709533e00d";

--- a/__tests__/services-concepts.test.ts
+++ b/__tests__/services-concepts.test.ts
@@ -1,9 +1,9 @@
-import { FILE_TYPE } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { getOrCreateConceptId } from "../app/services/concepts";
-import { doTransaction, endPgPool } from "../app/services/database";
-import { resetDatabase } from "../testing/db-utils";
+import { FILE_TYPE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { getOrCreateConceptId } from "@/app/services/concepts";
+import { doTransaction, endPgPool } from "@/app/services/database";
+import { resetDatabase } from "@/testing/db-utils";
 
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 beforeAll(async () => {
   await resetDatabase(false);

--- a/__tests__/source-study-select.test.tsx
+++ b/__tests__/source-study-select.test.tsx
@@ -4,20 +4,20 @@ import { render, screen, waitFor } from "@testing-library/react";
 jest.mock("@databiosphere/findable-ui/lib/auth/hooks/useAuth", () => ({
   useAuth: jest.fn(),
 }));
-jest.mock("../app/providers/entity/hook", () => ({
+jest.mock("@/app/providers/entity/hook", () => ({
   useEntity: jest.fn(),
 }));
-jest.mock("../app/common/utils", () => ({
-  ...jest.requireActual("../app/common/utils"),
+jest.mock("@/app/common/utils", () => ({
+  ...jest.requireActual("@/app/common/utils"),
   fetchResource: jest.fn(),
 }));
 
+import { HCAAtlasTrackerSourceStudy } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { getSourceStudyCitation } from "@/app/apis/catalog/hca-atlas-tracker/common/utils";
+import { fetchResource } from "@/app/common/utils";
+import { SourceStudy } from "@/app/components/Form/components/Select/components/SourceStudy/sourceStudy";
+import { useEntity } from "@/app/providers/entity/hook";
 import { useAuth } from "@databiosphere/findable-ui/lib/auth/hooks/useAuth";
-import { HCAAtlasTrackerSourceStudy } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { getSourceStudyCitation } from "../app/apis/catalog/hca-atlas-tracker/common/utils";
-import { fetchResource } from "../app/common/utils";
-import { SourceStudy } from "../app/components/Form/components/Select/components/SourceStudy/sourceStudy";
-import { useEntity } from "../app/providers/entity/hook";
 
 const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 const mockUseEntity = useEntity as jest.MockedFunction<typeof useEntity>;

--- a/__tests__/source-study-validation-results.test.ts
+++ b/__tests__/source-study-validation-results.test.ts
@@ -1,19 +1,9 @@
-import {
-  HCAAtlasTrackerValidationResult,
-  SYSTEM,
-  VALIDATION_ID,
-  VALIDATION_STATUS,
-  VALIDATION_TYPE,
-  VALIDATION_VARIABLE,
-} from "app/apis/catalog/hca-atlas-tracker/common/entities";
-import { getSourceStudyWithAtlasProperties } from "app/services/source-studies";
-import type { PoolClient } from "pg";
-import { endPgPool, getPoolClient } from "../app/services/database";
+import { endPgPool, getPoolClient } from "@/app/services/database";
 import {
   getSourceStudyValidationResults,
   VALIDATION_META_STATUS,
   ValidationMetaResult,
-} from "../app/services/validations";
+} from "@/app/services/validations";
 import {
   ATLAS_WITH_IL,
   ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_A,
@@ -28,9 +18,19 @@ import {
   SOURCE_STUDY_PUBLISHED_WITH_NO_HCA_OR_CELLXGENE,
   SOURCE_STUDY_PUBLISHED_WITH_NO_HCA_PRIMARY_DATA,
   SOURCE_STUDY_UNPUBLISHED_WITH_CELLXGENE,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { TestAtlas, TestSourceStudy } from "../testing/entities";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { TestAtlas, TestSourceStudy } from "@/testing/entities";
+import {
+  HCAAtlasTrackerValidationResult,
+  SYSTEM,
+  VALIDATION_ID,
+  VALIDATION_STATUS,
+  VALIDATION_TYPE,
+  VALIDATION_VARIABLE,
+} from "app/apis/catalog/hca-atlas-tracker/common/entities";
+import { getSourceStudyWithAtlasProperties } from "app/services/source-studies";
+import type { PoolClient } from "pg";
 
 let client: PoolClient;
 
@@ -45,11 +45,11 @@ type ExpectedNewValidationProperties = Pick<
   Partial<Pick<HCAAtlasTrackerValidationResult, "differences">>;
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/pg-app-connect-config");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
 
 const VALIDATIONS_UNPUBLISHED_WITH_CELLXGENE: ExpectedValidationProperties[] = [
   {

--- a/__tests__/source-study-validation-results.test.ts
+++ b/__tests__/source-study-validation-results.test.ts
@@ -1,4 +1,13 @@
+import {
+  HCAAtlasTrackerValidationResult,
+  SYSTEM,
+  VALIDATION_ID,
+  VALIDATION_STATUS,
+  VALIDATION_TYPE,
+  VALIDATION_VARIABLE,
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { endPgPool, getPoolClient } from "@/app/services/database";
+import { getSourceStudyWithAtlasProperties } from "@/app/services/source-studies";
 import {
   getSourceStudyValidationResults,
   VALIDATION_META_STATUS,
@@ -21,15 +30,6 @@ import {
 } from "@/testing/constants";
 import { resetDatabase } from "@/testing/db-utils";
 import { TestAtlas, TestSourceStudy } from "@/testing/entities";
-import {
-  HCAAtlasTrackerValidationResult,
-  SYSTEM,
-  VALIDATION_ID,
-  VALIDATION_STATUS,
-  VALIDATION_TYPE,
-  VALIDATION_VARIABLE,
-} from "app/apis/catalog/hca-atlas-tracker/common/entities";
-import { getSourceStudyWithAtlasProperties } from "app/services/source-studies";
 import type { PoolClient } from "pg";
 
 let client: PoolClient;

--- a/__tests__/update-atlas-task-counts.test.ts
+++ b/__tests__/update-atlas-task-counts.test.ts
@@ -1,26 +1,26 @@
 import {
   IngestionTaskCounts,
   SYSTEM,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { updateTaskCounts } from "../app/services/atlases";
-import { endPgPool } from "../app/services/database";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { updateTaskCounts } from "@/app/services/atlases";
+import { endPgPool } from "@/app/services/database";
 import {
   ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_A,
   ATLAS_WITH_SOURCE_STUDY_VALIDATIONS_B,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   getExistingAtlasFromDatabase,
   resetDatabase,
-} from "../testing/db-utils";
-import { TestAtlas } from "../testing/entities";
+} from "@/testing/db-utils";
+import { TestAtlas } from "@/testing/entities";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 beforeAll(async () => {
   await resetDatabase();

--- a/__tests__/update-entry-sheet-validations.test.ts
+++ b/__tests__/update-entry-sheet-validations.test.ts
@@ -1,23 +1,23 @@
-import { endPgPool } from "../app/services/database";
-import { startEntrySheetValidationsUpdate } from "../app/services/entry-sheets";
+import { endPgPool } from "@/app/services/database";
+import { startEntrySheetValidationsUpdate } from "@/app/services/entry-sheets";
 import {
   ATLAS_WITH_ENTRY_SHEET_VALIDATIONS_A,
   ENTRY_SHEET_ID_NEW,
   ENTRY_SHEET_ID_NO_STUDY,
   SOURCE_STUDY_WITH_ENTRY_SHEET_VALIDATIONS_FOO,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   getSourceStudyEntrySheetValidationsFromDatabase,
   resetDatabase,
-} from "../testing/db-utils";
+} from "@/testing/db-utils";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
-jest.mock("../app/utils/hca-validation-tools/hca-validation-tools-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/hca-validation-tools/hca-validation-tools-api");
 
 beforeAll(async () => {
   await resetDatabase();

--- a/__tests__/update-source-study-external-ids.test.ts
+++ b/__tests__/update-source-study-external-ids.test.ts
@@ -1,5 +1,5 @@
-import { endPgPool } from "../app/services/database";
-import { updateSourceStudyExternalIds } from "../app/services/source-studies";
+import { endPgPool } from "@/app/services/database";
+import { updateSourceStudyExternalIds } from "@/app/services/source-studies";
 import {
   CELLXGENE_ID_PUBLISHED_WITH_CHANGING_IDS,
   CELLXGENE_ID_PUBLISHED_WITH_NEW_CELLXGENE_ID,
@@ -19,18 +19,18 @@ import {
   SOURCE_STUDY_PUBLISHED_WITH_UPDATED_CELLXGENE_ID,
   SOURCE_STUDY_PUBLISHED_WITH_UPDATED_HCA_ID,
   SOURCE_STUDY_UNPUBLISHED_WITH_HCA,
-} from "../testing/constants";
+} from "@/testing/constants";
 import {
   getExistingSourceStudyFromDatabase,
   resetDatabase,
-} from "../testing/db-utils";
+} from "@/testing/db-utils";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 beforeAll(async () => {
   await resetDatabase();

--- a/__tests__/update-validations.test.ts
+++ b/__tests__/update-validations.test.ts
@@ -10,13 +10,13 @@ import {
   VALIDATION_VARIABLE,
 } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { endPgPool, getPoolClient, query } from "@/app/services/database";
+import { updateValidations } from "@/app/services/validations";
 import {
   THREAD_ID_BY_CONTENT_ADMIN,
   THREAD_ID_BY_STAKEHOLDER2,
 } from "@/testing/constants";
 import { resetDatabase } from "@/testing/db-utils";
 import { delay } from "@/testing/utils";
-import { updateValidations } from "app/services/validations";
 
 jest.mock(
   "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",

--- a/__tests__/update-validations.test.ts
+++ b/__tests__/update-validations.test.ts
@@ -1,4 +1,3 @@
-import { updateValidations } from "app/services/validations";
 import {
   ENTITY_TYPE,
   HCAAtlasTrackerDBComment,
@@ -9,22 +8,23 @@ import {
   VALIDATION_STATUS,
   VALIDATION_TYPE,
   VALIDATION_VARIABLE,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { endPgPool, getPoolClient, query } from "../app/services/database";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { endPgPool, getPoolClient, query } from "@/app/services/database";
 import {
   THREAD_ID_BY_CONTENT_ADMIN,
   THREAD_ID_BY_STAKEHOLDER2,
-} from "../testing/constants";
-import { resetDatabase } from "../testing/db-utils";
-import { delay } from "../testing/utils";
+} from "@/testing/constants";
+import { resetDatabase } from "@/testing/db-utils";
+import { delay } from "@/testing/utils";
+import { updateValidations } from "app/services/validations";
 
 jest.mock(
-  "../site-config/hca-atlas-tracker/local/authentication/next-auth-config",
+  "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config",
 );
-jest.mock("../app/utils/pg-app-connect-config");
-jest.mock("../app/utils/crossref/crossref-api");
-jest.mock("../app/services/hca-projects");
-jest.mock("../app/services/cellxgene");
+jest.mock("@/app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/crossref/crossref-api");
+jest.mock("@/app/services/hca-projects");
+jest.mock("@/app/services/cellxgene");
 
 const ENTITY_TYPE_TEST = "ENTITY_TYPE_TEST" as ENTITY_TYPE;
 

--- a/__tests__/use-back-path.test.ts
+++ b/__tests__/use-back-path.test.ts
@@ -4,8 +4,8 @@ jest.mock("next/router", () => ({
   useRouter: jest.fn(),
 }));
 
+import { useBackPath } from "@/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook";
 import { useRouter } from "next/router";
-import { useBackPath } from "../app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook";
 
 const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
 

--- a/__tests__/use-fetch-active-user.test.ts
+++ b/__tests__/use-fetch-active-user.test.ts
@@ -4,14 +4,14 @@ import { renderHook } from "@testing-library/react";
 jest.mock("@databiosphere/findable-ui/lib/auth/hooks/useAuth", () => ({
   useAuth: jest.fn(),
 }));
-jest.mock("../app/hooks/UseFetchActiveUser/query/useQuery", () => ({
+jest.mock("@/app/hooks/UseFetchActiveUser/query/useQuery", () => ({
   useQuery: jest.fn(),
 }));
 
+import { HCAAtlasTrackerActiveUser } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { useFetchActiveUser } from "@/app/hooks/UseFetchActiveUser/hook";
+import { useQuery } from "@/app/hooks/UseFetchActiveUser/query/useQuery";
 import { useAuth } from "@databiosphere/findable-ui/lib/auth/hooks/useAuth";
-import { HCAAtlasTrackerActiveUser } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { useFetchActiveUser } from "../app/hooks/UseFetchActiveUser/hook";
-import { useQuery } from "../app/hooks/UseFetchActiveUser/query/useQuery";
 
 const AUTH_STATUS_PENDING = "PENDING" as const;
 const AUTH_STATUS_SETTLED = "SETTLED" as const;

--- a/__tests__/utils-files.test.ts
+++ b/__tests__/utils-files.test.ts
@@ -1,4 +1,4 @@
-import { getFileBaseName, insertVersionInFilename } from "../app/utils/files";
+import { getFileBaseName, insertVersionInFilename } from "@/app/utils/files";
 
 describe("getFileBaseName", () => {
   it.each([

--- a/__tests__/validator-batch.test.ts
+++ b/__tests__/validator-batch.test.ts
@@ -12,7 +12,7 @@ import {
 } from "testing/constants";
 
 // Project-wide mocks for DB connection etc.
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 const batchMock = mockClient(BatchClient);
 

--- a/__tests__/validator-batch.test.ts
+++ b/__tests__/validator-batch.test.ts
@@ -1,15 +1,15 @@
+import { resetConfigCache } from "@/app/config/aws-resources";
+import { submitDatasetValidationJob } from "@/app/services/validator-batch";
+import {
+  TEST_S3_BUCKET,
+  TEST_VALIDATION_RESULTS_BUCKET,
+} from "@/testing/constants";
 import {
   BatchClient,
   SubmitJobCommand,
   SubmitJobCommandInput,
 } from "@aws-sdk/client-batch";
-import { resetConfigCache } from "app/config/aws-resources";
-import { submitDatasetValidationJob } from "app/services/validator-batch";
 import { mockClient } from "aws-sdk-client-mock";
-import {
-  TEST_S3_BUCKET,
-  TEST_VALIDATION_RESULTS_BUCKET,
-} from "testing/constants";
 
 // Project-wide mocks for DB connection etc.
 jest.mock("@/app/utils/pg-app-connect-config");

--- a/__tests__/version-parsing.test.ts
+++ b/__tests__/version-parsing.test.ts
@@ -1,5 +1,5 @@
-import { parseS3AtlasVersion } from "../app/utils/atlases";
-import { S3KeyFormatError } from "../app/utils/files";
+import { parseS3AtlasVersion } from "@/app/utils/atlases";
+import { S3KeyFormatError } from "@/app/utils/files";
 
 /**
  * Parameterized tests for atlas version parsing.

--- a/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
+++ b/app/apis/catalog/hca-atlas-tracker/aws/schemas.ts
@@ -1,6 +1,6 @@
+import { FILE_METADATA_COVERAGE_ENTITY_TYPES } from "@/app/apis/catalog/hca-atlas-tracker/common/constants";
+import { INTEGRITY_STATUS } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { array, boolean, InferType, number, object, string } from "yup";
-import { FILE_METADATA_COVERAGE_ENTITY_TYPES } from "../common/constants";
-import { INTEGRITY_STATUS } from "../common/entities";
 
 // AWS S3 and SNS Event Validation Schemas
 // These schemas validate the structure of AWS events received via SNS notifications

--- a/app/common/entities.ts
+++ b/app/common/entities.ts
@@ -7,7 +7,7 @@ import {
   SourceStudyId,
   UserId,
   ValidatorName,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 
 export enum FETCH_STATUS {
   ACCEPTED = 202,

--- a/app/common/utils.ts
+++ b/app/common/utils.ts
@@ -1,5 +1,5 @@
-import { APIValue } from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { RouteValue } from "../routes/entities";
+import { APIValue } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { RouteValue } from "@/app/routes/entities";
 import { DEFAULT_HEADERS } from "./constants";
 import { FETCH_STATUS, METHOD, PathParameter } from "./entities";
 

--- a/app/components/Detail/components/AddSourceStudy/addSourceStudy.tsx
+++ b/app/components/Detail/components/AddSourceStudy/addSourceStudy.tsx
@@ -1,12 +1,12 @@
 import { HCAAtlasTrackerSourceStudy } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { FormManager } from "@/app/components/common/Form/components/FormManager/formManager";
+import { Divider } from "@/app/components/Detail/components/TrackerForm/components/Divider/divider.styles";
+import { GeneralInfo } from "@/app/components/Detail/components/TrackerForm/components/Section/components/SourceStudy/components/Add/components/GeneralInfo/generalInfo";
+import { TrackerForm } from "@/app/components/Detail/components/TrackerForm/trackerForm";
 import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { FormManager as FormManagerProps } from "@/app/hooks/useFormManager/common/entities";
 import { NewSourceStudyData } from "@/app/views/AddNewSourceStudyView/common/entities";
 import { JSX } from "react";
-import { Divider } from "../TrackerForm/components/Divider/divider.styles";
-import { GeneralInfo } from "../TrackerForm/components/Section/components/SourceStudy/components/Add/components/GeneralInfo/generalInfo";
-import { TrackerForm } from "../TrackerForm/trackerForm";
 import { NoAccess } from "./components/NoAccess/noAccess";
 
 interface AddSourceStudyProps {

--- a/app/components/Detail/components/TrackerForm/components/Breadcrumbs/common/constants.ts
+++ b/app/components/Detail/components/TrackerForm/components/Breadcrumbs/common/constants.ts
@@ -1,5 +1,5 @@
+import { Breadcrumb } from "@/app/components/Detail/components/TrackerForm/components/Breadcrumbs/breadcrumbs";
 import { ROUTE } from "@/app/routes/constants";
-import { Breadcrumb } from "../breadcrumbs";
 
 export const BREADCRUMB_ATLAS: Breadcrumb = {
   path: ROUTE.ATLAS_STATUS,

--- a/app/components/Detail/components/TrackerForm/components/Breadcrumbs/common/utils.ts
+++ b/app/components/Detail/components/TrackerForm/components/Breadcrumbs/common/utils.ts
@@ -7,8 +7,8 @@ import {
 import { getAtlasName } from "@/app/apis/catalog/hca-atlas-tracker/common/utils";
 import { PathParameter } from "@/app/common/entities";
 import { getRouteURL } from "@/app/common/utils";
+import { Breadcrumb } from "@/app/components/Detail/components/TrackerForm/components/Breadcrumbs/breadcrumbs";
 import { isRouteValue } from "@/app/routes/utils";
-import { Breadcrumb } from "../breadcrumbs";
 import {
   BREADCRUMB_ATLAS,
   BREADCRUMB_ATLAS_SOURCE_DATASET,

--- a/app/components/Detail/components/ViewAtlasMetadataCorrectness/viewAtlasMetadataCorrectness.tsx
+++ b/app/components/Detail/components/ViewAtlasMetadataCorrectness/viewAtlasMetadataCorrectness.tsx
@@ -1,8 +1,8 @@
+import { HCAAtlasTrackerAtlas } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { SectionTitle } from "@databiosphere/findable-ui/lib/components/common/Section/components/SectionTitle/sectionTitle";
 import { Link } from "@databiosphere/findable-ui/lib/components/Links/components/Link/link";
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { Typography } from "@mui/material";
-import { HCAAtlasTrackerAtlas } from "app/apis/catalog/hca-atlas-tracker/common/entities";
 import { JSX } from "react";
 import { SectionPaper } from "./vewAtlasMetadataCorrectness.styles";
 

--- a/app/components/Detail/components/ViewComponentAtlases/viewComponentAtlases.tsx
+++ b/app/components/Detail/components/ViewComponentAtlases/viewComponentAtlases.tsx
@@ -1,3 +1,4 @@
+import { Divider } from "@/app/components/Detail/components/TrackerForm/components/Divider/divider.styles";
 import { EditFileArchivedStatus } from "@/app/components/Entity/components/common/Table/components/TableFeatures/RowSelection/components/EditFileArchivedStatus/editFileArchivedStatus";
 import { RowSelection } from "@/app/components/Entity/components/common/Table/components/TableFeatures/RowSelection/rowSelection";
 import { ArchivedStatusToggle } from "@/app/components/Entity/components/common/Table/components/TableToolbar/components/ArchivedStatusToggle/archiveStatusToggle";
@@ -8,7 +9,6 @@ import { ATLAS } from "@/app/hooks/UseFetchAtlas/query/constants";
 import { useEntity } from "@/app/providers/entity/hook";
 import { INTEGRATED_OBJECTS } from "@/app/views/ComponentAtlasesView/hooks/UseFetchComponentAtlases/query/constants";
 import { Fragment, JSX } from "react";
-import { Divider } from "../TrackerForm/components/Divider/divider.styles";
 import { useIntegratedObjectsTable } from "./hooks/UseIntegratedObjectsTable/hook";
 import { StyledToolbar } from "./viewComponentAtlases.styles";
 

--- a/app/components/Detail/components/ViewSourceStudy/viewSourceStudy.tsx
+++ b/app/components/Detail/components/ViewSourceStudy/viewSourceStudy.tsx
@@ -1,14 +1,14 @@
 import { HCAAtlasTrackerSourceStudy } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { FormManager } from "@/app/components/common/Form/components/FormManager/formManager";
+import { Divider } from "@/app/components/Detail/components/TrackerForm/components/Divider/divider.styles";
+import { GeneralInfo } from "@/app/components/Detail/components/TrackerForm/components/Section/components/SourceStudy/components/View/components/GeneralInfo/generalInfo";
+import { Identifiers } from "@/app/components/Detail/components/TrackerForm/components/Section/components/SourceStudy/components/View/components/Identifiers/identifiers";
+import { Metadata } from "@/app/components/Detail/components/TrackerForm/components/Section/components/SourceStudy/components/View/components/Metadata/metadata";
+import { TrackerForm } from "@/app/components/Detail/components/TrackerForm/trackerForm";
 import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { FormManager as FormManagerProps } from "@/app/hooks/useFormManager/common/entities";
 import { SourceStudyEditData } from "@/app/views/SourceStudyView/common/entities";
 import { JSX } from "react";
-import { Divider } from "../TrackerForm/components/Divider/divider.styles";
-import { GeneralInfo } from "../TrackerForm/components/Section/components/SourceStudy/components/View/components/GeneralInfo/generalInfo";
-import { Identifiers } from "../TrackerForm/components/Section/components/SourceStudy/components/View/components/Identifiers/identifiers";
-import { Metadata } from "../TrackerForm/components/Section/components/SourceStudy/components/View/components/Metadata/metadata";
-import { TrackerForm } from "../TrackerForm/trackerForm";
 
 interface ViewSourceStudyProps {
   formManager: FormManagerProps;

--- a/app/components/Entity/providers/archived/actions/updateArchived/dispatch.ts
+++ b/app/components/Entity/providers/archived/actions/updateArchived/dispatch.ts
@@ -1,4 +1,4 @@
-import { ArchivedActionKind } from "../entities";
+import { ArchivedActionKind } from "@/app/components/Entity/providers/archived/actions/entities";
 import { UpdateArchivedAction } from "./entities";
 
 /**

--- a/app/components/Entity/providers/archived/actions/updateArchived/entities.ts
+++ b/app/components/Entity/providers/archived/actions/updateArchived/entities.ts
@@ -1,4 +1,4 @@
-import { ArchivedActionKind } from "../entities";
+import { ArchivedActionKind } from "@/app/components/Entity/providers/archived/actions/entities";
 
 export type UpdateArchivedAction = {
   payload: UpdateArchivedPayload;

--- a/app/components/Forms/components/Atlas/common/constants.ts
+++ b/app/components/Forms/components/Atlas/common/constants.ts
@@ -1,3 +1,4 @@
+import { HCAAtlasTrackerAtlas } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { getPublicationCitation } from "@/app/apis/catalog/hca-atlas-tracker/common/utils";
 import { ControllerConfig } from "@/app/components/common/Form/components/Controllers/common/entities";
 import { BioNetwork } from "@/app/components/Form/components/Select/components/BioNetwork/bioNetwork";
@@ -8,7 +9,6 @@ import { getDOILink } from "@/app/viewModelBuilders/catalog/hca-atlas-tracker/co
 import { NewAtlasData } from "@/app/views/AddNewAtlasView/common/entities";
 import { FIELD_NAME } from "@/app/views/AtlasView/common/constants";
 import { AtlasEditData } from "@/app/views/AtlasView/common/entities";
-import { HCAAtlasTrackerAtlas } from "app/apis/catalog/hca-atlas-tracker/common/entities";
 
 type CommonControllerConfig = ControllerConfig<
   NewAtlasData | AtlasEditData,

--- a/app/components/Forms/components/Atlas/common/sections.ts
+++ b/app/components/Forms/components/Atlas/common/sections.ts
@@ -1,10 +1,10 @@
 import { HCAAtlasTrackerAtlas } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { SECTION_TITLES } from "@/app/components/Forms/common/constants";
 import { SectionConfig } from "@/app/components/Forms/common/entities";
+import { NewAtlasIntegrationLeadSection } from "@/app/components/Forms/components/Atlas/components/NewAtlasIntegrationLeadSection/newAtlasIntegrationLeadSection";
+import { ViewAtlasIntegrationLeadSection } from "@/app/components/Forms/components/Atlas/components/ViewAtlasIntegrationLeadSection/viewAtlasIntegrationLeadSection";
 import { NewAtlasData } from "@/app/views/AddNewAtlasView/common/entities";
 import { AtlasEditData } from "@/app/views/AtlasView/common/entities";
-import { NewAtlasIntegrationLeadSection } from "../components/NewAtlasIntegrationLeadSection/newAtlasIntegrationLeadSection";
-import { ViewAtlasIntegrationLeadSection } from "../components/ViewAtlasIntegrationLeadSection/viewAtlasIntegrationLeadSection";
 import * as C from "./constants";
 
 export const ADD_ATLAS_SECTION_CONFIGS: SectionConfig<

--- a/app/components/Forms/components/Atlas/components/NewAtlasIntegrationLeadSection/newAtlasIntegrationLeadSection.tsx
+++ b/app/components/Forms/components/Atlas/components/NewAtlasIntegrationLeadSection/newAtlasIntegrationLeadSection.tsx
@@ -1,8 +1,8 @@
 import { HCAAtlasTrackerAtlas } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { SectionContentProps } from "@/app/components/Forms/common/entities";
+import { IntegrationLeadSection } from "@/app/components/Forms/components/Atlas/components/IntegrationLeadSection/integrationLeadSection";
 import { NewAtlasData } from "@/app/views/AddNewAtlasView/common/entities";
 import { JSX } from "react";
-import { IntegrationLeadSection } from "../IntegrationLeadSection/integrationLeadSection";
 
 export const NewAtlasIntegrationLeadSection = ({
   formManager,

--- a/app/components/Forms/components/Atlas/components/ViewAtlasIntegrationLeadSection/viewAtlasIntegrationLeadSection.tsx
+++ b/app/components/Forms/components/Atlas/components/ViewAtlasIntegrationLeadSection/viewAtlasIntegrationLeadSection.tsx
@@ -1,8 +1,8 @@
 import { HCAAtlasTrackerAtlas } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { SectionContentProps } from "@/app/components/Forms/common/entities";
+import { IntegrationLeadSection } from "@/app/components/Forms/components/Atlas/components/IntegrationLeadSection/integrationLeadSection";
 import { AtlasEditData } from "@/app/views/AtlasView/common/entities";
 import { JSX } from "react";
-import { IntegrationLeadSection } from "../IntegrationLeadSection/integrationLeadSection";
 
 export const ViewAtlasIntegrationLeadSection = ({
   formManager,

--- a/app/components/Layout/components/Detail/components/DetailViewHero/components/AtlasStatuses/atlasStatuses.tsx
+++ b/app/components/Layout/components/Detail/components/DetailViewHero/components/AtlasStatuses/atlasStatuses.tsx
@@ -1,7 +1,7 @@
 import { HCAAtlasTrackerAtlas } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { AtlasPublishStatus } from "@/app/components/Layout/components/Detail/components/DetailViewHero/components/AtlasPublishStatus/atlasPublishStatus";
+import { AtlasStatus } from "@/app/components/Layout/components/Detail/components/DetailViewHero/components/AtlasStatus/atlasStatus";
 import { JSX } from "react";
-import { AtlasPublishStatus } from "../AtlasPublishStatus/atlasPublishStatus";
-import { AtlasStatus } from "../AtlasStatus/atlasStatus";
 
 export interface AtlasStatusesProps {
   statuses: Pick<HCAAtlasTrackerAtlas, "publishedAt" | "status">;

--- a/app/components/Layout/components/Detail/sticky/detailView.styles.ts
+++ b/app/components/Layout/components/Detail/sticky/detailView.styles.ts
@@ -1,5 +1,5 @@
+import { DetailView } from "@/app/components/Layout/components/Detail/detailView";
 import styled from "@emotion/styled";
-import { DetailView } from "../detailView";
 
 export const StyledDetailView = styled(DetailView)`
   max-height: 100vh;

--- a/app/components/Table/components/TableCell/components/BioNetworksCell/bioNetworksCell.tsx
+++ b/app/components/Table/components/TableCell/components/BioNetworksCell/bioNetworksCell.tsx
@@ -1,6 +1,6 @@
+import { BioNetworkCell } from "@/app/components/Table/components/TableCell/components/BioNetworkCell/bioNetworkCell";
 import { Stack } from "@mui/material";
 import { JSX } from "react";
-import { BioNetworkCell } from "../BioNetworkCell/bioNetworkCell";
 import { BioNetworksCellProps } from "./entities";
 
 export const BioNetworksCell = ({

--- a/app/components/Table/components/TableCell/components/CAPCell/utils.ts
+++ b/app/components/Table/components/TableCell/components/CAPCell/utils.ts
@@ -1,12 +1,12 @@
 import { CAP_INGEST_STATUS } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { Chip } from "@/app/components/common/Chip/chip";
-import { LinkProps } from "@databiosphere/findable-ui/lib/components/Links/components/Link/link";
-import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
-import { ComponentProps } from "react";
 import {
   CAP_INGEST_STATUS_COLOR,
   CAP_INGEST_STATUS_LABEL,
-} from "../CAPIngestStatusCell/constants";
+} from "@/app/components/Table/components/TableCell/components/CAPIngestStatusCell/constants";
+import { LinkProps } from "@databiosphere/findable-ui/lib/components/Links/components/Link/link";
+import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chip";
+import { ComponentProps } from "react";
 import { Props } from "./entities";
 
 /**

--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationStatus/validationStatus.tsx
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationStatus/validationStatus.tsx
@@ -1,5 +1,5 @@
+import { ValidationStatusChipCell } from "@/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationStatusChipCell/validationStatusChipCell";
 import { JSX } from "react";
-import { ValidationStatusChipCell } from "../ValidationStatusChipCell/validationStatusChipCell";
 import { Props } from "./entities";
 import { buildValidationStatus } from "./utils";
 

--- a/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.tsx
+++ b/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationSummary/validationSummary.tsx
@@ -5,6 +5,7 @@ import {
 } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { FILE_VALIDATOR_DESCRIPTIONS } from "@/app/apis/catalog/hca-atlas-tracker/common/validatorDescriptions";
 import { getRouteURL } from "@/app/common/utils";
+import { ValidationStatusChipCell } from "@/app/components/Table/components/TableCell/components/ValidationStatusCell/components/ValidationStatusChipCell/validationStatusChipCell";
 import {
   ANCHOR_TARGET,
   REL_ATTRIBUTE,
@@ -13,7 +14,6 @@ import { CHIP_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/chi
 import { Stack, Tooltip } from "@mui/material";
 import Link from "next/link";
 import { JSX, ReactNode } from "react";
-import { ValidationStatusChipCell } from "../ValidationStatusChipCell/validationStatusChipCell";
 import { ValidatorIcon } from "./components/ValidatorIcon/validatorIcon";
 import { INNER_STACK_PROPS, STACK_PROPS } from "./constants";
 import { Props } from "./entities";

--- a/app/components/common/AdminForm/components/AdminFormResults/adminFormResults.tsx
+++ b/app/components/common/AdminForm/components/AdminFormResults/adminFormResults.tsx
@@ -1,6 +1,6 @@
+import { AdminFormErrors } from "@/app/components/common/AdminForm/components/AdminFormErrors/adminFormErrors";
 import { FormResponseErrors } from "@/app/hooks/useForm/common/entities";
 import React, { JSX } from "react";
-import { AdminFormErrors } from "../AdminFormErrors/adminFormErrors";
 
 export interface Props {
   errors: FormResponseErrors | null;

--- a/app/components/common/Form/components/Controllers/common/entities.ts
+++ b/app/components/common/Form/components/Controllers/common/entities.ts
@@ -1,10 +1,10 @@
+import { LabelLinkConfig } from "@/app/components/common/Form/components/Controllers/components/InputController/inputController";
+import { SelectControllerProps } from "@/app/components/common/Form/components/Controllers/components/SelectController/selectController";
 import { InputProps } from "@/app/components/common/Form/components/Input/input";
 import { SelectProps } from "@/app/components/common/Form/components/Select/select";
 import { YupValidatedFormValues } from "@/app/hooks/useForm/common/entities";
 import { ComponentPropsWithoutRef, ElementType, ReactNode } from "react";
 import { FieldValues, Path } from "react-hook-form";
-import { LabelLinkConfig } from "../components/InputController/inputController";
-import { SelectControllerProps } from "../components/SelectController/selectController";
 
 export type ControllerInputConfig = Pick<InputProps, PickedInputProps>;
 

--- a/app/components/common/Form/components/Input/input.styles.ts
+++ b/app/components/common/Form/components/Input/input.styles.ts
@@ -1,6 +1,6 @@
+import { FormControl } from "@/app/components/common/Form/components/FormControl/formControl.styles";
 import { PALETTE } from "@databiosphere/findable-ui/lib/styles/common/constants/palette";
 import styled from "@emotion/styled";
-import { FormControl } from "../FormControl/formControl.styles";
 
 export const InputFormControl = styled(FormControl)`
   .MuiOutlinedInput-root {

--- a/app/components/common/Form/components/Input/input.tsx
+++ b/app/components/common/Form/components/Input/input.tsx
@@ -1,3 +1,9 @@
+import { ControllerViewBuilder } from "@/app/components/common/Form/components/Controllers/common/entities";
+import {
+  FormHelperText,
+  FormHelperTextProps,
+} from "@/app/components/common/Form/components/FormHelperText/formHelperText";
+import { FormLabel } from "@/app/components/common/Form/components/FormLabel/formLabel";
 import {
   OutlinedInput as MOutlinedInput,
   OutlinedInputProps as MOutlinedInputProps,
@@ -10,12 +16,6 @@ import {
   Ref,
   RefAttributes,
 } from "react";
-import { ControllerViewBuilder } from "../Controllers/common/entities";
-import {
-  FormHelperText,
-  FormHelperTextProps,
-} from "../FormHelperText/formHelperText";
-import { FormLabel } from "../FormLabel/formLabel";
 import { InputFormControl as FormControl } from "./input.styles";
 import { getInputComponent, getInputProps } from "./utils";
 

--- a/app/components/common/Form/components/Input/utils.ts
+++ b/app/components/common/Form/components/Input/utils.ts
@@ -1,9 +1,9 @@
-import { InputBaseComponentProps } from "@mui/material";
-import { ElementType } from "react";
 import {
   ControllerViewBuilder,
   ViewPropsOf,
-} from "../Controllers/common/entities";
+} from "@/app/components/common/Form/components/Controllers/common/entities";
+import { InputBaseComponentProps } from "@mui/material";
+import { ElementType } from "react";
 
 /**
  * Resolve the input component to render. The convention is:

--- a/app/components/common/Form/components/Select/select.tsx
+++ b/app/components/common/Form/components/Select/select.tsx
@@ -1,8 +1,8 @@
+import { FormControl } from "@/app/components/common/Form/components/FormControl/formControl.styles";
+import { FormHelperText } from "@/app/components/common/Form/components/FormHelperText/formHelperText";
+import { FormLabel } from "@/app/components/common/Form/components/FormLabel/formLabel";
 import { Select as MSelect, SelectProps as MSelectProps } from "@mui/material";
 import { forwardRef, JSX, ReactNode } from "react";
-import { FormControl } from "../FormControl/formControl.styles";
-import { FormHelperText } from "../FormHelperText/formHelperText";
-import { FormLabel } from "../FormLabel/formLabel";
 import { SELECT_PROPS } from "./constants";
 
 export type SelectProps = MSelectProps & {

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -1,3 +1,5 @@
+export { AddAtlas } from "@/app/views/EntitiesView/components/AddAtlas/addAtlas";
+export { AddUser } from "@/app/views/EntitiesView/components/AddUser/addUser";
 export { Alert } from "@databiosphere/findable-ui/lib/components/common/Alert/alert";
 export { SessionTimeout } from "@databiosphere/findable-ui/lib/components/common/Banner/components/SessionTimeout/sessionTimeout";
 export { GitHubIcon } from "@databiosphere/findable-ui/lib/components/common/CustomIcon/components/GitHubIcon/gitHubIcon";
@@ -21,8 +23,6 @@ export { LinkCell } from "@databiosphere/findable-ui/lib/components/Table/compon
 export { NTagCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/NTagCell/nTagCell";
 export { RowDrawer } from "@databiosphere/findable-ui/lib/components/Table/components/TableToolbar/components/RowPreview/components/RowDrawer/rowDrawer";
 export { AlertTitle } from "@mui/material";
-export { AddAtlas } from "../views/EntitiesView/components/AddAtlas/addAtlas";
-export { AddUser } from "../views/EntitiesView/components/AddUser/addUser";
 export { IconButton } from "./common/IconButton/iconButton";
 export { FileDownloadCell } from "./Entity/components/common/Table/components/TableCell/components/FileDownloadCell/fileDownloadCell";
 export { LinksCell } from "./Index/components/LinksCell/linksCell";

--- a/app/config/aws-resources.ts
+++ b/app/config/aws-resources.ts
@@ -1,4 +1,4 @@
-import { UnauthorizedAWSResourceError } from "../apis/catalog/hca-atlas-tracker/aws/errors";
+import { UnauthorizedAWSResourceError } from "@/app/apis/catalog/hca-atlas-tracker/aws/errors";
 
 interface AWSResourceConfig {
   s3_buckets: string[];

--- a/app/data/atlases.ts
+++ b/app/data/atlases.ts
@@ -1,11 +1,11 @@
-import pg from "pg";
 import {
   HCAAtlasTrackerDBAtlas,
   HCAAtlasTrackerDBAtlasForStatusSummary,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { query } from "../services/database";
-import { InvalidOperationError, NotFoundError } from "../utils/api-errors";
-import { AtlasSlugNameAndVersion } from "../utils/atlases";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { query } from "@/app/services/database";
+import { InvalidOperationError, NotFoundError } from "@/app/utils/api-errors";
+import { AtlasSlugNameAndVersion } from "@/app/utils/atlases";
+import pg from "pg";
 
 export const CONSTRAINT_ATLAS_SLUG_VERSION_UNIQUE =
   "atlases_slug_version_unique";

--- a/app/data/component-atlases.ts
+++ b/app/data/component-atlases.ts
@@ -1,10 +1,10 @@
-import pg from "pg";
 import {
   HCAAtlasTrackerDBComponentAtlas,
   HCAAtlasTrackerDBComponentAtlasForGlobalAPI,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { query } from "../services/database";
-import { NotFoundError } from "../utils/api-errors";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { query } from "@/app/services/database";
+import { NotFoundError } from "@/app/utils/api-errors";
+import pg from "pg";
 
 /**
  * Create a new latest component atlas version based on the given existing version.

--- a/app/data/concepts.ts
+++ b/app/data/concepts.ts
@@ -1,10 +1,10 @@
-import { NotFoundError } from "app/utils/api-errors";
-import pg from "pg";
 import {
   HCAAtlasTrackerDBAtlas,
   HCAAtlasTrackerDBConcept,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { query } from "../services/database";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { query } from "@/app/services/database";
+import { NotFoundError } from "app/utils/api-errors";
+import pg from "pg";
 
 /**
  * Get the ID of the concept matching the given info, if it exists.

--- a/app/data/concepts.ts
+++ b/app/data/concepts.ts
@@ -3,7 +3,7 @@ import {
   HCAAtlasTrackerDBConcept,
 } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { query } from "@/app/services/database";
-import { NotFoundError } from "app/utils/api-errors";
+import { NotFoundError } from "@/app/utils/api-errors";
 import pg from "pg";
 
 /**

--- a/app/data/files.ts
+++ b/app/data/files.ts
@@ -1,5 +1,4 @@
-import pg from "pg";
-import { ETagMismatchError } from "../apis/catalog/hca-atlas-tracker/aws/errors";
+import { ETagMismatchError } from "@/app/apis/catalog/hca-atlas-tracker/aws/errors";
 import {
   FILE_TYPE,
   FILE_VALIDATION_STATUS,
@@ -12,12 +11,13 @@ import {
   HCAAtlasTrackerDBFileValidationInfo,
   HCAAtlasTrackerDBSourceDataset,
   INTEGRITY_STATUS,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { getPublishedFromPublishedAt } from "../apis/catalog/hca-atlas-tracker/common/utils";
-import { getAtlasComponentAtlasVersionIds } from "../services/component-atlases";
-import { query } from "../services/database";
-import { InvalidOperationError, NotFoundError } from "../utils/api-errors";
-import { confirmQueryRowsContainIds } from "../utils/database";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { getPublishedFromPublishedAt } from "@/app/apis/catalog/hca-atlas-tracker/common/utils";
+import { getAtlasComponentAtlasVersionIds } from "@/app/services/component-atlases";
+import { query } from "@/app/services/database";
+import { InvalidOperationError, NotFoundError } from "@/app/utils/api-errors";
+import { confirmQueryRowsContainIds } from "@/app/utils/database";
+import pg from "pg";
 import { getAtlasSourceDatasetVersionIds } from "./source-datasets";
 
 export type FileUpsertResult = Pick<HCAAtlasTrackerDBFile, "etag" | "id"> & {

--- a/app/data/metadata-coverage.ts
+++ b/app/data/metadata-coverage.ts
@@ -1,6 +1,6 @@
+import { HCAAtlasTrackerDBAtlasForMetadataCoverage } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { query } from "@/app/services/database";
 import pg from "pg";
-import { HCAAtlasTrackerDBAtlasForMetadataCoverage } from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { query } from "../services/database";
 
 /**
  * Get every atlas along with the `metadata_coverage` blobs of its

--- a/app/data/source-datasets.ts
+++ b/app/data/source-datasets.ts
@@ -1,4 +1,3 @@
-import pg from "pg";
 import {
   HCAAtlasTrackerDBAtlas,
   HCAAtlasTrackerDBComponentAtlas,
@@ -8,12 +7,13 @@ import {
   HCAAtlasTrackerDBSourceDatasetForListAPI,
   HCAAtlasTrackerDBSourceDatasetInfo,
   PUBLICATION_STATUS,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { confirmAtlasExists } from "../services/atlases";
-import { doTransaction, query } from "../services/database";
-import { confirmSourceStudyExists } from "../services/source-studies";
-import { InvalidOperationError, NotFoundError } from "../utils/api-errors";
-import { confirmQueryRowsContainVersionIds } from "../utils/database";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { confirmAtlasExists } from "@/app/services/atlases";
+import { doTransaction, query } from "@/app/services/database";
+import { confirmSourceStudyExists } from "@/app/services/source-studies";
+import { InvalidOperationError, NotFoundError } from "@/app/utils/api-errors";
+import { confirmQueryRowsContainVersionIds } from "@/app/utils/database";
+import pg from "pg";
 
 const PLURAL_ENTITY_NAME = "source datasets";
 

--- a/app/data/source-studies.ts
+++ b/app/data/source-studies.ts
@@ -1,11 +1,11 @@
-import pg from "pg";
 import {
   GoogleSheetInfo,
   HCAAtlasTrackerDBSourceStudy,
   HCAAtlasTrackerDBSourceStudyWithSourceDatasets,
   WithLinkedAtlases,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { query } from "../services/database";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { query } from "@/app/services/database";
+import pg from "pg";
 
 /**
  * Get all source studies, under the initial database-level join with other entities needed for the global source studies API.

--- a/app/hooks/UseLogoutCallbackUrl/hook.ts
+++ b/app/hooks/UseLogoutCallbackUrl/hook.ts
@@ -1,6 +1,6 @@
+import { useCurrentPath } from "@/app/hooks/UseCurrentPath/hook";
 import { ROUTE } from "@/app/routes/constants";
 import { PUBLIC_PATHS } from "@/app/routes/publicPaths";
-import { useCurrentPath } from "../UseCurrentPath/hook";
 
 /**
  * Returns the `logoutCallbackUrl` to pass to `NextAuthAuthenticationProvider`.

--- a/app/hooks/useAdminAction.ts
+++ b/app/hooks/useAdminAction.ts
@@ -1,6 +1,6 @@
+import { METHOD } from "@/app/common/entities";
+import { fetchResource } from "@/app/common/utils";
 import { useCallback, useState } from "react";
-import { METHOD } from "../common/entities";
-import { fetchResource } from "../common/utils";
 import { FormResponseErrors } from "./useForm/common/entities";
 
 interface UseAdminAction<T> {

--- a/app/hooks/useAtlasTabBackPath.ts
+++ b/app/hooks/useAtlasTabBackPath.ts
@@ -1,7 +1,7 @@
-import { PathParameter } from "../common/entities";
-import { getRouteURL } from "../common/utils";
-import { useBackPath } from "../components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook";
-import { ROUTE } from "../routes/constants";
+import { PathParameter } from "@/app/common/entities";
+import { getRouteURL } from "@/app/common/utils";
+import { useBackPath } from "@/app/components/Layout/components/Detail/components/DetailViewHero/components/BackButton/hooks/UseBackPath/hook";
+import { ROUTE } from "@/app/routes/constants";
 
 /**
  * Returns the back-arrow path for an atlas detail tab. Honors an explicit

--- a/app/hooks/useAuthorization.ts
+++ b/app/hooks/useAuthorization.ts
@@ -1,8 +1,8 @@
-import { useContext } from "react";
 import {
   AuthorizationContext,
   AuthorizationContextProps,
-} from "../providers/authorization";
+} from "@/app/providers/authorization";
+import { useContext } from "react";
 
 export const useAuthorization = (): AuthorizationContextProps => {
   return useContext(AuthorizationContext);

--- a/app/hooks/useDeleteData.ts
+++ b/app/hooks/useDeleteData.ts
@@ -1,6 +1,6 @@
+import { METHOD } from "@/app/common/entities";
+import { fetchResource, isFetchStatusOk } from "@/app/common/utils";
 import { useCallback } from "react";
-import { METHOD } from "../common/entities";
-import { fetchResource, isFetchStatusOk } from "../common/utils";
 import { OnDeleteOptions } from "./useForm/common/entities";
 
 export interface UseDeleteData<T> {

--- a/app/hooks/useForm/common/entities.ts
+++ b/app/hooks/useForm/common/entities.ts
@@ -1,4 +1,5 @@
 import { METHOD } from "@/app/common/entities";
+import { UseForm } from "@/app/hooks/useForm/useForm";
 import {
   FieldValues,
   UseFormProps,
@@ -6,7 +7,6 @@ import {
   UseFormReturn,
 } from "react-hook-form";
 import { InferType, ObjectSchema } from "yup";
-import { UseForm } from "../useForm";
 
 export interface CustomUseFormOptions<T extends FieldValues> {
   defaultValues?: UseFormProps<YupValidatedFormValues<T>>["defaultValues"];

--- a/app/hooks/useFormManager/common/entities.ts
+++ b/app/hooks/useFormManager/common/entities.ts
@@ -1,5 +1,5 @@
+import { UseFormManager } from "@/app/hooks/useFormManager/useFormManager";
 import { RouteValue } from "@/app/routes/entities";
-import { UseFormManager } from "../useFormManager";
 
 export interface FormAccess {
   canEdit: boolean;

--- a/app/hooks/useFormManager/useFormManager.ts
+++ b/app/hooks/useFormManager/useFormManager.ts
@@ -1,11 +1,14 @@
+import { useAuthorization } from "@/app/hooks/useAuthorization";
+import {
+  FormMethod,
+  YupValidatedFormValues,
+} from "@/app/hooks/useForm/common/entities";
+import { useUserHasEditAuthorization } from "@/app/hooks/useUserHasEditAuthorization/useUserHasEditAuthorization";
 import { RouteValue } from "@/app/routes/entities";
 import { useAuth } from "@databiosphere/findable-ui/lib/auth/hooks/useAuth";
 import Router from "next/router";
 import { useCallback, useEffect, useState } from "react";
 import { FieldValues } from "react-hook-form";
-import { useAuthorization } from "../useAuthorization";
-import { FormMethod, YupValidatedFormValues } from "../useForm/common/entities";
-import { useUserHasEditAuthorization } from "../useUserHasEditAuthorization/useUserHasEditAuthorization";
 import {
   FormAccess,
   FormAction,

--- a/app/hooks/useUserHasEditAuthorization/useUserHasEditAuthorization.ts
+++ b/app/hooks/useUserHasEditAuthorization/useUserHasEditAuthorization.ts
@@ -2,11 +2,11 @@ import {
   HCAAtlasTrackerActiveUser,
   ROLE,
 } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { useAuthorization } from "@/app/hooks/useAuthorization";
 import { isRouteValue } from "@/app/routes/utils";
 import { useRouter } from "next/router";
 import type { ParsedUrlQuery } from "querystring";
 import { useMemo } from "react";
-import { useAuthorization } from "../useAuthorization";
 import { ROUTES } from "./common/constants";
 
 export interface UseUserHasEditAuthorization {

--- a/app/providers/authorization.tsx
+++ b/app/providers/authorization.tsx
@@ -1,14 +1,14 @@
+import {
+  HCAAtlasTrackerActiveUser,
+  ROLE,
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { useFetchActiveUser } from "@/app/hooks/UseFetchActiveUser/hook";
+import { useIsomorphicLayoutEffect } from "@/app/hooks/useIsomorphicLayoutEffect";
+import { ROUTE } from "@/app/routes/constants";
 import { useAuth } from "@databiosphere/findable-ui/lib/auth/hooks/useAuth";
 import { Main as DXMain } from "@databiosphere/findable-ui/lib/components/Layout/components/Main/main";
 import { useQueryClient } from "@tanstack/react-query";
 import { createContext, JSX, ReactNode, useEffect } from "react";
-import {
-  HCAAtlasTrackerActiveUser,
-  ROLE,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { useFetchActiveUser } from "../hooks/UseFetchActiveUser/hook";
-import { useIsomorphicLayoutEffect } from "../hooks/useIsomorphicLayoutEffect";
-import { ROUTE } from "../routes/constants";
 
 export interface AuthorizationContextProps {
   user?: HCAAtlasTrackerActiveUser;

--- a/app/query/useAuthedQuery.ts
+++ b/app/query/useAuthedQuery.ts
@@ -1,5 +1,4 @@
 import { METHOD } from "@/app/common/entities";
-import { queryFn } from "@/app/query/queryFn";
 import { useAuth } from "@databiosphere/findable-ui/lib/auth/hooks/useAuth";
 import {
   DefaultError,
@@ -7,6 +6,7 @@ import {
   UseQueryResult,
   useQuery as useReactQuery,
 } from "@tanstack/react-query";
+import { queryFn } from "./queryFn";
 
 export interface AuthedQueryOptions<TData, TView, TQueryKey extends QueryKey> {
   enabled?: boolean;

--- a/app/routes/adminPageGuard.ts
+++ b/app/routes/adminPageGuard.ts
@@ -1,7 +1,7 @@
+import { ROLE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { nextAuthOptions } from "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config";
 import { GetServerSidePropsContext, Redirect } from "next";
 import { getServerSession } from "next-auth";
-import { ROLE } from "../apis/catalog/hca-atlas-tracker/common/entities";
 import { ROUTE } from "./constants";
 
 /**

--- a/app/routes/authorization.ts
+++ b/app/routes/authorization.ts
@@ -1,4 +1,4 @@
-import { ROLE } from "../apis/catalog/hca-atlas-tracker/common/entities";
+import { ROLE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { ROUTE } from "./constants";
 import { PUBLIC_PATHS } from "./publicPaths";
 

--- a/app/services/__mocks__/cellxgene.ts
+++ b/app/services/__mocks__/cellxgene.ts
@@ -1,9 +1,9 @@
+import { CollectionInfo } from "@/app/services/cellxgene";
+import { RefreshDataResult } from "@/app/services/common/refresh-service";
 import {
   TEST_CELLXGENE_COLLECTIONS_BY_DOI,
   TEST_CELLXGENE_COLLECTIONS_BY_ID,
 } from "@/testing/constants";
-import { CollectionInfo } from "../cellxgene";
-import { RefreshDataResult } from "../common/refresh-service";
 
 export function isCellxGeneRefreshing(): boolean {
   return false;

--- a/app/services/__mocks__/hca-projects.ts
+++ b/app/services/__mocks__/hca-projects.ts
@@ -1,11 +1,11 @@
 import { ProjectsResponse } from "@/app/apis/azul/hca-dcp/common/responses";
+import { RefreshDataResult } from "@/app/services/common/refresh-service";
 import { getProjectsInfo, ProjectInfo } from "@/app/utils/hca-projects";
 import {
   TEST_HCA_PROJECTS_BY_DOI,
   TEST_HCA_PROJECTS_BY_ID,
   TEST_HCA_PROJECTS_WITH_UNAVAILABLE_SERVICE,
 } from "@/testing/constants";
-import { RefreshDataResult } from "../common/refresh-service";
 
 export function areProjectsRefreshing(): boolean {
   return false;

--- a/app/services/__mocks__/validator-batch.ts
+++ b/app/services/__mocks__/validator-batch.ts
@@ -1,7 +1,7 @@
 import {
   SubmitDatasetValidationJobParams,
   SubmitDatasetValidationJobResult,
-} from "../validator-batch";
+} from "@/app/services/validator-batch";
 
 export const submitDatasetValidationJob = jest.fn<
   SubmitDatasetValidationJobResult,

--- a/app/services/atlases.ts
+++ b/app/services/atlases.ts
@@ -1,7 +1,3 @@
-import { InvalidOperationError } from "@/app/utils/api-errors";
-import { getCrossrefPublicationInfo } from "@/app/utils/crossref/crossref";
-import pg from "pg";
-import { ValidationError } from "yup";
 import {
   ATLAS_STATUS,
   AtlasStatusSummary,
@@ -13,16 +9,16 @@ import {
   HCAAtlasTrackerDBAtlasOverview,
   REPROCESSED_STATUS,
   SYSTEM,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import {
   AtlasEditData,
   NewAtlasData,
-} from "../apis/catalog/hca-atlas-tracker/common/schema";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
 import {
   getCapIngestStatusFromParameters,
   getPublishedFromPublishedAt,
   isUuid,
-} from "../apis/catalog/hca-atlas-tracker/common/utils";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/utils";
 import {
   atlasIsLatestRevision,
   changeAtlasToPublished,
@@ -35,14 +31,21 @@ import {
   getAtlasNotFoundError,
   getAtlasPublishedAt,
   getAtlasSourceStudyIds,
-} from "../data/atlases";
-import { publishUnpublishedComponentAtlasesOfAtlas } from "../data/component-atlases";
-import { publishUnpublishedSourceDatasetsOfAtlas } from "../data/source-datasets";
-import { addAssociatedEntityToUsersAssociatedWith } from "../data/users";
-import { parseAtlasNameUrlSlug, slugifyAtlasShortName } from "../utils/atlases";
-import { normalizeDoi } from "../utils/doi";
-import { normalizeValidationSummary } from "../utils/files";
-import { getSheetTitleForApi } from "../utils/google-sheets-api";
+} from "@/app/data/atlases";
+import { publishUnpublishedComponentAtlasesOfAtlas } from "@/app/data/component-atlases";
+import { publishUnpublishedSourceDatasetsOfAtlas } from "@/app/data/source-datasets";
+import { addAssociatedEntityToUsersAssociatedWith } from "@/app/data/users";
+import { InvalidOperationError } from "@/app/utils/api-errors";
+import {
+  parseAtlasNameUrlSlug,
+  slugifyAtlasShortName,
+} from "@/app/utils/atlases";
+import { getCrossrefPublicationInfo } from "@/app/utils/crossref/crossref";
+import { normalizeDoi } from "@/app/utils/doi";
+import { normalizeValidationSummary } from "@/app/utils/files";
+import { getSheetTitleForApi } from "@/app/utils/google-sheets-api";
+import pg from "pg";
+import { ValidationError } from "yup";
 import { doTransaction, mapDatabaseError, query } from "./database";
 import { updateSourceStudyValidationsByEntityIds } from "./source-studies";
 

--- a/app/services/cellxgene.ts
+++ b/app/services/cellxgene.ts
@@ -1,6 +1,6 @@
+import { getCellxGeneCollections } from "@/app/utils/cellxgene-api";
+import { normalizeDoi } from "@/app/utils/doi";
 import { Options as KyOptions } from "ky";
-import { getCellxGeneCollections } from "../utils/cellxgene-api";
-import { normalizeDoi } from "../utils/doi";
 import {
   makeRefreshService,
   RefreshDataResult,

--- a/app/services/component-atlases.ts
+++ b/app/services/component-atlases.ts
@@ -1,4 +1,3 @@
-import pg from "pg";
 import {
   HCAAtlasTrackerDBAtlas,
   HCAAtlasTrackerDBComponentAtlas,
@@ -6,10 +5,11 @@ import {
   HCAAtlasTrackerDBComponentAtlasForDetailAPI,
   HCAAtlasTrackerDBComponentAtlasInfo,
   HCAAtlasTrackerDBFile,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { ComponentAtlasEditData } from "../apis/catalog/hca-atlas-tracker/common/schema";
-import { getSourceDatasetVersionsForAtlas } from "../data/source-datasets";
-import { InvalidOperationError, NotFoundError } from "../utils/api-errors";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { ComponentAtlasEditData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { getSourceDatasetVersionsForAtlas } from "@/app/data/source-datasets";
+import { InvalidOperationError, NotFoundError } from "@/app/utils/api-errors";
+import pg from "pg";
 import { updateDownloadNameIfChanged } from "./concepts";
 import { doTransaction, query } from "./database";
 

--- a/app/services/concepts.ts
+++ b/app/services/concepts.ts
@@ -14,7 +14,7 @@ import {
   InvalidOperationError,
   NotFoundError,
 } from "@/app/utils/api-errors";
-import { getFileBaseName, getFileExtension } from "app/utils/files";
+import { getFileBaseName, getFileExtension } from "@/app/utils/files";
 import pg from "pg";
 import { mapDatabaseError } from "./database";
 

--- a/app/services/concepts.ts
+++ b/app/services/concepts.ts
@@ -1,21 +1,21 @@
-import { getFileBaseName, getFileExtension } from "app/utils/files";
-import pg from "pg";
 import {
   HCAAtlasTrackerDBAtlas,
   HCAAtlasTrackerDBConcept,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import {
   createConcept,
   getAtlasesMatchingConceptAndRevision,
   getConcept,
   getConceptIdByInfo,
   setConceptBaseFilename,
-} from "../data/concepts";
+} from "@/app/data/concepts";
 import {
   ConflictError,
   InvalidOperationError,
   NotFoundError,
-} from "../utils/api-errors";
+} from "@/app/utils/api-errors";
+import { getFileBaseName, getFileExtension } from "app/utils/files";
+import pg from "pg";
 import { mapDatabaseError } from "./database";
 
 /**

--- a/app/services/database.ts
+++ b/app/services/database.ts
@@ -1,5 +1,5 @@
+import { getPoolConfig } from "@/app/utils/pg-app-connect-config";
 import pg from "pg";
-import { getPoolConfig } from "../utils/pg-app-connect-config";
 
 const { Pool } = pg;
 

--- a/app/services/entry-sheets.ts
+++ b/app/services/entry-sheets.ts
@@ -1,14 +1,14 @@
-import pg from "pg";
-import { ValidationError } from "yup";
 import {
   HCAAtlasTrackerDBAtlas,
   HCAAtlasTrackerDBEntrySheetValidation,
   HCAAtlasTrackerDBEntrySheetValidationListFields,
   NetworkKey,
   WithSourceStudyInfo,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { NotFoundError } from "../utils/api-errors";
-import { validateEntrySheet } from "../utils/hca-validation-tools/hca-validation-tools";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { NotFoundError } from "@/app/utils/api-errors";
+import { validateEntrySheet } from "@/app/utils/hca-validation-tools/hca-validation-tools";
+import pg from "pg";
+import { ValidationError } from "yup";
 import { getBaseModelAtlas } from "./atlases";
 import { doTransaction, query } from "./database";
 import {

--- a/app/services/files.ts
+++ b/app/services/files.ts
@@ -1,6 +1,4 @@
-import { VALID_FILE_TYPES_FOR_VALIDATION } from "app/apis/catalog/hca-atlas-tracker/common/constants";
-import { InvalidOperationError } from "app/utils/api-errors";
-import { getDbEntityFileVersion } from "../apis/catalog/hca-atlas-tracker/common/backend-utils";
+import { getDbEntityFileVersion } from "@/app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import {
   FILE_TYPE,
   FILE_VALIDATION_STATUS,
@@ -8,9 +6,9 @@ import {
   HCAAtlasTrackerDBSourceDataset,
   INTEGRITY_STATUS,
   PresignedUrlInfo,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { getComponentAtlasForAtlasFile } from "../data/component-atlases";
-import { getConceptForFile } from "../data/concepts";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { getComponentAtlasForAtlasFile } from "@/app/data/component-atlases";
+import { getConceptForFile } from "@/app/data/concepts";
 import {
   confirmLatestFilesExistOnAtlas,
   getAllFilesValidationParams,
@@ -21,9 +19,11 @@ import {
   setFileIntegrityStatus,
   setFilesArchiveStatus,
   setFileValidationStatus,
-} from "../data/files";
-import { getSourceDatasetForAtlasFile } from "../data/source-datasets";
-import { insertVersionInFilename } from "../utils/files";
+} from "@/app/data/files";
+import { getSourceDatasetForAtlasFile } from "@/app/data/source-datasets";
+import { insertVersionInFilename } from "@/app/utils/files";
+import { VALID_FILE_TYPES_FOR_VALIDATION } from "app/apis/catalog/hca-atlas-tracker/common/constants";
+import { InvalidOperationError } from "app/utils/api-errors";
 import { doTransaction } from "./database";
 import { getDownloadUrl } from "./s3-operations";
 import { submitDatasetValidationJob } from "./validator-batch";

--- a/app/services/files.ts
+++ b/app/services/files.ts
@@ -1,4 +1,5 @@
 import { getDbEntityFileVersion } from "@/app/apis/catalog/hca-atlas-tracker/common/backend-utils";
+import { VALID_FILE_TYPES_FOR_VALIDATION } from "@/app/apis/catalog/hca-atlas-tracker/common/constants";
 import {
   FILE_TYPE,
   FILE_VALIDATION_STATUS,
@@ -21,9 +22,8 @@ import {
   setFileValidationStatus,
 } from "@/app/data/files";
 import { getSourceDatasetForAtlasFile } from "@/app/data/source-datasets";
+import { InvalidOperationError } from "@/app/utils/api-errors";
 import { insertVersionInFilename } from "@/app/utils/files";
-import { VALID_FILE_TYPES_FOR_VALIDATION } from "app/apis/catalog/hca-atlas-tracker/common/constants";
-import { InvalidOperationError } from "app/utils/api-errors";
 import { doTransaction } from "./database";
 import { getDownloadUrl } from "./s3-operations";
 import { submitDatasetValidationJob } from "./validator-batch";

--- a/app/services/hca-projects.ts
+++ b/app/services/hca-projects.ts
@@ -1,6 +1,6 @@
+import { getAllProjects, getLatestCatalog } from "@/app/utils/hca-api";
+import { getProjectsInfo, ProjectInfo } from "@/app/utils/hca-projects";
 import { Options as KyOptions } from "ky";
-import { getAllProjects, getLatestCatalog } from "../utils/hca-api";
-import { getProjectsInfo, ProjectInfo } from "../utils/hca-projects";
 import {
   makeRefreshService,
   RefreshDataResult,

--- a/app/services/heatmaps.ts
+++ b/app/services/heatmaps.ts
@@ -1,10 +1,10 @@
-import { Class } from "@databiosphere/findable-ui/lib/common/entities";
 import {
   HCAAtlasTrackerDBEntrySheetValidation,
   Heatmap,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { getDataDictionaryClass } from "../utils/data-dictionary";
-import { EntrySheetValidationErrorInfo } from "../utils/hca-validation-tools/hca-validation-tools";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { getDataDictionaryClass } from "@/app/utils/data-dictionary";
+import { EntrySheetValidationErrorInfo } from "@/app/utils/hca-validation-tools/hca-validation-tools";
+import { Class } from "@databiosphere/findable-ui/lib/common/entities";
 import { getBaseModelAtlasEntrySheetValidations } from "./entry-sheets";
 
 const ENTITY_TYPES = ["dataset", "donor", "sample"] as const;

--- a/app/services/metadata-coverage.ts
+++ b/app/services/metadata-coverage.ts
@@ -1,5 +1,4 @@
-import pg from "pg";
-import { METADATA_COVERAGE_REPORT_CLASSES } from "../apis/catalog/hca-atlas-tracker/common/constants";
+import { METADATA_COVERAGE_REPORT_CLASSES } from "@/app/apis/catalog/hca-atlas-tracker/common/constants";
 import {
   AtlasMetadataCoverage,
   AtlasMetadataCoverageClass,
@@ -8,12 +7,13 @@ import {
   HCAAtlasTrackerDBAtlasForMetadataCoverage,
   MetadataCoverageReportClass,
   MetadataCoverageReportTier,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import {
   getAtlasComponentAtlasMetadataCoverage,
   getAtlasSourceDatasetMetadataCoverage,
-} from "../data/metadata-coverage";
-import { getDataDictionaryClass } from "../utils/data-dictionary";
+} from "@/app/data/metadata-coverage";
+import { getDataDictionaryClass } from "@/app/utils/data-dictionary";
+import pg from "pg";
 
 type FieldCatalog = Record<MetadataCoverageReportClass, Set<string>>;
 

--- a/app/services/s3-notification.ts
+++ b/app/services/s3-notification.ts
@@ -1,48 +1,51 @@
-import { PoolClient } from "pg";
 import {
   S3Event,
   S3EventRecord,
   s3EventSchema,
   SNSMessage,
-} from "../apis/catalog/hca-atlas-tracker/aws/schemas";
-import { dbEntityIsPublished } from "../apis/catalog/hca-atlas-tracker/common/backend-utils";
-import { VALID_FILE_TYPES_FOR_VALIDATION } from "../apis/catalog/hca-atlas-tracker/common/constants";
+} from "@/app/apis/catalog/hca-atlas-tracker/aws/schemas";
+import { dbEntityIsPublished } from "@/app/apis/catalog/hca-atlas-tracker/common/backend-utils";
+import { VALID_FILE_TYPES_FOR_VALIDATION } from "@/app/apis/catalog/hca-atlas-tracker/common/constants";
 import {
   FILE_TYPE,
   FILE_VALIDATION_STATUS,
   FileEventInfo,
   HCAAtlasTrackerDBFile,
   INTEGRITY_STATUS,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import {
   validateS3BucketAuthorization,
   validateSNSTopicAuthorization,
-} from "../config/aws-resources";
+} from "@/app/config/aws-resources";
 import {
   updateComponentAtlasVersionInAtlas,
   updateSourceDatasetVersionInAtlas,
-} from "../data/atlases";
+} from "@/app/data/atlases";
 import {
   createNewComponentAtlasVersion,
   markComponentAtlasAsNotLatest,
   updateSourceDatasetVersionInComponentAtlases,
-} from "../data/component-atlases";
+} from "@/app/data/component-atlases";
 import {
   FileUpsertResult,
   getLatestNotificationInfo,
   markPreviousVersionsAsNotLatest,
   upsertFileRecord,
-} from "../data/files";
+} from "@/app/data/files";
 import {
   createNewSourceDatasetVersion,
   markSourceDatasetAsNotLatest,
-} from "../data/source-datasets";
+} from "@/app/data/source-datasets";
 import {
   getAtlasMatchingConceptAndRevision,
   getOrCreateConceptId,
-} from "../services/concepts";
-import { InvalidOperationError } from "../utils/api-errors";
-import { parseNormalizedInfoFromS3Key, parseS3KeyPath } from "../utils/files";
+} from "@/app/services/concepts";
+import { InvalidOperationError } from "@/app/utils/api-errors";
+import {
+  parseNormalizedInfoFromS3Key,
+  parseS3KeyPath,
+} from "@/app/utils/files";
+import { PoolClient } from "pg";
 import { createComponentAtlas } from "./component-atlases";
 import { doTransaction } from "./database";
 import { startFileValidation } from "./files";

--- a/app/services/s3-notification.ts
+++ b/app/services/s3-notification.ts
@@ -36,10 +36,6 @@ import {
   createNewSourceDatasetVersion,
   markSourceDatasetAsNotLatest,
 } from "@/app/data/source-datasets";
-import {
-  getAtlasMatchingConceptAndRevision,
-  getOrCreateConceptId,
-} from "@/app/services/concepts";
 import { InvalidOperationError } from "@/app/utils/api-errors";
 import {
   parseNormalizedInfoFromS3Key,
@@ -47,6 +43,10 @@ import {
 } from "@/app/utils/files";
 import { PoolClient } from "pg";
 import { createComponentAtlas } from "./component-atlases";
+import {
+  getAtlasMatchingConceptAndRevision,
+  getOrCreateConceptId,
+} from "./concepts";
 import { doTransaction } from "./database";
 import { startFileValidation } from "./files";
 import { createSourceDataset } from "./source-datasets";

--- a/app/services/s3-operations.ts
+++ b/app/services/s3-operations.ts
@@ -1,3 +1,4 @@
+import { validateS3BucketAuthorization } from "@/app/config/aws-resources";
 import {
   DeleteObjectCommand,
   GetObjectCommand,
@@ -5,7 +6,6 @@ import {
   S3Client,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { validateS3BucketAuthorization } from "../config/aws-resources";
 
 const PRESIGNED_DOWNLOAD_URL_EXPIRATION_TIME = 172800; // 48 hours
 

--- a/app/services/s3-sync.ts
+++ b/app/services/s3-sync.ts
@@ -1,3 +1,4 @@
+import { S3EventRecord } from "@/app/apis/catalog/hca-atlas-tracker/aws/schemas";
 import {
   HeadObjectCommand,
   HeadObjectCommandOutput,
@@ -5,7 +6,6 @@ import {
   ListObjectsV2CommandOutput,
   S3Client,
 } from "@aws-sdk/client-s3";
-import { S3EventRecord } from "../apis/catalog/hca-atlas-tracker/aws/schemas";
 import { saveAndProcessFileRecord } from "./s3-notification";
 import { getDataBucketName } from "./s3-operations";
 

--- a/app/services/sns-dispatcher.ts
+++ b/app/services/sns-dispatcher.ts
@@ -1,6 +1,6 @@
-import { UnauthorizedAWSResourceError } from "../apis/catalog/hca-atlas-tracker/aws/errors";
-import { SNSMessage } from "../apis/catalog/hca-atlas-tracker/aws/schemas";
-import { validateSNSTopicAuthorization } from "../config/aws-resources";
+import { UnauthorizedAWSResourceError } from "@/app/apis/catalog/hca-atlas-tracker/aws/errors";
+import { SNSMessage } from "@/app/apis/catalog/hca-atlas-tracker/aws/schemas";
+import { validateSNSTopicAuthorization } from "@/app/config/aws-resources";
 import { processS3NotificationMessage } from "./s3-notification";
 import { processValidationResultsMessage } from "./validation-results-notification";
 

--- a/app/services/sns-subscription.ts
+++ b/app/services/sns-subscription.ts
@@ -1,7 +1,7 @@
-import { SNSMessage } from "../apis/catalog/hca-atlas-tracker/aws/schemas";
-import { validateSNSTopicAuthorization } from "../config/aws-resources";
-import { InvalidOperationError } from "../utils/api-errors";
-import { httpGet } from "../utils/http";
+import { SNSMessage } from "@/app/apis/catalog/hca-atlas-tracker/aws/schemas";
+import { validateSNSTopicAuthorization } from "@/app/config/aws-resources";
+import { InvalidOperationError } from "@/app/utils/api-errors";
+import { httpGet } from "@/app/utils/http";
 
 /**
  * Handles SNS subscription lifecycle messages (SubscriptionConfirmation, UnsubscribeConfirmation)

--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -1,4 +1,3 @@
-import pg from "pg";
 import {
   HCAAtlasTrackerDBSourceDataset,
   HCAAtlasTrackerDBSourceDatasetForAPI,
@@ -6,13 +5,13 @@ import {
   HCAAtlasTrackerDBSourceDatasetForListAPI,
   HCAAtlasTrackerDBSourceDatasetInfo,
   PUBLICATION_STATUS,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import {
   AtlasSourceDatasetEditData,
   SourceDatasetsSetPublicationStatusData,
   SourceDatasetsSetReprocessedStatusData,
   SourceDatasetsSetSourceStudyData,
-} from "../apis/catalog/hca-atlas-tracker/common/schema";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
 import {
   confirmSourceDatasetsAreEditable,
   getAtlasSourceDatasetVersionIds,
@@ -24,9 +23,10 @@ import {
   getSourceStudySourceDatasetVersionIds,
   setSourceDatasetsPublicationStatus,
   setSourceDatasetsSourceStudy,
-} from "../data/source-datasets";
-import { NotFoundError } from "../utils/api-errors";
-import { getSheetTitleForApi } from "../utils/google-sheets-api";
+} from "@/app/data/source-datasets";
+import { NotFoundError } from "@/app/utils/api-errors";
+import { getSheetTitleForApi } from "@/app/utils/google-sheets-api";
+import pg from "pg";
 import { getComponentAtlasVersionForAtlas } from "./component-atlases";
 import { updateDownloadNameIfChanged } from "./concepts";
 import { doTransaction, query } from "./database";

--- a/app/services/source-studies.ts
+++ b/app/services/source-studies.ts
@@ -35,10 +35,10 @@ import {
 } from "@/app/data/source-studies";
 import { AccessError, NotFoundError } from "@/app/utils/api-errors";
 import { getCrossrefPublicationInfo } from "@/app/utils/crossref/crossref";
+import { confirmQueryRowsContainIds } from "@/app/utils/database";
 import { normalizeDoi } from "@/app/utils/doi";
 import { getSpreadsheetIdFromUrl } from "@/app/utils/google-sheets";
 import { getSheetTitleForApi } from "@/app/utils/google-sheets-api";
-import { confirmQueryRowsContainIds } from "app/utils/database";
 import pg from "pg";
 import { ValidationError } from "yup";
 import { getBaseModelAtlas } from "./atlases";

--- a/app/services/source-studies.ts
+++ b/app/services/source-studies.ts
@@ -1,6 +1,3 @@
-import { confirmQueryRowsContainIds } from "app/utils/database";
-import pg from "pg";
-import { ValidationError } from "yup";
 import {
   ATLAS_STATUS,
   DOI_STATUS,
@@ -15,7 +12,7 @@ import {
   HCAAtlasTrackerDBSourceStudyWithRelatedEntities,
   HCAAtlasTrackerDBSourceStudyWithSourceDatasets,
   HCAAtlasTrackerDBValidation,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import {
   NewPublishedSourceStudyData,
   NewSourceStudyData,
@@ -23,24 +20,27 @@ import {
   PublishedSourceStudyEditData,
   SourceStudyEditData,
   UnpublishedSourceStudyEditData,
-} from "../apis/catalog/hca-atlas-tracker/common/schema";
-import { getPublicationDois } from "../apis/catalog/hca-atlas-tracker/common/utils";
-import { replaceSourceStudyInAtlases } from "../data/atlases";
-import { replaceEntrySheetValidationsSourceStudy } from "../data/entry-sheets";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { getPublicationDois } from "@/app/apis/catalog/hca-atlas-tracker/common/utils";
+import { replaceSourceStudyInAtlases } from "@/app/data/atlases";
+import { replaceEntrySheetValidationsSourceStudy } from "@/app/data/entry-sheets";
 import {
   getAtlasSourceDatasetVersionIds,
   replaceSourceDatasetsSourceStudy,
   unlinkAllSourceDatasetsFromSourceStudy,
-} from "../data/source-datasets";
+} from "@/app/data/source-datasets";
 import {
   getInitialJoinSourceStudiesForGlobalApi,
   setSourceStudyMetadataSpreadsheets,
-} from "../data/source-studies";
-import { AccessError, NotFoundError } from "../utils/api-errors";
-import { getCrossrefPublicationInfo } from "../utils/crossref/crossref";
-import { normalizeDoi } from "../utils/doi";
-import { getSpreadsheetIdFromUrl } from "../utils/google-sheets";
-import { getSheetTitleForApi } from "../utils/google-sheets-api";
+} from "@/app/data/source-studies";
+import { AccessError, NotFoundError } from "@/app/utils/api-errors";
+import { getCrossrefPublicationInfo } from "@/app/utils/crossref/crossref";
+import { normalizeDoi } from "@/app/utils/doi";
+import { getSpreadsheetIdFromUrl } from "@/app/utils/google-sheets";
+import { getSheetTitleForApi } from "@/app/utils/google-sheets-api";
+import { confirmQueryRowsContainIds } from "app/utils/database";
+import pg from "pg";
+import { ValidationError } from "yup";
 import { getBaseModelAtlas } from "./atlases";
 import { getCellxGeneIdByDoi } from "./cellxgene";
 import {

--- a/app/services/users.ts
+++ b/app/services/users.ts
@@ -1,13 +1,13 @@
 import {
-  NewUserData,
-  UserEditData,
-} from "app/apis/catalog/hca-atlas-tracker/common/schema";
-import {
   HCAAtlasTrackerDBUser,
   HCAAtlasTrackerDBUserWithAssociatedResources,
   ROLE,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { NotFoundError } from "../utils/api-errors";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { NotFoundError } from "@/app/utils/api-errors";
+import {
+  NewUserData,
+  UserEditData,
+} from "app/apis/catalog/hca-atlas-tracker/common/schema";
 import { getAllAtlases } from "./atlases";
 import { doTransaction, query } from "./database";
 

--- a/app/services/users.ts
+++ b/app/services/users.ts
@@ -3,11 +3,11 @@ import {
   HCAAtlasTrackerDBUserWithAssociatedResources,
   ROLE,
 } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
-import { NotFoundError } from "@/app/utils/api-errors";
 import {
   NewUserData,
   UserEditData,
-} from "app/apis/catalog/hca-atlas-tracker/common/schema";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { NotFoundError } from "@/app/utils/api-errors";
 import { getAllAtlases } from "./atlases";
 import { doTransaction, query } from "./database";
 

--- a/app/services/validation-results-notification.ts
+++ b/app/services/validation-results-notification.ts
@@ -1,5 +1,3 @@
-import { formatFileSize } from "@databiosphere/findable-ui/lib/utils/formatFileSize";
-import { FILE_VALIDATOR_NAMES } from "app/apis/catalog/hca-atlas-tracker/common/constants";
 import {
   DatasetValidatorMetadataCoverageEntity,
   DatasetValidatorResults,
@@ -8,7 +6,7 @@ import {
   datasetValidatorResultsSchema,
   DatasetValidatorToolReports,
   SNSMessage,
-} from "../apis/catalog/hca-atlas-tracker/aws/schemas";
+} from "@/app/apis/catalog/hca-atlas-tracker/aws/schemas";
 import {
   FILE_VALIDATION_STATUS,
   FileMetadataCoverage,
@@ -19,14 +17,16 @@ import {
   HCAAtlasTrackerDBFileDatasetInfo,
   HCAAtlasTrackerDBFileValidationInfo,
   INTEGRITY_STATUS,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { validateS3BucketAuthorization } from "../config/aws-resources";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { validateS3BucketAuthorization } from "@/app/config/aws-resources";
 import {
   addValidationResultsToFile,
   AddValidationResultsToFileParams,
   getLastValidationTimestamp,
-} from "../data/files";
-import { ConflictError, InvalidOperationError } from "../utils/api-errors";
+} from "@/app/data/files";
+import { ConflictError, InvalidOperationError } from "@/app/utils/api-errors";
+import { formatFileSize } from "@databiosphere/findable-ui/lib/utils/formatFileSize";
+import { FILE_VALIDATOR_NAMES } from "app/apis/catalog/hca-atlas-tracker/common/constants";
 import { doTransaction } from "./database";
 import {
   deleteObject,

--- a/app/services/validation-results-notification.ts
+++ b/app/services/validation-results-notification.ts
@@ -7,6 +7,7 @@ import {
   DatasetValidatorToolReports,
   SNSMessage,
 } from "@/app/apis/catalog/hca-atlas-tracker/aws/schemas";
+import { FILE_VALIDATOR_NAMES } from "@/app/apis/catalog/hca-atlas-tracker/common/constants";
 import {
   FILE_VALIDATION_STATUS,
   FileMetadataCoverage,
@@ -26,7 +27,6 @@ import {
 } from "@/app/data/files";
 import { ConflictError, InvalidOperationError } from "@/app/utils/api-errors";
 import { formatFileSize } from "@databiosphere/findable-ui/lib/utils/formatFileSize";
-import { FILE_VALIDATOR_NAMES } from "app/apis/catalog/hca-atlas-tracker/common/constants";
 import { doTransaction } from "./database";
 import {
   deleteObject,

--- a/app/services/validations.ts
+++ b/app/services/validations.ts
@@ -31,9 +31,9 @@ import {
   ValidationDBEntityOfType,
   ValidationDifference,
 } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { NewCommentThreadData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
 import { ForbiddenError, NotFoundError } from "@/app/utils/api-errors";
 import { ProjectInfo } from "@/app/utils/hca-projects";
-import { NewCommentThreadData } from "app/apis/catalog/hca-atlas-tracker/common/schema";
 import { dequal } from "dequal";
 import DOMPurify from "isomorphic-dompurify";
 import pg from "pg";

--- a/app/services/validations.ts
+++ b/app/services/validations.ts
@@ -1,16 +1,12 @@
-import { NewCommentThreadData } from "app/apis/catalog/hca-atlas-tracker/common/schema";
-import { dequal } from "dequal";
-import DOMPurify from "isomorphic-dompurify";
-import pg from "pg";
 import {
   getDbEntityCitation,
   getDbSourceStudyTierOneMetadataStatus,
-} from "../apis/catalog/hca-atlas-tracker/common/backend-utils";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import {
   ALLOWED_TASK_STATUSES_BY_VALIDATION_STATUS,
   DEFAULT_TASK_STATUS_BY_VALIDATION_STATUS,
   VALIDATION_STATUS_BY_TASK_STATUS,
-} from "../apis/catalog/hca-atlas-tracker/common/constants";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/constants";
 import {
   ENTITY_TYPE,
   HCAAtlasTrackerDBAtlas,
@@ -34,9 +30,13 @@ import {
   VALIDATION_VARIABLE,
   ValidationDBEntityOfType,
   ValidationDifference,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { ForbiddenError, NotFoundError } from "../utils/api-errors";
-import { ProjectInfo } from "../utils/hca-projects";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { ForbiddenError, NotFoundError } from "@/app/utils/api-errors";
+import { ProjectInfo } from "@/app/utils/hca-projects";
+import { NewCommentThreadData } from "app/apis/catalog/hca-atlas-tracker/common/schema";
+import { dequal } from "dequal";
+import DOMPurify from "isomorphic-dompurify";
+import pg from "pg";
 import { updateTaskCounts } from "./atlases";
 import { createCommentThread, deleteCommentThread } from "./comments";
 import { doTransaction, getPoolClient, query } from "./database";

--- a/app/services/validator-batch.ts
+++ b/app/services/validator-batch.ts
@@ -1,8 +1,8 @@
-import { BatchClient, SubmitJobCommand } from "@aws-sdk/client-batch";
 import {
   validateS3BucketAuthorization,
   validateSNSTopicAuthorization,
-} from "../config/aws-resources";
+} from "@/app/config/aws-resources";
+import { BatchClient, SubmitJobCommand } from "@aws-sdk/client-batch";
 
 export interface SubmitDatasetValidationJobParams {
   fileId: string;

--- a/app/utils/api-handler.ts
+++ b/app/utils/api-handler.ts
@@ -1,18 +1,18 @@
+import {
+  HCAAtlasTrackerDBUser,
+  ROLE,
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
+import { FormResponseErrors } from "@/app/hooks/useForm/common/entities";
+import {
+  atlasIsPublished,
+  getAtlasIdByUrlParameter,
+} from "@/app/services/atlases";
+import { query } from "@/app/services/database";
 import { nextAuthOptions } from "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config";
 import { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth";
 import { ValidationError } from "yup";
-import {
-  HCAAtlasTrackerDBUser,
-  ROLE,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { METHOD } from "../common/entities";
-import { FormResponseErrors } from "../hooks/useForm/common/entities";
-import {
-  atlasIsPublished,
-  getAtlasIdByUrlParameter,
-} from "../services/atlases";
-import { query } from "../services/database";
 import {
   ApiError,
   ForbiddenError,

--- a/app/utils/crossref/crossref.ts
+++ b/app/utils/crossref/crossref.ts
@@ -1,7 +1,7 @@
 import { PublicationInfo } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { normalizeDoi } from "@/app/utils/doi";
 import { stripHtml } from "string-strip-html";
 import { array, InferType, number, object, string, ValidationError } from "yup";
-import { normalizeDoi } from "../doi";
 import { fetchCrossrefWork } from "./crossref-api";
 
 const crossrefOrganizationAuthorSchema = object({

--- a/app/utils/files.ts
+++ b/app/utils/files.ts
@@ -11,7 +11,7 @@ import {
   AtlasSlugNameAndVersion,
   AtlasVersionNumbers,
   parseS3AtlasVersion,
-} from "@/app/utils/atlases";
+} from "./atlases";
 
 // Parsed S3 key path components
 interface S3KeyPathComponents {

--- a/app/utils/files.ts
+++ b/app/utils/files.ts
@@ -1,17 +1,17 @@
-import { FILE_VALIDATOR_NAMES } from "../apis/catalog/hca-atlas-tracker/common/constants";
+import { FILE_VALIDATOR_NAMES } from "@/app/apis/catalog/hca-atlas-tracker/common/constants";
 import {
   DBFileValidationSummary,
   FILE_TYPE,
   FileValidationSummary,
   NetworkKey,
   ValidatorSummaryStatus,
-} from "../apis/catalog/hca-atlas-tracker/common/entities";
-import { isNetworkKey } from "../apis/catalog/hca-atlas-tracker/common/utils";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { isNetworkKey } from "@/app/apis/catalog/hca-atlas-tracker/common/utils";
 import {
   AtlasSlugNameAndVersion,
   AtlasVersionNumbers,
   parseS3AtlasVersion,
-} from "../utils/atlases";
+} from "@/app/utils/atlases";
 
 // Parsed S3 key path components
 interface S3KeyPathComponents {

--- a/app/utils/hca-api.ts
+++ b/app/utils/hca-api.ts
@@ -1,9 +1,9 @@
+import { ProjectsResponse } from "@/app/apis/azul/hca-dcp/common/responses";
 import {
   AzulCatalogResponse,
   AzulEntitiesResponse,
 } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
 import ky, { Options as KyOptions } from "ky";
-import { ProjectsResponse } from "../apis/azul/hca-dcp/common/responses";
 
 const API_URL_CATALOGS =
   "https://service.azul.data.humancellatlas.org/index/catalogs";

--- a/app/utils/hca-projects.ts
+++ b/app/utils/hca-projects.ts
@@ -1,5 +1,5 @@
-import { ProjectsResponse } from "../apis/azul/hca-dcp/common/responses";
-import { normalizeDoi } from "../utils/doi";
+import { ProjectsResponse } from "@/app/apis/azul/hca-dcp/common/responses";
+import { normalizeDoi } from "@/app/utils/doi";
 
 export interface ProjectInfo {
   atlases: { shortName: string; version: string | null }[];

--- a/app/utils/hca-projects.ts
+++ b/app/utils/hca-projects.ts
@@ -1,5 +1,5 @@
 import { ProjectsResponse } from "@/app/apis/azul/hca-dcp/common/responses";
-import { normalizeDoi } from "@/app/utils/doi";
+import { normalizeDoi } from "./doi";
 
 export interface ProjectInfo {
   atlases: { shortName: string; version: string | null }[];

--- a/app/utils/hca-validation-tools/__mocks__/hca-validation-tools-api.ts
+++ b/app/utils/hca-validation-tools/__mocks__/hca-validation-tools-api.ts
@@ -1,10 +1,10 @@
 import { EntrySheetValidationResponse } from "@/app/utils/hca-validation-tools/hca-validation-tools";
-import { expectIsDefined } from "@/testing/utils";
 import {
   FETCH_ERROR_ENTRY_SHEET_IDS,
   TEST_ENTRY_SHEET_VALIDATION_FETCH_ERROR_MESSAGE,
   TEST_ENTRY_SHEET_VALIDATION_RESPONSES_BY_ID,
-} from "testing/constants";
+} from "@/testing/constants";
+import { expectIsDefined } from "@/testing/utils";
 
 export async function fetchEntrySheetValidationResults(
   googleSheetId: string,

--- a/app/utils/hca-validation-tools/__mocks__/hca-validation-tools-api.ts
+++ b/app/utils/hca-validation-tools/__mocks__/hca-validation-tools-api.ts
@@ -1,10 +1,10 @@
+import { EntrySheetValidationResponse } from "@/app/utils/hca-validation-tools/hca-validation-tools";
 import { expectIsDefined } from "@/testing/utils";
 import {
   FETCH_ERROR_ENTRY_SHEET_IDS,
   TEST_ENTRY_SHEET_VALIDATION_FETCH_ERROR_MESSAGE,
   TEST_ENTRY_SHEET_VALIDATION_RESPONSES_BY_ID,
 } from "testing/constants";
-import { EntrySheetValidationResponse } from "../hca-validation-tools";
 
 export async function fetchEntrySheetValidationResults(
   googleSheetId: string,

--- a/app/views/AddNewAtlasView/hooks/useAddAtlasForm.ts
+++ b/app/views/AddNewAtlasView/hooks/useAddAtlasForm.ts
@@ -2,8 +2,8 @@ import { HCAAtlasTrackerAtlas } from "@/app/apis/catalog/hca-atlas-tracker/commo
 import { NewAtlasData as APINewAtlasData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
 import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { useForm } from "@/app/hooks/useForm/useForm";
-import { NewAtlasData } from "../common/entities";
-import { newAtlasSchema } from "../common/schema";
+import { NewAtlasData } from "@/app/views/AddNewAtlasView/common/entities";
+import { newAtlasSchema } from "@/app/views/AddNewAtlasView/common/schema";
 
 const SCHEMA = newAtlasSchema;
 

--- a/app/views/AddNewAtlasView/hooks/useAddAtlasFormManager.ts
+++ b/app/views/AddNewAtlasView/hooks/useAddAtlasFormManager.ts
@@ -6,10 +6,10 @@ import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { FormManager } from "@/app/hooks/useFormManager/common/entities";
 import { useFormManager } from "@/app/hooks/useFormManager/useFormManager";
 import { ROUTE } from "@/app/routes/constants";
+import { NewAtlasData } from "@/app/views/AddNewAtlasView/common/entities";
+import { getIdentifierId } from "@/app/views/AddNewAtlasView/common/utils";
 import Router from "next/router";
 import { useCallback } from "react";
-import { NewAtlasData } from "../common/entities";
-import { getIdentifierId } from "../common/utils";
 
 export const useAddAtlasFormManager = (
   formMethod: FormMethod<NewAtlasData, HCAAtlasTrackerAtlas>,

--- a/app/views/AddNewSourceStudyView/hooks/useAddSourceStudyForm.ts
+++ b/app/views/AddNewSourceStudyView/hooks/useAddSourceStudyForm.ts
@@ -1,8 +1,8 @@
 import { HCAAtlasTrackerSourceStudy } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { useForm } from "@/app/hooks/useForm/useForm";
-import { NewSourceStudyData } from "../common/entities";
-import { newSourceStudySchema } from "../common/schema";
+import { NewSourceStudyData } from "@/app/views/AddNewSourceStudyView/common/entities";
+import { newSourceStudySchema } from "@/app/views/AddNewSourceStudyView/common/schema";
 
 const SCHEMA = newSourceStudySchema;
 

--- a/app/views/AddNewSourceStudyView/hooks/useAddSourceStudyFormManager.ts
+++ b/app/views/AddNewSourceStudyView/hooks/useAddSourceStudyFormManager.ts
@@ -6,18 +6,18 @@ import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { FormManager } from "@/app/hooks/useFormManager/common/entities";
 import { useFormManager } from "@/app/hooks/useFormManager/useFormManager";
 import { ROUTE } from "@/app/routes/constants";
-import Router from "next/router";
-import { useCallback } from "react";
 import {
   FIELD_NAME,
   NO_DOI_FIELDS,
   PUBLISHED_PREPRINT_FIELDS,
-} from "../common/constants";
+} from "@/app/views/AddNewSourceStudyView/common/constants";
 import {
   NewSourceStudyData,
   NewSourceStudyDataKeys,
   PUBLICATION_STATUS,
-} from "../common/entities";
+} from "@/app/views/AddNewSourceStudyView/common/entities";
+import Router from "next/router";
+import { useCallback } from "react";
 
 export const useAddSourceStudyFormManager = (
   pathParameter: PathParameter,

--- a/app/views/AddNewUserView/hooks/useAddUserForm.ts
+++ b/app/views/AddNewUserView/hooks/useAddUserForm.ts
@@ -5,8 +5,8 @@ import {
 import { NewUserData as ApiNewUserData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
 import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { useForm } from "@/app/hooks/useForm/useForm";
-import { NewUserData } from "../common/entities";
-import { newUserSchema } from "../common/schema";
+import { NewUserData } from "@/app/views/AddNewUserView/common/entities";
+import { newUserSchema } from "@/app/views/AddNewUserView/common/schema";
 
 const SCHEMA = newUserSchema;
 

--- a/app/views/AddNewUserView/hooks/useAddUserFormManager.ts
+++ b/app/views/AddNewUserView/hooks/useAddUserFormManager.ts
@@ -6,9 +6,9 @@ import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { FormManager } from "@/app/hooks/useFormManager/common/entities";
 import { useFormManager } from "@/app/hooks/useFormManager/useFormManager";
 import { ROUTE } from "@/app/routes/constants";
+import { NewUserData } from "@/app/views/AddNewUserView/common/entities";
 import Router from "next/router";
 import { useCallback } from "react";
-import { NewUserData } from "../common/entities";
 
 export const useAddUserFormManager = (
   formMethod: FormMethod<NewUserData, HCAAtlasTrackerUser>,

--- a/app/views/AtlasMetadataCorrectnessView/common/constants.ts
+++ b/app/views/AtlasMetadataCorrectnessView/common/constants.ts
@@ -1,5 +1,5 @@
 import { SectionConfig } from "@/app/components/Entity/components/EntityView/components/Section/entities";
-import { Tables } from "../components/Tables/tables";
+import { Tables } from "@/app/views/AtlasMetadataCorrectnessView/components/Tables/tables";
 
 export const METADATA_CORRECTNESS_VIEW_TABLES: SectionConfig<typeof Tables> = {
   Component: Tables,

--- a/app/views/AtlasMetadataCorrectnessView/components/Tables/tables.tsx
+++ b/app/views/AtlasMetadataCorrectnessView/components/Tables/tables.tsx
@@ -1,9 +1,9 @@
 import { TablePlaceholder } from "@/app/components/Table/components/TablePlaceholder/tablePlaceholder";
 import { useEntity } from "@/app/providers/entity/hook";
+import { Table } from "@/app/views/AtlasMetadataCorrectnessView/components/Table/table";
 import { EntityData } from "@/app/views/AtlasMetadataCorrectnessView/entities";
 import { FluidPaper } from "@databiosphere/findable-ui/lib/components/common/Paper/components/FluidPaper/fluidPaper";
 import { JSX } from "react";
-import { Table } from "../Table/table";
 import { StyledGrid } from "./tables.styles";
 import { filterClasses } from "./utils";
 

--- a/app/views/AtlasMetadataEntrySheetValidationView/common/constants.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/common/constants.ts
@@ -1,6 +1,6 @@
 import { SectionConfig } from "@/app/components/Entity/components/EntityView/components/Section/entities";
-import { Summary } from "../components/Summary/summary";
-import { ValidationReport } from "../components/ValidationReport/validationReport";
+import { Summary } from "@/app/views/AtlasMetadataEntrySheetValidationView/components/Summary/summary";
+import { ValidationReport } from "@/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/validationReport";
 
 export const METADATA_ENTRY_SHEET_VALIDATION_REPORT: SectionConfig<
   typeof ValidationReport

--- a/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entityValidationReport.tsx
+++ b/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/EntityValidationReport/entityValidationReport.tsx
@@ -1,4 +1,5 @@
 import { buildSheetsUrl } from "@/app/utils/google-sheets";
+import { Alert } from "@/app/views/AtlasMetadataEntrySheetValidationView/components/ValidationReport/components/Alert/alert";
 import {
   COLUMN_KEY,
   MAX_REPORTS_TO_DISPLAY,
@@ -14,7 +15,6 @@ import { BUTTON_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/b
 import { TYPOGRAPHY_PROPS } from "@databiosphere/findable-ui/lib/styles/common/mui/typography";
 import { Button, Divider, Typography } from "@mui/material";
 import { Fragment, JSX, useMemo, useState } from "react";
-import { Alert } from "../Alert/alert";
 import { ENTITY_NAME, GRID_PROPS } from "./constants";
 import { Props } from "./entities";
 import {

--- a/app/views/AtlasMetadataEntrySheetValidationView/hooks/UseEntrySheetSync/utils.ts
+++ b/app/views/AtlasMetadataEntrySheetValidationView/hooks/UseEntrySheetSync/utils.ts
@@ -1,6 +1,6 @@
 import { API } from "@/app/apis/catalog/hca-atlas-tracker/common/api";
 import { FETCH_STATUS, METHOD, PathParameter } from "@/app/common/entities";
-import { getRequestURL } from "app/common/utils";
+import { getRequestURL } from "@/app/common/utils";
 
 /**
  * Starts the sync process for an entry sheet validation.

--- a/app/views/AtlasMetadataEntrySheetsView/common/columns.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/common/columns.ts
@@ -1,8 +1,8 @@
 import { KeyValueCell } from "@/app/components/Table/components/TableCell/components/KeyValueCell/keyValueCell";
+import { ValidationSummaryCell } from "@/app/views/AtlasMetadataEntrySheetsView/components/Table/components/TableCell/components/ValidationSummaryCell/validationSummaryCell";
+import { MetadataEntrySheet } from "@/app/views/AtlasMetadataEntrySheetsView/entities";
 import { LinkCell } from "@databiosphere/findable-ui/lib/components/Table/components/TableCell/components/LinkCell/linkCell";
 import { ColumnDef } from "@tanstack/react-table";
-import { ValidationSummaryCell } from "../components/Table/components/TableCell/components/ValidationSummaryCell/validationSummaryCell";
-import { MetadataEntrySheet } from "../entities";
 import {
   buildDataSummary,
   buildEntrySheetTitle,

--- a/app/views/AtlasMetadataEntrySheetsView/common/constants.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/common/constants.ts
@@ -1,8 +1,8 @@
 import { SectionConfig } from "@/app/components/Entity/components/EntityView/components/Section/entities";
+import { Alert } from "@/app/views/AtlasMetadataEntrySheetsView/components/Alert/alert";
+import { Summary } from "@/app/views/AtlasMetadataEntrySheetsView/components/Summary/summary";
+import { Table } from "@/app/views/AtlasMetadataEntrySheetsView/components/Table/table";
 import { SORT_DIRECTION } from "@databiosphere/findable-ui/lib/config/entities";
-import { Alert } from "../components/Alert/alert";
-import { Summary } from "../components/Summary/summary";
-import { Table } from "../components/Table/table";
 import { COLUMNS } from "./columns";
 
 export const METADATA_ENTRY_SHEETS_INFO: SectionConfig<typeof Alert> = {

--- a/app/views/AtlasMetadataEntrySheetsView/common/viewBuilders.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/common/viewBuilders.ts
@@ -3,12 +3,12 @@ import { withBackOrigin } from "@/app/components/Layout/components/Detail/compon
 import { getPartialCellContext } from "@/app/components/Table/components/utils";
 import { ROUTE } from "@/app/routes/constants";
 import { buildSheetsUrl } from "@/app/utils/google-sheets";
+import { ValidationSummaryCellProps } from "@/app/views/AtlasMetadataEntrySheetsView/components/Table/components/TableCell/components/ValidationSummaryCell/types";
+import { MetadataEntrySheet } from "@/app/views/AtlasMetadataEntrySheetsView/entities";
 import { KeyValuePairsProps } from "@databiosphere/findable-ui/lib/components/common/KeyValuePairs/keyValuePairs";
 import { LinkProps } from "@mui/material";
 import { CellContext } from "@tanstack/react-table";
 import { formatDistanceToNowStrict } from "date-fns";
-import { ValidationSummaryCellProps } from "../components/Table/components/TableCell/components/ValidationSummaryCell/types";
-import { MetadataEntrySheet } from "../entities";
 
 /**
  * Returns data summary cell context.

--- a/app/views/AtlasMetadataEntrySheetsView/components/Table/table.tsx
+++ b/app/views/AtlasMetadataEntrySheetsView/components/Table/table.tsx
@@ -1,4 +1,5 @@
 import { Table as CommonTable } from "@/app/components/Entity/components/common/Table/table";
+import { StyledFluidPaper } from "@/app/components/Table/components/TablePaper/tablePaper.styles";
 import { TablePlaceholder } from "@/app/components/Table/components/TablePlaceholder/tablePlaceholder";
 import { CORE_OPTIONS } from "@/app/components/Table/options/core/constants";
 import { SORTING_OPTIONS } from "@/app/components/Table/options/sorting/constants";
@@ -8,7 +9,6 @@ import {
   MetadataEntrySheet,
 } from "@/app/views/AtlasMetadataEntrySheetsView/entities";
 import { useReactTable } from "@tanstack/react-table";
-import { StyledFluidPaper } from "app/components/Table/components/TablePaper/tablePaper.styles";
 import { JSX } from "react";
 import { Props } from "./entities";
 

--- a/app/views/AtlasMetadataEntrySheetsView/hooks/UseEntrySheetSync/utils.ts
+++ b/app/views/AtlasMetadataEntrySheetsView/hooks/UseEntrySheetSync/utils.ts
@@ -1,6 +1,6 @@
 import { API } from "@/app/apis/catalog/hca-atlas-tracker/common/api";
 import { FETCH_STATUS, METHOD, PathParameter } from "@/app/common/entities";
-import { getRequestURL } from "app/common/utils";
+import { getRequestURL } from "@/app/common/utils";
 
 /**
  * Starts the entry sheets sync process for an atlas.

--- a/app/views/AtlasSourceDatasetValidationView/atlasSourceDatasetValidationView.tsx
+++ b/app/views/AtlasSourceDatasetValidationView/atlasSourceDatasetValidationView.tsx
@@ -9,9 +9,9 @@ import { useFetchAtlas } from "@/app/hooks/UseFetchAtlas/hook";
 import { useFormManager } from "@/app/hooks/useFormManager/useFormManager";
 import { EntityProvider } from "@/app/providers/entity/provider";
 import { ROUTE } from "@/app/routes/constants";
+import { useFetchAtlasSourceDataset } from "@/app/views/AtlasSourceDatasetView/hooks/UseFetchAtlasSourceDataset/hook";
 import { ConditionalComponent } from "@databiosphere/findable-ui/lib/components/ComponentCreator/components/ConditionalComponent/conditionalComponent";
 import { Fragment, JSX } from "react";
-import { useFetchAtlasSourceDataset } from "../AtlasSourceDatasetView/hooks/UseFetchAtlasSourceDataset/hook";
 import { VIEW_SOURCE_DATASET_VALIDATION_SECTION_CONFIGS } from "./common/config";
 import { getBreadcrumbs, getTabs } from "./common/utils";
 

--- a/app/views/AtlasSourceDatasetValidationView/common/constants.ts
+++ b/app/views/AtlasSourceDatasetValidationView/common/constants.ts
@@ -1,5 +1,5 @@
 import { SectionConfig } from "@/app/components/Entity/components/EntityView/components/Section/entities";
-import { Report } from "../components/Report/report";
+import { Report } from "@/app/views/AtlasSourceDatasetValidationView/components/Report/report";
 
 export const SOURCE_DATASET_VALIDATION_REPORT: SectionConfig<typeof Report> = {
   Component: Report,

--- a/app/views/AtlasSourceDatasetView/hooks/useEditAtlasSourceDatasetForm.ts
+++ b/app/views/AtlasSourceDatasetView/hooks/useEditAtlasSourceDatasetForm.ts
@@ -6,10 +6,10 @@ import {
 import { PathParameter } from "@/app/common/entities";
 import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { useForm } from "@/app/hooks/useForm/useForm";
+import { FIELD_NAME } from "@/app/views/AtlasSourceDatasetView/common/constants";
+import { ViewAtlasSourceDatasetData } from "@/app/views/AtlasSourceDatasetView/common/entities";
+import { viewAtlasSourceDatasetSchema } from "@/app/views/AtlasSourceDatasetView/common/schema";
 import { formatFileSize } from "@databiosphere/findable-ui/lib/utils/formatFileSize";
-import { FIELD_NAME } from "../common/constants";
-import { ViewAtlasSourceDatasetData } from "../common/entities";
-import { viewAtlasSourceDatasetSchema } from "../common/schema";
 import { useFetchAtlasSourceDataset } from "./UseFetchAtlasSourceDataset/hook";
 
 const SCHEMA = viewAtlasSourceDatasetSchema;

--- a/app/views/AtlasSourceDatasetView/hooks/useEditAtlasSourceDatasetFormManager.ts
+++ b/app/views/AtlasSourceDatasetView/hooks/useEditAtlasSourceDatasetFormManager.ts
@@ -6,10 +6,10 @@ import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { FormManager } from "@/app/hooks/useFormManager/common/entities";
 import { useFormManager } from "@/app/hooks/useFormManager/useFormManager";
 import { ROUTE } from "@/app/routes/constants";
+import { ViewAtlasSourceDatasetData } from "@/app/views/AtlasSourceDatasetView/common/entities";
 import { useQueryClient } from "@tanstack/react-query";
 import Router from "next/router";
 import { useCallback } from "react";
-import { ViewAtlasSourceDatasetData } from "../common/entities";
 import { SOURCE_DATASET } from "./UseFetchAtlasSourceDataset/query/constants";
 
 type Payload = {

--- a/app/views/AtlasSourceDatasetsView/common/configs.ts
+++ b/app/views/AtlasSourceDatasetsView/common/configs.ts
@@ -1,6 +1,6 @@
 import { SectionConfig } from "@/app/components/Entity/components/EntityView/components/Section/entities";
-import { Alert } from "../components/Alert/alert";
-import { Table } from "../components/Table/table";
+import { Alert } from "@/app/views/AtlasSourceDatasetsView/components/Alert/alert";
+import { Table } from "@/app/views/AtlasSourceDatasetsView/components/Table/table";
 
 export const VIEW_SOURCE_DATASETS_INFO: SectionConfig<typeof Alert> = {
   Component: Alert,

--- a/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/EditPublicationStatus/hooks/useEditPublicationStatusForm.ts
+++ b/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/EditPublicationStatus/hooks/useEditPublicationStatusForm.ts
@@ -1,7 +1,7 @@
 import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { useForm } from "@/app/hooks/useForm/useForm";
-import { PublicationStatusEditData } from "../common/entities";
-import { publicationStatusEditSchema } from "../common/schema";
+import { PublicationStatusEditData } from "@/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/EditPublicationStatus/common/entities";
+import { publicationStatusEditSchema } from "@/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/EditPublicationStatus/common/schema";
 
 const SCHEMA = publicationStatusEditSchema;
 

--- a/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/EditPublicationStatus/hooks/useEditPublicationStatusManager.ts
+++ b/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/EditPublicationStatus/hooks/useEditPublicationStatusManager.ts
@@ -5,6 +5,7 @@ import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { FormManager } from "@/app/hooks/useFormManager/common/entities";
 import { useFormManager } from "@/app/hooks/useFormManager/useFormManager";
 import { useEntity } from "@/app/providers/entity/hook";
+import { PublicationStatusEditData } from "@/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/EditPublicationStatus/common/entities";
 import {
   AtlasSourceDataset,
   Entity,
@@ -13,7 +14,6 @@ import { SOURCE_DATASETS } from "@/app/views/AtlasSourceDatasetsView/hooks/UseFe
 import { useQueryClient } from "@tanstack/react-query";
 import { Table } from "@tanstack/react-table";
 import { useCallback } from "react";
-import { PublicationStatusEditData } from "../common/entities";
 
 export const useEditPublicationStatusFormManager = (
   formMethod: FormMethod<PublicationStatusEditData>,

--- a/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/EditReprocessedStatus/hooks/useEditReprocessedStatusForm.ts
+++ b/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/EditReprocessedStatus/hooks/useEditReprocessedStatusForm.ts
@@ -1,7 +1,7 @@
 import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { useForm } from "@/app/hooks/useForm/useForm";
-import { ReprocessedStatusEditData } from "../common/entities";
-import { reprocessedStatusEditSchema } from "../common/schema";
+import { ReprocessedStatusEditData } from "@/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/EditReprocessedStatus/common/entities";
+import { reprocessedStatusEditSchema } from "@/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/EditReprocessedStatus/common/schema";
 
 const SCHEMA = reprocessedStatusEditSchema;
 

--- a/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/EditReprocessedStatus/hooks/useEditReprocessedStatusFormManager.ts
+++ b/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/EditReprocessedStatus/hooks/useEditReprocessedStatusFormManager.ts
@@ -5,6 +5,7 @@ import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { FormManager } from "@/app/hooks/useFormManager/common/entities";
 import { useFormManager } from "@/app/hooks/useFormManager/useFormManager";
 import { useEntity } from "@/app/providers/entity/hook";
+import { ReprocessedStatusEditData } from "@/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/EditReprocessedStatus/common/entities";
 import {
   AtlasSourceDataset,
   Entity,
@@ -13,7 +14,6 @@ import { SOURCE_DATASETS } from "@/app/views/AtlasSourceDatasetsView/hooks/UseFe
 import { useQueryClient } from "@tanstack/react-query";
 import { Table } from "@tanstack/react-table";
 import { useCallback } from "react";
-import { ReprocessedStatusEditData } from "../common/entities";
 
 export const useEditReprocessedStatusFormManager = (
   formMethod: FormMethod<ReprocessedStatusEditData>,

--- a/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/SetSourceStudy/hooks/useEditSourceStudyForm.ts
+++ b/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/SetSourceStudy/hooks/useEditSourceStudyForm.ts
@@ -1,7 +1,7 @@
 import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { useForm } from "@/app/hooks/useForm/useForm";
-import { SourceStudyEditData } from "../common/entities";
-import { sourceStudyEditSchema } from "../common/schema";
+import { SourceStudyEditData } from "@/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/SetSourceStudy/common/entities";
+import { sourceStudyEditSchema } from "@/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/SetSourceStudy/common/schema";
 
 const SCHEMA = sourceStudyEditSchema;
 

--- a/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/SetSourceStudy/hooks/useEditSourceStudyManager.ts
+++ b/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/SetSourceStudy/hooks/useEditSourceStudyManager.ts
@@ -5,6 +5,7 @@ import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { FormManager } from "@/app/hooks/useFormManager/common/entities";
 import { useFormManager } from "@/app/hooks/useFormManager/useFormManager";
 import { useEntity } from "@/app/providers/entity/hook";
+import { SourceStudyEditData } from "@/app/views/AtlasSourceDatasetsView/components/Table/components/RowSelection/components/EditSelection/components/SetSourceStudy/common/entities";
 import {
   AtlasSourceDataset,
   Entity,
@@ -14,7 +15,6 @@ import { LABEL } from "@databiosphere/findable-ui/lib/apis/azul/common/entities"
 import { useQueryClient } from "@tanstack/react-query";
 import { Table } from "@tanstack/react-table";
 import { useCallback } from "react";
-import { SourceStudyEditData } from "../common/entities";
 
 export const useEditSourceStudyFormManager = (
   formMethod: FormMethod<SourceStudyEditData>,

--- a/app/views/AtlasView/hooks/useEditAtlasForm.ts
+++ b/app/views/AtlasView/hooks/useEditAtlasForm.ts
@@ -6,13 +6,13 @@ import { mapTargetCompletion } from "@/app/components/Form/components/Select/com
 import { useFetchAtlas } from "@/app/hooks/UseFetchAtlas/hook";
 import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { useForm } from "@/app/hooks/useForm/useForm";
+import { FIELD_NAME } from "@/app/views/AtlasView/common/constants";
+import { AtlasEditData } from "@/app/views/AtlasView/common/entities";
+import { atlasEditSchema } from "@/app/views/AtlasView/common/schema";
 import {
   ATLAS_ECOSYSTEM_PATHS,
   ATLAS_ECOSYSTEM_URLS,
 } from "@/site-config/common/constants";
-import { FIELD_NAME } from "../common/constants";
-import { AtlasEditData } from "../common/entities";
-import { atlasEditSchema } from "../common/schema";
 
 const SCHEMA = atlasEditSchema;
 

--- a/app/views/AtlasView/hooks/useEditAtlasFormManager.ts
+++ b/app/views/AtlasView/hooks/useEditAtlasFormManager.ts
@@ -8,10 +8,10 @@ import { FormManager } from "@/app/hooks/useFormManager/common/entities";
 import { useFormManager } from "@/app/hooks/useFormManager/useFormManager";
 import { ROUTE } from "@/app/routes/constants";
 import { getIdentifierId } from "@/app/views/AddNewAtlasView/common/utils";
+import { AtlasEditData } from "@/app/views/AtlasView/common/entities";
 import { useQueryClient } from "@tanstack/react-query";
 import Router from "next/router";
 import { useCallback } from "react";
-import { AtlasEditData } from "../common/entities";
 
 export const useEditAtlasFormManager = (
   pathParameter: PathParameter,

--- a/app/views/ComponentAtlasView/hooks/useEditIntegratedObjectFormManager.ts
+++ b/app/views/ComponentAtlasView/hooks/useEditIntegratedObjectFormManager.ts
@@ -6,10 +6,10 @@ import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { FormManager } from "@/app/hooks/useFormManager/common/entities";
 import { useFormManager } from "@/app/hooks/useFormManager/useFormManager";
 import { ROUTE } from "@/app/routes/constants";
+import { ViewIntegratedObjectData } from "@/app/views/ComponentAtlasView/common/entities";
 import { useQueryClient } from "@tanstack/react-query";
 import Router from "next/router";
 import { useCallback } from "react";
-import { ViewIntegratedObjectData } from "../common/entities";
 import { INTEGRATED_OBJECT } from "./UseFetchComponentAtlas/query/constants";
 
 type Payload = {

--- a/app/views/ComponentAtlasView/hooks/useViewComponentAtlasForm.ts
+++ b/app/views/ComponentAtlasView/hooks/useViewComponentAtlasForm.ts
@@ -6,10 +6,10 @@ import {
 import { PathParameter } from "@/app/common/entities";
 import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { useForm } from "@/app/hooks/useForm/useForm";
+import { FIELD_NAME } from "@/app/views/ComponentAtlasView/common/constants";
+import { ViewIntegratedObjectData } from "@/app/views/ComponentAtlasView/common/entities";
+import { viewIntegratedObjectSchema } from "@/app/views/ComponentAtlasView/common/schema";
 import { formatFileSize } from "@databiosphere/findable-ui/lib/utils/formatFileSize";
-import { FIELD_NAME } from "../common/constants";
-import { ViewIntegratedObjectData } from "../common/entities";
-import { viewIntegratedObjectSchema } from "../common/schema";
 import { useFetchComponentAtlas } from "./UseFetchComponentAtlas/hook";
 
 const SCHEMA = viewIntegratedObjectSchema;

--- a/app/views/EntitiesView/components/AddAtlas/addAtlas.tsx
+++ b/app/views/EntitiesView/components/AddAtlas/addAtlas.tsx
@@ -1,7 +1,7 @@
 import { ROUTE } from "@/app/routes/constants";
+import { ActionButton } from "@/app/views/EntitiesView/components/ActionButton/actionButton";
 import Link from "next/link";
 import { JSX } from "react";
-import { ActionButton } from "../ActionButton/actionButton";
 
 export const AddAtlas = (): JSX.Element | null => {
   return (

--- a/app/views/EntitiesView/components/AddUser/addUser.tsx
+++ b/app/views/EntitiesView/components/AddUser/addUser.tsx
@@ -1,7 +1,7 @@
 import { ROUTE } from "@/app/routes/constants";
+import { ActionButton } from "@/app/views/EntitiesView/components/ActionButton/actionButton";
 import Link from "next/link";
 import { JSX } from "react";
-import { ActionButton } from "../ActionButton/actionButton";
 
 export const AddUser = (): JSX.Element | null => {
   return (

--- a/app/views/IntegratedObjectSourceDatasetsView/common/configs.ts
+++ b/app/views/IntegratedObjectSourceDatasetsView/common/configs.ts
@@ -1,5 +1,5 @@
 import { SectionConfig } from "@/app/components/Entity/components/EntityView/components/Section/entities";
-import { Table } from "../components/Table/table";
+import { Table } from "@/app/views/IntegratedObjectSourceDatasetsView/components/Table/table";
 
 export const VIEW_INTEGRATED_OBJECT_SOURCE_DATASETS_TABLE: SectionConfig<
   typeof Table

--- a/app/views/IntegratedObjectSourceDatasetsView/components/Table/table.tsx
+++ b/app/views/IntegratedObjectSourceDatasetsView/components/Table/table.tsx
@@ -1,11 +1,11 @@
 import { Table as CommonTable } from "@/app/components/Entity/components/common/Table/table";
+import { StyledFluidPaper } from "@/app/components/Table/components/TablePaper/tablePaper.styles";
 import { TablePlaceholder } from "@/app/components/Table/components/TablePlaceholder/tablePlaceholder";
 import { StyledToolbar } from "@/app/components/Table/components/TableToolbar/tableToolbar.styles";
 import { useEntity } from "@/app/providers/entity/hook";
 import { ViewComponentAtlasSourceDatasetsSelection } from "@/app/views/IntegratedObjectSourceDatasetsView/components/ViewComponentAtlasSourceDatasetsSelection/viewComponentAtlasSourceDatasetsSelection";
 import { Entity } from "@/app/views/IntegratedObjectSourceDatasetsView/entities";
 import { Divider } from "@mui/material";
-import { StyledFluidPaper } from "app/components/Table/components/TablePaper/tablePaper.styles";
 import { Fragment, JSX } from "react";
 import { useIntegratedObjectSourceDatasetsTable } from "./hooks/UseIntegratedObjectSourceDatasetsTable/hook";
 

--- a/app/views/IntegratedObjectSourceDatasetsView/components/Table/table.tsx
+++ b/app/views/IntegratedObjectSourceDatasetsView/components/Table/table.tsx
@@ -2,11 +2,11 @@ import { Table as CommonTable } from "@/app/components/Entity/components/common/
 import { TablePlaceholder } from "@/app/components/Table/components/TablePlaceholder/tablePlaceholder";
 import { StyledToolbar } from "@/app/components/Table/components/TableToolbar/tableToolbar.styles";
 import { useEntity } from "@/app/providers/entity/hook";
+import { ViewComponentAtlasSourceDatasetsSelection } from "@/app/views/IntegratedObjectSourceDatasetsView/components/ViewComponentAtlasSourceDatasetsSelection/viewComponentAtlasSourceDatasetsSelection";
 import { Entity } from "@/app/views/IntegratedObjectSourceDatasetsView/entities";
 import { Divider } from "@mui/material";
 import { StyledFluidPaper } from "app/components/Table/components/TablePaper/tablePaper.styles";
 import { Fragment, JSX } from "react";
-import { ViewComponentAtlasSourceDatasetsSelection } from "../ViewComponentAtlasSourceDatasetsSelection/viewComponentAtlasSourceDatasetsSelection";
 import { useIntegratedObjectSourceDatasetsTable } from "./hooks/UseIntegratedObjectSourceDatasetsTable/hook";
 
 export const Table = (): JSX.Element => {

--- a/app/views/IntegratedObjectSourceDatasetsView/components/ViewComponentAtlasSourceDatasetsSelection/components/ComponentAtlasSourceDatasetsSelection/hooks/useComponentAtlasSourceDatasetsSelectionTableOptions.ts
+++ b/app/views/IntegratedObjectSourceDatasetsView/components/ViewComponentAtlasSourceDatasetsSelection/components/ComponentAtlasSourceDatasetsSelection/hooks/useComponentAtlasSourceDatasetsSelectionTableOptions.ts
@@ -6,9 +6,9 @@ import {
 } from "@/app/hooks/useTableOptions";
 import { FIELD_NAME } from "@/app/views/IntegratedObjectSourceDatasetsView/components/ViewComponentAtlasSourceDatasetsSelection/common/constants";
 import { ComponentAtlasSourceDatasetsEditData } from "@/app/views/IntegratedObjectSourceDatasetsView/components/ViewComponentAtlasSourceDatasetsSelection/common/entities";
+import { TABLE_OPTIONS } from "@/app/views/IntegratedObjectSourceDatasetsView/components/ViewComponentAtlasSourceDatasetsSelection/components/ComponentAtlasSourceDatasetsSelection/components/FormContent/components/Table/common/constants";
 import { Row, RowSelectionState } from "@tanstack/react-table";
 import { FormState } from "react-hook-form";
-import { TABLE_OPTIONS } from "../components/FormContent/components/Table/common/constants";
 
 export const useComponentAtlasSourceDatasetsSelectionTableOptions = (
   formMethod: FormMethod<

--- a/app/views/IntegratedObjectSourceDatasetsView/components/ViewComponentAtlasSourceDatasetsSelection/hooks/useComponentAtlasSourceDatasetsSelectionForm.ts
+++ b/app/views/IntegratedObjectSourceDatasetsView/components/ViewComponentAtlasSourceDatasetsSelection/hooks/useComponentAtlasSourceDatasetsSelectionForm.ts
@@ -1,9 +1,9 @@
 import { HCAAtlasTrackerSourceDataset } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { useForm } from "@/app/hooks/useForm/useForm";
-import { FIELD_NAME } from "../common/constants";
-import { ComponentAtlasSourceDatasetsEditData } from "../common/entities";
-import { componentAtlasSourceDatasetsEditSchema } from "../common/schema";
+import { FIELD_NAME } from "@/app/views/IntegratedObjectSourceDatasetsView/components/ViewComponentAtlasSourceDatasetsSelection/common/constants";
+import { ComponentAtlasSourceDatasetsEditData } from "@/app/views/IntegratedObjectSourceDatasetsView/components/ViewComponentAtlasSourceDatasetsSelection/common/entities";
+import { componentAtlasSourceDatasetsEditSchema } from "@/app/views/IntegratedObjectSourceDatasetsView/components/ViewComponentAtlasSourceDatasetsSelection/common/schema";
 
 const SCHEMA = componentAtlasSourceDatasetsEditSchema;
 

--- a/app/views/IntegratedObjectSourceDatasetsView/components/ViewComponentAtlasSourceDatasetsSelection/hooks/useComponentAtlasSourceDatasetsSelectionFormManager.ts
+++ b/app/views/IntegratedObjectSourceDatasetsView/components/ViewComponentAtlasSourceDatasetsSelection/hooks/useComponentAtlasSourceDatasetsSelectionFormManager.ts
@@ -6,12 +6,12 @@ import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { FormManager } from "@/app/hooks/useFormManager/common/entities";
 import { useFormManager } from "@/app/hooks/useFormManager/useFormManager";
 import { INTEGRATED_OBJECT } from "@/app/views/ComponentAtlasView/hooks/UseFetchComponentAtlas/query/constants";
+import { FIELD_NAME } from "@/app/views/IntegratedObjectSourceDatasetsView/components/ViewComponentAtlasSourceDatasetsSelection/common/constants";
+import { ComponentAtlasSourceDatasetsEditData } from "@/app/views/IntegratedObjectSourceDatasetsView/components/ViewComponentAtlasSourceDatasetsSelection/common/entities";
 import { INTEGRATED_OBJECT_SOURCE_DATASETS } from "@/app/views/IntegratedObjectSourceDatasetsView/hooks/UseFetchIntegratedObjectSourceDatasets/query/constants";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { FormState } from "react-hook-form";
-import { FIELD_NAME } from "../common/constants";
-import { ComponentAtlasSourceDatasetsEditData } from "../common/entities";
 
 export const useComponentAtlasSourceDatasetsSelectionFormManager = (
   pathParameter: PathParameter,

--- a/app/views/IntegratedObjectSourceDatasetsView/hooks/useEditIntegratedObjectSourceDatasets.ts
+++ b/app/views/IntegratedObjectSourceDatasetsView/hooks/useEditIntegratedObjectSourceDatasets.ts
@@ -3,8 +3,8 @@ import { PathParameter } from "@/app/common/entities";
 import { getRequestURL } from "@/app/common/utils";
 import { useDeleteData } from "@/app/hooks/useDeleteData";
 import { INTEGRATED_OBJECT } from "@/app/views/ComponentAtlasView/hooks/UseFetchComponentAtlas/query/constants";
+import { IntegratedObjectSourceDataset } from "@/app/views/IntegratedObjectSourceDatasetsView/entities";
 import { useQueryClient } from "@tanstack/react-query";
-import { IntegratedObjectSourceDataset } from "../entities";
 import { INTEGRATED_OBJECT_SOURCE_DATASETS } from "./UseFetchIntegratedObjectSourceDatasets/query/constants";
 
 export interface UseEditIntegratedObjectSourceDatasets {

--- a/app/views/IntegratedObjectSourceDatasetsView/integratedObjectSourceDatasetsView.tsx
+++ b/app/views/IntegratedObjectSourceDatasetsView/integratedObjectSourceDatasetsView.tsx
@@ -6,10 +6,10 @@ import { StyledDetailView } from "@/app/components/Layout/components/Detail/stic
 import { useFetchAtlas } from "@/app/hooks/UseFetchAtlas/hook";
 import { useFormManager } from "@/app/hooks/useFormManager/useFormManager";
 import { EntityProvider } from "@/app/providers/entity/provider";
+import { getTabs } from "@/app/views/ComponentAtlasView/common/utils";
+import { useFetchComponentAtlas } from "@/app/views/ComponentAtlasView/hooks/UseFetchComponentAtlas/hook";
 import { ConditionalComponent } from "@databiosphere/findable-ui/lib/components/ComponentCreator/components/ConditionalComponent/conditionalComponent";
 import { Fragment, JSX } from "react";
-import { getTabs } from "../ComponentAtlasView/common/utils";
-import { useFetchComponentAtlas } from "../ComponentAtlasView/hooks/UseFetchComponentAtlas/hook";
 import { VIEW_INTEGRATED_OBJECT_SOURCE_DATASETS_SECTION_CONFIGS } from "./common/config";
 import { getBreadcrumbs } from "./common/utils";
 import { useEditIntegratedObjectSourceDatasets } from "./hooks/useEditIntegratedObjectSourceDatasets";

--- a/app/views/IntegratedObjectValidationView/common/constants.ts
+++ b/app/views/IntegratedObjectValidationView/common/constants.ts
@@ -1,5 +1,5 @@
 import { SectionConfig } from "@/app/components/Entity/components/EntityView/components/Section/entities";
-import { Report } from "../components/Report/report";
+import { Report } from "@/app/views/IntegratedObjectValidationView/components/Report/report";
 
 export const INTEGRATED_OBJECT_VALIDATION_REPORT: SectionConfig<typeof Report> =
   {

--- a/app/views/IntegratedObjectValidationView/integratedObjectValidationView.tsx
+++ b/app/views/IntegratedObjectValidationView/integratedObjectValidationView.tsx
@@ -9,9 +9,9 @@ import { useFetchAtlas } from "@/app/hooks/UseFetchAtlas/hook";
 import { useFormManager } from "@/app/hooks/useFormManager/useFormManager";
 import { EntityProvider } from "@/app/providers/entity/provider";
 import { ROUTE } from "@/app/routes/constants";
+import { useFetchComponentAtlas } from "@/app/views/ComponentAtlasView/hooks/UseFetchComponentAtlas/hook";
 import { ConditionalComponent } from "@databiosphere/findable-ui/lib/components/ComponentCreator/components/ConditionalComponent/conditionalComponent";
 import { Fragment, JSX } from "react";
-import { useFetchComponentAtlas } from "../ComponentAtlasView/hooks/UseFetchComponentAtlas/hook";
 import { VIEW_INTEGRATED_OBJECT_VALIDATION_SECTION_CONFIGS } from "./common/config";
 import { getBreadcrumbs, getTabs } from "./common/utils";
 

--- a/app/views/SourceDatasetsView/components/ViewSourceDatasets/viewSourceDatasets.tsx
+++ b/app/views/SourceDatasetsView/components/ViewSourceDatasets/viewSourceDatasets.tsx
@@ -1,8 +1,8 @@
 import { Table as CommonTable } from "@/app/components/Entity/components/common/Table/table";
 import { StyledFluidPaper } from "@/app/components/Table/components/TablePaper/tablePaper.styles";
 import { TablePlaceholder } from "@/app/components/Table/components/TablePlaceholder/tablePlaceholder";
+import { useSourceDatasetsTable } from "@/app/views/SourceDatasetsView/components/Table/hooks/UseSourceDatasetsTable/hook";
 import { JSX } from "react";
-import { useSourceDatasetsTable } from "../Table/hooks/UseSourceDatasetsTable/hook";
 
 export const ViewSourceDatasets = (): JSX.Element => {
   const { table } = useSourceDatasetsTable();

--- a/app/views/SourceDatasetsView/sourceDatasetsView.tsx
+++ b/app/views/SourceDatasetsView/sourceDatasetsView.tsx
@@ -7,9 +7,9 @@ import { StyledDetailView } from "@/app/components/Layout/components/Detail/stic
 import { useFetchAtlas } from "@/app/hooks/UseFetchAtlas/hook";
 import { useFormManager } from "@/app/hooks/useFormManager/useFormManager";
 import { EntityProvider } from "@/app/providers/entity/provider";
+import { useFetchSourceStudy } from "@/app/views/SourceStudyView/hooks/UseFetchSourceStudy/hook";
 import { ConditionalComponent } from "@databiosphere/findable-ui/lib/components/ComponentCreator/components/ConditionalComponent/conditionalComponent";
 import { JSX } from "react";
-import { useFetchSourceStudy } from "../SourceStudyView/hooks/UseFetchSourceStudy/hook";
 import { getBreadcrumbs } from "./common/utils";
 import { ViewSourceDatasets } from "./components/ViewSourceDatasets/viewSourceDatasets";
 import { useFetchSourceDatasets } from "./hooks/UseFetchSourceDatasets/hook";

--- a/app/views/SourceStudyView/hooks/useEditSourceStudyForm.ts
+++ b/app/views/SourceStudyView/hooks/useEditSourceStudyForm.ts
@@ -4,13 +4,13 @@ import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { useForm } from "@/app/hooks/useForm/useForm";
 import { buildSheetsUrl } from "@/app/utils/google-sheets";
 import { PUBLICATION_STATUS } from "@/app/views/AddNewSourceStudyView/common/entities";
+import { FIELD_NAME } from "@/app/views/SourceStudyView/common/constants";
+import { SourceStudyEditData } from "@/app/views/SourceStudyView/common/entities";
+import { sourceStudyEditSchema } from "@/app/views/SourceStudyView/common/schema";
 import {
   ATLAS_ECOSYSTEM_PATHS,
   ATLAS_ECOSYSTEM_URLS,
 } from "@/site-config/common/constants";
-import { FIELD_NAME } from "../common/constants";
-import { SourceStudyEditData } from "../common/entities";
-import { sourceStudyEditSchema } from "../common/schema";
 import { useFetchSourceStudy } from "./UseFetchSourceStudy/hook";
 
 const SCHEMA = sourceStudyEditSchema;

--- a/app/views/SourceStudyView/hooks/useEditSourceStudyFormManager.ts
+++ b/app/views/SourceStudyView/hooks/useEditSourceStudyFormManager.ts
@@ -7,18 +7,18 @@ import { FormManager } from "@/app/hooks/useFormManager/common/entities";
 import { useFormManager } from "@/app/hooks/useFormManager/useFormManager";
 import { ROUTE } from "@/app/routes/constants";
 import { PUBLICATION_STATUS } from "@/app/views/AddNewSourceStudyView/common/entities";
-import { useQueryClient } from "@tanstack/react-query";
-import Router from "next/router";
-import { useCallback } from "react";
 import {
   FIELD_NAME,
   NO_DOI_FIELDS,
   PUBLISHED_PREPRINT_FIELDS,
-} from "../common/constants";
+} from "@/app/views/SourceStudyView/common/constants";
 import {
   SourceStudyEditData,
   SourceStudyEditDataKeys,
-} from "../common/entities";
+} from "@/app/views/SourceStudyView/common/entities";
+import { useQueryClient } from "@tanstack/react-query";
+import Router from "next/router";
+import { useCallback } from "react";
 import { SOURCE_STUDY } from "./UseFetchSourceStudy/query/constants";
 
 export const useEditSourceStudyFormManager = (

--- a/app/views/UserView/common/utils.ts
+++ b/app/views/UserView/common/utils.ts
@@ -1,9 +1,9 @@
+import { HCAAtlasTrackerUser } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { Breadcrumb } from "@/app/components/Detail/components/TrackerForm/components/Breadcrumbs/breadcrumbs";
 import {
   getUserBreadcrumb,
   getUsersBreadcrumb,
 } from "@/app/components/Detail/components/TrackerForm/components/Breadcrumbs/common/utils";
-import { HCAAtlasTrackerUser } from "app/apis/catalog/hca-atlas-tracker/common/entities";
 
 /**
  * Returns the breadcrumbs for the edit user view.

--- a/app/views/UserView/hooks/useEditUserForm.ts
+++ b/app/views/UserView/hooks/useEditUserForm.ts
@@ -7,9 +7,9 @@ import { PathParameter } from "@/app/common/entities";
 import { useFetchUser } from "@/app/hooks/UseFetchUser/hook";
 import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { useForm } from "@/app/hooks/useForm/useForm";
-import { FIELD_NAME } from "../common/constants";
-import { UserEditData } from "../common/entities";
-import { userEditSchema } from "../common/schema";
+import { FIELD_NAME } from "@/app/views/UserView/common/constants";
+import { UserEditData } from "@/app/views/UserView/common/entities";
+import { userEditSchema } from "@/app/views/UserView/common/schema";
 
 const SCHEMA = userEditSchema;
 

--- a/app/views/UserView/hooks/useEditUserFormManager.ts
+++ b/app/views/UserView/hooks/useEditUserFormManager.ts
@@ -7,10 +7,10 @@ import { FormMethod } from "@/app/hooks/useForm/common/entities";
 import { FormManager } from "@/app/hooks/useFormManager/common/entities";
 import { useFormManager } from "@/app/hooks/useFormManager/useFormManager";
 import { ROUTE } from "@/app/routes/constants";
+import { UserEditData } from "@/app/views/UserView/common/entities";
 import { useQueryClient } from "@tanstack/react-query";
 import Router from "next/router";
 import { useCallback } from "react";
-import { UserEditData } from "../common/entities";
 
 export const useEditUserFormManager = (
   pathParameter: PathParameter,

--- a/db_scripts/generate-test-files.ts
+++ b/db_scripts/generate-test-files.ts
@@ -1,8 +1,7 @@
-import pg from "pg";
 import {
   NETWORK_KEYS,
   WAVES,
-} from "../app/apis/catalog/hca-atlas-tracker/common/constants";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/constants";
 import {
   ATLAS_STATUS,
   FILE_TYPE,
@@ -16,29 +15,30 @@ import {
   INTEGRITY_STATUS,
   NetworkKey,
   Wave,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import {
   updateComponentAtlasVersionInAtlas,
   updateSourceDatasetVersionInAtlas,
-} from "../app/data/atlases";
+} from "@/app/data/atlases";
 import {
   createNewComponentAtlasVersion,
   markComponentAtlasAsNotLatest,
   updateSourceDatasetVersionInComponentAtlases,
-} from "../app/data/component-atlases";
+} from "@/app/data/component-atlases";
 import {
   markPreviousVersionsAsNotLatest,
   upsertFileRecord,
-} from "../app/data/files";
+} from "@/app/data/files";
 import {
   createNewSourceDatasetVersion,
   markSourceDatasetAsNotLatest,
-} from "../app/data/source-datasets";
-import { createAtlas } from "../app/services/atlases";
-import { createComponentAtlas } from "../app/services/component-atlases";
-import { getOrCreateConceptId } from "../app/services/concepts";
-import { doTransaction, endPgPool } from "../app/services/database";
-import { createSourceDataset } from "../app/services/source-datasets";
+} from "@/app/data/source-datasets";
+import { createAtlas } from "@/app/services/atlases";
+import { createComponentAtlas } from "@/app/services/component-atlases";
+import { getOrCreateConceptId } from "@/app/services/concepts";
+import { doTransaction, endPgPool } from "@/app/services/database";
+import { createSourceDataset } from "@/app/services/source-datasets";
+import pg from "pg";
 import { randomTestValueInRange } from "./utils";
 
 /**

--- a/db_scripts/generate-test-validation-results.ts
+++ b/db_scripts/generate-test-validation-results.ts
@@ -1,9 +1,8 @@
-import pg from "pg";
 import {
   DatasetValidatorToolReport,
   DatasetValidatorToolReports,
-} from "../app/apis/catalog/hca-atlas-tracker/aws/schemas";
-import { FILE_METADATA_COVERAGE_ENTITY_TYPES } from "../app/apis/catalog/hca-atlas-tracker/common/constants";
+} from "@/app/apis/catalog/hca-atlas-tracker/aws/schemas";
+import { FILE_METADATA_COVERAGE_ENTITY_TYPES } from "@/app/apis/catalog/hca-atlas-tracker/common/constants";
 import {
   FILE_VALIDATION_STATUS,
   FileMetadataCoverage,
@@ -17,12 +16,13 @@ import {
   HCAAtlasTrackerDBFileValidationInfo,
   HCAAtlasTrackerDBSourceDataset,
   INTEGRITY_STATUS,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { isFileMetadataCoverageEntityType } from "../app/apis/catalog/hca-atlas-tracker/common/utils";
-import { addValidationResultsToFile } from "../app/data/files";
-import { doTransaction, endPgPool } from "../app/services/database";
-import { toolReportsToValidationReportsAndSummary } from "../app/services/validation-results-notification";
-import dataDictionary from "../catalog/downloaded/data-dictionary.json";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { isFileMetadataCoverageEntityType } from "@/app/apis/catalog/hca-atlas-tracker/common/utils";
+import { addValidationResultsToFile } from "@/app/data/files";
+import { doTransaction, endPgPool } from "@/app/services/database";
+import { toolReportsToValidationReportsAndSummary } from "@/app/services/validation-results-notification";
+import dataDictionary from "@/catalog/downloaded/data-dictionary.json";
+import pg from "pg";
 import { randomTestProbabilityPasses, randomTestValueInRange } from "./utils";
 
 /**

--- a/docs/adr/2025-08-29-jest-pg-pool-lifecycle.md
+++ b/docs/adr/2025-08-29-jest-pg-pool-lifecycle.md
@@ -55,7 +55,7 @@ Adopt a lazy singleton `pg.Pool` in application code and standardize Jest setup/
 
 - `testing/setup.ts`
   - Registered via Jest `setupFilesAfterEnv`.
-  - `afterAll(async () => { const { endPgPool } = await import("../app/services/database"); await endPgPool(); });`
+  - `afterAll(async () => { const { endPgPool } = await import("@/app/services/database"); await endPgPool(); });`
   - Ensures the pool is closed exactly once after the entire test run.
 
 - `testing/db-utils.ts`

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -60,6 +60,17 @@ const config = [
               message:
                 "Reach outside this directory via the '@/' alias; relative imports are for ./ same-dir and descendants only.",
             },
+            {
+              // Bare repo-root imports resolve via `baseUrl: "."` (e.g.
+              // `app/foo`), which is a second specifier for the same module —
+              // defeating the one-string/one-grep goal above. Require the `@/`
+              // alias for every repo-root segment. (Does not touch the `images/*`
+              // path alias or any npm package.)
+              message:
+                "Import repo-root modules via the '@/' alias (e.g. '@/app/...'), not a bare baseUrl path.",
+              regex:
+                "^(app|catalog|db_scripts|migrations|pages|scripts|site-config|testing)/",
+            },
           ],
         },
       ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -50,13 +50,18 @@ const config = [
       // Keeps a module's internal and external references to the same string
       // (one grep finds every consumer) and stops the rule from depending on
       // how deep a file happens to sit. Uses the typescript-eslint variant so
-      // it also catches `import type` specifiers.
+      // it also catches `import type` specifiers. `@/` is a tsconfig path, so
+      // non-Next runtime entrypoints (scripts run outside `next`) must load it
+      // via `tsx` or `ts-node -r tsconfig-paths/register` for it to resolve.
       "@typescript-eslint/no-restricted-imports": [
         "error",
         {
           patterns: [
             {
-              group: ["..", "../*", "../**"],
+              // `".."` alone matches every parent-relative specifier (ESLint
+              // uses gitignore semantics, where a slash-free pattern matches at
+              // any depth); `"../**"` is kept only to make the intent explicit.
+              group: ["..", "../**"],
               message:
                 "Reach outside this directory via the '@/' alias; relative imports are for ./ same-dir and descendants only.",
             },
@@ -64,12 +69,12 @@ const config = [
               // Bare repo-root imports resolve via `baseUrl: "."` (e.g.
               // `app/foo`), which is a second specifier for the same module —
               // defeating the one-string/one-grep goal above. Require the `@/`
-              // alias for every repo-root segment. (Does not touch the `images/*`
-              // path alias or any npm package.)
+              // alias for every repo-root segment. Keep this list in sync with
+              // the repo's top-level source directories.
               message:
                 "Import repo-root modules via the '@/' alias (e.g. '@/app/...'), not a bare baseUrl path.",
               regex:
-                "^(app|catalog|db_scripts|migrations|pages|scripts|site-config|testing)/",
+                "^(@types|__mocks__|__tests__|app|catalog|db_scripts|migrations|pages|scripts|site-config|testing|types)/",
             },
           ],
         },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,14 +45,20 @@ const config = [
     ],
     rules: {
       "@eslint-community/eslint-comments/require-description": "error",
+      // Intra-repo import convention: relative imports only for same-directory
+      // and descendants (`./`); reach anything else through the `@/` alias.
+      // Keeps a module's internal and external references to the same string
+      // (one grep finds every consumer) and stops the rule from depending on
+      // how deep a file happens to sit. Uses the typescript-eslint variant so
+      // it also catches `import type` specifiers.
       "@typescript-eslint/no-restricted-imports": [
         "error",
         {
           patterns: [
             {
+              group: ["..", "../*", "../**"],
               message:
-                "Use the '@/' path alias instead of deep relative imports (2+ levels up).",
-              regex: "^\\.\\./\\.\\./",
+                "Reach outside this directory via the '@/' alias; relative imports are for ./ same-dir and descendants only.",
             },
           ],
         },

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,5 +1,5 @@
+import { NotFoundView } from "@/app/views/NotFoundView/notFoundView";
 import { JSX } from "react";
-import { NotFoundView } from "../app/views/NotFoundView/notFoundView";
 
 const NotFoundPage = (): JSX.Element => {
   return <NotFoundView />;

--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -1,5 +1,5 @@
+import { ROUTE } from "@/app/routes/constants";
 import { Error } from "@databiosphere/findable-ui/lib/components/Error/error";
-import { ROUTE } from "app/routes/constants";
 import { JSX } from "react";
 
 const ServerErrorPage = (): JSX.Element => {

--- a/pages/[entityListType]/index.tsx
+++ b/pages/[entityListType]/index.tsx
@@ -1,3 +1,4 @@
+import { config } from "@/app/config/config";
 import { EntitiesView } from "@/app/views/EntitiesView/entitiesView";
 import { AzulEntitiesStaticResponse } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
 import { Main as DXMain } from "@databiosphere/findable-ui/lib/components/Layout/components/Main/main.styles";
@@ -5,7 +6,6 @@ import { getEntityConfig } from "@databiosphere/findable-ui/lib/config/utils";
 import { getEntityService } from "@databiosphere/findable-ui/lib/hooks/useEntityService";
 import { EXPLORE_MODE } from "@databiosphere/findable-ui/lib/hooks/useExploreMode/types";
 import { seedDatabase } from "@databiosphere/findable-ui/lib/utils/seedDatabase";
-import { config } from "app/config/config";
 import { GetStaticPaths, GetStaticProps, GetStaticPropsContext } from "next";
 import { ParsedUrlQuery } from "querystring";
 import { JSX } from "react";

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,13 @@
+import { AppHeader } from "@/app/components/Layout/components/Header/appHeader";
+import { useLogoutCallbackUrl } from "@/app/hooks/UseLogoutCallbackUrl/hook";
+import { AuthorizationProvider } from "@/app/providers/authorization";
 import { makeQueryClient } from "@/app/query/queryClient";
+import { mergeAppTheme } from "@/app/theme/theme";
+import { BREAKPOINTS } from "@/site-config/common/constants";
+import {
+  SESSION_REFETCH_INTERVAL,
+  SESSION_TIMEOUT,
+} from "@/site-config/hca-atlas-tracker/local/authentication/constants";
 import "@databiosphere/findable-ui";
 import { AzulEntitiesStaticResponse } from "@databiosphere/findable-ui/lib/apis/azul/common/entities";
 import { Error } from "@databiosphere/findable-ui/lib/components/Error/error";
@@ -28,15 +37,6 @@ import { NextPage } from "next";
 import { Session } from "next-auth";
 import type { AppProps } from "next/app";
 import { JSX, useState } from "react";
-import { AppHeader } from "../app/components/Layout/components/Header/appHeader";
-import { useLogoutCallbackUrl } from "../app/hooks/UseLogoutCallbackUrl/hook";
-import { AuthorizationProvider } from "../app/providers/authorization";
-import { mergeAppTheme } from "../app/theme/theme";
-import { BREAKPOINTS } from "../site-config/common/constants";
-import {
-  SESSION_REFETCH_INTERVAL,
-  SESSION_TIMEOUT,
-} from "../site-config/hca-atlas-tracker/local/authentication/constants";
 
 export interface PageProps extends AzulEntitiesStaticResponse {
   pageTitle?: string;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,9 @@
 import { AppHeader } from "@/app/components/Layout/components/Header/appHeader";
+import { config } from "@/app/config/config";
 import { useLogoutCallbackUrl } from "@/app/hooks/UseLogoutCallbackUrl/hook";
 import { AuthorizationProvider } from "@/app/providers/authorization";
 import { makeQueryClient } from "@/app/query/queryClient";
+import { ROUTE } from "@/app/routes/constants";
 import { mergeAppTheme } from "@/app/theme/theme";
 import { BREAKPOINTS } from "@/site-config/common/constants";
 import {
@@ -31,8 +33,6 @@ import { AppCacheProvider } from "@mui/material-nextjs/v16-pagesRouter";
 import { createBreakpoints } from "@mui/system";
 import { deepmerge } from "@mui/utils";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { config } from "app/config/config";
-import { ROUTE } from "app/routes/constants";
 import { NextPage } from "next";
 import { Session } from "next-auth";
 import type { AppProps } from "next/app";

--- a/pages/api/atlases.ts
+++ b/pages/api/atlases.ts
@@ -1,8 +1,8 @@
 import { dbAtlasToApiAtlas } from "@/app/apis/catalog/hca-atlas-tracker/common/backend-utils";
+import { ROLE_GROUP } from "@/app/apis/catalog/hca-atlas-tracker/common/constants";
 import { METHOD } from "@/app/common/entities";
+import { getAllAtlases } from "@/app/services/atlases";
 import { handler, method, role } from "@/app/utils/api-handler";
-import { ROLE_GROUP } from "app/apis/catalog/hca-atlas-tracker/common/constants";
-import { getAllAtlases } from "app/services/atlases";
 
 /**
  * API route for atlas list.

--- a/pages/api/atlases/[atlasId].ts
+++ b/pages/api/atlases/[atlasId].ts
@@ -1,5 +1,7 @@
+import { dbAtlasToApiAtlas } from "@/app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE_GROUP } from "@/app/apis/catalog/hca-atlas-tracker/common/constants";
 import { ROLE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { atlasEditSchema } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
 import { METHOD } from "@/app/common/entities";
 import { getAtlas, updateAtlas } from "@/app/services/atlases";
 import {
@@ -9,8 +11,6 @@ import {
   resolveAtlasId,
   role,
 } from "@/app/utils/api-handler";
-import { dbAtlasToApiAtlas } from "app/apis/catalog/hca-atlas-tracker/common/backend-utils";
-import { atlasEditSchema } from "app/apis/catalog/hca-atlas-tracker/common/schema";
 import { NextApiRequest, NextApiResponse } from "next";
 
 /**

--- a/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId].ts
+++ b/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId].ts
@@ -1,5 +1,6 @@
 import { dbComponentAtlasFileToDetailApiComponentAtlas } from "@/app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE_GROUP } from "@/app/apis/catalog/hca-atlas-tracker/common/constants";
+import { ROLE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { componentAtlasEditSchema } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
 import { METHOD } from "@/app/common/entities";
 import {
@@ -7,7 +8,6 @@ import {
   updateComponentAtlas,
 } from "@/app/services/component-atlases";
 import { handleByMethod, handler, role } from "@/app/utils/api-handler";
-import { ROLE } from "app/apis/catalog/hca-atlas-tracker/common/entities";
 
 const getHandler = handler(role(ROLE_GROUP.READ), async (req, res) => {
   const atlasId = req.query.atlasId as string;

--- a/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId]/source-datasets.ts
+++ b/pages/api/atlases/[atlasId]/component-atlases/[componentAtlasId]/source-datasets.ts
@@ -1,4 +1,5 @@
 import { dbSourceDatasetToListApiSourceDataset } from "@/app/apis/catalog/hca-atlas-tracker/common/backend-utils";
+import { ROLE_GROUP } from "@/app/apis/catalog/hca-atlas-tracker/common/constants";
 import { ROLE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { componentAtlasAddSourceDatasetsSchema } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
 import { METHOD } from "@/app/common/entities";
@@ -13,7 +14,6 @@ import {
   integrationLeadAssociatedAtlasOnly,
   role,
 } from "@/app/utils/api-handler";
-import { ROLE_GROUP } from "app/apis/catalog/hca-atlas-tracker/common/constants";
 
 const getHandler = handler(role(ROLE_GROUP.READ), async (req, res) => {
   const atlasId = req.query.atlasId as string;

--- a/pages/api/atlases/[atlasId]/entry-sheet-validations.ts
+++ b/pages/api/atlases/[atlasId]/entry-sheet-validations.ts
@@ -1,7 +1,7 @@
+import { dbEntrySheetValidationToApiListModel } from "@/app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { METHOD } from "@/app/common/entities";
 import { getAtlasEntrySheetValidations } from "@/app/services/entry-sheets";
 import { handler, method, registeredUser } from "@/app/utils/api-handler";
-import { dbEntrySheetValidationToApiListModel } from "app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 
 /**
  * API route to get entry sheet validations of an atlas.

--- a/pages/api/atlases/[atlasId]/entry-sheet-validations/sync.ts
+++ b/pages/api/atlases/[atlasId]/entry-sheet-validations/sync.ts
@@ -1,6 +1,6 @@
 import { METHOD } from "@/app/common/entities";
+import { startAtlasEntrySheetValidationsUpdate } from "@/app/services/entry-sheets";
 import { handler, method, registeredUser } from "@/app/utils/api-handler";
-import { startAtlasEntrySheetValidationsUpdate } from "app/services/entry-sheets";
 
 /**
  * API route for triggering validation of an atlas's entry sheets.

--- a/pages/api/atlases/[atlasId]/files/archive.ts
+++ b/pages/api/atlases/[atlasId]/files/archive.ts
@@ -1,4 +1,5 @@
 import { ROLE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { filesSetIsArchivedSchema } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
 import { METHOD } from "@/app/common/entities";
 import { updateAtlasFilesArchiveStatus } from "@/app/services/files";
 import {
@@ -7,7 +8,6 @@ import {
   method,
   role,
 } from "@/app/utils/api-handler";
-import { filesSetIsArchivedSchema } from "app/apis/catalog/hca-atlas-tracker/common/schema";
 
 export default handler(
   method(METHOD.PATCH),

--- a/pages/api/atlases/[atlasId]/files/unarchive.ts
+++ b/pages/api/atlases/[atlasId]/files/unarchive.ts
@@ -1,4 +1,5 @@
 import { ROLE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { filesSetIsArchivedSchema } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
 import { METHOD } from "@/app/common/entities";
 import { updateAtlasFilesArchiveStatus } from "@/app/services/files";
 import {
@@ -7,7 +8,6 @@ import {
   method,
   role,
 } from "@/app/utils/api-handler";
-import { filesSetIsArchivedSchema } from "app/apis/catalog/hca-atlas-tracker/common/schema";
 
 export default handler(
   method(METHOD.PATCH),

--- a/pages/api/atlases/[atlasId]/heatmap.ts
+++ b/pages/api/atlases/[atlasId]/heatmap.ts
@@ -1,6 +1,6 @@
 import { METHOD } from "@/app/common/entities";
+import { getAtlasHeatmap } from "@/app/services/heatmaps";
 import { handler, method, registeredUser } from "@/app/utils/api-handler";
-import { getAtlasHeatmap } from "app/services/heatmaps";
 
 /**
  * API route to get heatmap data for an atlas.

--- a/pages/api/atlases/[atlasId]/publish.ts
+++ b/pages/api/atlases/[atlasId]/publish.ts
@@ -1,8 +1,8 @@
+import { dbAtlasToApiAtlas } from "@/app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD } from "@/app/common/entities";
 import { publishAtlas } from "@/app/services/atlases";
 import { handler, method, role } from "@/app/utils/api-handler";
-import { dbAtlasToApiAtlas } from "app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 
 /**
  * API route to publish an atlas.

--- a/pages/api/atlases/[atlasId]/source-datasets/publication-status.ts
+++ b/pages/api/atlases/[atlasId]/source-datasets/publication-status.ts
@@ -1,13 +1,13 @@
 import { ROLE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { sourceDatasetsSetPublicationStatusSchema } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
 import { METHOD } from "@/app/common/entities";
+import { setAtlasSourceDatasetsPublicationStatus } from "@/app/services/source-datasets";
 import {
   handler,
   integrationLeadAssociatedAtlasOnly,
   method,
   role,
 } from "@/app/utils/api-handler";
-import { setAtlasSourceDatasetsPublicationStatus } from "app/services/source-datasets";
 
 /**
  * API route for setting the publication status of source datasets for a given atlas.

--- a/pages/api/atlases/[atlasId]/source-datasets/reprocessed-status.ts
+++ b/pages/api/atlases/[atlasId]/source-datasets/reprocessed-status.ts
@@ -1,13 +1,13 @@
 import { ROLE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { sourceDatasetsSetReprocessedStatusSchema } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
 import { METHOD } from "@/app/common/entities";
+import { setAtlasSourceDatasetsReprocessedStatus } from "@/app/services/source-datasets";
 import {
   handler,
   integrationLeadAssociatedAtlasOnly,
   method,
   role,
 } from "@/app/utils/api-handler";
-import { setAtlasSourceDatasetsReprocessedStatus } from "app/services/source-datasets";
 
 /**
  * API route for setting the reprocessed status of source datasets for a given atlas.

--- a/pages/api/atlases/[atlasId]/source-datasets/source-study.ts
+++ b/pages/api/atlases/[atlasId]/source-datasets/source-study.ts
@@ -1,13 +1,13 @@
 import { ROLE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { sourceDatasetsSetSourceStudySchema } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
 import { METHOD } from "@/app/common/entities";
+import { setAtlasSourceDatasetsSourceStudy } from "@/app/services/source-datasets";
 import {
   handler,
   integrationLeadAssociatedAtlasOnly,
   method,
   role,
 } from "@/app/utils/api-handler";
-import { setAtlasSourceDatasetsSourceStudy } from "app/services/source-datasets";
 
 /**
  * API route for setting the source study of source datasets for a given atlas.

--- a/pages/api/atlases/[atlasId]/source-studies/create.ts
+++ b/pages/api/atlases/[atlasId]/source-studies/create.ts
@@ -2,13 +2,13 @@ import { dbSourceStudyToApiSourceStudy } from "@/app/apis/catalog/hca-atlas-trac
 import { ROLE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { newSourceStudySchema } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
 import { METHOD } from "@/app/common/entities";
+import { createSourceStudy } from "@/app/services/source-studies";
 import {
   handler,
   integrationLeadAssociatedAtlasOnly,
   method,
   role,
 } from "@/app/utils/api-handler";
-import { createSourceStudy } from "app/services/source-studies";
 
 /**
  * API route for creating a source study. Source study information is provided as a JSON body.

--- a/pages/api/metadata-coverage/atlases.ts
+++ b/pages/api/metadata-coverage/atlases.ts
@@ -3,6 +3,7 @@ import {
   FILE_TYPE,
   MetadataCoverageReportTier,
 } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { metadataCoverageTiersSchema } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
 import { METHOD } from "@/app/common/entities";
 import { getAtlasCompletenessRollup } from "@/app/services/metadata-coverage";
 import {
@@ -13,7 +14,6 @@ import {
   parseListParam,
   registeredUser,
 } from "@/app/utils/api-handler";
-import { metadataCoverageTiersSchema } from "app/apis/catalog/hca-atlas-tracker/common/schema";
 
 const ALLOWED_SOURCES = [
   FILE_TYPE.INTEGRATED_OBJECT,

--- a/pages/api/source-studies.ts
+++ b/pages/api/source-studies.ts
@@ -1,8 +1,8 @@
 import { dbSourceStudyToGlobalApiSourceStudy } from "@/app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE_GROUP } from "@/app/apis/catalog/hca-atlas-tracker/common/constants";
 import { METHOD } from "@/app/common/entities";
+import { getSourceStudiesForGlobalApi } from "@/app/services/source-studies";
 import { handler, method, role } from "@/app/utils/api-handler";
-import { getSourceStudiesForGlobalApi } from "app/services/source-studies";
 
 export default handler(
   method(METHOD.GET),

--- a/pages/api/source-study-cellxgene-ids.ts
+++ b/pages/api/source-study-cellxgene-ids.ts
@@ -1,6 +1,6 @@
 import { METHOD } from "@/app/common/entities";
+import { getCellxGeneSourceStudies } from "@/app/services/source-studies";
 import { handler, method } from "@/app/utils/api-handler";
-import { getCellxGeneSourceStudies } from "app/services/source-studies";
 
 export default handler(method(METHOD.GET), async (req, res) => {
   const cellxgeneIds = (await getCellxGeneSourceStudies()).map(

--- a/pages/api/sync-files.ts
+++ b/pages/api/sync-files.ts
@@ -1,6 +1,6 @@
 import { METHOD } from "@/app/common/entities";
+import { NotImplementedError } from "@/app/utils/api-errors";
 import { handler, method } from "@/app/utils/api-handler";
-import { NotImplementedError } from "app/utils/api-errors";
 
 export default handler(method(METHOD.POST), async () => {
   throw new NotImplementedError(

--- a/pages/api/tasks/completion-dates.ts
+++ b/pages/api/tasks/completion-dates.ts
@@ -1,9 +1,9 @@
-import { dbValidationToApiValidation } from "app/apis/catalog/hca-atlas-tracker/common/backend-utils";
-import { ROLE } from "app/apis/catalog/hca-atlas-tracker/common/entities";
-import { taskCompletionDatesSchema } from "app/apis/catalog/hca-atlas-tracker/common/schema";
-import { METHOD } from "app/common/entities";
-import { updateTargetCompletions } from "app/services/validations";
-import { handler, method, role } from "app/utils/api-handler";
+import { dbValidationToApiValidation } from "@/app/apis/catalog/hca-atlas-tracker/common/backend-utils";
+import { ROLE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { taskCompletionDatesSchema } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
+import { METHOD } from "@/app/common/entities";
+import { updateTargetCompletions } from "@/app/services/validations";
+import { handler, method, role } from "@/app/utils/api-handler";
 
 export default handler(
   method(METHOD.PATCH),

--- a/pages/api/users/[id]/disable.ts
+++ b/pages/api/users/[id]/disable.ts
@@ -1,3 +1,4 @@
+import { ROLE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD } from "@/app/common/entities";
 import { query } from "@/app/services/database";
 import {
@@ -6,7 +7,6 @@ import {
   method,
   role,
 } from "@/app/utils/api-handler";
-import { ROLE } from "app/apis/catalog/hca-atlas-tracker/common/entities";
 
 /**
  * API route for setting a user as disabled.

--- a/pages/api/users/[id]/enable.ts
+++ b/pages/api/users/[id]/enable.ts
@@ -1,3 +1,4 @@
+import { ROLE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD } from "@/app/common/entities";
 import { query } from "@/app/services/database";
 import {
@@ -6,7 +7,6 @@ import {
   method,
   role,
 } from "@/app/utils/api-handler";
-import { ROLE } from "app/apis/catalog/hca-atlas-tracker/common/entities";
 
 /**
  * API route for setting a user as not disabled.

--- a/pages/api/validate-files.ts
+++ b/pages/api/validate-files.ts
@@ -1,7 +1,7 @@
 import { ROLE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD } from "@/app/common/entities";
+import { validateAllFiles } from "@/app/services/files";
 import { handler, method, role } from "@/app/utils/api-handler";
-import { validateAllFiles } from "app/services/files";
 
 export default handler(
   method(METHOD.POST),

--- a/pages/cellxgene-in-progress/index.tsx
+++ b/pages/cellxgene-in-progress/index.tsx
@@ -1,5 +1,5 @@
+import { CellxGeneInProgressView } from "@/app/views/CellxGeneInProgressView/cellxgeneInProgressView";
 import { Main } from "@databiosphere/findable-ui/lib/components/Layout/components/ContentLayout/components/Main/main";
-import { CellxGeneInProgressView } from "app/views/CellxGeneInProgressView/cellxgeneInProgressView";
 import { GetStaticProps } from "next";
 import { JSX } from "react";
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,10 +1,10 @@
+import { ROUTE } from "@/app/routes/constants";
+import { HomeView } from "@/app/views/HomeView/homeView";
+import { nextAuthOptions } from "@/site-config/hca-atlas-tracker/local/authentication/next-auth-config";
 import { GetServerSideProps } from "next";
 import { getServerSession } from "next-auth";
 import { ClientSafeProvider, getProviders } from "next-auth/react";
 import { JSX } from "react";
-import { ROUTE } from "../app/routes/constants";
-import { HomeView } from "../app/views/HomeView/homeView";
-import { nextAuthOptions } from "../site-config/hca-atlas-tracker/local/authentication/next-auth-config";
 
 interface Props {
   providers: ClientSafeProvider[];

--- a/scripts/migration-down.ts
+++ b/scripts/migration-down.ts
@@ -1,6 +1,6 @@
+import { getPoolConfig } from "@/app/utils/pg-migrate-connect-config";
 import migrate from "node-pg-migrate";
 import pg from "pg";
-import { getPoolConfig } from "../app/utils/pg-migrate-connect-config";
 import { assertMigrationDownAllowed } from "./migration-down-guard";
 
 // Block destructive migration rollbacks in deployed (AWS dev/prod) environments.

--- a/scripts/migration-runner.ts
+++ b/scripts/migration-runner.ts
@@ -1,6 +1,6 @@
+import { getPoolConfig } from "@/app/utils/pg-migrate-connect-config";
 import migrate from "node-pg-migrate";
 import pg from "pg";
-import { getPoolConfig } from "../app/utils/pg-migrate-connect-config";
 
 const { Pool } = pg;
 

--- a/site-config/hca-atlas-tracker/dev/config.ts
+++ b/site-config/hca-atlas-tracker/dev/config.ts
@@ -1,5 +1,9 @@
 import { SiteConfig } from "@/site-config/common/entities";
-import { GIT_HUB_REPO_URL, makeConfig, PORTAL_URL } from "../local/config";
+import {
+  GIT_HUB_REPO_URL,
+  makeConfig,
+  PORTAL_URL,
+} from "@/site-config/hca-atlas-tracker/local/config";
 
 // Template constants
 const BROWSER_URL =

--- a/site-config/hca-atlas-tracker/local/index/integratedObjects/categoryGroupConfig.ts
+++ b/site-config/hca-atlas-tracker/local/index/integratedObjects/categoryGroupConfig.ts
@@ -6,7 +6,7 @@ import {
 import {
   CAP_INGEST_STATUS_CATEGORY_CONFIG,
   TIER1_VALIDATION_STATUS_CATEGORY_CONFIG,
-} from "../common/categoryConfig";
+} from "@/site-config/hca-atlas-tracker/local/index/common/categoryConfig";
 
 export const CATEGORY_GROUP_CONFIG: SiteConfig["categoryGroupConfig"] = {
   categoryGroups: [

--- a/site-config/hca-atlas-tracker/local/index/sourceDatasets/categoryGroupConfig.ts
+++ b/site-config/hca-atlas-tracker/local/index/sourceDatasets/categoryGroupConfig.ts
@@ -6,7 +6,7 @@ import {
 import {
   CAP_INGEST_STATUS_CATEGORY_CONFIG,
   TIER1_VALIDATION_STATUS_CATEGORY_CONFIG,
-} from "../common/categoryConfig";
+} from "@/site-config/hca-atlas-tracker/local/index/common/categoryConfig";
 
 export const CATEGORY_GROUP_CONFIG: SiteConfig["categoryGroupConfig"] = {
   categoryGroups: [

--- a/site-config/hca-atlas-tracker/prod/config.ts
+++ b/site-config/hca-atlas-tracker/prod/config.ts
@@ -1,5 +1,8 @@
 import { SiteConfig } from "@/site-config/common/entities";
-import { GIT_HUB_REPO_URL, makeConfig } from "../local/config";
+import {
+  GIT_HUB_REPO_URL,
+  makeConfig,
+} from "@/site-config/hca-atlas-tracker/local/config";
 import { authenticationConfig } from "./authentication/authentication";
 
 // Template constants

--- a/testing/constants.ts
+++ b/testing/constants.ts
@@ -1,4 +1,4 @@
-import { ProjectsResponse } from "../app/apis/azul/hca-dcp/common/responses";
+import { ProjectsResponse } from "@/app/apis/azul/hca-dcp/common/responses";
 import {
   ATLAS_STATUS,
   DOI_STATUS,
@@ -9,10 +9,10 @@ import {
   PublicationInfo,
   REPROCESSED_STATUS,
   ROLE,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { CellxGeneCollection } from "../app/utils/cellxgene-api";
-import { CrossrefWork } from "../app/utils/crossref/crossref";
-import { EntrySheetValidationResponse } from "../app/utils/hca-validation-tools/hca-validation-tools";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { CellxGeneCollection } from "@/app/utils/cellxgene-api";
+import { CrossrefWork } from "@/app/utils/crossref/crossref";
+import { EntrySheetValidationResponse } from "@/app/utils/hca-validation-tools/hca-validation-tools";
 import {
   TestAtlas,
   TestComment,

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -23,11 +23,11 @@ import {
   getPoolClient,
   query,
 } from "@/app/services/database";
+import { updateSourceStudyValidationsByEntityId } from "@/app/services/source-studies";
 import {
   getFileBaseName,
   parseNormalizedInfoFromS3Key,
 } from "@/app/utils/files";
-import { updateSourceStudyValidationsByEntityId } from "app/services/source-studies";
 import migrate from "node-pg-migrate";
 import { MigrationDirection } from "node-pg-migrate/dist/types";
 import pg from "pg";

--- a/testing/db-utils.ts
+++ b/testing/db-utils.ts
@@ -1,7 +1,3 @@
-import { updateSourceStudyValidationsByEntityId } from "app/services/source-studies";
-import migrate from "node-pg-migrate";
-import { MigrationDirection } from "node-pg-migrate/dist/types";
-import pg from "pg";
 import {
   FILE_TYPE,
   FILE_VALIDATION_STATUS,
@@ -19,18 +15,22 @@ import {
   HCAAtlasTrackerDBValidation,
   HCAAtlasTrackerSourceStudy,
   INTEGRITY_STATUS,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { updateTaskCounts } from "../app/services/atlases";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { updateTaskCounts } from "@/app/services/atlases";
 import {
   doTransaction,
   endPgPool,
   getPoolClient,
   query,
-} from "../app/services/database";
+} from "@/app/services/database";
 import {
   getFileBaseName,
   parseNormalizedInfoFromS3Key,
-} from "../app/utils/files";
+} from "@/app/utils/files";
+import { updateSourceStudyValidationsByEntityId } from "app/services/source-studies";
+import migrate from "node-pg-migrate";
+import { MigrationDirection } from "node-pg-migrate/dist/types";
+import pg from "pg";
 import {
   INITIAL_EXPLICIT_TEST_CONCEPTS,
   INITIAL_STANDALONE_TEST_FILES,

--- a/testing/entities.ts
+++ b/testing/entities.ts
@@ -20,7 +20,7 @@ import {
   REPROCESSED_STATUS,
   ROLE,
   Wave,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 
 export interface TestUser {
   authorization: string;

--- a/testing/setup.ts
+++ b/testing/setup.ts
@@ -17,7 +17,7 @@ Object.defineProperty(globalThis, "crypto", {
   },
 });
 
-jest.mock("../app/utils/pg-app-connect-config");
+jest.mock("@/app/utils/pg-app-connect-config");
 
 process.env.GOOGLE_SERVICE_ACCOUNT =
   '"TEST_GOOGLE_SERVICE_ACCOUNT_CREDENTIALS"';
@@ -33,6 +33,6 @@ process.env.AWS_RESOURCE_CONFIG = JSON.stringify({
 
 // Loaded via setupFilesAfterEnv: hooks are available synchronously.
 afterAll(async () => {
-  const { endPgPool } = await import("../app/services/database");
+  const { endPgPool } = await import("@/app/services/database");
   await endPgPool();
 });

--- a/testing/sns-testing.ts
+++ b/testing/sns-testing.ts
@@ -1,6 +1,3 @@
-import { METHOD } from "app/common/entities";
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
 import {
   DatasetValidatorMetadataCoverage,
   DatasetValidatorResults,
@@ -10,8 +7,8 @@ import {
   S3Event,
   S3Object,
   SNSMessage,
-} from "../app/apis/catalog/hca-atlas-tracker/aws/schemas";
-import { FILE_METADATA_COVERAGE_ENTITY_TYPES } from "../app/apis/catalog/hca-atlas-tracker/common/constants";
+} from "@/app/apis/catalog/hca-atlas-tracker/aws/schemas";
+import { FILE_METADATA_COVERAGE_ENTITY_TYPES } from "@/app/apis/catalog/hca-atlas-tracker/common/constants";
 import {
   FileMetadataCoverage,
   FileValidationReport,
@@ -23,11 +20,14 @@ import {
   HCAAtlasTrackerDBFileValidationInfo,
   INTEGRITY_STATUS,
   SYSTEM,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
-import { resetConfigCache } from "../app/config/aws-resources";
-import { query } from "../app/services/database";
-import { slugifyAtlasShortName } from "../app/utils/atlases";
-import snsHandler from "../pages/api/sns";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { resetConfigCache } from "@/app/config/aws-resources";
+import { query } from "@/app/services/database";
+import { slugifyAtlasShortName } from "@/app/utils/atlases";
+import snsHandler from "@/pages/api/sns";
+import { METHOD } from "app/common/entities";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 import { getFileFromDatabase } from "./db-utils";
 import { expectIsDefined } from "./utils";
 

--- a/testing/sns-testing.ts
+++ b/testing/sns-testing.ts
@@ -21,11 +21,11 @@ import {
   INTEGRITY_STATUS,
   SYSTEM,
 } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { METHOD } from "@/app/common/entities";
 import { resetConfigCache } from "@/app/config/aws-resources";
 import { query } from "@/app/services/database";
 import { slugifyAtlasShortName } from "@/app/utils/atlases";
 import snsHandler from "@/pages/api/sns";
-import { METHOD } from "app/common/entities";
 import { NextApiRequest, NextApiResponse } from "next";
 import httpMocks from "node-mocks-http";
 import { getFileFromDatabase } from "./db-utils";

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -1,6 +1,4 @@
-import { NextApiRequest, NextApiResponse } from "next";
-import httpMocks from "node-mocks-http";
-import { ProjectsResponse } from "../app/apis/azul/hca-dcp/common/responses";
+import { ProjectsResponse } from "@/app/apis/azul/hca-dcp/common/responses";
 import {
   DOI_STATUS,
   FILE_PUBLISHED_STATUS,
@@ -34,22 +32,24 @@ import {
   REPROCESSED_STATUS,
   ROLE,
   SYSTEM,
-} from "../app/apis/catalog/hca-atlas-tracker/common/entities";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import {
   NewUserData,
   UserEditData,
-} from "../app/apis/catalog/hca-atlas-tracker/common/schema";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
 import {
   getPublishedCitation,
   getUnpublishedCitation,
-} from "../app/apis/catalog/hca-atlas-tracker/common/utils";
-import { METHOD } from "../app/common/entities";
-import { Handler } from "../app/utils/api-handler";
-import { slugifyAtlasShortName } from "../app/utils/atlases";
+} from "@/app/apis/catalog/hca-atlas-tracker/common/utils";
+import { METHOD } from "@/app/common/entities";
+import { Handler } from "@/app/utils/api-handler";
+import { slugifyAtlasShortName } from "@/app/utils/atlases";
 import {
   normalizeValidationSummary,
   removeFileExtension,
-} from "../app/utils/files";
+} from "@/app/utils/files";
+import { NextApiRequest, NextApiResponse } from "next";
+import httpMocks from "node-mocks-http";
 import {
   ATLAS_DRAFT,
   DEFAULT_USERS_BY_ROLE,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,7 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"],
-      "images/*": ["images/*"]
+      "@/*": ["./*"]
     },
     "plugins": [
       {

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,5 +1,5 @@
+import type { ROLE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import type { DefaultSession } from "next-auth";
-import type { ROLE } from "../app/apis/catalog/hca-atlas-tracker/common/entities";
 
 // Augment NextAuth's Session/JWT with the user's role so middleware and SSR
 // can read it from the JWT without a DB call. Populated by the `jwt`/`session`


### PR DESCRIPTION
## Summary

Closes #1507.

Tighten the intra-repo import convention so it stops being a review conversation: **relative (`./`) only for same-directory and descendants; `@/` alias for everything else — no `../` ever.**

### The rule (`eslint.config.mjs`)

Swapped the deep-only regex (`^\.\./\.\./`, which banned `../../` but allowed single-level `../`) for the group pattern `["..", "../**"]` (a slash-free `..` already matches at any depth, so an explicit `../*` would be redundant). This bans **all** parent-relative imports, catches `import type` specifiers (via the typescript-eslint variant), and also catches a bare `".."`. One config block, since the tracker has a single `@/` → repo-root alias (mirrors [galaxyproject/brc-analytics#1573](https://github.com/galaxyproject/brc-analytics/issues/1573), which needs one block per package alias).

### The sweep

A codemod resolved every parent-relative specifier to its `@/` equivalent — **1,263 specifiers across 227 files**, zero escaping repo root. Coverage goes beyond `from`/`export … from` to `import()`, `import type()`, and `jest.mock`/`doMock`/`unmock`/`requireActual`, so a module's internal and external references share one string and **a single `grep` finds every consumer** (the point of the convention). `@/` resolves identically in tsc, webpack/next, and jest (`moduleNameMapper`), and — verified before converting `scripts/` + `db_scripts/` — at runtime under both `tsx` and `ts-node -r tsconfig-paths/register`.

### The doc

The convention is documented in the `eslint.config.mjs` comment block above the rule (rule + rationale), which satisfies #1507's "alongside the lint config" ask, and in `CLAUDE.md`'s **Code Style Enforcement** section — the tracked doc devs and agents read. (An earlier edit to `.claude/rules/CODING_STANDARDS.md` was gitignored, so it never entered the repo.)

## Verification

| Gate | Result |
|---|---|
| `lint` | 0 errors (pre-existing `todo-tag` warnings only) |
| `typecheck` | clean |
| `build:local` | succeeds |
| `test` | 1200/1200 pass, 87 suites (all 267 converted `jest.mock` paths resolve) |
| `check-format` | clean |
| `/code-review` | 0 findings (also confirmed all `@/…` targets resolve **case-exact**, guarding a macOS→Linux-CI break) |

No new unit tests: the change is a mechanical rename, and the lint rule is itself the regression guard.

Pairs with #1506 (type-only imports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

