### PR TITLE
fix: gate presigned-url download button on !isfetching to avoid a stale url on dialog reopen (#1501)

### DIFF
--- a/__tests__/atlas-status-dashboard.test.tsx
+++ b/__tests__/atlas-status-dashboard.test.tsx
@@ -1,5 +1,4 @@
 import { type AtlasStatusSummary } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
-import { mergeAppTheme } from "@/app/theme/theme";
 import { StatusDashboard } from "@/app/views/AtlasStatusView/components/StatusDashboard/statusDashboard";
 import {
   BADGE_VARIANT,
@@ -14,19 +13,11 @@ import {
   getValidationStatus,
   getWarningStatus,
 } from "@/app/views/AtlasStatusView/components/StatusDashboard/utils";
-import { createAppTheme } from "@databiosphere/findable-ui/lib/theme/theme";
+import { TEST_THEME } from "@/testing/theme";
 import { ThemeProvider } from "@mui/material";
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import { type JSX, type ReactNode } from "react";
-
-// Theme must include the app-only "caution" palette because mergeAppTheme's
-// MuiChip override reads theme.palette.caution when the theme is built.
-const THEME = mergeAppTheme(
-  createAppTheme({
-    palette: { caution: { light: "#FFEB78", main: "#956F00" } },
-  }),
-);
 
 // A populated summary exercising every badge/row branch: unpublished studies,
 // an unspecified-datasets remainder, CAP funnels with published subsets, and
@@ -85,7 +76,7 @@ const ZERO_SUMMARY: AtlasStatusSummary = {
 };
 
 function Wrapper({ children }: { children: ReactNode }): JSX.Element {
-  return <ThemeProvider theme={THEME}>{children}</ThemeProvider>;
+  return <ThemeProvider theme={TEST_THEME}>{children}</ThemeProvider>;
 }
 
 describe("StatusDashboard", () => {

--- a/__tests__/file-download-dialog.test.tsx
+++ b/__tests__/file-download-dialog.test.tsx
@@ -1,0 +1,98 @@
+import {
+  type FileId,
+  type PresignedUrlInfo,
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { TEST_THEME } from "@/testing/theme";
+import { withConsoleErrorHiding } from "@/testing/utils";
+
+jest.mock(
+  "@/app/components/Entity/components/common/Table/components/TableCell/components/FileDownloadCell/hooks/UseRequestPreSignedURL/hook",
+  () => ({ useRequestPreSignedURL: jest.fn() }),
+);
+
+import { Dialog } from "@/app/components/Entity/components/common/Table/components/TableCell/components/FileDownloadCell/components/Dialog/dialog";
+import { useRequestPreSignedURL } from "@/app/components/Entity/components/common/Table/components/TableCell/components/FileDownloadCell/hooks/UseRequestPreSignedURL/hook";
+import { ThemeProvider } from "@mui/material";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+const mockUseRequestPreSignedURL =
+  useRequestPreSignedURL as jest.MockedFunction<typeof useRequestPreSignedURL>;
+
+const FILE_ID = "file-1" as FileId;
+const STALE_URL = "https://s3.example.com/presigned/OLD";
+const FRESH_URL = "https://s3.example.com/presigned/FRESH";
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("file download Dialog presigned-URL gating", () => {
+  it("does not expose the URL while the query is fetching (dialog reopen)", async () => {
+    // Simulate a reopen refetch: previous data.url is still populated but
+    // isFetching is true, so the freshly-generated URL hasn't landed yet.
+    mockUseRequestPreSignedURL.mockReturnValue(
+      hookResultOf({ filename: "old.h5ad", url: STALE_URL }, true),
+    );
+
+    // The disabled Download button renders href="" (a MUI-typing workaround so
+    // the `download` prop stays valid on the Button), which React warns about;
+    // expected while the URL is gated.
+    await withConsoleErrorHiding(async () => {
+      renderDialog();
+    });
+
+    const control = getDownloadControl();
+    expect(control).toBeDisabled();
+    expect(control).not.toHaveAttribute("href", STALE_URL);
+    // CodeSection shows the loading state, not the (stale) URL.
+    expect(screen.queryByText("Presigned URL")).not.toBeInTheDocument();
+    expect(screen.queryByText(STALE_URL)).not.toBeInTheDocument();
+  });
+
+  it("exposes the freshly-fetched URL once the query settles", () => {
+    mockUseRequestPreSignedURL.mockReturnValue(
+      hookResultOf({ filename: "fresh.h5ad", url: FRESH_URL }, false),
+    );
+
+    renderDialog();
+
+    const control = getDownloadControl();
+    expect(control).not.toBeDisabled();
+    expect(control).toHaveAttribute("href", FRESH_URL);
+    expect(screen.getByText("Presigned URL")).toBeInTheDocument();
+  });
+});
+
+/**
+ * Get the Download control (an anchor when enabled, a button when disabled).
+ * @returns The Download control element.
+ */
+function getDownloadControl(): HTMLElement {
+  return screen.getByText("Download").closest("a, button") as HTMLElement;
+}
+
+/**
+ * Build a minimal useRequestPreSignedURL() return exposing data and isFetching.
+ * @param data - Presigned URL info, or undefined.
+ * @param isFetching - Whether the query is fetching.
+ * @returns Mock hook return.
+ */
+function hookResultOf(
+  data: PresignedUrlInfo | undefined,
+  isFetching: boolean,
+): ReturnType<typeof useRequestPreSignedURL> {
+  return { data, isFetching } as ReturnType<typeof useRequestPreSignedURL>;
+}
+
+/**
+ * Render the download Dialog (open) within the app theme.
+ * @returns Render result.
+ */
+function renderDialog(): ReturnType<typeof render> {
+  return render(
+    <ThemeProvider theme={TEST_THEME}>
+      <Dialog fileId={FILE_ID} onClose={jest.fn()} open />
+    </ThemeProvider>,
+  );
+}

--- a/app/components/Entity/components/common/Table/components/TableCell/components/FileDownloadCell/components/Dialog/dialog.tsx
+++ b/app/components/Entity/components/common/Table/components/TableCell/components/FileDownloadCell/components/Dialog/dialog.tsx
@@ -18,8 +18,13 @@ export const Dialog = ({
   open,
   sizeBytes = 0,
 }: Props): JSX.Element => {
-  const { data } = useRequestPreSignedURL({ fileId, open });
-  const { filename: downloadFileName, url } = data ?? {};
+  const { data, isFetching } = useRequestPreSignedURL({ fileId, open });
+  const { filename: downloadFileName } = data ?? {};
+  // Gate the presigned URL on the fetch completing. On dialog reopen React Query
+  // refetches (staleTime: 0) while the previous data.url is still populated, so
+  // without this the Download button would briefly point at the prior URL. A
+  // brief loading state is preferable for a security-sensitive, expiring URL.
+  const url = isFetching ? undefined : data?.url;
   return (
     <StyledDialog {...DIALOG_PROPS} onClose={onClose} open={open}>
       <DialogTitle onClose={onClose} title="Download from HCA Atlas Tracker" />

--- a/app/components/Entity/components/common/Table/components/TableCell/components/FileDownloadCell/hooks/UseRequestPreSignedURL/query/useQuery.ts
+++ b/app/components/Entity/components/common/Table/components/TableCell/components/FileDownloadCell/hooks/UseRequestPreSignedURL/query/useQuery.ts
@@ -31,6 +31,12 @@ export const useQuery = (
     enabled: open && Boolean(atlasId) && Boolean(fileId),
     method: METHOD.POST,
     queryKey: [PRESIGNED_URL, atlasId, fileId],
+    // A presigned URL stays valid for ~48h, so there's no need to refetch it on
+    // network reconnect while the dialog is open — doing so would flip
+    // `isFetching` true and momentarily hide the already-valid URL (the Dialog
+    // gates display on `!isFetching`). The only intended refetch is on reopen,
+    // which the `enabled` transition drives with `staleTime: 0` below.
+    refetchOnReconnect: false,
     requestUrl,
     // A presigned URL is generated per request, so refetch each time the dialog
     // opens rather than serving a stale one.

--- a/app/query/useAuthedQuery.ts
+++ b/app/query/useAuthedQuery.ts
@@ -12,6 +12,7 @@ export interface AuthedQueryOptions<TData, TView, TQueryKey extends QueryKey> {
   enabled?: boolean;
   method?: METHOD;
   queryKey: TQueryKey;
+  refetchOnReconnect?: boolean;
   requestUrl: string;
   select?: (data: TData) => TView;
   staleTime?: number;
@@ -29,6 +30,7 @@ export interface AuthedQueryOptions<TData, TView, TQueryKey extends QueryKey> {
  * @param options.enabled - Extra enablement gate ANDed with authentication (default true).
  * @param options.method - HTTP method (default GET).
  * @param options.queryKey - Query key.
+ * @param options.refetchOnReconnect - Optional refetch-on-reconnect override (defaults to the query client default).
  * @param options.requestUrl - Request URL.
  * @param options.select - Optional selector mapping the response to the view shape.
  * @param options.staleTime - Optional staleTime override (defaults to the query client default).
@@ -42,6 +44,7 @@ export const useAuthedQuery = <
   enabled = true,
   method = METHOD.GET,
   queryKey,
+  refetchOnReconnect,
   requestUrl,
   select,
   staleTime,
@@ -57,6 +60,7 @@ export const useAuthedQuery = <
     enabled: isAuthenticated && enabled,
     queryFn: queryFn<TData, TQueryKey>(requestUrl, method),
     queryKey,
+    refetchOnReconnect,
     select,
     staleTime,
     // Gate throwOnError on auth (not just `enabled`): `enabled: false` stops

--- a/testing/theme.ts
+++ b/testing/theme.ts
@@ -1,0 +1,13 @@
+import { mergeAppTheme } from "@/app/theme/theme";
+import { createAppTheme } from "@databiosphere/findable-ui/lib/theme/theme";
+
+/**
+ * App theme for rendering components in tests. Includes the app-only "caution"
+ * palette because `mergeAppTheme`'s MuiChip override reads
+ * `theme.palette.caution` at build time.
+ */
+export const TEST_THEME = mergeAppTheme(
+  createAppTheme({
+    palette: { caution: { light: "#FFEB78", main: "#956F00" } },
+  }),
+);


### PR DESCRIPTION
## Summary

Closes #1501. Follow-up from the React Query migration of `useRequestPreSignedURL` (#1498 / #1472).

The file-download dialog fetches a presigned URL with `staleTime: 0` and `enabled: open`. On **reopen**, React Query refetches, but the **previous** `data.url` stays populated during the refetch — so the Download button is enabled immediately and briefly points at the prior URL. Cheap, defensive fix for a security-sensitive, expiring URL.

## Changes

- **`Dialog/dialog.tsx`** — gate the URL on the fetch completing:
  ```ts
  const { data, isFetching } = useRequestPreSignedURL({ fileId, open });
  const url = isFetching ? undefined : data?.url;
  ```
  A reopen now shows a brief loading state (button disabled, no URL rendered) until the freshly-generated URL lands. The cosmetic `filename` display is left unchanged (prop fallback, not security-sensitive).

- **`UseRequestPreSignedURL/query/useQuery.ts`** — `refetchOnReconnect: false`. A presigned URL is valid ~48h, so a network reconnect while the dialog is open shouldn't background-refetch and momentarily hide the already-valid URL (which the `!isFetching` gate would otherwise do). `refetchOnWindowFocus` is already `false` globally, so the query's only refetch is now the intended reopen transition.

- **`app/query/useAuthedQuery.ts`** — added a `refetchOnReconnect?` passthrough so the shared hook can express the above (it previously only exposed `enabled`/`method`/`queryKey`/`requestUrl`/`select`/`staleTime`).

## Tests

- **`__tests__/file-download-dialog.test.tsx`** (new) — mocks `useRequestPreSignedURL`; asserts (a) while fetching, the Download control is disabled, the stale URL is not in its `href`, and the code section shows the loading state; (b) once settled, the control is enabled with the fresh URL. The disabled button renders `href=""` (a MUI-typing workaround so the `download` prop stays valid) which React warns about — suppressed via the repo's `withConsoleErrorHiding`.
- **`testing/theme.ts`** (new) — extracted the shared `TEST_THEME`, deduped from `atlas-status-dashboard.test.tsx` (which now imports it).

The `refetchOnReconnect` + shared-theme changes address findings from a high-effort `/code-review` of the initial fix.

## Verification

| Gate | Result |
|---|---|
| `lint` | 0 errors |
| `typecheck` | clean |
| `build:local` | succeeds |
| `test` | 1202/1202 |
| `check-format` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)