### PR TITLE
chore: drop tsconfig baseurl so bare repo-root imports fail to resolve (#1511)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -73,10 +73,13 @@ const config = [
               message:
                 "Reach outside this directory via the '@/' alias; relative imports are for ./ same-dir and descendants only.",
             },
-            // Bare repo-root imports (e.g. `app/foo`) need no lint rule: tsconfig
-            // has no `baseUrl` and jest's `moduleDirectories` omits `<rootDir>`,
-            // so they fail to resolve at compile/test time. Only the `@/` alias
-            // reaches repo-root modules.
+            // Bare repo-root imports (e.g. `app/foo`) need no lint rule: with no
+            // `baseUrl` in tsconfig they fail typecheck (TS2307), which CI and
+            // the pre-commit hook enforce. (jest's SWC transform still resolves a
+            // static bare import via Next's implicit baseUrl, so jest is not a
+            // backstop; the trimmed `moduleDirectories` only closes runtime
+            // `require`/`jest.mock` paths.) Only the `@/` alias reaches repo-root
+            // modules.
           ],
         },
       ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -73,17 +73,10 @@ const config = [
               message:
                 "Reach outside this directory via the '@/' alias; relative imports are for ./ same-dir and descendants only.",
             },
-            {
-              // Bare repo-root imports resolve via `baseUrl: "."` (e.g.
-              // `app/foo`), which is a second specifier for the same module —
-              // defeating the one-string/one-grep goal above. Require the `@/`
-              // alias for every repo-root segment. Keep this list in sync with
-              // the repo's top-level source directories.
-              message:
-                "Import repo-root modules via the '@/' alias (e.g. '@/app/...'), not a bare baseUrl path.",
-              regex:
-                "^(@types|__mocks__|__tests__|app|catalog|db_scripts|migrations|pages|scripts|site-config|testing|types)/",
-            },
+            // Bare repo-root imports (e.g. `app/foo`) need no lint rule: tsconfig
+            // has no `baseUrl` and jest's `moduleDirectories` omits `<rootDir>`,
+            // so they fail to resolve at compile/test time. Only the `@/` alias
+            // reaches repo-root modules.
           ],
         },
       ],

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,9 @@ const createJestConfig = nextJest({
 const customJestConfig = {
   // Add more setup options before each test is run
   // setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
-  // if using TypeScript with a baseUrl set to the root directory then you need the below for alias' to work
+  // node_modules only (no <rootDir>): closes runtime resolution of bare
+  // repo-root specifiers (e.g. require("app/foo")) now that tsconfig has no
+  // baseUrl. The `@/` alias resolves via moduleNameMapper below regardless.
   moduleDirectories: ["node_modules"],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/$1",

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,7 @@ const customJestConfig = {
   // Add more setup options before each test is run
   // setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   // if using TypeScript with a baseUrl set to the root directory then you need the below for alias' to work
-  moduleDirectories: ["node_modules", "<rootDir>/"],
+  moduleDirectories: ["node_modules"],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/$1",
     "^ky$": "<rootDir>/__mocks__/ky.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
     },


### PR DESCRIPTION
## Summary

Closes #1511. Follow-up to #1507.

#1507 banned bare repo-root imports (e.g. `import { x } from "app/foo"`, resolved via `baseUrl: "."`) with a `no-restricted-imports` **regex** enumerating the top-level source dirs Ã¢ÂÂ a hand-maintained denylist. This removes the *mechanism* those imports rely on, so they can't resolve at all, and retires the regex.

## Changes

- **`tsconfig.json`** Ã¢ÂÂ removed `"baseUrl": "."`. TypeScript resolves `paths` (`@/*`) relative to the tsconfig dir without it, so the alias keeps working; a bare `app/foo` now fails to compile with `TS2307: Cannot find module 'app/foo'`.
- **`jest.config.js`** Ã¢ÂÂ `moduleDirectories: ["node_modules"]` (dropped `<rootDir>/`), which independently let bare specifiers resolve in tests. `@/` still resolves via `moduleNameMapper` (`^@/(.*)$` Ã¢ÂÂ `<rootDir>/$1`), unaffected.
- **`eslint.config.mjs`** Ã¢ÂÂ removed the bare-root regex from `no-restricted-imports` (the `..`/`../**` parent-relative pattern stays), replaced with a short comment noting bare-root now fails to resolve.

## Trade-off

The lint rule gave a pointed message ("Import repo-root modules via the '@/' alias"); dropping `baseUrl` instead surfaces TypeScript's generic `Cannot find module 'app/foo'`. Acceptable Ã¢ÂÂ it fails at compile/type time and the fix (`@/app/foo`) is obvious Ã¢ÂÂ and it's not a denylist that rots as directories are added.

## Verification

`@/` still resolves everywhere; a bare-root import now fails:

| Path | Result |
|---|---|
| `typecheck` | `@/` resolves; bare `app/...` Ã¢ÂÂ `TS2307` (verified with a probe file) |
| `build:local` | succeeds (next/webpack) |
| `test` | 1211/1211 (jest `@/` via `moduleNameMapper`; note: jest is NOT a backstop for bare imports â see below) |
| `ts-node -r tsconfig-paths/register` (migrate) | `@/` resolves (tsconfig-paths defaults baseUrl to the config dir) |
| `tsx` (db scripts) | `@/` resolves |
| `lint` / `check-format` | 0 errors / clean |

**Enforcement is typecheck-only (which is sufficient).** A static bare import still resolves in jest — with no `baseUrl`, Next computes an implicit baseUrl (the tsconfig dir) and its SWC transform rewrites the specifier before jest's resolver runs — so jest is not a backstop. The `moduleDirectories` change only closes runtime `require`/`jest.mock` bare paths. The real guard is `typecheck` (TS2307), run by CI (`run-checks.yml`) and the pre-commit hook.

No new tests: the change is config, and CI's `typecheck` Ã¢ÂÂ which now rejects bare-root imports Ã¢ÂÂ is itself the durable guard (a jest test can't cleanly assert a compile failure).

Ã°ÂÂ¤Â Generated with [Claude Code](https://claude.com/claude-code)
