### PR TITLE
fix: copy tsconfig.json into runner image so the migrate entrypoint can resolve @/ imports (#1530)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+out

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -22,7 +22,9 @@ ENV ENVIRONMENT ${ENVIRONMENT}
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-RUN npm run build:${ENVIRONMENT}
+# Next's build peaks ~2.5GB of JS heap; V8's default cap (~2GB on ~8GB hosts,
+# e.g. a default-sized Docker Desktop VM) OOMs it.
+RUN NODE_OPTIONS=--max-old-space-size=4096 npm run build:${ENVIRONMENT}
 
 # Run stage
 FROM base AS runner
@@ -42,13 +44,14 @@ COPY --from=builder /app/scripts ./scripts
 # images; the runtime guard in the script is the secondary safeguard.
 RUN rm -f ./scripts/migration-down.ts
 COPY --from=builder /app/migrations ./migrations
+# The migrate entrypoint's `ts-node -r tsconfig-paths/register` needs the
+# `@/*` path mapping from tsconfig.json to resolve imports at boot.
+COPY --from=builder /app/tsconfig.json ./tsconfig.json
 COPY --from=builder /app/app/utils/pg-app-connect-config.ts  ./app/utils/pg-app-connect-config.ts
 COPY --from=builder /app/app/utils/pg-migrate-connect-config.ts  ./app/utils/pg-migrate-connect-config.ts
 
-RUN pwd
 RUN chmod +x ./scripts/entrypoint.sh
 
 EXPOSE 3000
 ENV PORT 3000
-#CMD ["pm2-runtime", "start", "npm", "--", "start"]
 ENTRYPOINT ["./scripts/entrypoint.sh"]


### PR DESCRIPTION
## What changed

- **`Dockerfile.node` runner stage**: copies `tsconfig.json` into the image, grouped with the other migrate-entrypoint support files (`migrations/`, the two `pg-*-connect-config.ts` copies).
- **`Dockerfile.node` builder stage**: the build command runs with `NODE_OPTIONS=--max-old-space-size=4096` (RUN-scoped, so it applies to nothing else and cannot reach the runtime image).
- **New `.dockerignore`** (`node_modules`, `.next`, `out`): local `docker build` no longer uploads a multi-GB context or overlays the host's darwin `node_modules` over the container's fresh linux `npm ci` tree. CI images were never affected (clean checkout); this makes locally built images faithful to CI-built ones.
- Removed a debug `RUN pwd` layer and a stale commented-out `CMD` in the runner stage.

## Why

Since #1510 converted `scripts/migration-runner.ts` to the `@/` alias, **every deployed container has crashed at boot in every environment**: the runner stage never copied `tsconfig.json`, so the migrate entrypoint's `ts-node -r tsconfig-paths/register` had no `@/*` mapping ("Couldn't find tsconfig.json. tsconfig-paths will be skipped" → `TS2307`), `entrypoint.sh` exited before pm2 started, health checks failed, and App Runner silently rolled back to the last healthy image (dev still serves `548e828d`) — while CI stayed green, because the workflows build and push the image but never run it. See #1530 for the full incident trail.

The heap-cap line exists because Next's post-compile phases peak ~2.5GB, above the ~2GB default cap V8 derives on ~8GB hosts (default Docker Desktop VM) — local image builds OOMed. CI's 16GB runners derive a 4GB cap and were never affected.

## Assumptions I made

- Migrations themselves import only `node-pg-migrate` (verified — no `@/` imports in `migrations/`), so `tsconfig.json` plus the already-copied `app/utils/pg-*-connect-config.ts` files complete the entrypoint's dependency set.
- The `@/`-alias import in `migration-runner.ts` stays (repo convention bans `../` imports); the deeper long-term shape — precompiling migrations to JS so the prod image needs no ts-node/tsconfig at all — is deliberately not attempted here and will be proposed as a follow-up issue.
- On ≤4GB Docker VMs the 4096 cap means a kernel OOM-kill instead of V8's clearer error — accepted, since such hosts couldn't build before either.
- `.git` is deliberately **not** in `.dockerignore`: `set-version.sh` runs git commands during the in-image build.

## How to verify

Issue #1530's definition of done: a container built from main boots successfully, verified inside the image filesystem.

1. **Repro the incident (optional)**: on `main`, `docker build --build-arg ENVIRONMENT=local -t tracker-unfixed -f Dockerfile.node .` then `docker run --rm tracker-unfixed` → crashes with `TS2307: Cannot find module '@/app/utils/pg-migrate-connect-config'`.
2. **Build this branch**: `docker build --build-arg ENVIRONMENT=local -t tracker-fixed -f Dockerfile.node .` (also confirms the build no longer OOMs on a default Docker Desktop VM; context transfer is ~1.4MB).
3. **Boot it against a scratch DB**:
   ```bash
   docker run -d --name pg -e POSTGRES_USER=root -e POSTGRES_DB=atlas-tracker -e POSTGRES_HOST_AUTH_METHOD=trust postgres:14
   docker run -d --name app --network container:pg -e APP_ENV=local -e USER=root tracker-fixed
   docker logs -f app
   ```
   Expect: "Running database migrations..." → 69 `### MIGRATION ... (UP) ###` lines → "Starting application with pm2-runtime...". (`docker rm -f app pg` to clean up.)
4. **After merge**: the push triggers a dev deploy; the dev footer at test-tracker.data.humancellatlas.dev.clevercanary.com should finally advance from `Unversioned-548e828` to the new build, and to a proper version string on the next release.

Closes #1530

🤖 Generated with [Claude Code](https://claude.com/claude-code)