### PR TITLE
refactor: dry usedeletesourcestudy onto usedeletedata and drop the deleted detail from cache (#1503)

### DIFF
--- a/__tests__/delete-source-study.test.ts
+++ b/__tests__/delete-source-study.test.ts
@@ -1,0 +1,104 @@
+import { METHOD } from "@/app/common/entities";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import {
+  createElement,
+  type FunctionComponent,
+  type PropsWithChildren,
+} from "react";
+
+jest.mock("@/app/hooks/useDeleteData");
+jest.mock("next/router", () => ({
+  __esModule: true,
+  default: { push: jest.fn() },
+}));
+
+import { useDeleteData } from "@/app/hooks/useDeleteData";
+import { SOURCE_STUDIES } from "@/app/views/SourceStudiesView/hooks/UseFetchSourceStudies/query/constants";
+import { SOURCE_STUDY } from "@/app/views/SourceStudyView/hooks/UseFetchSourceStudy/query/constants";
+import { useDeleteSourceStudy } from "@/app/views/SourceStudyView/hooks/useDeleteSourceStudy";
+import Router from "next/router";
+
+const mockUseDeleteData = useDeleteData as jest.MockedFunction<
+  typeof useDeleteData
+>;
+const mockPush = Router.push as jest.MockedFunction<typeof Router.push>;
+
+const ATLAS_ID = "atlas-1";
+const SOURCE_STUDY_ID = "study-1";
+const PATH_PARAMETER = { atlasId: ATLAS_ID, sourceStudyId: SOURCE_STUDY_ID };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseDeleteData.mockReturnValue({ onDelete: jest.fn() });
+});
+
+describe("useDeleteSourceStudy", () => {
+  it("wires useDeleteData with the source-study DELETE endpoint and an onSuccess", () => {
+    renderHook(() => useDeleteSourceStudy(PATH_PARAMETER), {
+      wrapper: wrapperFor(new QueryClient()),
+    });
+
+    expect(mockUseDeleteData).toHaveBeenCalledWith(
+      expect.stringContaining(SOURCE_STUDY_ID),
+      METHOD.DELETE,
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+    // The request URL is atlas-scoped.
+    expect(mockUseDeleteData.mock.calls[0][0]).toContain(ATLAS_ID);
+  });
+
+  it("removes the deleted detail from cache and redirects on delete success", () => {
+    const queryClient = new QueryClient();
+    // Seed the destination list (still containing the study) and the study's
+    // own detail query, as they would be while sitting on the detail page.
+    queryClient.setQueryData(
+      [SOURCE_STUDIES, ATLAS_ID],
+      [{ id: SOURCE_STUDY_ID }, { id: "study-2" }],
+    );
+    queryClient.setQueryData([SOURCE_STUDY, ATLAS_ID, SOURCE_STUDY_ID], {
+      id: SOURCE_STUDY_ID,
+    });
+
+    renderHook(() => useDeleteSourceStudy(PATH_PARAMETER), {
+      wrapper: wrapperFor(queryClient),
+    });
+
+    const onSuccess = mockUseDeleteData.mock.calls[0][2]?.onSuccess;
+    expect(onSuccess).toBeDefined();
+    onSuccess?.();
+
+    // Deleted detail is dropped from cache via removeQueries (not invalidated —
+    // that would refetch a now-404 resource on the still-mounted detail page).
+    expect(
+      queryClient.getQueryData([SOURCE_STUDY, ATLAS_ID, SOURCE_STUDY_ID]),
+    ).toBeUndefined();
+    // The list is NOT invalidated: its staleTime: 0 mount refetch after the
+    // redirect covers navigation staleness (per app/query/README).
+    expect(
+      queryClient.getQueryState([SOURCE_STUDIES, ATLAS_ID])?.isInvalidated,
+    ).toBe(false);
+    // Redirect to the atlas-scoped source studies list.
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith(expect.stringContaining(ATLAS_ID));
+    expect(mockPush.mock.calls[0][0]).not.toContain(SOURCE_STUDY_ID);
+  });
+});
+
+/**
+ * Build a QueryClientProvider wrapper around the given client so hooks that call
+ * useQueryClient have one available.
+ * @param queryClient - Query client to provide.
+ * @returns Wrapper component.
+ */
+function wrapperFor(
+  queryClient: QueryClient,
+): FunctionComponent<PropsWithChildren> {
+  return function QueryWrapper({ children }: PropsWithChildren) {
+    return createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children,
+    );
+  };
+}

