### PR TITLE
fix: repair main lint break from #1513/#1514 collision; add VS Code type-only auto-import setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,9 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-# editors
-/.vscode
+# editors (shared VS Code settings are tracked; everything else stays local)
+/.vscode/*
+!/.vscode/settings.json
 .idea
 
 # hygen

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.preferences.preferTypeOnlyAutoImports": true
+}

--- a/migrations/1785547478737_drop-files-source-study-id.ts
+++ b/migrations/1785547478737_drop-files-source-study-id.ts
@@ -1,4 +1,4 @@
-import { MigrationBuilder } from "node-pg-migrate";
+import { type MigrationBuilder } from "node-pg-migrate";
 
 export function up(pgm: MigrationBuilder): void {
   pgm.dropColumn({ name: "files", schema: "hat" }, "source_study_id");


### PR DESCRIPTION
## Summary

Two small related changes:

### 1. Fix: `main` currently fails `npm run lint` (blocks every pre-commit)

A cross-PR semantic collision: #1513's new migration (`import { MigrationBuilder } from "node-pg-migrate"`) merged after #1514's type-import sweep branched, so it never received the `type` marker — and #1514's CI, green on its own branch, couldn't see the new file. Current `main` now has one `@typescript-eslint/consistent-type-imports` error, and since the husky pre-commit hook runs repo-wide lint, **every commit in every branch off current main is blocked** until this lands. One-word fix via `eslint --fix`.

### 2. Chore: VS Code auto-import emits `type` markers

With the #1506 rule in place, VS Code's default auto-import inserts plain `import { Foo }` for type-only symbols — an immediate lint error. `typescript.preferences.preferTypeOnlyAutoImports` makes auto-import add the `type` marker up front, so generated imports pass lint without a fix-up pass (follow-up suggested in the #1514 review).

`.gitignore` changes from ignoring `/.vscode` wholesale to ignoring `/.vscode/*` with `!/.vscode/settings.json` negated, so the shared settings file is tracked while launch configs etc. stay local. **Note for anyone with a pre-existing personal `.vscode/settings.json` in this repo**: checkout will refuse to overwrite it; move it aside and merge manually (one-time).

## Verification

- `npm run lint`: **0 errors** (13 pre-existing TODO warnings) — restores a green repo-wide lint
- `tsc --noEmit`: clean
- `check-format`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)