### PR TITLE
feat: retail detail shape from source dataset patch api and use on frontend (#1523)

### DIFF
--- a/__tests__/api-atlases-id-source-datasets-id.test.ts
+++ b/__tests__/api-atlases-id-source-datasets-id.test.ts
@@ -1,7 +1,6 @@
 import {
   type FileValidationSummary,
   type HCAAtlasTrackerDetailSourceDataset,
-  type HCAAtlasTrackerSourceDataset,
 } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { type AtlasSourceDatasetEditData } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
 import { METHOD } from "@/app/common/entities";
@@ -44,7 +43,7 @@ import {
   getConceptFromDatabase,
   resetDatabase,
 } from "@/testing/db-utils";
-import { type TestUser } from "@/testing/entities";
+import { type TestSourceDataset, type TestUser } from "@/testing/entities";
 import {
   assertExpectDefined,
   delay,
@@ -690,12 +689,21 @@ describe(`${TEST_ROUTE} (PATCH)`, () => {
   });
 
   it("updates and returns source dataset when PATCH requested by user with CONTENT_ADMIN role", async () => {
+    const expectedData: TestSourceDataset = {
+      ...SOURCE_DATASET_ATLAS_LINKED_A_FOO,
+      capUrl: null,
+      metadataSpreadsheetTitle: "Sheet Bar",
+      metadataSpreadsheetUrl: A_FOO_EDIT_DATA.metadataSpreadsheetUrl,
+    };
+
     const callCountBefore = getSheetTitleMock.mock.calls.length;
     const conceptBefore = await getConceptFromDatabase(
       SOURCE_DATASET_ATLAS_LINKED_A_FOO.id,
     );
     assertExpectDefined(conceptBefore);
+
     await delay(10); // Ensure timestamps can be different
+
     const res = await doSourceDatasetRequest(
       ATLAS_WITH_MISC_SOURCE_STUDIES.id,
       SOURCE_DATASET_ATLAS_LINKED_A_FOO.id,
@@ -704,18 +712,15 @@ describe(`${TEST_ROUTE} (PATCH)`, () => {
       true,
       A_FOO_EDIT_DATA,
     );
+
     expect(res._getStatusCode()).toEqual(200);
-    const sourceDataset = res._getJSONData() as HCAAtlasTrackerSourceDataset;
-    expect(sourceDataset.capUrl).toBeNull();
-    expect(sourceDataset.downloadName).toEqual(A_FOO_EDIT_DATA.downloadName);
-    expect(sourceDataset.metadataSpreadsheetTitle).toEqual("Sheet Bar");
-    expect(sourceDataset.metadataSpreadsheetUrl).toEqual(
-      A_FOO_EDIT_DATA.metadataSpreadsheetUrl,
-    );
-    expect(sourceDataset.title).toEqual(
-      SOURCE_DATASET_ATLAS_LINKED_A_FOO.file.datasetInfo.title,
-    );
+    const sourceDataset =
+      res._getJSONData() as HCAAtlasTrackerDetailSourceDataset;
+
+    expectDetailApiSourceDatasetToMatchTest(sourceDataset, expectedData);
+
     expect(getSheetTitleMock).toHaveBeenCalledTimes(callCountBefore + 1);
+
     const conceptAfter = await getConceptFromDatabase(
       SOURCE_DATASET_ATLAS_LINKED_A_FOO.id,
     );
@@ -724,10 +729,16 @@ describe(`${TEST_ROUTE} (PATCH)`, () => {
     expect(conceptAfter.updated_at.getTime()).toEqual(
       conceptBefore.updated_at.getTime(),
     );
+
     await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_ATLAS_LINKED_B_FOO);
   });
 
   it("sets CAP URL and clears metadata spreadsheet fields when PATCH requested with only CAP URL specified", async () => {
+    const expectedData: TestSourceDataset = {
+      ...SOURCE_DATASET_ATLAS_LINKED_A_BAR,
+      capUrl: A_BAR_EDIT_DATA.capUrl,
+    };
+
     const res = await doSourceDatasetRequest(
       ATLAS_WITH_MISC_SOURCE_STUDIES.id,
       SOURCE_DATASET_ATLAS_LINKED_A_BAR.id,
@@ -737,15 +748,24 @@ describe(`${TEST_ROUTE} (PATCH)`, () => {
       A_BAR_EDIT_DATA,
     );
     expect(res._getStatusCode()).toEqual(200);
-    const sourceDataset = res._getJSONData() as HCAAtlasTrackerSourceDataset;
+    const sourceDataset =
+      res._getJSONData() as HCAAtlasTrackerDetailSourceDataset;
+
     expect(sourceDataset.capUrl).toEqual(A_BAR_EDIT_DATA.capUrl);
-    expect(sourceDataset.downloadName).toEqual(A_BAR_EDIT_DATA.downloadName);
     expect(sourceDataset.metadataSpreadsheetTitle).toBeNull();
     expect(sourceDataset.metadataSpreadsheetUrl).toBeNull();
+
+    expectDetailApiSourceDatasetToMatchTest(sourceDataset, expectedData);
+
     await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_ATLAS_LINKED_B_FOO);
   });
 
   it("sets CAP URL to null and clears metadata spreadsheet fields when PATCH requested with only empty string CAP URL", async () => {
+    const expectedData: TestSourceDataset = {
+      ...SOURCE_DATASET_WITH_SOURCE_STUDY_FOO,
+      capUrl: null,
+    };
+
     const res = await doSourceDatasetRequest(
       ATLAS_WITH_MISC_SOURCE_STUDIES_C.id,
       SOURCE_DATASET_WITH_SOURCE_STUDY_FOO.id,
@@ -755,11 +775,13 @@ describe(`${TEST_ROUTE} (PATCH)`, () => {
       WSS_FOO_EDIT_DATA,
     );
     expect(res._getStatusCode()).toEqual(200);
-    const sourceDataset = res._getJSONData() as HCAAtlasTrackerSourceDataset;
+    const sourceDataset =
+      res._getJSONData() as HCAAtlasTrackerDetailSourceDataset;
+
     expect(sourceDataset.capUrl).toBeNull();
-    expect(sourceDataset.downloadName).toEqual(WSS_FOO_EDIT_DATA.downloadName);
-    expect(sourceDataset.metadataSpreadsheetTitle).toBeNull();
-    expect(sourceDataset.metadataSpreadsheetUrl).toBeNull();
+
+    expectDetailApiSourceDatasetToMatchTest(sourceDataset, expectedData);
+
     await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_ATLAS_LINKED_B_FOO);
   });
 
@@ -769,6 +791,14 @@ describe(`${TEST_ROUTE} (PATCH)`, () => {
       downloadName: "new-download-name",
       metadataSpreadsheetUrl: null,
     };
+    const expectedData: TestSourceDataset = {
+      ...SOURCE_DATASET_ATLAS_LINKED_B_BAR,
+      capUrl: null,
+      metadataSpreadsheetTitle: null,
+      metadataSpreadsheetUrl: null,
+    };
+    const expectedBaseFilename = editData.downloadName + ".h5ad";
+
     const res = await doSourceDatasetRequest(
       ATLAS_WITH_MISC_SOURCE_STUDIES.id,
       SOURCE_DATASET_ATLAS_LINKED_B_BAR.id,
@@ -778,16 +808,21 @@ describe(`${TEST_ROUTE} (PATCH)`, () => {
       editData,
     );
     expect(res._getStatusCode()).toEqual(200);
-    const sourceDataset = res._getJSONData() as HCAAtlasTrackerSourceDataset;
-    expect(sourceDataset.capUrl).toBeNull();
+    const sourceDataset =
+      res._getJSONData() as HCAAtlasTrackerDetailSourceDataset;
+
     expect(sourceDataset.downloadName).toEqual(editData.downloadName);
-    expect(sourceDataset.metadataSpreadsheetTitle).toBeNull();
-    expect(sourceDataset.metadataSpreadsheetUrl).toBeNull();
+
+    expectDetailApiSourceDatasetToMatchTest(sourceDataset, expectedData, {
+      getExpectedBaseFilename: () => expectedBaseFilename,
+    });
+
     const concept = await getConceptFromDatabase(
       SOURCE_DATASET_ATLAS_LINKED_B_BAR.id,
     );
     assertExpectDefined(concept);
-    expect(concept.base_filename).toEqual(editData.downloadName + ".h5ad");
+    expect(concept.base_filename).toEqual(expectedBaseFilename);
+
     await expectSourceDatasetToBeUnchanged(SOURCE_DATASET_ATLAS_LINKED_B_FOO);
   });
 });

--- a/app/services/source-datasets.ts
+++ b/app/services/source-datasets.ts
@@ -1,6 +1,5 @@
 import {
   type HCAAtlasTrackerDBSourceDataset,
-  type HCAAtlasTrackerDBSourceDatasetForAPI,
   type HCAAtlasTrackerDBSourceDatasetForDetailAPI,
   type HCAAtlasTrackerDBSourceDatasetForListAPI,
   type HCAAtlasTrackerDBSourceDatasetInfo,
@@ -170,7 +169,7 @@ export async function updateAtlasSourceDataset(
   atlasId: string,
   sourceDatasetId: string,
   inputData: AtlasSourceDatasetEditData,
-): Promise<HCAAtlasTrackerDBSourceDatasetForAPI> {
+): Promise<HCAAtlasTrackerDBSourceDatasetForDetailAPI> {
   const sourceDatasetVersion = await getSourceDatasetVersionForAtlas(
     sourceDatasetId,
     atlasId,

--- a/app/views/AtlasSourceDatasetView/hooks/UseFetchAtlasSourceDataset/hook.ts
+++ b/app/views/AtlasSourceDatasetView/hooks/UseFetchAtlasSourceDataset/hook.ts
@@ -7,8 +7,9 @@ import { useQuery } from "./query/useQuery";
 
 /**
  * Fetches the atlas source dataset for the given path parameter via React
- * Query. Editing the source dataset refreshes it by invalidating its query key
- * (`[SOURCE_DATASET, atlasId, sourceDatasetId]`) at the mutation site.
+ * Query. Mutation sites refresh it through its query key (`[SOURCE_DATASET,
+ * atlasId, sourceDatasetId]`): editing writes the PATCH response straight into
+ * the cache with `setQueryData`, while archiving invalidates the key to refetch.
  * @param pathParameter - Path parameter (atlas ID + source dataset ID).
  * @returns React Query result for the source dataset (`data` is the dataset).
  */

--- a/app/views/AtlasSourceDatasetView/hooks/useEditAtlasSourceDatasetForm.ts
+++ b/app/views/AtlasSourceDatasetView/hooks/useEditAtlasSourceDatasetForm.ts
@@ -1,4 +1,7 @@
-import { type HCAAtlasTrackerSourceDataset } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import {
+  type HCAAtlasTrackerDetailSourceDataset,
+  type HCAAtlasTrackerSourceDataset,
+} from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import {
   getApiEntityFileVersion,
   getCapIngestStatus,
@@ -16,13 +19,15 @@ const SCHEMA = viewAtlasSourceDatasetSchema;
 
 export const useEditAtlasSourceDatasetForm = (
   pathParameter: PathParameter,
-): FormMethod<ViewAtlasSourceDatasetData, HCAAtlasTrackerSourceDataset> => {
+): FormMethod<
+  ViewAtlasSourceDatasetData,
+  HCAAtlasTrackerDetailSourceDataset
+> => {
   const { data: sourceDataset } = useFetchAtlasSourceDataset(pathParameter);
-  return useForm<ViewAtlasSourceDatasetData, HCAAtlasTrackerSourceDataset>(
-    SCHEMA,
-    sourceDataset,
-    mapSchemaValues,
-  );
+  return useForm<
+    ViewAtlasSourceDatasetData,
+    HCAAtlasTrackerDetailSourceDataset
+  >(SCHEMA, sourceDataset, mapSchemaValues);
 };
 
 /**

--- a/app/views/AtlasSourceDatasetView/hooks/useEditAtlasSourceDatasetFormManager.ts
+++ b/app/views/AtlasSourceDatasetView/hooks/useEditAtlasSourceDatasetFormManager.ts
@@ -1,5 +1,5 @@
 import { API } from "@/app/apis/catalog/hca-atlas-tracker/common/api";
-import { type HCAAtlasTrackerSourceDataset } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
+import { type HCAAtlasTrackerDetailSourceDataset } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { METHOD, type PathParameter } from "@/app/common/entities";
 import { getRequestURL, getRouteURL } from "@/app/common/utils";
 import { type FormMethod } from "@/app/hooks/useForm/common/entities";
@@ -21,7 +21,7 @@ export const useEditAtlasSourceDatasetFormManager = (
   pathParameter: PathParameter,
   formMethod: FormMethod<
     ViewAtlasSourceDatasetData,
-    HCAAtlasTrackerSourceDataset
+    HCAAtlasTrackerDetailSourceDataset
   >,
 ): FormManager => {
   const queryClient = useQueryClient();
@@ -44,21 +44,21 @@ export const useEditAtlasSourceDatasetFormManager = (
         mapPayload(payload),
         {
           onReset: reset,
-          onSuccess: () => {
-            // Invalidate rather than setQueryData (the pattern the other edit
-            // managers use): the PATCH returns the base source-dataset shape,
-            // but the detail query holds the detail shape (base +
-            // validationReports), so caching the response would drop
-            // validationReports from the view. Invalidating refetches the full
-            // detail shape instead. (If the PATCH is changed to return the
-            // detail shape, this can setQueryData like the other managers.)
-            queryClient.invalidateQueries({
-              queryKey: [
-                SOURCE_DATASET,
-                pathParameter.atlasId,
-                pathParameter.sourceDatasetId,
-              ],
-            });
+          onSuccess: (data) => {
+            // The PATCH returns the same detail shape as the detail query, so
+            // write the response back into the cache (no refetch round-trip);
+            // this refreshes the detail whether we stay or navigate away. Cancel
+            // any in-flight GET first: unlike invalidateQueries, setQueryData
+            // doesn't cancel it, so a GET resolving after the save could clobber
+            // the cache with pre-save data. (setQueryData is a no-op if data is
+            // undefined.)
+            const queryKey = [
+              SOURCE_DATASET,
+              pathParameter.atlasId,
+              pathParameter.sourceDatasetId,
+            ];
+            queryClient.cancelQueries({ queryKey });
+            queryClient.setQueryData(queryKey, data);
             if (url) Router.push(url);
           },
         },

--- a/pages/api/atlases/[atlasId]/source-datasets/[sourceDatasetId].ts
+++ b/pages/api/atlases/[atlasId]/source-datasets/[sourceDatasetId].ts
@@ -1,7 +1,4 @@
-import {
-  dbSourceDatasetToApiSourceDataset,
-  dbSourceDatasetToDetailApiSourceDataset,
-} from "@/app/apis/catalog/hca-atlas-tracker/common/backend-utils";
+import { dbSourceDatasetToDetailApiSourceDataset } from "@/app/apis/catalog/hca-atlas-tracker/common/backend-utils";
 import { ROLE_GROUP } from "@/app/apis/catalog/hca-atlas-tracker/common/constants";
 import { ROLE } from "@/app/apis/catalog/hca-atlas-tracker/common/entities";
 import { atlasSourceDatasetEditSchema } from "@/app/apis/catalog/hca-atlas-tracker/common/schema";
@@ -27,7 +24,7 @@ const patchHandler = handler(role(ROLE.CONTENT_ADMIN), async (req, res) => {
   const sourceDatasetId = req.query.sourceDatasetId as string;
   const inputData = await atlasSourceDatasetEditSchema.validate(req.body);
   res.json(
-    dbSourceDatasetToApiSourceDataset(
+    dbSourceDatasetToDetailApiSourceDataset(
       await updateAtlasSourceDataset(atlasId, sourceDatasetId, inputData),
     ),
   );

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -753,25 +753,45 @@ export function expectApiSourceDatasetsToMatchTest(
 export function expectDetailApiSourceDatasetToMatchTest(
   apiSourceDataset: HCAAtlasTrackerDetailSourceDataset,
   testSourceDataset: TestSourceDataset,
+  funcs?: ApiSourceDatasetCheckFuncs,
 ): void {
-  expectApiSourceDatasetToMatchTest(
-    apiSourceDataset,
-    testSourceDataset,
-    true,
-    (testFile) => {
+  expectApiSourceDatasetToMatchTest(apiSourceDataset, testSourceDataset, {
+    ...funcs,
+    doAdditionalChecks(testFile) {
       expect(apiSourceDataset.validationReports).toEqual(
         testFile.validationReports,
       );
+      funcs?.doAdditionalChecks?.(testFile);
     },
-  );
+    doValidationReportsCheck(apiSourceDataset) {
+      expect(apiSourceDataset).toHaveProperty("validationReports");
+    },
+  });
+}
+
+interface ApiSourceDatasetCheckFuncs {
+  doAdditionalChecks?: (testFile: NormalizedTestFile) => void;
+  doValidationReportsCheck?: (
+    apiSourceDataset: HCAAtlasTrackerSourceDataset,
+  ) => void;
+  getExpectedBaseFilename?: (
+    testSourceDataset: Required<TestSourceDataset>,
+  ) => string;
 }
 
 export function expectApiSourceDatasetToMatchTest(
   apiSourceDataset: HCAAtlasTrackerSourceDataset,
   baseTestSourceDataset: TestSourceDataset,
-  expectDetail = false,
-  doAdditionalChecks?: (file: NormalizedTestFile) => void,
+  funcs: ApiSourceDatasetCheckFuncs = {},
 ): void {
+  const {
+    doAdditionalChecks,
+    doValidationReportsCheck = (apiDataset): void => {
+      expect(apiDataset).not.toHaveProperty("validationReports");
+    },
+    getExpectedBaseFilename = getTestEntityBaseFilename,
+  } = funcs;
+
   const testSourceDataset = fillTestSourceDatasetDefaults(
     baseTestSourceDataset,
   );
@@ -781,7 +801,7 @@ export function expectApiSourceDatasetToMatchTest(
 
   expect(apiSourceDataset.assay).toEqual(testFile.datasetInfo?.assay ?? []);
   expect(apiSourceDataset.baseFileName).toEqual(
-    getTestEntityBaseFilename(testSourceDataset),
+    getExpectedBaseFilename(testSourceDataset),
   );
   expect(apiSourceDataset.capUrl).toEqual(testSourceDataset.capUrl);
   expect(apiSourceDataset.cellCount).toEqual(
@@ -831,11 +851,7 @@ export function expectApiSourceDatasetToMatchTest(
   );
   expect(apiSourceDataset.wipNumber).toEqual(testSourceDataset.wipNumber);
 
-  if (expectDetail) {
-    expect(apiSourceDataset).toHaveProperty("validationReports");
-  } else {
-    expect(apiSourceDataset).not.toHaveProperty("validationReports");
-  }
+  doValidationReportsCheck(apiSourceDataset);
 
   doAdditionalChecks?.(testFile);
 }

--- a/testing/utils.ts
+++ b/testing/utils.ts
@@ -753,7 +753,7 @@ export function expectApiSourceDatasetsToMatchTest(
 export function expectDetailApiSourceDatasetToMatchTest(
   apiSourceDataset: HCAAtlasTrackerDetailSourceDataset,
   testSourceDataset: TestSourceDataset,
-  funcs?: ApiSourceDatasetCheckFuncs,
+  funcs?: Omit<ApiSourceDatasetCheckFuncs, "doValidationReportsCheck">,
 ): void {
   expectApiSourceDatasetToMatchTest(apiSourceDataset, testSourceDataset, {
     ...funcs,


### PR DESCRIPTION
Closes #1523

Notes:
- Turns out the only backend changes needed were to the type annotations and the choice of API mapping function -- the function being used to query the data for the PATCH response was actually already the detail one!
- I made some changes to how the API's tests are done, to better test the response shape