--- a/app/views/SourceStudiesView/hooks/UseFetchSourceStudies/query/useQuery.ts
+++ b/app/views/SourceStudiesView/hooks/UseFetchSourceStudies/query/useQuery.ts
@@ -24,6 +24,8 @@ export const useQuery = (
     // The list's columns (dataset count, HCA and entry-sheet status) are
     // derived from other entities and change out-of-band, so this query must
     // refetch on every mount to match the pre-React-Query behavior, rather
-    // than serving the app-default 5-minute stale window.
+    // than serving the app-default 5-minute stale window. This mount refetch
+    // also covers delete-then-redirect (useDeleteSourceStudy): landing on the
+    // list refetches it without the deleted study, no invalidation needed.
     staleTime: 0,
   });

--- a/app/views/SourceStudyView/hooks/useDeleteSourceStudy.ts
+++ b/app/views/SourceStudyView/hooks/useDeleteSourceStudy.ts
@@ -22,10 +22,12 @@ export const useDeleteSourceStudy = (
     {
       onSuccess: () => {
         const { atlasId, sourceStudyId } = pathParameter;
-        // Drop the deleted study's own detail query from the cache. Use
-        // removeQueries, not invalidateQueries: the detail page is still mounted
-        // here, so invalidating would refetch the just-deleted study and 404 —
-        // removeQueries just evicts it without a refetch.
+        // Drop the deleted study's own detail query from the cache.
+        // removeQueries, not invalidateQueries: invalidateQueries would refetch
+        // the active detail observer (the detail page is still mounted here) and
+        // 404 on the deleted study. removeQueries doesn't proactively refetch,
+        // and the redirect below unmounts the detail observer immediately
+        // regardless.
         queryClient.removeQueries({
           queryKey: [SOURCE_STUDY, atlasId, sourceStudyId],
         });

--- a/app/views/SourceStudyView/hooks/useDeleteSourceStudy.ts
+++ b/app/views/SourceStudyView/hooks/useDeleteSourceStudy.ts
@@ -1,48 +1,44 @@
 import { API } from "@/app/apis/catalog/hca-atlas-tracker/common/api";
 import { METHOD, type PathParameter } from "@/app/common/entities";
-import {
-  fetchResource,
-  getRequestURL,
-  getRouteURL,
-  isFetchStatusOk,
-} from "@/app/common/utils";
+import { getRequestURL, getRouteURL } from "@/app/common/utils";
+import { useDeleteData } from "@/app/hooks/useDeleteData";
 import { ROUTE } from "@/app/routes/constants";
+import { SOURCE_STUDY } from "@/app/views/SourceStudyView/hooks/UseFetchSourceStudy/query/constants";
+import { useQueryClient } from "@tanstack/react-query";
 import Router from "next/router";
-import { useCallback } from "react";
 
 export interface UseDeleteSourceStudy {
-  onDelete: () => void;
+  onDelete: () => Promise<void>;
 }
 
 export const useDeleteSourceStudy = (
   pathParameter: PathParameter,
 ): UseDeleteSourceStudy => {
-  const onDelete = useCallback(async (): Promise<void> => {
-    const res = await fetchResource(
-      getRequestURL(API.ATLAS_SOURCE_STUDY, pathParameter),
-      METHOD.DELETE,
-    );
-    if (isFetchStatusOk(res.status)) {
-      onDeleteSuccess(pathParameter);
-    } else {
-      throw new Error(
-        await res
-          .json()
-          .then(({ message }) => message)
-          .catch(() => `Received ${res.status} response`),
-      );
-    }
-  }, [pathParameter]);
+  const queryClient = useQueryClient();
+
+  const { onDelete } = useDeleteData(
+    getRequestURL(API.ATLAS_SOURCE_STUDY, pathParameter),
+    METHOD.DELETE,
+    {
+      onSuccess: () => {
+        const { atlasId, sourceStudyId } = pathParameter;
+        // Drop the deleted study's own detail query from the cache. Use
+        // removeQueries, not invalidateQueries: the detail page is still mounted
+        // here, so invalidating would refetch the just-deleted study and 404 —
+        // removeQueries just evicts it without a refetch.
+        queryClient.removeQueries({
+          queryKey: [SOURCE_STUDY, atlasId, sourceStudyId],
+        });
+        // The destination list isn't invalidated: it's staleTime: 0, so its
+        // mount refetch after the redirect already drops the deleted study.
+        // Per app/query/README, navigation staleness is the staleTime: 0 axis;
+        // invalidation is only for mutating a list that stays mounted.
+        Router.push(getRouteURL(ROUTE.ATLAS_SOURCE_STUDIES, pathParameter));
+      },
+    },
+  );
 
   return {
     onDelete,
   };
 };
-
-/**
- * Delete side effect "onSuccess"; redirects to the source studies page.
- * @param pathParameter - Path parameter.
- */
-function onDeleteSuccess(pathParameter: PathParameter): void {
-  Router.push(getRouteURL(ROUTE.ATLAS_SOURCE_STUDIES, pathParameter));
-}


### PR DESCRIPTION
## Summary

Closes #1503. Follow-up from the TanStack Query migration (#1472 / #1498).

`useDeleteSourceStudy` (the one delete-then-redirect flow) duplicated `useDeleteData`'s `fetchResource` + status-check + error-extraction and did **no cache work** before `Router.push`. This collapses it onto the shared `useDeleteData` (mirroring the `useEditIntegratedObjectSourceDatasets` reference) and adds cache handling for the deleted entity.

## What changed

- **`useDeleteSourceStudy.ts`** — now a thin `useDeleteData(url, DELETE, { onSuccess })` wrapper. On success it:
  - `removeQueries([SOURCE_STUDY, atlasId, sourceStudyId])` — evicts the deleted study's own detail query. Uses `removeQueries`, **not** `invalidateQueries`: the detail page is still mounted, and invalidating an active observer would refetch the just-deleted study and 404. `removeQueries` evicts without a refetch (verified empirically).
  - `Router.push` to the atlas source-studies list.
- **`UseFetchSourceStudies/query/useQuery.ts`** — comment only, noting the list's `staleTime: 0` mount refetch also covers delete-then-redirect.
- **`__tests__/delete-source-study.test.ts`** (new) — asserts the hook wires `useDeleteData` with the atlas-scoped DELETE URL, and that on success it removes the deleted detail, does **not** invalidate the list, and redirects to the list route.

## Reconciliation with the documented convention (why no list invalidation)

The issue proposed `invalidateQueries` on the parent list, arguing the redirect flow "only appears to work because of `staleTime: 0`." A high-effort `/code-review` flagged — correctly — that this **contradicts `app/query/README.md`**:

> `staleTime: 0` handles staleness across a **remount** (navigate away and back → refetch on mount) … you just don't invalidate it merely to cover navigation (the mount refetch already does).

Delete-then-redirect **is** navigation/remount, and the list is `staleTime: 0`, so its mount refetch already drops the deleted study. The proposed list `invalidateQueries` is therefore **redundant** and would itself be the anti-pattern the README warns against, so it's omitted. `staleTime: 0` here is the *designed* mechanism for navigation freshness, not a coincidence.

Net delivery vs. the literal proposal: the DRY refactor + deleted-detail eviction land; the list invalidation is intentionally dropped as redundant.

## Out of scope / follow-up

Delete call sites fire-and-forget `onDelete()` (no `await`/`.catch`), so a **failed** delete surfaces no error — a pre-existing call-site gap this refactor deliberately preserves. Tracked in **#1520**.

## Verification

| Gate | Result |
|---|---|
| `lint` | 0 errors |
| `typecheck` | clean |
| `build:local` | succeeds |
| `test` | 1202/1202 |
| `check-format` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)